### PR TITLE
feat(redteam): add runtime tags to redteam run

### DIFF
--- a/site/docs/integrations/ci-cd.md
+++ b/site/docs/integrations/ci-cd.md
@@ -66,6 +66,20 @@ npx promptfoo@latest redteam run
 
 See our [red team quickstart](/docs/red-team/quickstart) for security testing details.
 
+#### Attach CI/CD Context with Tags
+
+Use repeatable `--tag key=value` flags to attach pipeline context to an evaluation
+without modifying `promptfooconfig.yaml` or a red team scan template. Tags are saved
+with the eval and included when results are shared.
+
+```bash
+npx promptfoo@latest eval --tag ci.run-id="$CI_PIPELINE_ID" --tag git.sha="$CI_COMMIT_SHA"
+npx promptfoo@latest redteam run --tag ci.run-id="$CI_PIPELINE_ID" --tag git.sha="$CI_COMMIT_SHA"
+```
+
+`promptfoo redteam eval` accepts the same `--tag` option when running previously
+generated probes from `redteam.yaml`.
+
 ### 2. Output Formats
 
 Promptfoo supports multiple output formats for different CI/CD needs:

--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -29,6 +29,15 @@ Red teams happen in three steps:
 
 `promptfoo redteam run` is a shortcut that combines `redteam generate` and `redteam eval` steps, ensuring that your generated test cases are always synced with the latest configuration.
 
+In CI/CD, use repeatable `--tag key=value` options with `redteam run` or
+`redteam eval` to record run-specific context without changing your scan template or
+generated `redteam.yaml`. Tags are saved with the eval and included when results are
+shared.
+
+```bash
+promptfoo redteam run --tag ci.run-id="$CI_RUN_ID" --tag git.sha="$GIT_SHA"
+```
+
 ## Configuration Structure
 
 The red team configuration uses the following YAML structure:

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -898,6 +898,7 @@ Run the complete red teaming process (init, generate, and evaluate).
 | `-c, --config [path]`                              | Path to configuration file                                              | promptfooconfig.yaml |
 | `-o, --output [path]`                              | Path to output file for generated tests                                 | redteam.yaml         |
 | `-d, --description <text>`                         | Custom description/name for this scan run                               |                      |
+| `--tag <key=value>`                                | Set a run-specific eval tag. May be specified multiple times.           |                      |
 | `--no-cache`                                       | Do not read or write results to disk cache                              | false                |
 | `-j, --max-concurrency <number>`                   | Maximum number of concurrent API calls                                  |                      |
 | `--delay <number>`                                 | Delay in milliseconds between API calls                                 |                      |
@@ -908,6 +909,14 @@ Run the complete red teaming process (init, generate, and evaluate).
 | `--filter-prompts <pattern>`                       | Only run tests with prompts whose id or label matches the regex pattern |                      |
 | `--filter-providers, --filter-targets <providers>` | Only run tests with these providers (regex match)                       |                      |
 | `-t, --target <id>`                                | Cloud provider target ID to run the scan on                             |                      |
+
+Use `--tag` to attach CI/CD context to the evaluation result without changing the
+scan template or generated `redteam.yaml`. CLI tags override matching tags from the
+configuration and are included when the eval is shared.
+
+```sh
+promptfoo redteam run --tag ci.run-id=$CI_RUN_ID --tag git.sha=$GIT_COMMIT
+```
 
 ## `promptfoo redteam discover`
 
@@ -987,7 +996,8 @@ Generate poisoned documents for RAG testing.
 
 ## `promptfoo redteam eval`
 
