### PR TITLE
fix(assertions): don't classify gen_ai.tool.definitions chat spans as tool calls

### DIFF
--- a/src/assertions/trajectoryUtils.ts
+++ b/src/assertions/trajectoryUtils.ts
@@ -139,12 +139,29 @@ function extractToolName(span: TraceSpan): string | undefined {
       continue;
     }
 
-    if (/tool.?name|function.?name/i.test(key)) {
-      return value.trim();
+    const trimmed = value.trim();
+
+    // A tool name is always a scalar identifier. Some chat/generation spans carry the list
+    // of *available* tools as a JSON-serialized array/object under a `tool`-matching key
+    // (e.g. `gen_ai.tool.definitions` from pydantic-ai). Never treat such a structured
+    // value as a tool name, or those chat spans get misclassified as tool calls. (#9523)
+    if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (parsed !== null && typeof parsed === 'object') {
+          continue;
+        }
+      } catch {
+        // Not JSON — fall through and treat it as an ordinary string tool name.
+      }
     }
 
-    if (/(^|[._])tool($|[._])/i.test(key) && !/result|output/i.test(key)) {
-      return value.trim();
+    if (/tool.?name|function.?name/i.test(key)) {
+      return trimmed;
+    }
+
+    if (/(^|[._])tool($|[._])/i.test(key) && !/result|output|definition/i.test(key)) {
+      return trimmed;
     }
   }
 

--- a/test/assertions/trajectory.test.ts
+++ b/test/assertions/trajectory.test.ts
@@ -131,6 +131,60 @@ describe('trajectory utilities', () => {
     });
   });
 
+  it('does not classify a chat span carrying gen_ai.tool.definitions as a tool', () => {
+    // pydantic-ai (and other GenAI-convention tracers) put the list of *available* tools on
+    // each chat span as a JSON array under gen_ai.tool.definitions; that must not be read as
+    // a tool call. Real tool calls use gen_ai.tool.name. Regression for #9523.
+    const toolDefinitions = JSON.stringify([
+      { type: 'function', name: 'orders', description: 'List orders' },
+      { type: 'function', name: 'order_rows', description: 'List order rows' },
+    ]);
+    const steps = extractTrajectorySteps({
+      ...mockTraceData,
+      spans: [
+        {
+          spanId: 'chat-1',
+          name: 'chat gpt-4o-mini',
+          startTime: 1000,
+          endTime: 1100,
+          attributes: { 'gen_ai.tool.definitions': toolDefinitions },
+        },
+        {
+          spanId: 'exec-1',
+          name: 'execute_tool',
+          startTime: 1200,
+          endTime: 1300,
+          attributes: { 'gen_ai.tool.name': 'order_rows' },
+        },
+      ],
+    });
+
+    expect(steps.map((step) => ({ type: step.type, name: step.name }))).toEqual([
+      { type: 'span', name: 'chat gpt-4o-mini' },
+      { type: 'tool', name: 'order_rows' },
+    ]);
+  });
+
+  it('still reads a plain string tool name from a generic tool attribute', () => {
+    // The structured-value guard must not break scalar tool-name fallbacks.
+    const steps = extractTrajectorySteps({
+      ...mockTraceData,
+      spans: [
+        {
+          spanId: 'custom-tool',
+          name: 'invoke',
+          startTime: 1000,
+          endTime: 1100,
+          attributes: { 'app.tool': 'lookup_customer' },
+        },
+      ],
+    });
+
+    expect(steps.map((step) => ({ type: step.type, name: step.name }))).toEqual([
+      { type: 'tool', name: 'lookup_customer' },
+    ]);
+  });
+
   it('only treats a generic query attribute as search when the span looks search-like', () => {
     const steps = extractTrajectorySteps({
       ...mockTraceData,


### PR DESCRIPTION
## Summary

Fixes #9523. `trajectory:tool-sequence` with `mode: exact` (and every other trajectory assertion) over-counts tool steps for traces from pydantic-ai and other OpenTelemetry GenAI-convention backends.

LLM chat/generation spans carry a `gen_ai.tool.definitions` attribute — the JSON-serialized list of tools _available_ to the model. The fallback in `extractToolName` matched that key via the broad `/(^|[._])tool($|[._])/i` regex and returned the whole JSON array as a "tool name", so each chat span was misclassified as a `type: 'tool'` step. A 3-turn run with 6 real tool calls reported 9 tool steps, and `mode: exact` failed even when the agent called exactly the right tools.

## Fix

In the `extractToolName` fallback loop (`src/assertions/trajectoryUtils.ts`):

- Skip any attribute value that is a JSON array or object — a tool name is always a scalar identifier, never a serialized list of tool definitions. This is the general guard and covers `gen_ai.tool.definitions` regardless of key name.
- Also exclude `definition` from the broad tool-key fallback (alongside the existing `result`/`output`), matching intent.

Real tool calls (`gen_ai.tool.name`, etc.) are unaffected — they're resolved by the canonical `getToolNameFromAttributes` allowlist before the fallback ever runs, and scalar string fallbacks (e.g. a custom `app.tool: lookup_customer`) still work.

## Test plan

- Reproduced the bug first (a `chat` span with `gen_ai.tool.definitions` yielded an extra `tool` step), then confirmed the fix.
- Added two regression tests in `test/assertions/trajectory.test.ts`:
  - a chat span carrying `gen_ai.tool.definitions` is classified as a `span`, not a `tool`, while the sibling `execute_tool` span (`gen_ai.tool.name`) is the only tool step;
  - a scalar generic tool attribute (`app.tool`) still resolves to a tool name (guard doesn't regress fallbacks).
- `npx vitest run test/assertions/trajectory.test.ts` → 96 pass. `npm run tsc` clean.

Closes #9523.
