### PR TITLE
fix(providers): preserve n8n array body templates

### DIFF
--- a/src/providers/n8n.ts
+++ b/src/providers/n8n.ts
@@ -252,6 +252,8 @@ function stableStringify(value: unknown): string {
 const SENSITIVE_HEADER_PATTERN =
   /^(authorization|cookie|proxy-authorization|x-?api-?key|x-?auth-?token|x-?access-?token|x-?secret|x-?signature|bearer)$/i;
 
+type N8nRequestBody = Record<string, any> | any[] | string;
+
 function redactHeadersForFingerprint(
   headers: Record<string, string> | undefined,
 ): Record<string, string> | undefined {
@@ -370,12 +372,9 @@ export class N8nProvider implements ApiProvider {
     };
   }
 
-  private addSessionField(
-    body: Record<string, any> | string,
-    context?: CallApiContextParams,
-  ): Record<string, any> | string {
+  private addSessionField(body: N8nRequestBody, context?: CallApiContextParams): N8nRequestBody {
     const sessionId = this.getRequestSessionId(context);
-    if (!sessionId || typeof body === 'string') {
+    if (!sessionId || typeof body !== 'object' || body === null || Array.isArray(body)) {
       return body;
     }
 
@@ -383,10 +382,7 @@ export class N8nProvider implements ApiProvider {
     return body[sessionField] === undefined ? { ...body, [sessionField]: sessionId } : body;
   }
 
-  private buildRequestBody(
-    prompt: string,
-    context?: CallApiContextParams,
-  ): Record<string, any> | string {
+  private buildRequestBody(prompt: string, context?: CallApiContextParams): N8nRequestBody {
     const templateVars = this.getTemplateVars(prompt, context);
     const nunjucks = getNunjucksEngine();
     const renderValue = (value: any): any => {
@@ -434,7 +430,7 @@ export class N8nProvider implements ApiProvider {
     return this.addSessionField(renderValue(this.config.body), context);
   }
 
-  private buildGetUrl(body: Record<string, any> | string): string {
+  private buildGetUrl(body: N8nRequestBody): string {
     const requestUrl = new URL(this.getUrl());
 
     if (typeof body === 'string') {

--- a/test/providers/n8n.test.ts
+++ b/test/providers/n8n.test.ts
@@ -260,6 +260,32 @@ describe('N8nProvider', () => {
       );
     });
 
+    it('should preserve JSON array body templates when a session ID is supplied', async () => {
+      vi.mocked(fetchWithCache).mockResolvedValue(createMockResponse({ output: 'Response' }));
+
+      const provider = new N8nProvider('https://n8n.example.com/webhook/agent', {
+        config: {
+          body: '[{"message":"{{prompt}}"}]',
+        },
+      });
+
+      await provider.callApi('Hello', {
+        vars: { sessionId: 'session-123' },
+        prompt: { raw: 'Hello', label: 'test' },
+      });
+
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        'https://n8n.example.com/webhook/agent',
+        expect.objectContaining({
+          body: JSON.stringify([{ message: 'Hello' }]),
+        }),
+        expect.any(Number),
+        'text',
+        true,
+        0,
+      );
+    });
+
     it('should use custom headers', async () => {
       const mockResponse = createMockResponse({ output: 'Response' });
       vi.mocked(fetchWithCache).mockResolvedValue(mockResponse);


### PR DESCRIPTION
## Summary
- Fixes n8n webhook request body handling after PR #9527 added automatic session ID injection for custom object bodies.
- JSON string body templates can intentionally parse to arrays; with `vars.sessionId`, the helper spread the array into an object like `{"0":{"message":"Hello"},"sessionId":"session-123"}`, changing the outbound webhook contract.
- Only inject session fields into non-array objects; array and scalar custom templates are preserved, and users can still include `{{sessionId}}` explicitly inside those templates.

## Test Plan
- Red/green: `node_modules/.bin/vitest run test/providers/n8n.test.ts -t "preserve JSON array body templates"`
- `node_modules/.bin/vitest run test/providers/n8n.test.ts`
- `npm run f`
- `npm run l`
- `git diff --check`
- `npm run tsc` attempted; blocked by existing Anthropic SDK fixture type drift around `output_tokens_details`, unrelated to n8n.