### PR TITLE
fix(providers): inject n8n sessions into custom bodies

### DIFF
--- a/src/providers/n8n.ts
+++ b/src/providers/n8n.ts
@@ -370,6 +370,19 @@ export class N8nProvider implements ApiProvider {
     };
   }
 
+  private addSessionField(
+    body: Record<string, any> | string,
+    context?: CallApiContextParams,
+  ): Record<string, any> | string {
+    const sessionId = this.getRequestSessionId(context);
+    if (!sessionId || typeof body === 'string') {
+      return body;
+    }
+
+    const sessionField = this.config.sessionField || 'sessionId';
+    return body[sessionField] === undefined ? { ...body, [sessionField]: sessionId } : body;
+  }
+
   private buildRequestBody(
     prompt: string,
     context?: CallApiContextParams,
@@ -395,26 +408,17 @@ export class N8nProvider implements ApiProvider {
 
     // Default body structure
     if (!this.config.body) {
-      const body: Record<string, any> = { prompt };
-
-      // Include session ID if available
-      const sessionField = this.config.sessionField || 'sessionId';
-      const sessionId = this.getRequestSessionId(context);
-      if (sessionId) {
-        body[sessionField] = sessionId;
-      }
-
-      return body;
+      return this.addSessionField({ prompt }, context);
     }
 
     // Custom body template
     if (typeof this.config.body === 'string') {
       try {
-        return renderValue(JSON.parse(this.config.body));
+        return this.addSessionField(renderValue(JSON.parse(this.config.body)), context);
       } catch {
         const rendered = nunjucks.renderString(this.config.body, templateVars);
         try {
-          return JSON.parse(rendered);
+          return this.addSessionField(JSON.parse(rendered), context);
         } catch {
           if (/^\s*[\[{]/.test(this.config.body)) {
             throw new Error(
@@ -427,7 +431,7 @@ export class N8nProvider implements ApiProvider {
     }
 
     // Object body - render template values
-    return renderValue(this.config.body);
+    return this.addSessionField(renderValue(this.config.body), context);
   }
 
   private buildGetUrl(body: Record<string, any> | string): string {

--- a/test/providers/n8n.test.ts
+++ b/test/providers/n8n.test.ts
@@ -484,6 +484,69 @@ describe('N8nProvider', () => {
       );
     });
 
+    it('should add an explicit session ID to a custom body using the configured field', async () => {
+      vi.mocked(fetchWithCache).mockResolvedValue(createMockResponse({ output: 'Hello!' }));
+
+      const provider = new N8nProvider('https://n8n.example.com/webhook/agent', {
+        config: {
+          body: { message: '{{prompt}}' },
+          sessionField: 'conversationId',
+        },
+      });
+
+      await provider.callApi('Hello', {
+        vars: { sessionId: 'my-session-123' },
+        prompt: { raw: 'Hello', label: 'test' },
+      });
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        'https://n8n.example.com/webhook/agent',
+        expect.objectContaining({
+          body: JSON.stringify({
+            message: 'Hello',
+            conversationId: 'my-session-123',
+          }),
+        }),
+        expect.any(Number),
+        'text',
+        true,
+        0,
+      );
+    });
+
+    it('should preserve an explicit session field value in a custom body', async () => {
+      vi.mocked(fetchWithCache).mockResolvedValue(createMockResponse({ output: 'Hello!' }));
+
+      const provider = new N8nProvider('https://n8n.example.com/webhook/agent', {
+        config: {
+          body: {
+            message: '{{prompt}}',
+            conversationId: 'template-session',
+          },
+          sessionField: 'conversationId',
+        },
+      });
+
+      await provider.callApi('Hello', {
+        vars: { sessionId: 'context-session' },
+        prompt: { raw: 'Hello', label: 'test' },
+      });
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        'https://n8n.example.com/webhook/agent',
+        expect.objectContaining({
+          body: JSON.stringify({
+            message: 'Hello',
+            conversationId: 'template-session',
+          }),
+        }),
+        expect.any(Number),
+        'text',
+        true,
+        0,
+      );
+    });
+
     it('should send an explicit session ID after a response exposes a different session', async () => {
       vi.mocked(fetchWithCache)
         .mockResolvedValueOnce(createMockResponse({ output: 'First', sessionId: 'server-session' }))


### PR DESCRIPTION
## Summary
- inject a supplied n8n session ID into rendered custom object bodies when the configured session field is absent
- preserve explicit session-field values already provided by a custom template
- cover both automatic injection and explicit-value preservation

## Root cause
The n8n provider only added `sessionField` to its default body. Custom object and JSON-object templates silently omitted the supplied session ID unless users manually repeated `{{sessionId}}` in the template.

## Validation
- `npx vitest run test/providers/n8n.test.ts --sequence.shuffle=false`
- `npm run f`
- `npm run l`

## Base issue
- `npm run tsc` currently fails on unchanged `main` fixtures under `test/providers/anthropic/` and `test/providers/claude-agent-sdk.test.ts` because `output_tokens_details` is not present in the installed `Usage` type. This PR does not touch those files or types.