### PR TITLE
ci(release): advance last-release-sha to fix release-please history-scan timeout

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-v-in-tag": false,
   "include-v-in-release-name": false,
   "commit-batch-size": 1,
-  "last-release-sha": "195df77800b749679f73ed3f258d858d33d55b48",
+  "last-release-sha": "40501990e8c988644401663360aa26714cee1718",
   "separate-pull-requests": true,
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

The `release-please` job for the **0.121.13** release ([run 26609142822](https://github.com/promptfoo/promptfoo/actions/runs/26609142822)) failed. The release itself was created first, so **npm and docker publication were unaffected** — `promptfoo@0.121.13` is live and verified (clean install + a real eval both pass), and the multi-arch docker images published and were attested. The failure is isolated to release-please's post-release history scan, and left unfixed it will recur on every future release and could eventually fail *before* a release is created.

## Root cause

After creating the release/tag, release-please walks back through `main`'s merge commits via GitHub's GraphQL API to collect commits since the last releases. The walk is floored by `last-release-sha`. That value was pinned to the **0.121.9** commit (`195df778`, 2026-04-27) by the original "harden release-please history scan" change and **never advanced**.

Four releases later that floor sits **468 commits** behind HEAD. release-please paginated ~123 pages of merge commits and GitHub's GraphQL query errored out:

```
❯ Fetching merge commits on branch main with cursor: 4860e990... 123
##[error]release-please failed: Request failed due to following response errors:
 - Something went wrong while executing your query ...
```

Measured distances from the release commit (`4860e990`):

| Boundary | Commits behind HEAD | Date |
|---|---|---|
| `last-release-sha` = `195df778` (0.121.9) | **468** ← binding floor | Apr 27 |
| `code-scan-action-0.1.6` (`40501990`) | 143 | May 20 |
| `0.121.12` tag | 144 | May 20 |

## Fix

Advance `last-release-sha` to the **code-scan-action 0.1.6** release commit (`40501990`, 2026-05-20) — the oldest still-relevant package release boundary. This:

- Cuts the scan from **468 → 143 commits**, clearing the GraphQL timeout.
- Is old enough to **preserve the pending code-scan-action 0.1.7 release** (PR #9446) — those commits all come after `40501990`.
- Keeps root (`promptfoo`) releases correct — root bounds at its own `0.121.13` tag (0 commits since), not at this floor.
- Passes the existing `test/release-please.test.ts` guard (40-char, reachable SHA).

## Test plan

- [x] `npx vitest run test/release-please.test.ts` — 3/3 pass
- [x] Confirmed `40501990…` is reachable on `main` and is the `chore(main): release code-scan-action 0.1.6` commit
- [ ] Merging this PR pushes to `main`, which triggers a `release-please` run — that run is the live validation (it now scans 143 commits instead of 468). Will confirm it goes green.

## Durable follow-up (not in this PR)

`last-release-sha` is a static pin, so the window grows again as commits accumulate above `40501990`. The lasting fixes:
1. **Release `code-scan-action` regularly** (e.g. merge #9446) so its boundary tracks HEAD and the floor can be advanced near HEAD.
2. **Automate** advancing `last-release-sha` (or give `code-scan-action` independent scan bounding) so it can't silently go stale.