### PR TITLE
fix(cli): validate optimization split input

### DIFF
--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -190,6 +190,8 @@ targets one resolved prompt/provider pair at a time.
 
 When `--validation-split` is omitted, optimization uses the full eval set and
 may overfit to the configured cases.
+Validation splitting requires explicit `tests`; configs that use `scenarios`
+must be expanded into explicit test cases first.
 
 See [Prompt Optimization](/docs/usage/prompt-optimization) for workflow guidance,
 target selection details, and validation split recommendations.

--- a/site/docs/usage/prompt-optimization.md
+++ b/site/docs/usage/prompt-optimization.md
@@ -75,6 +75,10 @@ promptfoo optimize --validation-split 0.2
 
 With `0.2`, promptfoo searches on roughly 80% of the configured tests and judges candidate adoption on the held-out 20%. The split is optional and may be any value greater than `0` and less than or equal to `0.5`.
 
+:::note
+Validation splitting requires explicit `tests`. If your config uses `scenarios`, expand them into explicit test cases before passing `--validation-split`.
+:::
+
 ## Practical guidance
 
 Prompt optimization is only as good as the eval it searches against. Before optimizing:

--- a/src/commands/optimize.ts
+++ b/src/commands/optimize.ts
@@ -107,7 +107,7 @@ export async function doOptimize(options: OptimizeOptions): Promise<void> {
 }
 
 function parseValidationSplit(value: string): number {
-  const split = Number.parseFloat(value);
+  const split = Number(value);
   if (!Number.isFinite(split) || split <= 0 || split > 0.5) {
     throw new InvalidArgumentError(
       '--validation-split must be greater than 0 and less than or equal to 0.5',

--- a/test/commands/optimize.test.ts
+++ b/test/commands/optimize.test.ts
@@ -234,6 +234,11 @@ describe('optimize command', () => {
       '0.75',
       '--validation-split must be greater than 0 and less than or equal to 0.5',
     ],
+    [
+      '--validation-split',
+      '0.2typo',
+      '--validation-split must be greater than 0 and less than or equal to 0.5',
+    ],
   ])('rejects invalid %s values', async (flag, value, message) => {
     const program = new Command();
     program.exitOverride();


### PR DESCRIPTION
## Summary
- reject partially parsed `--validation-split` values such as `0.2typo`
- add CLI regression coverage for malformed input
- clarify that validation splitting requires explicit test cases rather than scenario-based configs

## Extracted From
- Split from #9506 to keep the release-audit fixes independently reviewable.

## Validation
- `npm run l` and `npm run f`
- `npx vitest run test/commands/optimize.test.ts` (14 tests passed)
- `SKIP_OG_GENERATION=true npm --prefix site run build`