### PR TITLE
fix(cache): make the fetch cache key stable across processes

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -288,14 +288,22 @@ type PreparedFetchResponse = {
 const inflightFetchResponses = new Map<string, Promise<SerializedFetchResponse>>();
 const IGNORED_FETCH_CACHE_OPTION_KEYS = new Set(['method', 'signal']);
 const FETCH_CACHE_SECRET_HMAC_CONTEXT = 'promptfoo:fetch-cache-secret-key';
-const FETCH_CACHE_SECRET_HMAC_KEY = crypto.randomBytes(32);
+// A fixed, compiled-in salt (NOT a secret). It must be deterministic across
+// processes so that a request carrying a static secret — or a binary body —
+// hashes to the same on-disk cache key on every run and stays cacheable. A
+// per-process random key broke that: each `promptfoo eval` run produced a new
+// key and re-hit the upstream endpoint. The salt only domain-separates the
+// one-way HMAC so raw secrets are never written into the cache key; it does not
+// need to be unpredictable, and this matches the pre-existing (pre-isolation)
+// behavior of hashing the value directly.
+const FETCH_CACHE_SECRET_HMAC_SALT = 'promptfoo:fetch-cache-secret-hmac-salt:v1';
 const abortSignalIds = new WeakMap<AbortSignal, number>();
 let nextAbortSignalId = 0;
 
 function fingerprintFetchCacheSecret(value: string) {
   return {
     __promptfooSecretFingerprint: crypto
-      .createHmac('sha256', FETCH_CACHE_SECRET_HMAC_KEY)
+      .createHmac('sha256', FETCH_CACHE_SECRET_HMAC_SALT)
       .update(FETCH_CACHE_SECRET_HMAC_CONTEXT)
       .update('\0')
       .update(value)
@@ -423,7 +431,7 @@ function hashBytesForCacheKey(bytes: ArrayBuffer | ArrayBufferView) {
   return {
     byteLength: buffer.byteLength,
     hmacSha256: crypto
-      .createHmac('sha256', FETCH_CACHE_SECRET_HMAC_KEY)
+      .createHmac('sha256', FETCH_CACHE_SECRET_HMAC_SALT)
       .update(`${FETCH_CACHE_SECRET_HMAC_CONTEXT}:bytes`)
       .update('\0')
       .update(buffer)

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -896,6 +896,48 @@ describe('fetchWithCache', () => {
       }
     });
 
+    it('produces a stable secret-bearing cache key across module loads (cacheable across processes)', async () => {
+      const secretRequest = [
+        'https://api.example.com/data',
+        {
+          method: 'POST',
+          headers: { Authorization: 'Bearer secret-header-token' },
+          body: JSON.stringify({ apiKey: 'secret-body-token' }),
+        },
+        1000,
+      ] as const;
+
+      // Cache key produced by the currently-loaded cache module.
+      const cache = getCache();
+      mockFetchWithRetries.mockResolvedValue(mockFetchWithRetriesResponse(true, { data: 'x' }));
+      await fetchWithCache(...secretRequest);
+      const firstKey = vi
+        .mocked(cache.set)
+        .mock.calls.map(([cacheKey]) => String(cacheKey))
+        .at(-1);
+      expect(firstKey).toBeDefined();
+
+      // Re-import the module to emulate a fresh process. The secret fingerprint
+      // salt must be a fixed constant (not per-process random) for the same
+      // secret-bearing request to map to the same key — otherwise the on-disk
+      // cache never hits across runs.
+      vi.resetModules();
+      const freshFetchModule = await import('../src/util/fetch/index');
+      vi.mocked(freshFetchModule.fetchWithRetries).mockResolvedValue(
+        mockFetchWithRetriesResponse(true, { data: 'x' }),
+      );
+      const freshCacheModule = await import('../src/cache');
+      freshCacheModule.enableCache();
+      const freshCache = freshCacheModule.getCache();
+      await freshCacheModule.fetchWithCache(...secretRequest);
+      const secondKey = vi
+        .mocked(freshCache.set)
+        .mock.calls.map(([cacheKey]) => String(cacheKey))
+        .at(-1);
+
+      expect(secondKey).toBe(firstKey);
+    });
+
     it('should isolate cloud requests by injected API key without storing the key', async () => {
       const cache = getCache();
       const restoreEnv = mockProcessEnv({ PROMPTFOO_API_KEY: 'secret-cloud-token-one' });


### PR DESCRIPTION
## Summary

The fetch cache key fingerprints secret-bearing fields (and hashes all binary request bodies) with an HMAC keyed by `crypto.randomBytes(32)` generated **once per process**:

```ts
const FETCH_CACHE_SECRET_HMAC_KEY = crypto.randomBytes(32);
```

Because the on-disk key is derived from that fingerprint, it **changed on every run** for any request carrying a static secret (API key in a header/body/query string) or a binary body. Repeated `promptfoo eval` runs therefore never hit the disk cache for those requests and re-called the upstream endpoint every time — extra latency, cost, and load. (Within a single process the cache still worked, and credential isolation was correct, which is why this slipped through.)

This was introduced by the auth-token cache isolation work (#8636).

## Fix

Replace the per-process random key with a fixed, compiled-in salt (renamed `…_HMAC_SALT` to make the intent clear). The salt is **not a secret** — it only domain-separates the one-way HMAC so raw secrets are never written into the cache key, while keeping the key deterministic across processes so the cache hits across runs.

- Credential isolation is unchanged: different secrets still produce different keys.
- Raw secrets are still never stored in the key (HMAC is one-way).
- This matches the pre-isolation behavior, which hashed the value directly (also deterministic, with no salt) — so it's strictly ≥ that security posture.

## Tests

- New regression test: the same secret-bearing request maps to the **same** cache key across a fresh module load (emulating a separate process). Verified that it **fails** with the prior `crypto.randomBytes(32)` key and passes with the fixed salt.
- Full `cache.test.ts` (53 tests) passes; `tsc` and `biome ci` clean.

Part of a set of small fixes flagged during a pre-release audit of changes since `0.121.12`.