### PR TITLE
fix(providers): redact MLflow Gateway api key and restore Novita routing test

### DIFF
--- a/src/providers/mlflow-gateway.ts
+++ b/src/providers/mlflow-gateway.ts
@@ -130,4 +130,20 @@ export class MlflowGatewayChatCompletionProvider extends OpenAiChatCompletionPro
       'environment variable or add `apiKey` to the provider config.'
     );
   }
+
+  // Redact an inline apiKey when serialized, matching the sibling OpenAI-derived
+  // providers (minimax, orcarouter, openrouter, ...). The base
+  // OpenAiChatCompletionProvider does not implement toJSON(), so without this a
+  // Bearer token set inline in config would be written out verbatim wherever the
+  // provider is JSON.stringify-ed.
+  toJSON() {
+    return {
+      provider: 'mlflow-gateway',
+      model: this.modelName,
+      config: {
+        ...this.config,
+        ...(this.config.apiKey && { apiKey: undefined }),
+      },
+    };
+  }
 }

--- a/test/providers/mlflow-gateway.test.ts
+++ b/test/providers/mlflow-gateway.test.ts
@@ -122,6 +122,17 @@ describe('MlflowGatewayChatCompletionProvider', () => {
     expect(provider.config.apiKeyRequired).toBe(false);
   });
 
+  it('redacts an inline apiKey when serialized with toJSON()', () => {
+    const provider = new MlflowGatewayChatCompletionProvider('my-endpoint', {
+      config: { gatewayUrl: 'http://localhost:5000', apiKey: 'secret-bearer-token' },
+    });
+
+    const json = provider.toJSON();
+    expect(json).toMatchObject({ provider: 'mlflow-gateway', model: 'my-endpoint' });
+    expect(json.config?.apiKey).toBeUndefined();
+    expect(JSON.stringify(json)).not.toContain('secret-bearer-token');
+  });
+
   it('should honor explicit apiKeyRequired true', () => {
     const provider = new MlflowGatewayChatCompletionProvider('my-endpoint', {
       config: { gatewayUrl: 'http://localhost:5000', apiKeyRequired: true },

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -756,6 +756,57 @@ describe('Provider Registry', () => {
       ).rejects.toThrow(/Unsupported NVIDIA NIM provider subtype "embedding"/);
     });
 
+    it('should route novita sub-types and reject unknown ones', async () => {
+      const factory = providerMap.find((f) => f.test('novita:meta/llama-3.1-8b-instruct'));
+      expect(factory).toBeDefined();
+
+      const novitaOptions = { ...mockProviderOptions, id: undefined };
+
+      // Shorthand `novita:<model>` resolves to chat.
+      const shorthand = await factory!.create(
+        'novita:meta/llama-3.1-8b-instruct',
+        novitaOptions,
+        mockContext,
+      );
+      expect(shorthand.id()).toBe('novita:chat:meta/llama-3.1-8b-instruct');
+
+      // Explicit sub-types resolve to their respective providers.
+      const chat = await factory!.create(
+        'novita:chat:meta/llama-3.1-8b-instruct',
+        novitaOptions,
+        mockContext,
+      );
+      expect(chat.id()).toBe('novita:chat:meta/llama-3.1-8b-instruct');
+
+      const completion = await factory!.create(
+        'novita:completion:meta/llama-3.1-8b-instruct',
+        novitaOptions,
+        mockContext,
+      );
+      expect(completion.id()).toBe('novita:completion:meta/llama-3.1-8b-instruct');
+
+      const embedding = await factory!.create(
+        'novita:embedding:baai/bge-m3',
+        novitaOptions,
+        mockContext,
+      );
+      expect(embedding.id()).toBe('novita:embedding:baai/bge-m3');
+
+      // Unknown sub-types (image, moderation, typos) fail-fast instead of silently
+      // routing to chat — a routing regression flagged in `src/providers/AGENTS.md`.
+      await expect(factory!.create('novita:image:foo', novitaOptions, mockContext)).rejects.toThrow(
+        /Unknown Novita provider sub-type "image"/,
+      );
+      await expect(
+        factory!.create('novita:moderation:bar', novitaOptions, mockContext),
+      ).rejects.toThrow(/Unknown Novita provider sub-type "moderation"/);
+
+      // Missing model after the prefix should throw.
+      await expect(factory!.create('novita:', novitaOptions, mockContext)).rejects.toThrow(
+        /Novita model name is required/,
+      );
+    });
+
     it('should handle orcarouter provider correctly', async () => {
       const factory = providerMap.find((f) => f.test('orcarouter:openai/gpt-4o'));
       expect(factory).toBeDefined();


### PR DESCRIPTION
## Summary

Two small provider-hygiene fixes flagged during a pre-release audit of changes since `0.121.12`.

### 1. Redact inline `apiKey` for the MLflow Gateway provider (#8860)

`MlflowGatewayChatCompletionProvider` had no `toJSON()` override, and the base `OpenAiChatCompletionProvider` doesn't implement one either. So an `apiKey` set **inline** in an `mlflow-gateway:*` provider config would be serialized **verbatim** anywhere the provider object is `JSON.stringify`-ed, while every sibling OpenAI-derived provider (`minimax`, `orcarouter`, `openrouter`, `deepseek`, `perplexity`, …) redacts it. Added a matching `toJSON()` that strips an inline `apiKey`.

### 2. Restore the Novita registry routing test (#8190 / #9491)

The Novita commit added a `registry.test.ts` test asserting that the `novita:` prefix dispatches sub-types (`chat`/`completion`/`embedding`) to the correct provider class and fail-fasts on unknown sub-types. The later NVIDIA NIM commit (`fa3e4a9a43`) was rebased over a base that already contained that test and **replaced the block in place**, silently dropping the coverage. Restored it (verified it passes against current Novita behavior — IDs and error messages match).

## Note

The audit also flagged that MiniMax drops the inherited default `max_tokens: 1024` cap. That is **intentionally left as-is**: imposing OpenAI's 1024 cap would truncate output for MiniMax reasoning models, and relying on MiniMax's server-side default is the better behavior. Not changed here.

## Tests

- New: MLflow `toJSON()` redacts an inline `apiKey`.
- Restored: Novita registry sub-type routing + fail-fast test.
- All touched provider suites pass (84 tests); `tsc` and `biome ci` clean.