### PR TITLE
fix(providers): normalize Claude Opus compatibility

### DIFF
--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -178,6 +178,7 @@ The `thinking` configuration controls Claude's reasoning behavior:
 
 - `type: enabled` - Activates extended thinking
 - `budget_tokens` - Maximum tokens allocated for thinking (minimum 1024)
+- For Claude Opus 4.7 and 4.8, promptfoo converts `type: enabled` to adaptive thinking because manual thinking is not accepted by those models.
 
 Use `showThinking: true` to include the model's reasoning process in the output, or `false` to only show the final response.
 
@@ -804,7 +805,7 @@ config:
 
 For Claude models (e.g., `anthropic.claude-sonnet-4-6`, `anthropic.claude-sonnet-4-5-20250929-v1:0`, `anthropic.claude-haiku-4-5-20251001-v1:0`, `anthropic.claude-sonnet-4-20250514-v1:0`, `anthropic.us.claude-3-5-sonnet-20241022-v2:0`), you can use the following configuration options:
 
-**Note**: Claude Opus 4.8 (`anthropic.claude-opus-4-8`) and Claude Opus 4.7 (`anthropic.claude-opus-4-7`) are available via cross-region inference profiles (`us.`, `eu.`, `jp.`, `global.`) and — at launch — through the base foundation model ID in select regions. Claude Opus 4.6 (`anthropic.claude-opus-4-6-v1`) and Claude Opus 4.5 (`anthropic.claude-opus-4-5-20251101-v1:0`) still require an inference profile ARN and cannot be used as a direct model ID. See the [Application Inference Profiles](#application-inference-profiles) section for setup. promptfoo automatically omits unsupported sampling parameters (`temperature`, `topP`) for Opus 4.7 and 4.8 (deprecated at the model level).
+**Note**: Claude Opus 4.8 (`anthropic.claude-opus-4-8`) and Claude Opus 4.7 (`anthropic.claude-opus-4-7`) are available via cross-region inference profiles (`us.`, `eu.`, `jp.`, `global.`) and — at launch — through the base foundation model ID in select regions. Claude Opus 4.6 (`anthropic.claude-opus-4-6-v1`) and Claude Opus 4.5 (`anthropic.claude-opus-4-5-20251101-v1:0`) still require an inference profile ARN and cannot be used as a direct model ID. See the [Application Inference Profiles](#application-inference-profiles) section for setup. promptfoo automatically omits unsupported sampling parameters (`temperature`, `topP`) and converts configured manual thinking to adaptive thinking for Opus 4.7 and 4.8.
 
 ```yaml
 config:

--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -889,6 +889,10 @@ providers:
       max_tokens: 4096
 ```
 
+:::note
+The `azure:chat:` provider and `isClaudeOpus47OrLater` only apply to Azure Claude deployments that expose the OpenAI-compatible chat-completions API. Some Azure AI Foundry models-as-a-service Claude deployments only support the Anthropic Messages API and return `api_not_supported` for chat completions; those deployments are not reachable via `azure:chat:`. Use Option 1 (the Anthropic Messages API endpoint) for them.
+:::
+
 Available Claude deployments on Azure AI Foundry:
 
 | Model                        | Description       |

--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -701,6 +701,7 @@ These properties can be set under the provider `config` key:
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | o1                    | Set to `true` if your Azure deployment uses an o1 model. **(Deprecated, use `isReasoningModel` instead)**                                       |
 | isReasoningModel      | Set to `true` if your Azure deployment uses a reasoning model (o1, o3, o3-mini, o4-mini). **Required for reasoning models**                     |
+| isClaudeOpus47OrLater | Set to `true` for a custom-named Claude Opus 4.7 or 4.8 chat deployment so unsupported sampling parameters are omitted.                         |
 | max_completion_tokens | Maximum tokens to generate for reasoning models. Only used when `isReasoningModel` is `true`                                                    |
 | reasoning_effort      | Controls reasoning depth: 'low', 'medium', or 'high'. Only used when `isReasoningModel` is `true`                                               |
 | temperature           | Controls randomness (0-2). Not supported for reasoning models                                                                                   |
@@ -876,7 +877,17 @@ providers:
       max_tokens: 4096
 ```
 
-Opus 4.7 and 4.8 deployments automatically omit `temperature` and `top_p` from the request body on this path too.
+Opus 4.7 and 4.8 deployments whose names contain the model identifier automatically omit `temperature` and `top_p` from the request body on this path too. If your Azure deployment uses a custom alias, set `isClaudeOpus47OrLater: true`:
+
+```yaml
+providers:
+  - id: azure:chat:prod-claude
+    config:
+      apiHost: 'your-deployment.services.ai.azure.com'
+      apiVersion: '2025-04-01-preview'
+      isClaudeOpus47OrLater: true
+      max_tokens: 4096
+```
 
 Available Claude deployments on Azure AI Foundry:
 

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -615,7 +615,7 @@ See [Google's SafetySetting API documentation](https://ai.google.dev/api/generat
 - Support for text, code, and analysis tasks
 - Tool use (function calling) capabilities
 - Available in multiple regions (us-east5, europe-west1, asia-southeast1) plus the `global` endpoint for Opus 4.7
-- Claude Opus 4.7: adaptive thinking and `xhigh` effort level; promptfoo automatically omits `temperature` (deprecated for this model) and forwards the rest of the Anthropic Messages body to Vertex's `rawPredict` endpoint
+- Claude Opus 4.7 and 4.8: promptfoo automatically omits deprecated sampling parameters and converts configured manual thinking (`type: enabled`) to adaptive thinking before forwarding the request to Vertex's `rawPredict` endpoint
 - Quota limits vary by model version (20-245 QPM)
 
 ## Advanced Usage

--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -112,7 +112,10 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
    * strip the sampling params here and leave the rest of the chat body intact.
    */
   protected isSamplingParamsDeprecatedClaudeModel(): boolean {
-    return isSamplingParamsDeprecatedClaudeModel(this.deploymentName);
+    return (
+      Boolean(this.config.isClaudeOpus47OrLater) ||
+      isSamplingParamsDeprecatedClaudeModel(this.deploymentName)
+    );
   }
 
   async getOpenAiBody(

--- a/src/providers/azure/types.ts
+++ b/src/providers/azure/types.ts
@@ -30,6 +30,8 @@ export interface AzureCompletionOptions {
   /** @deprecated Use isReasoningModel instead. Indicates if the model should be treated as a reasoning model */
   o1?: boolean;
   isReasoningModel?: boolean; // Indicates if the model should be treated as a reasoning model (o1, o3-mini, etc.)
+  /** Treat a custom-named deployment as Claude Opus 4.7 or 4.8 for sampling compatibility. */
+  isClaudeOpus47OrLater?: boolean;
   max_completion_tokens?: number; // Maximum number of tokens to generate for reasoning models
 
   // Azure cognitive services params

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -76,10 +76,13 @@ export interface BedrockConverseOptions extends BedrockOptions {
   stop?: string[]; // Alias for compatibility
 
   // Extended thinking (Claude models)
-  thinking?: {
-    type: 'enabled';
-    budget_tokens: number;
-  };
+  thinking?:
+    | {
+        type: 'enabled';
+        budget_tokens: number;
+      }
+    | { type: 'adaptive' }
+    | { type: 'disabled' };
 
   // Reasoning configuration (Amazon Nova 2 models)
   // Note: When reasoning is enabled, temperature/topP/topK must NOT be set
@@ -1168,7 +1171,11 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
 
     // Add thinking configuration for Claude models
     if (this.config.thinking) {
-      fields.thinking = this.config.thinking;
+      fields.thinking =
+        isSamplingParamsDeprecatedClaudeModel(this.modelName) &&
+        this.config.thinking.type === 'enabled'
+          ? { type: 'adaptive' }
+          : this.config.thinking;
     }
 
     // Add reasoning configuration for Amazon Nova 2 models

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -88,10 +88,13 @@ export interface BedrockClaudeMessagesCompletionOptions extends BedrockOptions {
     type: 'any' | 'auto' | 'tool';
     name?: string;
   };
-  thinking?: {
-    type: 'enabled';
-    budget_tokens: number;
-  };
+  thinking?:
+    | {
+        type: 'enabled';
+        budget_tokens: number;
+      }
+    | { type: 'adaptive' }
+    | { type: 'disabled' };
 }
 
 interface BedrockLlamaGenerationOptions extends BedrockOptions {
@@ -1645,7 +1648,11 @@ export const BEDROCK_MODEL = {
         undefined,
       );
       addConfigParam(params, 'tool_choice', config?.tool_choice, undefined, undefined);
-      addConfigParam(params, 'thinking', config?.thinking, undefined, undefined);
+      const thinking =
+        samplingParamsDeprecated && config?.thinking?.type === 'enabled'
+          ? { type: 'adaptive' as const }
+          : config?.thinking;
+      addConfigParam(params, 'thinking', thinking, undefined, undefined);
       if (systemPrompt) {
         addConfigParam(params, 'system', systemPrompt, undefined, undefined);
       }

--- a/src/providers/google/types.ts
+++ b/src/providers/google/types.ts
@@ -109,10 +109,10 @@ export interface Tool {
   // google_search?: object;
 }
 
-export interface ClaudeThinkingConfig {
-  type: 'enabled' | 'disabled';
-  budget_tokens?: number;
-}
+export type ClaudeThinkingConfig =
+  | { type: 'enabled'; budget_tokens?: number }
+  | { type: 'adaptive' }
+  | { type: 'disabled' };
 
 export interface CompletionOptions {
   apiKey?: string;

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -291,9 +291,15 @@ export class VertexChatProvider extends GoogleGenericProvider {
       }
     }
 
-    const thinkingConfig: ClaudeThinkingConfig | undefined =
+    const samplingParamsDeprecated = isSamplingParamsDeprecatedClaudeModel(this.modelName);
+    const requestedThinkingConfig: ClaudeThinkingConfig | undefined =
       this.config.thinking || (thinking as ClaudeThinkingConfig | undefined);
-    const isThinkingEnabled = thinkingConfig?.type === 'enabled';
+    const thinkingConfig: ClaudeThinkingConfig | undefined =
+      samplingParamsDeprecated && requestedThinkingConfig?.type === 'enabled'
+        ? { type: 'adaptive' }
+        : requestedThinkingConfig;
+    const isThinkingEnabled =
+      thinkingConfig?.type === 'enabled' || thinkingConfig?.type === 'adaptive';
 
     let maxTokens = this.config.max_tokens || this.config.maxOutputTokens || 0;
     if (!maxTokens) {
@@ -301,8 +307,8 @@ export class VertexChatProvider extends GoogleGenericProvider {
     }
     // Claude requires max_tokens >= budget_tokens when thinking is enabled
     if (
-      isThinkingEnabled &&
-      thinkingConfig?.budget_tokens &&
+      thinkingConfig?.type === 'enabled' &&
+      thinkingConfig.budget_tokens &&
       maxTokens < thinkingConfig.budget_tokens
     ) {
       maxTokens = thinkingConfig.budget_tokens + 1024;
@@ -312,7 +318,6 @@ export class VertexChatProvider extends GoogleGenericProvider {
     // level — the underlying Anthropic API returns 400 for any request that
     // pins `temperature`, `top_p`, or `top_k`. Vertex forwards the request body
     // verbatim to rawPredict, so suppress all three here too.
-    const samplingParamsDeprecated = isSamplingParamsDeprecatedClaudeModel(this.modelName);
     const resolvedTemperature = samplingParamsDeprecated ? undefined : this.config.temperature;
     const resolvedTopP = samplingParamsDeprecated
       ? undefined

--- a/test/providers/azure/chat.test.ts
+++ b/test/providers/azure/chat.test.ts
@@ -788,6 +788,23 @@ describe('AzureChatCompletionProvider', () => {
       expect(body).not.toHaveProperty('reasoning_effort');
     });
 
+    it('omits sampling params for a custom Claude deployment when configured explicitly', async () => {
+      const provider = new AzureChatCompletionProvider('prod-claude-deployment', {
+        config: {
+          apiHost: 'test.azure.com',
+          apiKey: 'test-key',
+          isClaudeOpus47OrLater: true,
+          max_tokens: 512,
+          temperature: 0.5,
+          top_p: 0.9,
+        },
+      });
+      const { body } = await (provider as any).getOpenAiBody('hi');
+      expect(body).toHaveProperty('max_tokens', 512);
+      expect(body).not.toHaveProperty('temperature');
+      expect(body).not.toHaveProperty('top_p');
+    });
+
     it('should use max_completion_tokens for reasoning models', async () => {
       const provider = new AzureChatCompletionProvider('test-deployment', {
         config: {

--- a/test/providers/azure/chat.test.ts
+++ b/test/providers/azure/chat.test.ts
@@ -805,6 +805,76 @@ describe('AzureChatCompletionProvider', () => {
       expect(body).not.toHaveProperty('top_p');
     });
 
+    it('keeps temperature and top_p for a custom Claude deployment without isClaudeOpus47OrLater', async () => {
+      // Regression guard: an existing custom-named Claude deployment that has
+      // not opted in via isClaudeOpus47OrLater must keep its sampling params.
+      const provider = new AzureChatCompletionProvider('prod-claude-deployment', {
+        config: {
+          apiHost: 'test.azure.com',
+          apiKey: 'test-key',
+          max_tokens: 512,
+          temperature: 0.5,
+          top_p: 0.9,
+        },
+      });
+      const { body } = await (provider as any).getOpenAiBody('hi');
+      expect(body).toHaveProperty('max_tokens', 512);
+      expect(body).toHaveProperty('temperature', 0.5);
+      expect(body).toHaveProperty('top_p', 0.9);
+    });
+
+    it('omits sampling params for an opus-4-7-named deployment even without the flag', async () => {
+      // Baseline name-match path: deployment name matches opus-4-7, so sampling
+      // params are stripped without setting isClaudeOpus47OrLater.
+      const provider = new AzureChatCompletionProvider('claude-opus-4-7', {
+        config: {
+          apiHost: 'test.azure.com',
+          apiKey: 'test-key',
+          max_tokens: 512,
+          temperature: 0.5,
+          top_p: 0.9,
+        },
+      });
+      const { body } = await (provider as any).getOpenAiBody('hi');
+      expect(body).toHaveProperty('max_tokens', 512);
+      expect(body).not.toHaveProperty('temperature');
+      expect(body).not.toHaveProperty('top_p');
+    });
+
+    it('omits sampling params for an opus-4-8-named deployment even without the flag', async () => {
+      // Baseline name-match path for the 4.8 variant.
+      const provider = new AzureChatCompletionProvider('claude-opus-4-8', {
+        config: {
+          apiHost: 'test.azure.com',
+          apiKey: 'test-key',
+          max_tokens: 512,
+          temperature: 0.5,
+          top_p: 0.9,
+        },
+      });
+      const { body } = await (provider as any).getOpenAiBody('hi');
+      expect(body).toHaveProperty('max_tokens', 512);
+      expect(body).not.toHaveProperty('temperature');
+      expect(body).not.toHaveProperty('top_p');
+    });
+
+    it('keeps temperature and top_p for a plain non-Claude deployment', async () => {
+      // Non-Claude deployments (e.g. gpt-4o) must be unaffected by the Opus path.
+      const provider = new AzureChatCompletionProvider('gpt-4o', {
+        config: {
+          apiHost: 'test.azure.com',
+          apiKey: 'test-key',
+          max_tokens: 512,
+          temperature: 0.5,
+          top_p: 0.9,
+        },
+      });
+      const { body } = await (provider as any).getOpenAiBody('hi');
+      expect(body).toHaveProperty('max_tokens', 512);
+      expect(body).toHaveProperty('temperature', 0.5);
+      expect(body).toHaveProperty('top_p', 0.9);
+    });
+
     it('should use max_completion_tokens for reasoning models', async () => {
       const provider = new AzureChatCompletionProvider('test-deployment', {
         config: {

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -1940,6 +1940,99 @@ Third line`;
       );
     });
 
