### PR TITLE
fix(util): restore nested SAS tokens after array reorder

### DIFF
--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -2,9 +2,6 @@
  * Generic utility functions for sanitizing objects to prevent logging of secrets and credentials
  * Uses a custom recursive approach for reliable deep object sanitization.
  */
-
-import { isDeepStrictEqual } from 'node:util';
-
 import safeStringify from 'fast-safe-stringify';
 
 const MAX_DEPTH = 4;
@@ -256,22 +253,121 @@ export function redactAzureBlobSasTokens<T>(value: T): T {
   return Object.fromEntries(redactedEntries) as T;
 }
 
-/**
- * Find a stored array entry whose redacted form matches `redactedValue`,
- * regardless of its position in the stored array. Only the SAS `sig` is
- * redacted, so the rest of the blob URI is preserved and acts as a stable
- * identity for the match, including when the URI is nested inside an object.
- */
-function findStoredSasMatchByValue(
-  redactedValue: unknown,
-  storedItems: readonly unknown[],
-): unknown | undefined {
-  for (const stored of storedItems) {
-    if (isDeepStrictEqual(redactAzureBlobSasTokens(stored), redactedValue)) {
-      return stored;
+type RestoreResult<T> = {
+  value: T;
+  restored: boolean;
+};
+
+function collectStoredAzureBlobSasTokens(
+  value: unknown,
+  tokensByRedactedUri = new Map<string, string>(),
+): Map<string, string> {
+  if (typeof value === 'string') {
+    const redacted = redactAzureBlobSasToken(value);
+    if (redacted !== value && !tokensByRedactedUri.has(redacted)) {
+      tokensByRedactedUri.set(redacted, value);
     }
+    return tokensByRedactedUri;
   }
-  return undefined;
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStoredAzureBlobSasTokens(item, tokensByRedactedUri);
+    }
+    return tokensByRedactedUri;
+  }
+
+  if (!value || typeof value !== 'object' || isClassInstance(value)) {
+    return tokensByRedactedUri;
+  }
+
+  for (const item of Object.values(value)) {
+    collectStoredAzureBlobSasTokens(item, tokensByRedactedUri);
+  }
+  return tokensByRedactedUri;
+}
+
+function restoreAzureBlobSasTokensFromMap<T>(
+  value: T,
+  tokensByRedactedUri: ReadonlyMap<string, string>,
+): RestoreResult<T> {
+  if (typeof value === 'string') {
+    const storedValue = tokensByRedactedUri.get(value);
+    return storedValue === undefined
+      ? { value, restored: false }
+      : { value: storedValue as T, restored: true };
+  }
+
+  if (Array.isArray(value)) {
+    let restored = false;
+    const restoredItems = value.map((item) => {
+      const result = restoreAzureBlobSasTokensFromMap(item, tokensByRedactedUri);
+      restored ||= result.restored;
+      return result.value;
+    });
+    return restored ? { value: restoredItems as T, restored } : { value, restored };
+  }
+
+  if (!value || typeof value !== 'object' || isClassInstance(value)) {
+    return { value, restored: false };
+  }
+
+  let restored = false;
+  const restoredEntries = Object.entries(value).map(([key, item]) => {
+    const result = restoreAzureBlobSasTokensFromMap(item, tokensByRedactedUri);
+    restored ||= result.restored;
+    return [key, result.value];
+  });
+  return restored
+    ? { value: Object.fromEntries(restoredEntries) as T, restored }
+    : { value, restored };
+}
+
+function restoreAzureBlobSasTokensWithResult<T>(value: T, storedValue: unknown): RestoreResult<T> {
+  if (typeof value === 'string') {
+    if (typeof storedValue === 'string' && value === redactAzureBlobSasToken(storedValue)) {
+      return { value: storedValue as T, restored: storedValue !== value };
+    }
+    return { value, restored: false };
+  }
+
+  if (Array.isArray(value)) {
+    const storedItems = Array.isArray(storedValue) ? storedValue : [];
+    const storedTokensByRedactedUri = collectStoredAzureBlobSasTokens(storedItems);
+    let restored = false;
+    const restoredItems = value.map((item, index) => {
+      const positional = restoreAzureBlobSasTokensWithResult(item, storedItems[index]);
+
+      // Positional restore fails when array entries are reordered, inserted, or
+      // edited outside the URI field. Also match by redacted URI identity so
+      // unchanged nested SAS references keep their stored signature.
+      const fallback = restoreAzureBlobSasTokensFromMap(
+        positional.value,
+        storedTokensByRedactedUri,
+      );
+      restored ||= positional.restored || fallback.restored;
+      return fallback.value;
+    });
+    return restored ? { value: restoredItems as T, restored } : { value, restored };
+  }
+
+  if (!value || typeof value !== 'object' || isClassInstance(value)) {
+    return { value, restored: false };
+  }
+
+  const storedObject =
+    storedValue && typeof storedValue === 'object' && !Array.isArray(storedValue)
+      ? (storedValue as Record<string, unknown>)
+      : {};
+  let restored = false;
+  const restoredEntries = Object.entries(value).map(([key, item]) => {
+    const result = restoreAzureBlobSasTokensWithResult(item, storedObject[key]);
+    restored ||= result.restored;
+    return [key, result.value];
+  });
+  return restored
+    ? { value: Object.fromEntries(restoredEntries) as T, restored }
+    : { value, restored };
 }
 
 /**
@@ -279,47 +375,7 @@ function findStoredSasMatchByValue(
  * If the caller edits the resource or supplies a replacement token, retain its value.
  */
 export function restoreAzureBlobSasTokens<T>(value: T, storedValue: unknown): T {
-  if (typeof value === 'string') {
-    if (typeof storedValue === 'string' && value === redactAzureBlobSasToken(storedValue)) {
-      return storedValue as T;
-    }
-    return value;
-  }
-
-  if (Array.isArray(value)) {
-    const storedItems = Array.isArray(storedValue) ? storedValue : [];
-    return value.map((item, index) => {
-      const positional = restoreAzureBlobSasTokens(item, storedItems[index]);
-      // Positional restore fails when the array was reordered or had entries
-      // inserted/removed since it was sanitized, leaving a redacted SAS
-      // placeholder in place. Fall back to matching a stored token by value (its
-      // blob URI) so the real `sig` is restored regardless of position.
-      if (isDeepStrictEqual(positional, item)) {
-        const storedMatch = findStoredSasMatchByValue(item, storedItems);
-        if (storedMatch !== undefined) {
-          const restored = restoreAzureBlobSasTokens(item, storedMatch);
-          if (!isDeepStrictEqual(restored, item)) {
-            return restored;
-          }
-        }
-      }
-      return positional;
-    }) as T;
-  }
-
-  if (!value || typeof value !== 'object' || isClassInstance(value)) {
-    return value;
-  }
-
-  const storedObject =
-    storedValue && typeof storedValue === 'object' && !Array.isArray(storedValue)
-      ? (storedValue as Record<string, unknown>)
-      : {};
-  const restoredEntries = Object.entries(value).map(([key, item]) => [
-    key,
-    restoreAzureBlobSasTokens(item, storedObject[key]),
-  ]);
-  return Object.fromEntries(restoredEntries) as T;
+  return restoreAzureBlobSasTokensWithResult(value, storedValue).value;
 }
 
 /**

--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -3,6 +3,8 @@
  * Uses a custom recursive approach for reliable deep object sanitization.
  */
 
+import { isDeepStrictEqual } from 'node:util';
+
 import safeStringify from 'fast-safe-stringify';
 
 const MAX_DEPTH = 4;
@@ -255,16 +257,17 @@ export function redactAzureBlobSasTokens<T>(value: T): T {
 }
 
 /**
- * Find a stored string whose redacted form matches `redactedValue`, regardless of
- * its position in the stored array. Only the SAS `sig` is redacted, so the rest
- * of the blob URI is preserved and acts as a stable identity for the match.
+ * Find a stored array entry whose redacted form matches `redactedValue`,
+ * regardless of its position in the stored array. Only the SAS `sig` is
+ * redacted, so the rest of the blob URI is preserved and acts as a stable
+ * identity for the match, including when the URI is nested inside an object.
  */
 function findStoredSasMatchByValue(
-  redactedValue: string,
+  redactedValue: unknown,
   storedItems: readonly unknown[],
-): string | undefined {
+): unknown | undefined {
   for (const stored of storedItems) {
-    if (typeof stored === 'string' && redactAzureBlobSasToken(stored) === redactedValue) {
+    if (isDeepStrictEqual(redactAzureBlobSasTokens(stored), redactedValue)) {
       return stored;
     }
   }
@@ -291,10 +294,13 @@ export function restoreAzureBlobSasTokens<T>(value: T, storedValue: unknown): T 
       // inserted/removed since it was sanitized, leaving a redacted SAS
       // placeholder in place. Fall back to matching a stored token by value (its
       // blob URI) so the real `sig` is restored regardless of position.
-      if (typeof item === 'string' && positional === item) {
-        const restored = findStoredSasMatchByValue(item, storedItems);
-        if (restored !== undefined && restored !== item) {
-          return restored;
+      if (isDeepStrictEqual(positional, item)) {
+        const storedMatch = findStoredSasMatchByValue(item, storedItems);
+        if (storedMatch !== undefined) {
+          const restored = restoreAzureBlobSasTokens(item, storedMatch);
+          if (!isDeepStrictEqual(restored, item)) {
+            return restored;
+          }
         }
       }
       return positional;

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -138,6 +138,62 @@ describe('sanitizeObject', () => {
       });
     });
 
+    it('restores nested array SAS tokens by value when object entries are reordered', () => {
+      const stored = {
+        tests: [
+          {
+            vars: {
+              suite: 'a',
+              file: 'az://account/container/a.yaml?sp=r&sig=secret-a',
+            },
+          },
+          {
+            vars: {
+              suite: 'b',
+              file: 'az://account/container/b.yaml?sp=r&sig=secret-b',
+            },
+          },
+        ],
+      };
+
+      const restored = restoreAzureBlobSasTokens(
+        {
+          tests: [
+            {
+              vars: {
+                suite: 'b',
+                file: 'az://account/container/b.yaml?sp=r&sig=%5BREDACTED%5D',
+              },
+            },
+            {
+              vars: {
+                suite: 'a',
+                file: 'az://account/container/a.yaml?sp=r&sig=%5BREDACTED%5D',
+              },
+            },
+          ],
+        },
+        stored,
+      );
+
+      expect(restored).toEqual({
+        tests: [
+          {
+            vars: {
+              suite: 'b',
+              file: 'az://account/container/b.yaml?sp=r&sig=secret-b',
+            },
+          },
+          {
+            vars: {
+              suite: 'a',
+              file: 'az://account/container/a.yaml?sp=r&sig=secret-a',
+            },
+          },
+        ],
+      });
+    });
+
     it('does not restore an entry the user edited to point at a different blob', () => {
       const stored = {
         tests: ['az://account/container/a.yaml?sp=r&sig=secret-a'],

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -194,6 +194,68 @@ describe('sanitizeObject', () => {
       });
     });
 
+    it('restores nested array SAS tokens when unrelated object fields are edited', () => {
+      const stored = {
+        tests: [
+          {
+            description: 'old description',
+            vars: {
+              suite: 'a',
+              file: 'az://account/container/a.yaml?sp=r&sig=secret-a',
+            },
+          },
+          {
+            description: 'second test',
+            vars: {
+              suite: 'b',
+              file: 'az://account/container/b.yaml?sp=r&sig=secret-b',
+            },
+          },
+        ],
+      };
+
+      const restored = restoreAzureBlobSasTokens(
+        {
+          tests: [
+            {
+              description: 'edited description',
+              vars: {
+                suite: 'b',
+                file: 'az://account/container/b.yaml?sp=r&sig=%5BREDACTED%5D',
+              },
+            },
+            {
+              description: 'old description',
+              vars: {
+                suite: 'a',
+                file: 'az://account/container/a.yaml?sp=r&sig=%5BREDACTED%5D',
+              },
+            },
+          ],
+        },
+        stored,
+      );
+
+      expect(restored).toEqual({
+        tests: [
+          {
+            description: 'edited description',
+            vars: {
+              suite: 'b',
+              file: 'az://account/container/b.yaml?sp=r&sig=secret-b',
+            },
+          },
+          {
+            description: 'old description',
+            vars: {
+              suite: 'a',
+              file: 'az://account/container/a.yaml?sp=r&sig=secret-a',
+            },
+          },
+        ],
+      });
+    });
+
     it('does not restore an entry the user edited to point at a different blob', () => {
       const stored = {
         tests: ['az://account/container/a.yaml?sp=r&sig=secret-a'],


### PR DESCRIPTION
## Summary

Promptfoo redacts Azure Blob SAS `sig` values before sanitized configs are shown or written back. When a user saves an unchanged redacted config, the server restores the original stored SAS token so reruns can still read the blob without exposing the secret in the UI.

PR #9516 fixed this for reordered arrays of raw Azure Blob URI strings, but config arrays often contain objects, such as test cases with nested `vars.file` values. The first version of this PR handled reordered object arrays only when the whole redacted object still matched; reviewer feedback correctly pointed out that this missed normal edits like changing a test description while keeping the same nested blob URI.

This change now matches stored SAS tokens by their redacted Azure Blob URI identity instead of by whole array-object equality. The fallback builds a browser-safe lookup once per stored array, then recursively restores matching nested redacted URI strings after positional restore runs. That keeps edited non-URI fields, restores unchanged nested SAS references, avoids `node:util` in the browser-shared sanitizer module, and avoids repeatedly deep-scanning every stored object for every array item.

## Testing

- `/Users/wholley/.nvm/versions/node/v24.16.0/bin/node node_modules/vitest/vitest.mjs run test/util/sanitizer.test.ts -t "restores nested array SAS tokens when unrelated object fields are edited"` (failed before fix, passed after fix)
- `/Users/wholley/.nvm/versions/node/v24.16.0/bin/node node_modules/vitest/vitest.mjs run test/util/sanitizer.test.ts`
- `npm run test:app -- src/stores/evalConfig.test.ts --run`
- `npm run f`
- `npm run l`
- `git diff --check`

## Notes

- `npm run tsc` was attempted with the ignored `node_modules` symlink to `/Users/wholley/code/promptfoo/node_modules`, but that shared dependency tree has older Anthropic SDK types and fails in unrelated Anthropic test fixtures on `output_tokens_details`.
