### PR TITLE
fix(db): serialize libsql test database cleanup

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,5 +1,4 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { randomUUID } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 import * as path from 'path';
 
@@ -8,8 +7,8 @@ import { getEnvBool } from '../envars';
 import logger from '../logger';
 import { getConfigDirectoryPath } from '../util/config/manage';
 import {
+  closeTestDatabaseClient,
   registerTestDatabaseClient,
-  resetTestDatabaseClient,
   unregisterTestDatabaseClient,
 } from './testing';
 
@@ -152,19 +151,13 @@ export async function getDb() {
         import('drizzle-orm/libsql/node'),
       ]);
       const isTesting = getEnvBool('IS_TESTING');
-      // libsql opens fresh connections for top-level transactions, so a connection-local
-      // `:memory:` database is not sufficient. Give each test module graph its own
-      // file-backed database so internal connections share state without leaking schema
-      // through the process-global `file::memory:?cache=shared` database.
-      const dbUrl = isTesting
-        ? pathToFileURL(
-            path.resolve(getConfigDirectoryPath(true), `promptfoo-test-${randomUUID()}.db`),
-          ).href
-        : pathToFileURL(getDbPath()).href;
+      // libsql opens fresh connections for top-level transactions, so tests need a
+      // shared in-memory database rather than connection-local `:memory:`.
+      const dbUrl = isTesting ? 'file::memory:?cache=shared' : pathToFileURL(getDbPath()).href;
       const client = createClient({ url: dbUrl });
       sqliteInstance = client;
       if (isTesting) {
-        registerTestDatabaseClient(client);
+        await registerTestDatabaseClient(client);
       }
 
       await configureDatabase(client, isTesting);
@@ -207,13 +200,13 @@ export async function closeDb() {
       }
 
       if (isTesting) {
-        await resetTestDatabaseClient(sqliteInstance);
+        await closeTestDatabaseClient(sqliteInstance);
+      } else {
+        // libsql Client.close() is synchronous; the WAL checkpoint above already
+        // awaited the I/O that needed to finish before the underlying connection drops.
+        sqliteInstance.close();
       }
 
