### PR TITLE
fix(webui): render negative-only metric charts

### DIFF
--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -699,6 +699,67 @@ describe('ResultsCharts', () => {
       expect(values).toEqual([0, 0, 0, 0]);
     });
 
+    it('should preserve relative metric chart values if named scores are all negative', () => {
+      const mockTableWithNegativeNamedScores = {
+        head: {
+          prompts: [
+            {
+              provider: 'test-provider-1',
+              metrics: {
+                namedScores: {
+                  penalty: -0.8,
+                  risk: -0.5,
+                },
+              },
+            },
+            {
+              provider: 'test-provider-2',
+              metrics: {
+                namedScores: {
+                  penalty: -0.2,
+                  risk: -0.1,
+                },
+              },
+            },
+          ],
+          vars: [],
+        },
+        body: [
+          {
+            outputs: [
+              { score: 0.7, pass: true, text: 'test 1' },
+              { score: 0.8, pass: true, text: 'test 2' },
+            ],
+            vars: [],
+          },
+        ],
+      };
+
+      const scores = calculateScores(mockTableWithNegativeNamedScores);
+
+      vi.mocked(useTableStore).mockReturnValue({
+        table: mockTableWithNegativeNamedScores,
+        evalId: 'test-eval',
+        config: { description: 'test config' },
+        setTable: vi.fn(),
+        fetchEvalData: vi.fn(),
+      });
+
+      render(<ResultsCharts {...defaultProps} scores={scores} />);
+
+      const chartCalls = vi.mocked(Chart).mock.calls;
+      const metricChartConfig = chartCalls
+        .map(([, config]) => config)
+        .find((config) => {
+          const labels = config.data?.labels;
+          return Array.isArray(labels) && labels.includes('penalty');
+        });
+
+      expect(metricChartConfig).toBeDefined();
+      const values = metricChartConfig!.data!.datasets.flatMap((dataset) => dataset.data ?? []);
+      expect(values).toEqual([-1, -1, -0.25, -0.2]);
+    });
+
     it('should normalize each named metric independently when one metric is all zero', () => {
       // `accuracy` is all zero (exercises the zero-max guard), while `precision` and
       // `coverage` have different maxima. Per-key normalization divides each metric by

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -436,18 +436,19 @@ function MetricChart({ table }: ChartProps) {
 
     const namedScoreKeys = Object.keys(table.head.prompts[0].metrics?.namedScores || {});
     const labels = namedScoreKeys;
-    // Compute each metric's max once; it depends only on the key, not the prompt.
-    const maxValueByKey = new Map(
-      namedScoreKeys.map((key) => [
-        key,
-        Math.max(...table.head.prompts.map((p) => p.metrics?.namedScores[key] || 0)),
-      ]),
+    // Compute each metric's normalization value once; it depends only on the key, not the prompt.
+    const normalizationValueByKey = new Map(
+      namedScoreKeys.map((key) => {
+        const values = table.head.prompts.map((p) => p.metrics?.namedScores[key] || 0);
+        const maxValue = Math.max(...values);
+        return [key, maxValue > 0 ? maxValue : Math.max(...values.map(Math.abs))];
+      }),
     );
     const datasets = table.head.prompts.map((prompt, promptIdx) => {
       const data = namedScoreKeys.map((key) => {
         const value = prompt.metrics?.namedScores[key] || 0;
-        const maxValue = maxValueByKey.get(key) ?? 0;
-        return maxValue > 0 ? value / maxValue : 0;
+        const normalizationValue = normalizationValueByKey.get(key) ?? 0;
+        return normalizationValue > 0 ? value / normalizationValue : 0;
       });
       return {
         label: `${table.head.prompts[promptIdx].provider}`,


### PR DESCRIPTION
## Summary
- normalize negative-only named metrics by their maximum magnitude
- preserve existing behavior for positive, mixed, and all-zero metric series
- add regression coverage for negative-only metric charts

## Root cause
Metric charts divided values only when a metric's maximum was positive. A valid all-negative series therefore rendered every value as zero and hid relative differences between providers.

## Validation
- `npm run test:app -- src/pages/eval/components/ResultsCharts.test.tsx --run`
- `npm --prefix src/app run tsc`
- `npm run f`
- `npm run l`