### PR TITLE
fix(providers): stop double-counting xAI reasoning tokens in cost

### DIFF
--- a/src/providers/xai/chat.ts
+++ b/src/providers/xai/chat.ts
@@ -483,9 +483,14 @@ export function calculateXAICost(
   completionTokens?: number,
   reasoningTokens?: number,
 ): number | undefined {
-  // xAI reports reasoning separately from completion tokens and bills both at
-  // the output rate. Reasoning-only responses still have billable output.
-  const billableOutputTokens = (completionTokens ?? 0) + (reasoningTokens ?? 0);
+  // xAI follows the OpenAI token convention: completion/output tokens already
+  // INCLUDE reasoning tokens (reasoning is a sub-breakdown, not a separate
+  // addend). Bill completion tokens at the output rate exactly like
+  // calculateOpenAICost; adding reasoningTokens on top double-counts them.
+  // Fall back to reasoning tokens only when the API reports zero completion
+  // tokens (a reasoning-only turn) so it is not billed as free.
+  const completion = completionTokens ?? 0;
+  const billableOutputTokens = completion > 0 ? completion : (reasoningTokens ?? 0);
   if (promptTokens == null || billableOutputTokens <= 0) {
     return undefined;
   }
@@ -678,8 +683,8 @@ class XAIProvider extends OpenAiChatCompletionProvider {
       if (response.tokenUsage && !response.cached) {
         // The OpenAI base provider does not surface the raw API body, so
         // `usage.cost_in_usd_ticks` (which xAI does return for chat completions)
-        // is not reachable here. Fall back to local pricing math, which
-        // includes reasoning tokens at the output rate.
+        // is not reachable here. Fall back to local pricing math. Completion
+        // tokens already include reasoning tokens, so they are not added on top.
         const reasoningTokens = response.tokenUsage.completionDetails?.reasoning || 0;
         response.cost = calculateXAICost(
           this.modelName,

--- a/test/providers/xai/chat.test.ts
+++ b/test/providers/xai/chat.test.ts
@@ -680,30 +680,33 @@ describe('xAI Chat Provider', () => {
       expect(cost).toBe(2.5);
     });
 
-    it('bills reasoning tokens at the output rate', () => {
+    it('does not double-count reasoning tokens already included in completion tokens', () => {
       // grok-3-mini-beta: input $0.30/M, output $0.50/M.
       const baseline = calculateXAICost('grok-3-mini-beta', {}, 500, 500);
       // 500 input @ 0.30/M + 500 output @ 0.50/M = 0.00015 + 0.00025 = 0.0004
       expect(baseline).toBeCloseTo(0.0004, 10);
 
+      // completion_tokens already INCLUDES reasoning_tokens (the OpenAI
+      // convention xAI follows), so passing reasoning separately must not add
+      // to the bill — the cost is identical to the baseline.
       const withReasoning = calculateXAICost('grok-3-mini-beta', {}, 500, 500, 200);
-      // Adds 200 reasoning @ 0.50/M = 0.0001 → total 0.0005
-      expect(withReasoning).toBeCloseTo(0.0005, 10);
+      expect(withReasoning).toBeCloseTo(0.0004, 10);
     });
 
     it('bills a reasoning-only response (no other completion tokens)', () => {
-      // grok-3-mini-beta: input $0.30/M, output $0.50/M. A turn whose entire
-      // output is reasoning still has a real cost — the reasoning tokens are
-      // billed at the output rate even though completionTokens is 0.
+      // grok-3-mini-beta: input $0.30/M, output $0.50/M. A turn that reports
+      // zero completion tokens but non-zero reasoning still has a real cost: we
+      // fall back to billing the reasoning tokens at the output rate.
       const cost = calculateXAICost('grok-3-mini-beta', {}, 500, 0, 200);
       // 500 input @ 0.30/M + 200 reasoning @ 0.50/M = 0.00015 + 0.0001
       expect(cost).toBeCloseTo(0.00025, 10);
     });
 
-    it('bills output when input tokens are reported as zero', () => {
+    it('bills only completion tokens (reasoning included) when input tokens are zero', () => {
       const cost = calculateXAICost('grok-3-mini-beta', {}, 0, 200, 50);
-      // 0 input @ 0.30/M + 250 output @ 0.50/M.
-      expect(cost).toBeCloseTo(0.000125, 10);
+      // 0 input @ 0.30/M + 200 completion @ 0.50/M (the 50 reasoning tokens are
+      // already part of the 200 completion tokens, not added on top).
+      expect(cost).toBeCloseTo(0.0001, 10);
     });
   });
 
@@ -890,12 +893,15 @@ describe('xAI Chat Provider', () => {
       expect(typeof result.cost).toBe('number');
     });
 
-    it('includes separately reported reasoning tokens in cost', async () => {
+    it('does not double-count reasoning tokens already included in completion tokens', async () => {
       mockFetchWithCache.mockResolvedValueOnce({
         data: {
           choices: [{ message: { content: 'reasoned answer' } }],
           usage: {
             prompt_tokens: 500,
+            // completion_tokens already includes the 200 reasoning tokens
+            // (prompt 500 + completion 500 = total 1000 confirms reasoning is a
+            // subset of completion, not a separate addend).
             completion_tokens: 500,
             total_tokens: 1000,
             completion_tokens_details: { reasoning_tokens: 200 },
@@ -912,11 +918,11 @@ describe('xAI Chat Provider', () => {
 
       const result = await provider.callApi('test prompt');
 
-      // grok-3-mini-beta: input $0.30/M, output $0.50/M. xAI prices
-      // reasoning separately from completion tokens, so bill 700 output tokens:
-      // 500 input @ 0.30/M + 700 output @ 0.50/M = 0.00015 + 0.00035.
+      // grok-3-mini-beta: input $0.30/M, output $0.50/M. Reasoning tokens are
+      // already part of the 500 completion tokens, so bill 500 output tokens:
+      // 500 input @ 0.30/M + 500 output @ 0.50/M = 0.00015 + 0.00025 = 0.0004.
       expect(result.tokenUsage?.completionDetails?.reasoning).toBe(200);
-      expect(result.cost).toBeCloseTo(0.0005, 10);
+      expect(result.cost).toBeCloseTo(0.0004, 10);
     });
   });
 });

--- a/test/providers/xai/responses.test.ts
+++ b/test/providers/xai/responses.test.ts
@@ -248,9 +248,9 @@ describe('XAIResponsesProvider', () => {
 
     const result = await provider.callApi('hello');
 
-    // xAI prices the 5 completion and 3 reasoning tokens separately at the
-    // output rate: 10 input @ $1.25/M + 8 output @ $2.50/M.
-    expect(result.cost).toBeCloseTo(0.0000325, 10);
+    // output_tokens (5) already includes the 3 reasoning tokens, so they are
+    // not billed twice: 10 input @ $1.25/M + 5 output @ $2.50/M.
+    expect(result.cost).toBeCloseTo(0.000025, 10);
     expect(result.tokenUsage?.completionDetails?.reasoning).toBe(3);
   });
 
@@ -286,8 +286,9 @@ describe('XAIResponsesProvider', () => {
 
     const result = await provider.callApi('hello');
 
-    // 0 input @ $1.25/M + 8 output @ $2.50/M.
-    expect(result.cost).toBeCloseTo(0.00002, 10);
+    // 0 input @ $1.25/M + 5 output @ $2.50/M (output_tokens already includes
+    // the 3 reasoning tokens, so reasoning is not added on top).
+    expect(result.cost).toBeCloseTo(0.0000125, 10);
   });
 
   it('parses streamed Responses API events', async () => {


### PR DESCRIPTION
## Summary

`calculateXAICost` over-reported cost for xAI reasoning models by counting reasoning tokens twice.

```ts
const billableOutputTokens = (completionTokens ?? 0) + (reasoningTokens ?? 0);
```

xAI follows the OpenAI token convention where `completion_tokens` (chat) / `output_tokens` (responses) **already include** reasoning tokens — `reasoning_tokens` is a sub-breakdown, not a separate addend. The repo's own `calculateOpenAICost` bills `completion_tokens` alone. Adding reasoning on top inflated reported cost by `reasoning_tokens * outputRate` on every reasoning-model turn that fell back to local pricing math (i.e. when `cost_in_usd_ticks` is absent).

PR #9326, titled "stop double-counting xAI reasoning tokens in cost", actually shipped the additive math and baked the doubled values into its test fixtures. One of those fixtures (`prompt_tokens: 500`, `completion_tokens: 500`, `total_tokens: 1000`, `reasoning_tokens: 200`) is itself proof that reasoning is a subset of completion — `500 + 500 = 1000` leaves no room for a separate 200 — yet the cost was computed on 700 output tokens.

## Fix

- Bill `completionTokens` at the output rate (reasoning already included), matching `calculateOpenAICost`.
- Fall back to `reasoningTokens` **only** when `completionTokens` is reported as zero, so a genuine reasoning-only turn is still billed rather than treated as free.
- Correct the chat and responses fixtures to the non-doubled values:
  - chat `(500, 500, 200)`: `0.0005` → `0.0004`
  - chat end-to-end `grok-3-mini-beta`: `0.0005` → `0.0004`
  - responses `output 5 / reasoning 3`: `0.0000325` → `0.000025`
  - responses zero-input: `0.00002` → `0.0000125`

## Impact

For example, a reasoning-heavy `grok-4.3` turn ($2.50/M output) previously over-reported cost by up to ~30–60%. Users budgeting or comparing model costs in promptfoo now see accurate numbers. No data loss; cost-reporting only.

## Tests

All 241 xAI tests pass; `tsc` and `biome ci` clean. This is part of a set of small fixes flagged during a pre-release audit of changes since `0.121.12`.