### PR TITLE
fix(eval): preserve prompt optimizer progress when a later round fails

### DIFF
--- a/src/optimizer/promptOptimizer.ts
+++ b/src/optimizer/promptOptimizer.ts
@@ -245,6 +245,66 @@ export async function generateOptimizedPromptCandidates(params: {
   return candidates;
 }
 
+/**
+ * Generates candidates for an optimization round, returning `null` to signal the
+ * caller should stop optimizing while keeping the best prompt found so far.
+ *
+ * A first-round failure rethrows so genuine misconfiguration (bad provider,
+ * unparseable output, no candidates at all) surfaces instead of being hidden
+ * behind a silent "no improvement" exit. A later-round failure is expected as
+ * the prompt converges (the suggestions provider returns only duplicates or the
+ * unchanged prompt) or on a transient provider error, so it is logged and the
+ * already-adopted improvements from earlier rounds are preserved.
+ */
+async function generateRoundCandidatesOrStop(
+  round: number,
+  params: Parameters<typeof generateOptimizedPromptCandidates>[0],
+): Promise<PromptOptimizationCandidate[] | null> {
+  try {
+    return await generateOptimizedPromptCandidates(params);
+  } catch (error) {
+    if (round === 1) {
+      throw error;
+    }
+    logger.warn(
+      chalk.yellow(
+        `Stopping optimization after round ${round - 1}: round ${round} could not generate new prompt candidates (${error instanceof Error ? error.message : String(error)}). Keeping the best prompt found so far.`,
+      ),
+    );
+    return null;
+  }
+}
+
+function logOptimizationOutcome(params: {
+  improved: boolean;
+  baselinePrompt: CompletedPrompt;
+  bestPrompt: CompletedPrompt;
+  baselineValidationPrompt?: CompletedPrompt;
+  bestValidationPrompt?: CompletedPrompt;
+}): void {
+  const { improved, baselinePrompt, bestPrompt, baselineValidationPrompt, bestValidationPrompt } =
+    params;
+  if (baselineValidationPrompt && bestValidationPrompt) {
+    logger.info(
+      improved
+        ? chalk.green(
+            `Optimization improved validation score from ${formatScore(baselineValidationPrompt)} to ${formatScore(bestValidationPrompt)}.`,
+          )
+        : chalk.yellow(
+            `No candidate exceeded the baseline validation score of ${formatScore(baselineValidationPrompt)}.`,
+          ),
+    );
+    return;
+  }
+  logger.info(
+    improved
+      ? chalk.green(
+          `Optimization improved score from ${formatScore(baselinePrompt)} to ${formatScore(bestPrompt)}.`,
+        )
+      : chalk.yellow(`No candidate exceeded the baseline score of ${formatScore(baselinePrompt)}.`),
+  );
+}
+
 function selectBestPrompt(prompts: CompletedPrompt[]): CompletedPrompt {
   const [firstPrompt, ...rest] = prompts;
   if (!firstPrompt) {
@@ -756,12 +816,19 @@ export async function optimizePromptTestSuite(
   );
 
   for (let round = 1; round <= DEFAULT_ROUNDS; round += 1) {
-    const candidates = await generateOptimizedPromptCandidates({
+    const candidates = await generateRoundCandidatesOrStop(round, {
       prompt: currentPromptSource.raw,
       failures: currentFailures,
       successes: currentSuccesses,
       history,
     });
+    // Later rounds frequently fail to produce *new* candidates as the prompt
+    // converges, or on a transient provider error. Don't discard the
+    // improvements already adopted in earlier rounds: stop and return the best
+    // prompt found so far (a first-round failure rethrows inside the helper).
+    if (candidates === null) {
+      break;
+    }
     allCandidates = [...allCandidates, ...candidates];
 
     logger.info(
@@ -857,33 +924,13 @@ export async function optimizePromptTestSuite(
           scoreOf(bestPrompt) > scoreOf(baselinePrompt))
       : scoreOf(bestPrompt) > scoreOf(baselinePrompt);
 
-  if (improved) {
-    if (baselineValidationPrompt && bestValidationPrompt) {
-      logger.info(
-        chalk.green(
-          `Optimization improved validation score from ${formatScore(baselineValidationPrompt)} to ${formatScore(bestValidationPrompt)}.`,
-        ),
-      );
-    } else {
-      logger.info(
-        chalk.green(
-          `Optimization improved score from ${formatScore(baselinePrompt)} to ${formatScore(bestPrompt)}.`,
-        ),
-      );
-    }
-  } else {
-    if (baselineValidationPrompt && bestValidationPrompt) {
-      logger.info(
-        chalk.yellow(
-          `No candidate exceeded the baseline validation score of ${formatScore(baselineValidationPrompt)}.`,
-        ),
-      );
-    } else {
-      logger.info(
-        chalk.yellow(`No candidate exceeded the baseline score of ${formatScore(baselinePrompt)}.`),
-      );
-    }
-  }
+  logOptimizationOutcome({
+    improved,
+    baselinePrompt,
+    bestPrompt,
+    baselineValidationPrompt,
+    bestValidationPrompt,
+  });
 
   return {
     baselineEval,

--- a/test/optimizer/promptOptimizer.test.ts
+++ b/test/optimizer/promptOptimizer.test.ts
@@ -180,6 +180,84 @@ describe('prompt optimizer', () => {
     );
   });
 
+  it('keeps an earlier-round improvement when a later round fails to generate candidates', async () => {
+    const provider = createMockProvider({
+      id: 'optimizer-provider',
+      response: optimizerResponse('Optimized B'),
+    });
+    // Round 1 generation succeeds; round 2 generation fails (e.g. the prompt has
+    // converged and the suggestions provider returns an error / no new candidates).
+    vi.mocked(provider.callApi)
+      .mockResolvedValueOnce(optimizerResponse('Optimized B'))
+      .mockResolvedValueOnce({ error: 'simulated suggestions provider failure' });
+    vi.mocked(getDefaultProviders).mockResolvedValue({
+      embeddingProvider: provider,
+      gradingJsonProvider: provider,
+      gradingProvider: provider,
+      moderationProvider: provider,
+      suggestionsProvider: provider,
+      synthesizeProvider: provider,
+    } as any);
+
+    const baselineEval = evalWith(
+      [completedPrompt('Prompt B', 'B', 0.5)],
+      [evalResult(0, false, 'Missed the required JSON format.')],
+    );
+    const round1Eval = evalWith(
+      [
+        completedPrompt('Prompt B', 'B', 0.5),
+        completedPrompt('Optimized B', 'B [optimized 1]', 0.9),
+      ],
+      [],
+    );
+
+    vi.mocked(evaluate).mockResolvedValueOnce(baselineEval).mockResolvedValueOnce(round1Eval);
+
+    const testSuite: TestSuite = {
+      providers: [createMockProvider({ id: 'target-provider' })],
+      prompts: [{ raw: 'Prompt B', label: 'B' }],
+      tests: [{}],
+    };
+
+    const result = await optimizePromptTestSuite({}, testSuite);
+
+    // The round-1 improvement must survive the round-2 failure instead of the
+    // whole command throwing and discarding it.
+    expect(result.improved).toBe(true);
+    expect(result.bestPrompt.label).toBe('B [optimized 1]');
+    expect(result.rounds).toHaveLength(1);
+    // Round 2 generation was attempted (and failed) before stopping.
+    expect(provider.callApi).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a first-round candidate generation failure instead of reporting no improvement', async () => {
+    const provider = createMockProvider({ id: 'optimizer-provider' });
+    vi.mocked(provider.callApi).mockResolvedValueOnce({
+      error: 'simulated suggestions provider failure',
+    });
+    vi.mocked(getDefaultProviders).mockResolvedValue({
+      embeddingProvider: provider,
+      gradingJsonProvider: provider,
+      gradingProvider: provider,
+      moderationProvider: provider,
+      suggestionsProvider: provider,
+      synthesizeProvider: provider,
+    } as any);
+
+    const baselineEval = evalWith([completedPrompt('Prompt B', 'B', 0.5)], []);
+    vi.mocked(evaluate).mockResolvedValueOnce(baselineEval);
+
+    const testSuite: TestSuite = {
+      providers: [createMockProvider({ id: 'target-provider' })],
+      prompts: [{ raw: 'Prompt B', label: 'B' }],
+      tests: [{}],
+    };
+
+    await expect(optimizePromptTestSuite({}, testSuite)).rejects.toThrow(
+      /Failed to generate optimized prompt candidates/,
+    );
+  });
+
   it('defaults to the first prompt and provider', async () => {
     const provider = createMockProvider({
       id: 'optimizer-provider',


### PR DESCRIPTION
## Summary

The prompt optimizer (`promptfoo optimize`) could throw away a successful prompt improvement if a *later* round failed to generate candidates.

The round loop awaited `generateOptimizedPromptCandidates()` with no error handling:

```ts
for (let round = 1; round <= DEFAULT_ROUNDS; round += 1) {
  const candidates = await generateOptimizedPromptCandidates({ ... });
  ...
}
```

That function throws whenever the suggestions provider errors, returns unparseable output, or returns **only duplicate/unchanged candidates** — which becomes increasingly likely as the prompt converges across rounds (and is amplified by `cache: false`). An exception in round 2 or 3 propagated out of `optimizePromptTestSuite`, was caught only by `doOptimize`'s handler (which sets `process.exitCode = 1`), and the improved prompt **already adopted in round 1 was discarded with no output** — losing work the user already paid for.

## Fix

- Wrap candidate generation in `generateRoundCandidatesOrStop()`:
  - A **first-round** failure still rethrows, so genuine misconfiguration (bad provider, unparseable output, no candidates at all) surfaces loudly instead of being hidden behind a silent "no improvement" exit. This preserves the existing fail-fast behavior and its tests.
  - A **later-round** failure is logged (`Stopping optimization after round N…`) and the loop stops, returning the best prompt found so far.
- Extracted the end-of-run outcome logging into `logOptimizationOutcome()` to keep `optimizePromptTestSuite` under the Biome cognitive-complexity ceiling (the salvage `break` pushed it over).

## Tests

- New: a round-1 improvement survives a round-2 generation failure (`improved === true`, best prompt retained, `rounds` has length 1).
- New: a first-round generation failure still rejects with the original error.
- All 26 optimizer tests pass; `tsc` and `biome ci` clean.

This is part of a set of small fixes flagged during a pre-release audit of changes since `0.121.12`.