### PR TITLE
docs(site): repair provider metadata and anchors

### DIFF
--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -549,6 +549,8 @@ promptfoo eval --no-cache
 
 See the [Google Video example](https://github.com/promptfoo/promptfoo/tree/main/examples/google-video) for complete configurations.
 
+<a id="gemini-20-flash"></a>
+
 ### Basic Configuration
 
 The provider supports various configuration options that can be used to customize the behavior of the model:

--- a/site/docs/providers/mlflow-gateway.md
+++ b/site/docs/providers/mlflow-gateway.md
@@ -1,6 +1,8 @@
 ---
+title: MLflow AI Gateway
 sidebar_label: MLflow Gateway
-description: Use MLflow AI Gateway as an LLM provider in promptfoo for unified multi-provider access with built-in governance.
+sidebar_position: 56
+description: Use MLflow AI Gateway with promptfoo to evaluate models through managed endpoints, server-side credentials, fallbacks, usage tracking, and budget policies.
 ---
 
 # MLflow AI Gateway
@@ -72,7 +74,7 @@ promptfoo eval
 
 You can pass additional configuration via the `config` key:
 
-```yaml title="promptfooconfig.yaml"
+```yaml
 providers:
   - id: mlflow-gateway:my-chat-endpoint
     config:

--- a/site/docs/providers/novita.md
+++ b/site/docs/providers/novita.md
@@ -53,7 +53,7 @@ and `top_p` are forwarded through the shared provider implementation. Promptfoo
 uses Novita's documented `https://api.novita.ai/openai/v1` base URL by default.
 For an OpenAI-compatible proxy or test server, set `apiBaseUrl` explicitly:
 
-```yaml title="promptfooconfig.yaml"
+```yaml
 providers:
   - id: novita:chat:meta-llama/llama-3.3-70b-instruct
     config:

--- a/site/docs/providers/nvidia.md
+++ b/site/docs/providers/nvidia.md
@@ -1,6 +1,7 @@
 ---
 title: NVIDIA NIM
-description: Use NVIDIA's hosted inference API (build.nvidia.com) with promptfoo for evaluating Llama, Qwen, Nemotron, DeepSeek, and Mistral models.
+sidebar_position: 58
+description: Use NVIDIA NIM hosted inference APIs with promptfoo to evaluate Llama, Qwen, Nemotron, DeepSeek, and Mistral chat models through OpenAI-compatible endpoints.
 ---
 
 # NVIDIA NIM

--- a/site/docs/providers/orcarouter.md
+++ b/site/docs/providers/orcarouter.md
@@ -1,6 +1,8 @@
 ---
+title: OrcaRouter
 sidebar_label: OrcaRouter
-description: 'Access OpenAI, Anthropic, Google, DeepSeek, Grok, Qwen and more through OrcaRouter, an OpenAI-compatible adaptive routing gateway with per-workspace tunable strategies.'
+sidebar_position: 59
+description: 'Use OrcaRouter with promptfoo to evaluate OpenAI-compatible routed models, configure adaptive or fallback routing, and compare upstream providers in one eval.'
 ---
 
 # OrcaRouter
@@ -32,7 +34,7 @@ OrcaRouter's full live catalog is at [orcarouter.ai/models](https://www.orcarout
 
 ## Basic Configuration
 
-```yaml title="promptfooconfig.yaml"
+```yaml
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 providers:
   - id: orcarouter:openai/gpt-4o-mini
@@ -53,7 +55,7 @@ If you route OrcaRouter traffic through a proxy or compatible gateway, set `apiB
 
 The same pattern applies to `apiKeyEnvar` — set it to read your API key from a custom environment variable name (default `ORCAROUTER_API_KEY`).
 
-```yaml title="promptfooconfig.yaml"
+```yaml
 providers:
   - id: orcarouter:openai/gpt-4o-mini
     config:
@@ -67,7 +69,7 @@ providers:
 
 You can also pass a `models` fallback list and a `route` mode for hard-failover behavior:
 
-```yaml title="promptfooconfig.yaml"
+```yaml
 providers:
   - id: orcarouter:openai/gpt-4o
     config:
@@ -88,7 +90,7 @@ OrcaRouter's own docs show fallback configuration as `extra_body: { models, rout
 
 Reasoning-capable models (Anthropic Claude Opus, OpenAI GPT-5 family, DeepSeek Reasoner, Gemini reasoning previews, etc.) may return a `reasoning` field alongside `content`. By default, promptfoo prefixes the reasoning content as `Thinking: ...\n\n<actual response>`. Hide it with `showThinking: false`:
 
-```yaml title="promptfooconfig.yaml"
+```yaml
 providers:
   - id: orcarouter:anthropic/claude-opus-4.7
     config:

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -186,6 +186,8 @@ providers:
 
 ## Model Capabilities
 
+<a id="gemini-20-pro-specifications"></a>
+
 ### Gemini Model Specifications
 
 Current Gemini models on Vertex AI (2.5 and 3.x):

--- a/site/docs/usage/prompt-optimization.md
+++ b/site/docs/usage/prompt-optimization.md
@@ -2,7 +2,7 @@
 title: Prompt Optimization
 sidebar_position: 11
 sidebar_label: Prompt optimization
-description: Optimize one prompt against one provider with promptfoo. Learn how candidate search, validation splits, target selection, and result review work.
+description: Optimize one prompt against one provider with promptfoo. Learn how candidate search, validation splits, target selection, and result review work safely.
 ---
 
 # Prompt Optimization

--- a/site/docs/usage/troubleshooting.md
+++ b/site/docs/usage/troubleshooting.md
@@ -139,6 +139,8 @@ prompts:
 - Building new templates designed for object navigation
 - Working with complex nested data structures
 
+<a id="nodejs-version-mismatch-error"></a>
+
 ## libsql binding not found
 
 You may see this error if the libsql platform binding for your OS/architecture is


### PR DESCRIPTION
## Summary
- add complete frontmatter metadata for recently added provider pages
- remove filename labels from YAML fragments that are not runnable configurations
- preserve legacy documentation anchors for Google, Vertex, and troubleshooting links
- bring the prompt-optimization page description into the documentation metadata convention

## Extracted From
- Split from #9506 to keep documentation-only cleanup separate from runtime fixes.

## Validation
- `npx prettier --write site/docs/providers/google.md site/docs/providers/mlflow-gateway.md site/docs/providers/novita.md site/docs/providers/nvidia.md site/docs/providers/orcarouter.md site/docs/providers/vertex.md site/docs/usage/prompt-optimization.md site/docs/usage/troubleshooting.md`
- `SKIP_OG_GENERATION=true npm --prefix site run build`