### PR TITLE
ci(release): advance last-release-sha to the 0.121.13 commit

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-v-in-tag": false,
   "include-v-in-release-name": false,
   "commit-batch-size": 1,
-  "last-release-sha": "40501990e8c988644401663360aa26714cee1718",
+  "last-release-sha": "4860e990c7e9a2f8f677173fb92cf9867b34d03f",
   "separate-pull-requests": true,
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

Follow-up to #9517 and the `code-scan-action 0.1.7` release (#9446). Now that `code-scan-action` has been released, its boundary tracks HEAD, so the **oldest** package release boundary is root `promptfoo 0.121.13` (`4860e990`) — only **2 commits** behind HEAD. Point `last-release-sha` there.

This minimizes release-please's GraphQL merge-commit scan and gives the most headroom before drift can recur.

| `last-release-sha` | Points at | Commits behind HEAD |
|---|---|---|
| before (#9517) | `40501990` = code-scan-action **0.1.6** | 145 |
| **after (this PR)** | `4860e990` = root **0.121.13** | **2** |

## Safety

The floor stays at or before every package's last release:
- root `promptfoo 0.121.13` → `4860e990` (this value)
- `code-scan-action 0.1.7` → newer than `4860e990`

So no package loses unreleased commits; root's next release still picks up everything after `4860e990`.

## Test plan

- [x] `npx vitest run test/release-please.test.ts` — 3/3 pass (40-char, reachable SHA)
- [ ] Merge triggers a release-please run that scans ~2 commits and stays green.

## Note on durability

`last-release-sha` is still a static pin. It will drift again as `code-scan-action` lags behind future root releases — slower now, but the lasting fix remains automating the bump or releasing `code-scan-action` on a regular cadence.