### PR TITLE
fix(server): restore Azure Blob SAS tokens by value, not array position

### DIFF
--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -255,6 +255,23 @@ export function redactAzureBlobSasTokens<T>(value: T): T {
 }
 
 /**
+ * Find a stored string whose redacted form matches `redactedValue`, regardless of
+ * its position in the stored array. Only the SAS `sig` is redacted, so the rest
+ * of the blob URI is preserved and acts as a stable identity for the match.
+ */
+function findStoredSasMatchByValue(
+  redactedValue: string,
+  storedItems: readonly unknown[],
+): string | undefined {
+  for (const stored of storedItems) {
+    if (typeof stored === 'string' && redactAzureBlobSasToken(stored) === redactedValue) {
+      return stored;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Preserve stored SAS credentials when a sanitized config is written back unchanged.
  * If the caller edits the resource or supplies a replacement token, retain its value.
  */
@@ -268,7 +285,20 @@ export function restoreAzureBlobSasTokens<T>(value: T, storedValue: unknown): T 
 
   if (Array.isArray(value)) {
     const storedItems = Array.isArray(storedValue) ? storedValue : [];
-    return value.map((item, index) => restoreAzureBlobSasTokens(item, storedItems[index])) as T;
+    return value.map((item, index) => {
+      const positional = restoreAzureBlobSasTokens(item, storedItems[index]);
+      // Positional restore fails when the array was reordered or had entries
+      // inserted/removed since it was sanitized, leaving a redacted SAS
+      // placeholder in place. Fall back to matching a stored token by value (its
+      // blob URI) so the real `sig` is restored regardless of position.
+      if (typeof item === 'string' && positional === item) {
+        const restored = findStoredSasMatchByValue(item, storedItems);
+        if (restored !== undefined && restored !== item) {
+          return restored;
+        }
+      }
+      return positional;
+    }) as T;
   }
 
   if (!value || typeof value !== 'object' || isClassInstance(value)) {

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -107,6 +107,51 @@ describe('sanitizeObject', () => {
         tests: 'az://account/container/edited.yaml?sp=r&sig=%5BREDACTED%5D',
       });
     });
+
+    it('restores array SAS tokens by value when entries are reordered or inserted', () => {
+      const stored = {
+        tests: [
+          'az://account/container/a.yaml?sp=r&sig=secret-a',
+          'az://account/container/b.yaml?sp=r&sig=secret-b',
+        ],
+      };
+
+      // The user reordered the entries and inserted a new (non-Azure) one before
+      // re-running, so positions no longer line up with the stored array.
+      const restored = restoreAzureBlobSasTokens(
+        {
+          tests: [
+            'inline test case',
+            'az://account/container/b.yaml?sp=r&sig=%5BREDACTED%5D',
+            'az://account/container/a.yaml?sp=r&sig=%5BREDACTED%5D',
+          ],
+        },
+        stored,
+      );
+
+      expect(restored).toEqual({
+        tests: [
+          'inline test case',
+          'az://account/container/b.yaml?sp=r&sig=secret-b',
+          'az://account/container/a.yaml?sp=r&sig=secret-a',
+        ],
+      });
+    });
+
+    it('does not restore an entry the user edited to point at a different blob', () => {
+      const stored = {
+        tests: ['az://account/container/a.yaml?sp=r&sig=secret-a'],
+      };
+
+      const restored = restoreAzureBlobSasTokens(
+        { tests: ['az://account/container/changed.yaml?sp=r&sig=%5BREDACTED%5D'] },
+        stored,
+      );
+
+      expect(restored).toEqual({
+        tests: ['az://account/container/changed.yaml?sp=r&sig=%5BREDACTED%5D'],
+      });
+    });
   });
 
   describe('function handling', () => {


### PR DESCRIPTION
## Summary

`restoreAzureBlobSasTokens` matched array entries **positionally** — each `value[index]` was restored against `storedItems[index]`:

```ts
return value.map((item, index) => restoreAzureBlobSasTokens(item, storedItems[index]));
```

When a user loads a redacted config into the eval-creator and **reorders or inserts** entries in a `tests` array before re-running with `sourceEvalId`, the redacted `az://...?sig=%5BREDACTED%5D` placeholder no longer lines up with its stored token. The equality check fails, the real `sig` is not restored, and the eval runs with `sig=[REDACTED]` — failing Azure Blob authentication.

## Fix

Keep positional restore (unchanged for objects and aligned arrays), but when it leaves a still-redacted SAS placeholder in an array entry, fall back to matching a stored token **by value**: only the `sig` is redacted, so the rest of the blob URI is a stable identity for the lookup. Entries the user edited to point at a *different* blob are left untouched (no spurious restore).

## Tests

- New: array SAS tokens are restored correctly when entries are reordered and a non-Azure entry is inserted.
- New: an entry edited to point at a different blob is **not** restored.
- Full `sanitizer.test.ts` (178 tests) passes; `tsc` and `biome ci` clean.

Narrow edit-and-rerun edge case flagged during a pre-release audit of changes since `0.121.12`.