+    it('should keep manual thinking enabled for non-deprecated Claude models', async () => {
+      // claude-3-5-sonnet is not in the sampling-params-deprecated set, so an
+      // explicit budget_tokens thinking config must pass through untouched
+      // rather than being downgraded to adaptive.
+      const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
+        config: {
+          region: 'us-east-1',
+          thinking: {
+            type: 'enabled',
+            budget_tokens: 12000,
+          },
+        },
+      });
+
+      mockSend.mockResolvedValueOnce(createMockConverseResponse('Test'));
+
+      await provider.callApi('Test');
+
+      const { ConverseCommand } = (await import(
+        '@aws-sdk/client-bedrock-runtime'
+      )) as unknown as MockBedrockModule;
+      expect(ConverseCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalModelRequestFields: {
+            thinking: {
+              type: 'enabled',
+              budget_tokens: 12000,
+            },
+          },
+        }),
+      );
+    });
+
+    it('should pass through disabled thinking unchanged for Claude Opus 4.8', async () => {
+      // Only type: 'enabled' is rewritten to adaptive for deprecated Opus
+      // models; a disabled thinking block must be forwarded as-is.
+      const provider = new AwsBedrockConverseProvider('anthropic.claude-opus-4-8', {
+        config: {
+          region: 'us-east-1',
+          thinking: {
+            type: 'disabled',
+          },
+        },
+      });
+
+      mockSend.mockResolvedValueOnce(createMockConverseResponse('Test'));
+
+      await provider.callApi('Test');
+
+      const { ConverseCommand } = (await import(
+        '@aws-sdk/client-bedrock-runtime'
+      )) as unknown as MockBedrockModule;
+      expect(ConverseCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalModelRequestFields: {
+            thinking: {
+              type: 'disabled',
+            },
+          },
+        }),
+      );
+    });
+
+    it('should pass through adaptive thinking unchanged for Claude Opus 4.8', async () => {
+      // An already-adaptive thinking block must not be touched by the
+      // enabled->adaptive conversion for deprecated Opus models.
+      const provider = new AwsBedrockConverseProvider('anthropic.claude-opus-4-8', {
+        config: {
+          region: 'us-east-1',
+          thinking: {
+            type: 'adaptive',
+          },
+        },
+      });
+
+      mockSend.mockResolvedValueOnce(createMockConverseResponse('Test'));
+
+      await provider.callApi('Test');
+
+      const { ConverseCommand } = (await import(
+        '@aws-sdk/client-bedrock-runtime'
+      )) as unknown as MockBedrockModule;
+      expect(ConverseCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalModelRequestFields: {
+            thinking: {
+              type: 'adaptive',
+            },
+          },
+        }),
+      );
+    });
+
     it('should merge custom additional fields with thinking', async () => {
       const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
         config: {

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -1911,6 +1911,35 @@ Third line`;
       );
     });
 
+    it('should convert manual thinking to adaptive for Claude Opus 4.8', async () => {
+      const provider = new AwsBedrockConverseProvider('anthropic.claude-opus-4-8', {
+        config: {
+          region: 'us-east-1',
+          thinking: {
+            type: 'enabled',
+            budget_tokens: 16000,
+          },
+        },
+      });
+
+      mockSend.mockResolvedValueOnce(createMockConverseResponse('Test'));
+
+      await provider.callApi('Test');
+
+      const { ConverseCommand } = (await import(
+        '@aws-sdk/client-bedrock-runtime'
+      )) as unknown as MockBedrockModule;
+      expect(ConverseCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalModelRequestFields: {
+            thinking: {
+              type: 'adaptive',
+            },
+          },
+        }),
+      );
+    });
+
     it('should merge custom additional fields with thinking', async () => {
       const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
         config: {

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -657,6 +657,20 @@ describe('AwsBedrockGenericProvider', () => {
       expect(params.temperature).toBeUndefined();
     });
 
+    it('converts manual thinking to adaptive for Claude Opus 4.8 on Bedrock invokeModel', async () => {
+      const config: BedrockClaudeMessagesCompletionOptions = {
+        region: 'us-east-1',
+        thinking: { type: 'enabled', budget_tokens: 5000 },
+      };
+      const params = await BEDROCK_MODEL.CLAUDE_MESSAGES.params(
+        config,
+        'hi',
+        undefined,
+        'us.anthropic.claude-opus-4-8',
+      );
+      expect(params.thinking).toEqual({ type: 'adaptive' });
+    });
+
     it('silently omits temperature on Claude Opus 4.8 invokeModel path (no per-request warning)', async () => {
       // The shared CLAUDE_MESSAGES.params handler has no per-instance state to
       // dedup a warning across requests, so it normalizes silently; the Anthropic

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -671,6 +671,48 @@ describe('AwsBedrockGenericProvider', () => {
       expect(params.thinking).toEqual({ type: 'adaptive' });
     });
 
+    it('keeps manual thinking enabled for non-deprecated Claude Opus 4.6 on Bedrock invokeModel', async () => {
+      const config: BedrockClaudeMessagesCompletionOptions = {
+        region: 'us-east-1',
+        thinking: { type: 'enabled', budget_tokens: 5000 },
+      };
+      const params = await BEDROCK_MODEL.CLAUDE_MESSAGES.params(
+        config,
+        'hi',
+        undefined,
+        'us.anthropic.claude-opus-4-6-v1',
+      );
+      expect(params.thinking).toEqual({ type: 'enabled', budget_tokens: 5000 });
+    });
+
+    it('keeps disabled thinking unchanged for Claude Opus 4.8 on Bedrock invokeModel', async () => {
+      const config: BedrockClaudeMessagesCompletionOptions = {
+        region: 'us-east-1',
+        thinking: { type: 'disabled' },
+      };
+      const params = await BEDROCK_MODEL.CLAUDE_MESSAGES.params(
+        config,
+        'hi',
+        undefined,
+        'us.anthropic.claude-opus-4-8',
+      );
+      expect(params.thinking).toEqual({ type: 'disabled' });
+    });
+
+    it('keeps adaptive thinking unchanged for Claude Opus 4.8 on Bedrock invokeModel', async () => {
+      const config: BedrockClaudeMessagesCompletionOptions = {
+        region: 'us-east-1',
+        thinking: { type: 'adaptive' },
+      };
+      const params = await BEDROCK_MODEL.CLAUDE_MESSAGES.params(
+        config,
+        'hi',
+        undefined,
+        'us.anthropic.claude-opus-4-8',
+      );
+      expect(params.thinking).toEqual({ type: 'adaptive' });
+    });
+
     it('silently omits temperature on Claude Opus 4.8 invokeModel path (no per-request warning)', async () => {
       // The shared CLAUDE_MESSAGES.params handler has no per-instance state to
       // dedup a warning across requests, so it normalizes silently; the Anthropic

--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -2884,6 +2884,19 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
       expect(requestData.max_tokens).toBe(11024);
     });
 
+    it('should convert manual thinking to adaptive for Claude Opus 4.8', async () => {
+      provider = new VertexChatProvider('claude-opus-4-8', {
+        config: {
+          thinking: { type: 'enabled', budget_tokens: 5000 },
+        },
+      });
+      setupClaudeMocks();
+
+      await provider.callClaudeApi('Hello');
+
+      expect(getRequestData().thinking).toEqual({ type: 'adaptive' });
+    });
+
     it('should ensure max_tokens >= budget_tokens when thinking is enabled', async () => {
       provider = new VertexChatProvider('claude-3-5-sonnet-v2@20241022', {
         config: {

--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -2897,6 +2897,58 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
       expect(getRequestData().thinking).toEqual({ type: 'adaptive' });
     });
 
+    it('should keep manual thinking enabled and bump max_tokens for non-deprecated Claude models', async () => {
+      provider = new VertexChatProvider('claude-3-5-sonnet-v2@20241022', {
+        config: {
+          thinking: { type: 'enabled', budget_tokens: 5000 },
+        },
+      });
+      setupClaudeMocks();
+
+      await provider.callClaudeApi('Hello');
+
+      const requestData = getRequestData();
+      // Non-deprecated models keep manual thinking verbatim (NOT converted to adaptive)
+      expect(requestData.thinking).toEqual({ type: 'enabled', budget_tokens: 5000 });
+      // max_tokens guard still fires for type 'enabled': bumped to budget_tokens + 1024
+      expect(requestData.max_tokens).toBe(6024);
+    });
+
+    it('should not bump max_tokens when adaptive conversion drops budget_tokens for Claude Opus 4.8', async () => {
+      provider = new VertexChatProvider('claude-opus-4-8', {
+        config: {
+          thinking: { type: 'enabled', budget_tokens: 5000 },
+        },
+      });
+      setupClaudeMocks();
+
+      await provider.callClaudeApi('Hello');
+
+      const requestData = getRequestData();
+      // Manual thinking is converted to adaptive (no budget_tokens)
+      expect(requestData.thinking).toEqual({ type: 'adaptive' });
+      // The max_tokens guard only fires for type 'enabled', so adaptive does not
+      // force max_tokens to budget + 1024; it stays at the thinking-enabled default
+      expect(requestData.max_tokens).toBe(2048);
+    });
+
+    it('should pass through disabled thinking for Claude Opus 4.8 and treat it as not-enabled', async () => {
+      provider = new VertexChatProvider('claude-opus-4-8', {
+        config: {
+          thinking: { type: 'disabled' },
+        },
+      });
+      setupClaudeMocks();
+
+      await provider.callClaudeApi('Hello');
+
+      const requestData = getRequestData();
+      // 'disabled' is not 'enabled', so it passes through unchanged (not adaptive)
+      expect(requestData.thinking).toEqual({ type: 'disabled' });
+      // Disabled thinking is treated as not-enabled, so the default max_tokens is 512
+      expect(requestData.max_tokens).toBe(512);
+    });
+
     it('should ensure max_tokens >= budget_tokens when thinking is enabled', async () => {
       provider = new VertexChatProvider('claude-3-5-sonnet-v2@20241022', {
         config: {


### PR DESCRIPTION
## Summary
- support custom Azure deployment aliases for Claude Opus 4.7/4.8 sampling restrictions
- convert manual thinking configuration to adaptive thinking for Opus 4.7/4.8 on Vertex and both Bedrock paths
- document the compatibility behavior across Azure, Vertex, and Bedrock

## Extracted From
- Split from #9506 to keep the release-audit fixes independently reviewable.

## Validation
- `npm run l` and `npm run f` (pass with existing non-blocking complexity warnings in touched provider modules)
- `npx vitest run test/providers/azure/chat.test.ts test/providers/google/vertex.test.ts test/providers/bedrock/index.test.ts test/providers/bedrock/converse.test.ts` (522 tests passed)
- `SKIP_OG_GENERATION=true npm --prefix site run build`