-Works the same as [`promptfoo eval`](#promptfoo-eval), but defaults to loading `redteam.yaml`.
+Works the same as [`promptfoo eval`](#promptfoo-eval), including repeatable `--tag`
+options for run-specific labels, but defaults to loading `redteam.yaml`.
 
 ## `promptfoo redteam report`
 

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -893,22 +893,22 @@ Start browser UI and open to red team setup.
 
 Run the complete red teaming process (init, generate, and evaluate).
 
-| Option                                             | Description                                                             | Default              |
-| -------------------------------------------------- | ----------------------------------------------------------------------- | -------------------- |
-| `-c, --config [path]`                              | Path to configuration file                                              | promptfooconfig.yaml |
-| `-o, --output [path]`                              | Path to output file for generated tests                                 | redteam.yaml         |
-| `-d, --description <text>`                         | Custom description/name for this scan run                               |                      |
-| `--tag <key=value>`                                | Set a run-specific eval tag. May be specified multiple times.           |                      |
-| `--no-cache`                                       | Do not read or write results to disk cache                              | false                |
-| `-j, --max-concurrency <number>`                   | Maximum number of concurrent API calls                                  |                      |
-| `--delay <number>`                                 | Delay in milliseconds between API calls                                 |                      |
-| `--remote`                                         | Force remote inference wherever possible                                | false                |
-| `--force`                                          | Force generation even if no changes are detected                        | false                |
-| `--no-progress-bar`                                | Do not show progress bar                                                |                      |
-| `--strict`                                         | Fail if any plugins fail to generate test cases                         | false                |
-| `--filter-prompts <pattern>`                       | Only run tests with prompts whose id or label matches the regex pattern |                      |
-| `--filter-providers, --filter-targets <providers>` | Only run tests with these providers (regex match)                       |                      |
-| `-t, --target <id>`                                | Cloud provider target ID to run the scan on                             |                      |
+| Option                                             | Description                                                                      | Default              |
+| -------------------------------------------------- | -------------------------------------------------------------------------------- | -------------------- |
+| `-c, --config [path]`                              | Path to configuration file                                                       | promptfooconfig.yaml |
+| `-o, --output [path]`                              | Path to output file for generated tests                                          | redteam.yaml         |
+| `-d, --description <text>`                         | Custom description/name for this scan run                                        |                      |
+| `--tag <key=value>`                                | Set an eval tag. Can be specified multiple times; CLI tags override config tags. |                      |
+| `--no-cache`                                       | Do not read or write results to disk cache                                       | false                |
+| `-j, --max-concurrency <number>`                   | Maximum number of concurrent API calls                                           |                      |
+| `--delay <number>`                                 | Delay in milliseconds between API calls                                          |                      |
+| `--remote`                                         | Force remote inference wherever possible                                         | false                |
+| `--force`                                          | Force generation even if no changes are detected                                 | false                |
+| `--no-progress-bar`                                | Do not show progress bar                                                         |                      |
+| `--strict`                                         | Fail if any plugins fail to generate test cases                                  | false                |
+| `--filter-prompts <pattern>`                       | Only run tests with prompts whose id or label matches the regex pattern          |                      |
+| `--filter-providers, --filter-targets <providers>` | Only run tests with these providers (regex match)                                |                      |
+| `-t, --target <id>`                                | Cloud provider target ID to run the scan on                                      |                      |
 
 Use `--tag` to attach CI/CD context to the evaluation result without changing the
 scan template or generated `redteam.yaml`. CLI tags override matching tags from the

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 
 import chalk from 'chalk';
 import chokidar from 'chokidar';
-import { InvalidArgumentError } from 'commander';
 import dedent from 'dedent';
 import ora from 'ora';
 import { z } from 'zod';
@@ -53,6 +52,7 @@ import { filterProviders } from './eval/filterProviders';
 import { filterTests } from './eval/filterTests';
 import { warnIfRedteamConfigHasNoTests } from './eval/redteamWarning';
 import { generateEvalSummary } from './eval/summary';
+import { collectKeyValueOption } from './options';
 import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from './retry';
 import { notCloudEnabledShareInstructions } from './share';
 import type { Command } from 'commander';
@@ -75,22 +75,6 @@ const EvalCommandSchema = CommandLineOptionsSchema.extend({
 }).partial();
 
 type EvalCommandOptions = z.infer<typeof EvalCommandSchema>;
-
-function collectKeyValueOption(
-  optionName: string,
-  value: string,
-  previous: Record<string, string> | undefined,
-): Record<string, string> {
-  const separatorIndex = value.indexOf('=');
-  const key = separatorIndex === -1 ? '' : value.slice(0, separatorIndex);
-  const val = separatorIndex === -1 ? undefined : value.slice(separatorIndex + 1);
-
-  if (!key || val === undefined) {
-    throw new InvalidArgumentError(`${optionName} must be specified in key=value format.`);
-  }
-
-  return { ...previous, [key]: val };
-}
 
 function runtimeTagsForEval(
   cmdObj: Partial<CommandLineOptions & Command>,

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -52,7 +52,7 @@ import { filterProviders } from './eval/filterProviders';
 import { filterTests } from './eval/filterTests';
 import { warnIfRedteamConfigHasNoTests } from './eval/redteamWarning';
 import { generateEvalSummary } from './eval/summary';
-import { collectKeyValueOption } from './options';
+import { collectKeyValueOption, normalizeTagOption } from './options';
 import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from './retry';
 import { notCloudEnabledShareInstructions } from './share';
 import type { Command } from 'commander';
@@ -1280,10 +1280,9 @@ export function evalCommand(
     .action(async (opts: EvalCommandOptions, command: Command) => {
       let validatedOpts: z.infer<typeof EvalCommandSchema>;
       try {
-        const optsWithAliases = {
-          ...opts,
-          tags: (opts as EvalCommandOptions & { tag?: Record<string, string> }).tag ?? opts.tags,
-        };
+        const optsWithAliases = normalizeTagOption(
+          opts as EvalCommandOptions & { tag?: Record<string, string> },
+        );
         validatedOpts = EvalCommandSchema.parse(optsWithAliases);
       } catch (err) {
         logger.error(dedent`

--- a/src/commands/options.ts
+++ b/src/commands/options.ts
@@ -1,0 +1,17 @@
+import { InvalidArgumentError } from 'commander';
+
+export function collectKeyValueOption(
+  optionName: string,
+  value: string,
+  previous: Record<string, string> | undefined,
+): Record<string, string> {
+  const separatorIndex = value.indexOf('=');
+  const key = separatorIndex === -1 ? '' : value.slice(0, separatorIndex);
+  const val = separatorIndex === -1 ? undefined : value.slice(separatorIndex + 1);
+
+  if (!key || val === undefined) {
+    throw new InvalidArgumentError(`${optionName} must be specified in key=value format.`);
+  }
+
+  return { ...previous, [key]: val };
+}

--- a/src/commands/options.ts
+++ b/src/commands/options.ts
@@ -15,3 +15,20 @@ export function collectKeyValueOption(
 
   return { ...previous, [key]: val };
 }
+
+/**
+ * Normalize Commander's repeatable `--tag` option into the canonical `tags` field.
+ *
+ * Commander accumulates `--tag key=value` flags under the transient `tag` key (see the
+ * `collectKeyValueOption` coercion). This collapses that alias into `tags`, dropping `tag`
+ * so only the canonical field survives. CLI tags (`tag`) take precedence over any
+ * pre-existing `tags`. Returns a new object; the input is not mutated. When neither field
+ * is present, no `tags` key is added.
+ */
+export function normalizeTagOption<
+  T extends { tag?: Record<string, string>; tags?: Record<string, string> },
+>(rawOpts: T): Omit<T, 'tag'> {
+  const { tag, ...rest } = rawOpts;
+  const tags = tag ?? rest.tags;
+  return tags === undefined ? rest : { ...rest, tags };
+}

--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import dedent from 'dedent';
 import { z } from 'zod';
 import cliState from '../../cliState';
+import { collectKeyValueOption } from '../../commands/options';
 import { CLOUD_PROVIDER_PREFIX } from '../../constants';
 import { EmailValidationError } from '../../globalConfig/accounts';
 import logger from '../../logger';
@@ -15,6 +16,8 @@ import { poisonCommand } from './poison';
 import type { Command } from 'commander';
 
 const UUID_REGEX = /^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/;
+
+type RedteamRunCliOptions = RedteamRunOptions & { tag?: Record<string, string> };
 
 export function redteamRunCommand(program: Command) {
   program
@@ -60,7 +63,17 @@ export function redteamRunCommand(program: Command) {
     )
     .option('-t, --target <id>', 'Cloud provider target ID to run the scan on')
     .option('-d, --description <text>', 'Custom description/name for this scan run')
-    .action(async (opts: RedteamRunOptions) => {
+    .option(
+      '--tag <key=value>',
+      'Set an eval tag in key=value format. Can be specified multiple times; CLI tags override config tags.',
+      (value: string, previous: Record<string, string> | undefined) =>
+        collectKeyValueOption('--tag', value, previous),
+    )
+    .action(async (rawOpts: RedteamRunCliOptions) => {
+      const { tag, ...optionsWithoutTag } = rawOpts;
+      const opts: RedteamRunOptions =
+        tag === undefined ? optionsWithoutTag : { ...optionsWithoutTag, tags: tag };
+
       setupEnv(opts.envPath);
       telemetry.record('redteam run', {});
 

--- a/src/redteam/commands/run.ts
+++ b/src/redteam/commands/run.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import dedent from 'dedent';
 import { z } from 'zod';
 import cliState from '../../cliState';
-import { collectKeyValueOption } from '../../commands/options';
+import { collectKeyValueOption, normalizeTagOption } from '../../commands/options';
 import { CLOUD_PROVIDER_PREFIX } from '../../constants';
 import { EmailValidationError } from '../../globalConfig/accounts';
 import logger from '../../logger';
@@ -17,7 +17,7 @@ import type { Command } from 'commander';
 
 const UUID_REGEX = /^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$/;
 
-type RedteamRunCliOptions = RedteamRunOptions & { tag?: Record<string, string> };
+type RedteamRunCliOptions = Omit<RedteamRunOptions, 'tags'> & { tag?: Record<string, string> };
 
 export function redteamRunCommand(program: Command) {
   program
@@ -70,9 +70,7 @@ export function redteamRunCommand(program: Command) {
         collectKeyValueOption('--tag', value, previous),
     )
     .action(async (rawOpts: RedteamRunCliOptions) => {
-      const { tag, ...optionsWithoutTag } = rawOpts;
-      const opts: RedteamRunOptions =
-        tag === undefined ? optionsWithoutTag : { ...optionsWithoutTag, tags: tag };
+      const opts: RedteamRunOptions = normalizeTagOption(rawOpts);
 
       setupEnv(opts.envPath);
       telemetry.record('redteam run', {});

--- a/src/redteam/shared.ts
+++ b/src/redteam/shared.ts
@@ -87,7 +87,10 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
 
     // Generate new test cases
     logger.info('Generating test cases...');
-    // Run-specific tags describe the eval result, not the reusable generated probes.
+    // Strip run-specific tags from the generation options so they do not leak into the
+    // reusable generated redteam.yaml (which feeds `doGenerateRedteam`). The tags still reach
+    // the eval below via `evalOptions`, which is destructured from the untouched `options`
+    // object (see the `doEval` call), where they are persisted onto the eval result.
     const { maxConcurrency, tags: _runtimeTags, ...passThroughOptions } = options;
 
     let redteamConfig;

--- a/src/redteam/shared.ts
+++ b/src/redteam/shared.ts
@@ -87,7 +87,8 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
 
     // Generate new test cases
     logger.info('Generating test cases...');
-    const { maxConcurrency, ...passThroughOptions } = options;
+    // Run-specific tags describe the eval result, not the reusable generated probes.
+    const { maxConcurrency, tags: _runtimeTags, ...passThroughOptions } = options;
 
     let redteamConfig;
     const generationStartTime = Date.now();

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -318,6 +318,7 @@ export interface RedteamRunOptions {
   verbose?: boolean;
   progressBar?: boolean;
   description?: string;
+  tags?: Record<string, string>;
   strict?: boolean;
 
   // Used by webui

--- a/test/commands/options.test.ts
+++ b/test/commands/options.test.ts
@@ -1,0 +1,91 @@
+import { InvalidArgumentError } from 'commander';
+import { describe, expect, it } from 'vitest';
+import { collectKeyValueOption, normalizeTagOption } from '../../src/commands/options';
+
+describe('collectKeyValueOption', () => {
+  it('parses a key=value pair into a record', () => {
+    expect(collectKeyValueOption('--tag', 'env=ci', undefined)).toEqual({ env: 'ci' });
+  });
+
+  it('merges onto the previous accumulator (repeatable option)', () => {
+    expect(collectKeyValueOption('--tag', 'run=123', { env: 'ci' })).toEqual({
+      env: 'ci',
+      run: '123',
+    });
+  });
+
+  it('keeps everything after the first "=" so values may contain "="', () => {
+    expect(collectKeyValueOption('--tag', 'token=a=b=c', undefined)).toEqual({ token: 'a=b=c' });
+  });
+
+  it('lets a later occurrence of the same key override an earlier one', () => {
+    const first = collectKeyValueOption('--tag', 'build=first', undefined);
+    expect(collectKeyValueOption('--tag', 'build=second', first)).toEqual({ build: 'second' });
+  });
+
+  it('accepts an explicitly empty value (key=)', () => {
+    expect(collectKeyValueOption('--tag', 'empty=', undefined)).toEqual({ empty: '' });
+  });
+
+  it.each(['invalid', '=value'])('throws InvalidArgumentError for malformed input %p', (value) => {
+    expect(() => collectKeyValueOption('--tag', value, undefined)).toThrow(InvalidArgumentError);
+    expect(() => collectKeyValueOption('--tag', value, undefined)).toThrow(
+      '--tag must be specified in key=value format.',
+    );
+  });
+
+  it('includes the option name in the error message', () => {
+    expect(() => collectKeyValueOption('--var', 'nope', undefined)).toThrow(
+      '--var must be specified in key=value format.',
+    );
+  });
+
+  it('stores a "__proto__" key as a harmless own property without polluting Object.prototype', () => {
+    const result = collectKeyValueOption('--tag', '__proto__=evil', { a: '1' });
+
+    expect(Object.prototype.hasOwnProperty.call(result, '__proto__')).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(result, '__proto__')?.value).toBe('evil');
+    // The prototype chain must remain untouched.
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(({} as Record<string, unknown>).evil).toBeUndefined();
+  });
+});
+
+describe('normalizeTagOption', () => {
+  it('rewrites the Commander "tag" alias to the canonical "tags" field', () => {
+    const result = normalizeTagOption({ tag: { env: 'ci' } });
+
+    expect(result).toEqual({ tags: { env: 'ci' } });
+    expect(result).not.toHaveProperty('tag');
+  });
+
+  it('passes through an existing "tags" field when no "tag" alias is present', () => {
+    expect(normalizeTagOption({ tags: { env: 'ci' } })).toEqual({ tags: { env: 'ci' } });
+  });
+
+  it('prefers the CLI "tag" alias over a pre-existing "tags" field', () => {
+    const result = normalizeTagOption({ tag: { env: 'cli' }, tags: { env: 'config' } });
+
+    expect(result).toEqual({ tags: { env: 'cli' } });
+    expect(result).not.toHaveProperty('tag');
+  });
+
+  it('adds no "tags" key when neither "tag" nor "tags" is present', () => {
+    const input: { config: string; tag?: Record<string, string>; tags?: Record<string, string> } =
+      { config: 'promptfooconfig.yaml' };
+    const result = normalizeTagOption(input);
+
+    expect(result).toEqual({ config: 'promptfooconfig.yaml' });
+    expect(result).not.toHaveProperty('tags');
+    expect(result).not.toHaveProperty('tag');
+  });
+
+  it('preserves unrelated options and does not mutate the input', () => {
+    const input = { config: 'a.yaml', verbose: true, tag: { env: 'ci' } };
+    const result = normalizeTagOption(input);
+
+    expect(result).toEqual({ config: 'a.yaml', verbose: true, tags: { env: 'ci' } });
+    // Input is left untouched.
+    expect(input).toEqual({ config: 'a.yaml', verbose: true, tag: { env: 'ci' } });
+  });
+});

--- a/test/redteam/commands/run.test.ts
+++ b/test/redteam/commands/run.test.ts
@@ -345,6 +345,57 @@ describe('redteamRunCommand', () => {
     });
   });
 
+  describe('--tag flag for run-specific eval tags', () => {
+    it('should document the repeatable --tag option in help text', () => {
+      const runCommand = program.commands.find((cmd) => cmd.name() === 'run');
+      expect(runCommand).toBeDefined();
+
+      const helpText = runCommand!.helpInformation();
+
+      expect(helpText).toContain('--tag <key=value>');
+      expect(helpText).toContain('Set an eval tag in key=value format.');
+    });
+
+    it('should pass repeated tags to the evaluation stage with Commander normalization', async () => {
+      const runCommand = program.commands.find((cmd) => cmd.name() === 'run');
+      expect(runCommand).toBeDefined();
+
+      await runCommand!.parseAsync([
+        'node',
+        'test',
+        '--tag',
+        'build=first',
+        '--tag',
+        'build=second',
+        '--tag',
+        'token=a=b',
+        '--tag',
+        'empty=',
+      ]);
+
+      const options = vi.mocked(doRedteamRun).mock.calls[0][0];
+      expect(options).toMatchObject({
+        tags: {
+          build: 'second',
+          token: 'a=b',
+          empty: '',
+        },
+        eventSource: 'cli',
+      });
+      expect(options).not.toHaveProperty('tag');
+    });
+
+    it.each(['invalid', '=value'])('should reject malformed --tag value %s', (tagValue) => {
+      const runCommand = program.commands.find((cmd) => cmd.name() === 'run');
+      expect(runCommand).toBeDefined();
+      runCommand!.exitOverride();
+
+      expect(() => runCommand!.parseOptions(['--tag', tagValue])).toThrow(
+        '--tag must be specified in key=value format.',
+      );
+    });
+  });
+
   describe('error handling', () => {
     it('should suppress stack trace when doRedteamRun throws ProbeLimitExceededError', async () => {
       vi.mocked(doRedteamRun).mockRejectedValueOnce(new ProbeLimitExceededError(100, 100));

--- a/test/redteam/commands/run.test.ts
+++ b/test/redteam/commands/run.test.ts
@@ -385,6 +385,18 @@ describe('redteamRunCommand', () => {
       expect(options).not.toHaveProperty('tag');
     });
 
+    it('should not add a tags property when no --tag is provided', async () => {
+      const runCommand = program.commands.find((cmd) => cmd.name() === 'run');
+      expect(runCommand).toBeDefined();
+
+      await runCommand!.parseAsync(['node', 'test']);
+
+      const options = vi.mocked(doRedteamRun).mock.calls[0][0];
+      // Avoid clobbering config-level tags with an undefined/empty runtime value.
+      expect(options).not.toHaveProperty('tags');
+      expect(options).not.toHaveProperty('tag');
+    });
+
     it.each(['invalid', '=value'])('should reject malformed --tag value %s', (tagValue) => {
       const runCommand = program.commands.find((cmd) => cmd.name() === 'run');
       expect(runCommand).toBeDefined();

--- a/test/redteam/shared.test.ts
+++ b/test/redteam/shared.test.ts
@@ -190,6 +190,23 @@ describe('doRedteamRun', () => {
     );
   });
 
+  it('should apply runtime tags to the eval without adding them to generated test cases', async () => {
+    const tags = {
+      'ci.run-id': '123',
+      'git.sha': 'abc123',
+    };
+
+    await doRedteamRun({ tags });
+
+    expect(vi.mocked(doGenerateRedteam).mock.calls[0][0]).not.toHaveProperty('tags');
+    expect(doEval).toHaveBeenCalledWith(
+      expect.objectContaining({ tags }),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   describe('liveRedteamConfig temporary file handling', () => {
     const mockConfig = {
       prompts: ['Test prompt'],

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -659,6 +659,34 @@ describe('createShareableUrl', () => {
       expect(mockFetch.mock.calls[0][1].body).not.toContain('azure-secret');
     });
 
+    it('includes eval tags in the shared config payload', async () => {
+      vi.mocked(cloudConfig.isEnabled).mockReturnValue(false);
+      mockEval.config = {
+        tags: {
+          'ci.run-id': '123',
+          'git.sha': 'abc123',
+        },
+      };
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ id: mockEval.id }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+
+      await createShareableUrl(mockEval as Eval);
+
+      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(requestBody.config.tags).toEqual({
+        'ci.run-id': '123',
+        'git.sha': 'abc123',
+      });
+    });
+
     it('sends eval with trace data when traces are available', async () => {
       vi.mocked(cloudConfig.isEnabled).mockReturnValue(true);
       vi.mocked(cloudConfig.getAppUrl).mockReturnValue('https://app.example.com');


### PR DESCRIPTION
## Summary

- add repeatable `--tag key=value` support to `promptfoo redteam run`, matching the existing `eval` and `redteam eval` behavior
- persist and share run-specific CI/CD tags with the eval result while keeping runtime tags out of generated `redteam.yaml`
- document tag usage for redteam and CI/CD flows and cover parsing, stage isolation, persistence, and sharing behavior

## Related Issue

- [FOO-159: Extend promptfoo run / promptfoo eval to add more metadata](https://linear.app/openai/issue/FOO-159/extend-promptfoo-run-promptfoo-eval-to-add-more-metadata)

## Testing

- `npm run l` (passes; reports existing non-blocking complexity warnings in large eval/redteam orchestration functions)
- `npm run f` (passes; reports the same non-blocking complexity warnings)
- `npm run tsc`
- `npx vitest run test/commands/eval.test.ts test/redteam/commands/run.test.ts test/redteam/shared.test.ts test/share.test.ts test/util/databaseWrite.test.ts --sequence.shuffle=false`
- `npx vitest run --config vitest.smoke.config.ts test/smoke/filters-and-flags.test.ts --sequence.shuffle=false`
- `PROMPTFOO_DISABLE_UPDATE=true PROMPTFOO_DISABLE_TELEMETRY=true npm run local -- redteam run --help`
- `SKIP_OG_GENERATION=true npm --prefix site run build`


---

### Follow-up: review hardening (commit `f930305`)

A post-review pass to consolidate and lock the tag handling (no behavior change):

- Extracted a shared `normalizeTagOption` helper into `src/commands/options.ts` and used it in **both** the `eval` and `redteam run` actions, replacing two divergent `tag`→`tags` idioms with one canonical implementation.
- Tightened `RedteamRunCliOptions` to `Omit<RedteamRunOptions, 'tags'> & { tag?: ... }` so the alias rewrite is the sole producer of `tags`.
- Clarified the `shared.ts` comment to note that runtime tags are stripped from generation but still reach the eval via `evalOptions`.
- Aligned the `redteam run --tag` docs row with the registered `--help` text.
- Added `test/commands/options.test.ts` covering `collectKeyValueOption` and `normalizeTagOption` (malformed input, empty value, `=`-in-value, duplicate keys, and a `__proto__` own-property / no-prototype-pollution case), plus a no-`--tag` regression test for `redteam run`.

Verified end-to-end against the local build: `eval --tag` and `redteam run --tag` persist tags to the eval (confirmed via the SQLite DB), CLI tags override config tags, and runtime tags never leak into the generated `redteam.yaml`. `tsc` clean; affected unit suites green; full CI green.