-      // libsql Client.close() is synchronous; the WAL checkpoint above already
-      // awaited the I/O that needed to finish before the underlying connection drops.
-      unregisterTestDatabaseClient(sqliteInstance);
-      sqliteInstance.close();
       logger.debug('Database connection closed successfully');
     } catch (err) {
       logger.error(`Error closing database connection: ${err}`);

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -30,6 +30,7 @@ export class DrizzleLogWriter implements LogWriter {
 let dbInstance: Drizzle | null = null;
 let dbPromise: Promise<Drizzle> | null = null;
 let sqliteInstance: Client | null = null;
+let sqliteInstanceIsTesting = false;
 
 export function getDbPath() {
   return path.resolve(getConfigDirectoryPath(true /* createIfNotExists */), 'promptfoo.db');
@@ -156,6 +157,7 @@ export async function getDb() {
       const dbUrl = isTesting ? 'file::memory:?cache=shared' : pathToFileURL(getDbPath()).href;
       const client = createClient({ url: dbUrl });
       sqliteInstance = client;
+      sqliteInstanceIsTesting = isTesting;
       if (isTesting) {
         await registerTestDatabaseClient(client);
       }
@@ -171,6 +173,7 @@ export async function getDb() {
         sqliteInstance.close();
       }
       sqliteInstance = null;
+      sqliteInstanceIsTesting = false;
       dbInstance = null;
       dbPromise = null;
       throw error;
@@ -188,9 +191,8 @@ export async function getDb() {
 export async function closeDb() {
   if (sqliteInstance) {
     try {
-      const isTesting = getEnvBool('IS_TESTING');
       // Attempt to checkpoint WAL file before closing
-      if (!isTesting && !getEnvBool('PROMPTFOO_DISABLE_WAL_MODE', false)) {
+      if (!sqliteInstanceIsTesting && !getEnvBool('PROMPTFOO_DISABLE_WAL_MODE', false)) {
         try {
           await sqliteInstance.execute('PRAGMA wal_checkpoint(TRUNCATE)');
           logger.debug('Successfully checkpointed WAL file before closing');
@@ -199,7 +201,7 @@ export async function closeDb() {
         }
       }
 
-      if (isTesting) {
+      if (sqliteInstanceIsTesting) {
         await closeTestDatabaseClient(sqliteInstance);
       } else {
         // libsql Client.close() is synchronous; the WAL checkpoint above already
@@ -214,6 +216,7 @@ export async function closeDb() {
       // to prevent reuse of a potentially corrupted connection
     } finally {
       sqliteInstance = null;
+      sqliteInstanceIsTesting = false;
       dbInstance = null;
       dbPromise = null;
     }

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 import * as path from 'path';
 
@@ -151,9 +152,15 @@ export async function getDb() {
         import('drizzle-orm/libsql/node'),
       ]);
       const isTesting = getEnvBool('IS_TESTING');
-      // libsql opens fresh connections for top-level transactions, so tests need a
-      // shared in-memory database rather than connection-local `:memory:`.
-      const dbUrl = isTesting ? 'file::memory:?cache=shared' : pathToFileURL(getDbPath()).href;
+      // libsql opens fresh connections for top-level transactions, so a connection-local
+      // `:memory:` database is not sufficient. Give each test module graph its own
+      // file-backed database so internal connections share state without leaking schema
+      // through the process-global `file::memory:?cache=shared` database.
+      const dbUrl = isTesting
+        ? pathToFileURL(
+            path.resolve(getConfigDirectoryPath(true), `promptfoo-test-${randomUUID()}.db`),
+          ).href
+        : pathToFileURL(getDbPath()).href;
       const client = createClient({ url: dbUrl });
       sqliteInstance = client;
       if (isTesting) {

--- a/src/database/testing.ts
+++ b/src/database/testing.ts
@@ -1,8 +1,10 @@
 type TestDatabaseClient = Pick<import('@libsql/client/node').Client, 'close' | 'execute'>;
 
 const TEST_DATABASE_CLIENTS_KEY = '__promptfooTestDatabaseClients';
+const TEST_DATABASE_OPERATION_QUEUE_KEY = '__promptfooTestDatabaseOperationQueue';
 type TestDatabaseGlobal = typeof globalThis & {
   [TEST_DATABASE_CLIENTS_KEY]?: Set<TestDatabaseClient>;
+  [TEST_DATABASE_OPERATION_QUEUE_KEY]?: Promise<void>;
 };
 
 function getTestDatabaseClients(): Set<TestDatabaseClient> {
@@ -10,8 +12,22 @@ function getTestDatabaseClients(): Set<TestDatabaseClient> {
   return (testGlobal[TEST_DATABASE_CLIENTS_KEY] ??= new Set<TestDatabaseClient>());
 }
 
-export function registerTestDatabaseClient(client: TestDatabaseClient): void {
-  getTestDatabaseClients().add(client);
+function enqueueTestDatabaseOperation<T>(operation: () => Promise<T> | T): Promise<T> {
+  const testGlobal = globalThis as TestDatabaseGlobal;
+  const result = (testGlobal[TEST_DATABASE_OPERATION_QUEUE_KEY] ?? Promise.resolve()).then(
+    operation,
+  );
+  testGlobal[TEST_DATABASE_OPERATION_QUEUE_KEY] = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+export async function registerTestDatabaseClient(client: TestDatabaseClient): Promise<void> {
+  await enqueueTestDatabaseOperation(() => {
+    getTestDatabaseClients().add(client);
+  });
 }
 
 export function unregisterTestDatabaseClient(client: TestDatabaseClient): void {
@@ -42,15 +58,44 @@ export async function resetTestDatabaseClient(client: TestDatabaseClient): Promi
   }
 }
 
-export async function closeTestDatabaseClients(): Promise<void> {
-  const clients = (globalThis as TestDatabaseGlobal)[TEST_DATABASE_CLIENTS_KEY];
-  if (!clients) {
-    return;
-  }
+export async function closeTestDatabaseClient(client: TestDatabaseClient): Promise<void> {
+  await enqueueTestDatabaseOperation(async () => {
+    const clients = (globalThis as TestDatabaseGlobal)[TEST_DATABASE_CLIENTS_KEY];
+    if (!clients?.delete(client)) {
+      client.close();
+      return;
+    }
 
-  for (const client of clients) {
-    await resetTestDatabaseClient(client);
-    client.close();
-  }
-  clients.clear();
+    try {
+      // libsql requires a process-wide shared in-memory cache for its internal
+      // connections. Reset it only after the final module graph has stopped using it.
+      if (clients.size === 0) {
+        await resetTestDatabaseClient(client);
+      }
+    } finally {
+      client.close();
+    }
+  });
+}
+
+export async function closeTestDatabaseClients(): Promise<void> {
+  await enqueueTestDatabaseOperation(async () => {
+    const clients = (globalThis as TestDatabaseGlobal)[TEST_DATABASE_CLIENTS_KEY];
+    if (!clients?.size) {
+      return;
+    }
+
+    const clientsToClose = [...clients];
+    const resetClient = clientsToClose.pop()!;
+    clients.clear();
+
+    try {
+      for (const client of clientsToClose) {
+        client.close();
+      }
+      await resetTestDatabaseClient(resetClient);
+    } finally {
+      resetClient.close();
+    }
+  });
 }

--- a/test/database/isolation.test.ts
+++ b/test/database/isolation.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { closeTestDatabaseClients, resetTestDatabaseClient } from '../../src/database/testing';
+import {
+  closeTestDatabaseClient,
+  closeTestDatabaseClients,
+  registerTestDatabaseClient,
+  resetTestDatabaseClient,
+} from '../../src/database/testing';
 
 describe('database test isolation', () => {
   afterEach(async () => {
@@ -7,7 +12,7 @@ describe('database test isolation', () => {
     vi.resetModules();
   });
 
-  it('does not share the testing database between live isolated module instances', async () => {
+  it('keeps the testing database intact until the last isolated module instance closes', async () => {
     const firstDatabaseModule = await import('../../src/database/index');
     const firstDb = await firstDatabaseModule.getDb();
     await firstDb.run('CREATE TABLE isolated_module_marker (id TEXT PRIMARY KEY)');
@@ -17,10 +22,21 @@ describe('database test isolation', () => {
     const secondDatabaseModule = await import('../../src/database/index');
     const secondDb = await secondDatabaseModule.getDb();
 
-    await expect(secondDb.all('SELECT id FROM isolated_module_marker')).rejects.toThrow();
-    await expect(firstDb.all('SELECT id FROM isolated_module_marker')).resolves.toEqual([
+    await expect(secondDb.all('SELECT id FROM isolated_module_marker')).resolves.toEqual([
       { id: 'first' },
     ]);
+
+    await firstDatabaseModule.closeDb();
+    await expect(secondDb.all('SELECT id FROM isolated_module_marker')).resolves.toEqual([
+      { id: 'first' },
+    ]);
+
+    await secondDatabaseModule.closeDb();
+    vi.resetModules();
+
+    const thirdDatabaseModule = await import('../../src/database/index');
+    const thirdDb = await thirdDatabaseModule.getDb();
+    await expect(thirdDb.all('SELECT id FROM isolated_module_marker')).rejects.toThrow();
   });
 
   it('drops supported schema objects while escaping their identifiers', async () => {
@@ -47,5 +63,45 @@ describe('database test isolation', () => {
     expect(execute).toHaveBeenCalledWith('DROP TRIGGER IF EXISTS "isolated_trigger"');
     expect(execute).not.toHaveBeenCalledWith('DROP INDEX IF EXISTS "ignored_index"');
     expect(execute).toHaveBeenLastCalledWith('PRAGMA foreign_keys = ON');
+  });
+
+  it('waits for schema cleanup before registering another client', async () => {
+    let resolveSchemaQuery!: (value: { rows: never[] }) => void;
+    const firstClient = {
+      close: vi.fn(),
+      execute: vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveSchemaQuery = resolve;
+            }),
+        )
+        .mockResolvedValue({ rows: [] }),
+    } as unknown as Parameters<typeof registerTestDatabaseClient>[0];
+    const secondClient = {
+      close: vi.fn(),
+      execute: vi.fn().mockResolvedValue({ rows: [] }),
+    } as unknown as Parameters<typeof registerTestDatabaseClient>[0];
+
+    await registerTestDatabaseClient(firstClient);
+    const closePromise = closeTestDatabaseClient(firstClient);
+    await vi.waitFor(() => expect(firstClient.execute).toHaveBeenCalledTimes(1));
+
+    let registrationFinished = false;
+    const registerPromise = registerTestDatabaseClient(secondClient).then(() => {
+      registrationFinished = true;
+    });
+    await Promise.resolve();
+    expect(registrationFinished).toBe(false);
+
+    resolveSchemaQuery({ rows: [] });
+    await closePromise;
+    await registerPromise;
+    expect(registrationFinished).toBe(true);
+
+    await closeTestDatabaseClient(secondClient);
+    expect(firstClient.close).toHaveBeenCalledOnce();
+    expect(secondClient.close).toHaveBeenCalledOnce();
   });
 });

--- a/test/database/isolation.test.ts
+++ b/test/database/isolation.test.ts
@@ -5,6 +5,7 @@ import {
   registerTestDatabaseClient,
   resetTestDatabaseClient,
 } from '../../src/database/testing';
+import { mockProcessEnv } from '../util/utils';
 
 describe('database test isolation', () => {
   afterEach(async () => {
@@ -103,5 +104,24 @@ describe('database test isolation', () => {
     await closeTestDatabaseClient(secondClient);
     expect(firstClient.close).toHaveBeenCalledOnce();
     expect(secondClient.close).toHaveBeenCalledOnce();
+  });
+
+  it('uses the initialization mode when the environment changes before close', async () => {
+    const firstDatabaseModule = await import('../../src/database/index');
+    const firstDb = await firstDatabaseModule.getDb();
+    await firstDb.run('CREATE TABLE env_change_marker (id TEXT PRIMARY KEY)');
+
+    const restoreEnv = mockProcessEnv({ IS_TESTING: undefined });
+    try {
+      await firstDatabaseModule.closeDb();
+    } finally {
+      restoreEnv();
+    }
+
+    vi.resetModules();
+    const secondDatabaseModule = await import('../../src/database/index');
+    const secondDb = await secondDatabaseModule.getDb();
+
+    await expect(secondDb.all('SELECT id FROM env_change_marker')).rejects.toThrow();
   });
 });

--- a/test/database/isolation.test.ts
+++ b/test/database/isolation.test.ts
@@ -7,17 +7,20 @@ describe('database test isolation', () => {
     vi.resetModules();
   });
 
-  it('does not share the testing database between isolated module instances', async () => {
+  it('does not share the testing database between live isolated module instances', async () => {
     const firstDatabaseModule = await import('../../src/database/index');
     const firstDb = await firstDatabaseModule.getDb();
     await firstDb.run('CREATE TABLE isolated_module_marker (id TEXT PRIMARY KEY)');
+    await firstDb.run("INSERT INTO isolated_module_marker VALUES ('first')");
 
-    await closeTestDatabaseClients();
     vi.resetModules();
     const secondDatabaseModule = await import('../../src/database/index');
     const secondDb = await secondDatabaseModule.getDb();
 
     await expect(secondDb.all('SELECT id FROM isolated_module_marker')).rejects.toThrow();
+    await expect(firstDb.all('SELECT id FROM isolated_module_marker')).resolves.toEqual([
+      { id: 'first' },
+    ]);
   });
 
   it('drops supported schema objects while escaping their identifiers', async () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -56,5 +56,5 @@ afterAll(async () => {
   vi.resetModules();
 
   // Each worker gets a unique config dir, so we can safely remove only its own files.
-  rmSync(TEST_CONFIG_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -56,5 +56,5 @@ afterAll(async () => {
   vi.resetModules();
 
   // Each worker gets a unique config dir, so we can safely remove only its own files.
-  rmSync(TEST_CONFIG_DIR, { recursive: true, force: true });
+  rmSync(TEST_CONFIG_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 });


### PR DESCRIPTION
## Summary
- keep libsql test databases on the required shared in-memory cache instead of temporary files
- serialize test database registration and cleanup across Vitest module graphs
- reset shared schema only after the final registered test client closes
- preserve the mode captured when a database opens so later environment changes cannot bypass cleanup
- cover overlapping live module graphs, registration during cleanup, and environment changes before close with regression tests

## Context
CI run [#44017](https://github.com/promptfoo/promptfoo/actions/runs/26658842259) intermittently failed on Node 26 / Windows shard 3 when `test/commands/import.test.ts` queried the `evals` table during its duplicate-import collision test. The shared in-memory schema was being reset while another live module graph still needed it.

The initial PR revision tried unique temporary SQLite files. Windows CI run [#44042](https://github.com/promptfoo/promptfoo/actions/runs/26660515495) showed that libsql retains those file handles long enough for teardown to fail with `EBUSY`, so this revision removes the file-backed approach and fixes shared-cache lifecycle ordering directly.

## Testing
- `npx vitest run test/database/isolation.test.ts test/commands/import.test.ts --sequence.shuffle=false --reporter=verbose`
- `npx vitest run test/database/isolation.test.ts test/database.test.ts test/database/index.test.ts test/commands/import.test.ts --sequence.seed=<11|22|33|44|55|77> --reporter=dot`
- `npm run l`
- `npx @biomejs/biome check src/database/index.ts src/database/testing.ts test/database/isolation.test.ts vitest.setup.ts`
- `git diff --check origin/main...HEAD`

## Local environment notes
- `npm run tsc` is blocked locally because the installed dependency overlay has older Anthropic SDK types that reject existing `output_tokens_details` fixtures. CI compilation remains authoritative.
- `npm run f` runs Biome cleanly, then exits because its Prettier half receives no matching files.