### PR TITLE
fix(util): don't misreport a missing transitive dep as the optional package

### DIFF
--- a/src/util/packageImportErrors.ts
+++ b/src/util/packageImportErrors.ts
@@ -1,14 +1,47 @@
+const MODULE_NOT_FOUND_CODES = new Set(['MODULE_NOT_FOUND', 'ERR_MODULE_NOT_FOUND']);
+
+/**
+ * Extracts the module/package specifier that actually failed to resolve from a
+ * Node module-resolution error message, e.g. `foo` from
+ * `Cannot find package 'foo' imported from /path/to/importer.js`.
+ *
+ * Returns null when no quoted specifier is present (older or non-standard
+ * message shapes), so callers can fall back to a looser check.
+ */
+function extractMissingSpecifier(message: string): string | null {
+  const match = message.match(/Cannot find (?:module|package)\s+['"]([^'"]+)['"]/);
+  return match ? match[1] : null;
+}
+
 export function isMissingPackageImportError(error: unknown, packageName: string): boolean {
-  if (!(error instanceof Error) || !error.message.includes(packageName)) {
+  if (!(error instanceof Error)) {
     return false;
   }
 
   const code = 'code' in error && typeof error.code === 'string' ? error.code : undefined;
-
-  return (
-    code === 'MODULE_NOT_FOUND' ||
-    code === 'ERR_MODULE_NOT_FOUND' ||
+  const looksLikeModuleResolutionError =
+    (code != null && MODULE_NOT_FOUND_CODES.has(code)) ||
     error.message.includes('Cannot find module') ||
-    error.message.includes('Cannot find package')
-  );
+    error.message.includes('Cannot find package');
+  if (!looksLikeModuleResolutionError) {
+    return false;
+  }
+
+  // Compare against the specifier that actually failed to resolve, not the whole
+  // message. Node includes the importer path too, so a missing *transitive*
+  // dependency of an installed optional package produces something like
+  // `Cannot find package 'dep' imported from .../node_modules/<pkg>/index.js`,
+  // which contains <pkg> in the importer path. A naive `message.includes(pkg)`
+  // would misreport that as <pkg> itself being absent and tell the user to
+  // install a package they already have.
+  const missingSpecifier = extractMissingSpecifier(error.message);
+  if (missingSpecifier == null) {
+    // No quoted specifier to compare; fall back to the looser substring check so
+    // we don't regress detection for non-standard message shapes.
+    return error.message.includes(packageName);
+  }
+
+  // Match the package itself or a subpath import of it (e.g. `<pkg>/feature`),
+  // but not a different package whose path merely mentions <pkg>.
+  return missingSpecifier === packageName || missingSpecifier.startsWith(`${packageName}/`);
 }

--- a/test/util/packageImportErrors.test.ts
+++ b/test/util/packageImportErrors.test.ts
@@ -29,4 +29,51 @@ describe('isMissingPackageImportError', () => {
 
     expect(isMissingPackageImportError(error, '@googleapis/sheets')).toBe(false);
   });
+
+  it('recognizes the optional package itself from a realistic ESM message', () => {
+    const error = Object.assign(
+      new Error(
+        "Cannot find package '@googleapis/sheets' imported from /app/dist/src/googleSheets.js",
+      ),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+
+    expect(isMissingPackageImportError(error, '@googleapis/sheets')).toBe(true);
+  });
+
+  it('recognizes a subpath import of the optional package', () => {
+    const error = Object.assign(
+      new Error(
+        "Cannot find package '@googleapis/sheets/build/index' imported from /app/dist/src/googleSheets.js",
+      ),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+
+    expect(isMissingPackageImportError(error, '@googleapis/sheets')).toBe(true);
+  });
+
+  it('does not misreport a missing transitive dependency as the optional package (ESM)', () => {
+    // The optional package is installed, but one of ITS dependencies is not.
+    // The package name appears only in the importer path, not as the failed
+    // specifier, so it must not be reported as the package itself being absent.
+    const error = Object.assign(
+      new Error(
+        "Cannot find package 'gaxios' imported from /app/node_modules/@googleapis/sheets/build/index.js",
+      ),
+      { code: 'ERR_MODULE_NOT_FOUND' },
+    );
+
+    expect(isMissingPackageImportError(error, '@googleapis/sheets')).toBe(false);
+  });
+
+  it('does not misreport a missing transitive dependency as the optional package (CommonJS)', () => {
+    const error = Object.assign(
+      new Error(
+        "Cannot find module 'gaxios'\nRequire stack:\n- /app/node_modules/@googleapis/sheets/build/index.js",
+      ),
+      { code: 'MODULE_NOT_FOUND' },
+    );
+
+    expect(isMissingPackageImportError(error, '@googleapis/sheets')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

`isMissingPackageImportError(error, packageName)` matched `packageName` anywhere in the error message:

```ts
if (!(error instanceof Error) || !error.message.includes(packageName)) {
  return false;
}
```

Node's module-resolution errors include the **importer path**, so a missing *transitive* dependency of an **installed** optional package produces, e.g.:

```
Cannot find package 'gaxios' imported from /app/node_modules/@googleapis/sheets/build/index.js
```

That message contains `@googleapis/sheets` in the importer path, so the helper classified it as `@googleapis/sheets` itself being absent. The callers (`loadGoogleSheetsApi`, the MCP SDK loaders in `mcp/client.ts` + `commands/mcp/server.ts`, and the OpenAI agents provider) then told the user to `install @googleapis/sheets` — a package they already have — hiding the real missing module.

## Fix

Compare against the **specifier that actually failed to resolve** (the quoted name after `Cannot find module`/`Cannot find package`) rather than scanning the whole message. Match the package itself or a subpath import of it (`<pkg>/feature`), but not a different package whose importer path merely mentions `<pkg>`. Falls back to the prior substring check when no quoted specifier is present, so non-standard message shapes and the existing tests are unaffected.

## Tests

- New regression: a missing transitive dependency (`gaxios`) of an installed `@googleapis/sheets` is **not** reported as the package being missing (ESM and CJS message shapes).
- New: realistic ESM `Cannot find package '<pkg>' imported from …` and subpath-import messages are still detected as the package missing.
- All existing helper + caller optional-dependency tests pass; `tsc` and `biome ci` clean.

Diagnostic-quality fix flagged during a pre-release audit of changes since `0.121.12`.