### PR TITLE
fix(providers): reject MiniMax function_call

### DIFF
--- a/site/docs/providers/minimax.md
+++ b/site/docs/providers/minimax.md
@@ -37,6 +37,7 @@ providers:
 - `max_completion_tokens` - Maximum completion tokens; the OpenAI-compatible API currently allows up to `2048`. Legacy `max_tokens` config is translated to this field for compatibility.
 - `apiBaseUrl` - Optional custom MiniMax-compatible proxy endpoint
 - `top_p`
+- `tools` and `tool_choice` - Use these for tool calling. MiniMax rejects the deprecated `function_call` parameter.
 
 When MiniMax reports prompt-cache reads, promptfoo calculates cost using the returned cached token count and the model's cache-read rate.
 

--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -189,6 +189,12 @@ class MiniMaxProvider extends OpenAiChatCompletionProvider {
     const result = await super.getOpenAiBody(prompt, context, callApiOptions);
     const { body, config } = result;
 
+    if (body.function_call !== undefined) {
+      throw new Error(
+        'MiniMax does not support function_call. Use tools and tool_choice for tool calling instead.',
+      );
+    }
+
     // MiniMax's OpenAI-compatible API accepts max_completion_tokens, not max_tokens.
     const maxCompletionTokens = config.max_completion_tokens ?? config.max_tokens;
     if (maxCompletionTokens === undefined) {

--- a/test/providers/minimax.test.ts
+++ b/test/providers/minimax.test.ts
@@ -262,6 +262,20 @@ describe('MiniMaxProvider', () => {
     expect(json.config.apiKeyEnvar).toBe('MINIMAX_API_KEY');
   });
 
+  it('should reject deprecated function_call configuration', async () => {
+    const provider = createMiniMaxProvider('minimax:MiniMax-M2.7', {
+      config: {
+        config: {
+          function_call: 'auto',
+        },
+      },
+    });
+
+    await expect((provider as any).getOpenAiBody('Call a tool')).rejects.toThrow(
+      'MiniMax does not support function_call. Use tools and tool_choice for tool calling instead.',
+    );
+  });
+
   it('should preserve explicit API endpoint and API key environment overrides', () => {
     const restoreCustomEnv = mockProcessEnv({ CUSTOM_MINIMAX_KEY: 'custom-minimax-key' });
     try {


### PR DESCRIPTION
## Summary
- reject deprecated `function_call` configurations before sending MiniMax chat requests
- direct tool-calling users to supported `tools` and `tool_choice` parameters
- add focused regression coverage and provider documentation

## Extracted From
- Split from #9506 to keep the release-audit fixes independently reviewable.

## Validation
- `npm run l` and `npm run f`
- `npx vitest run test/providers/minimax.test.ts` (48 tests passed)
- `SKIP_OG_GENERATION=true npm --prefix site run build`