### PR TITLE
fix(providers): suppress optional GCP metadata warning

### DIFF
--- a/src/providers/google/auth.ts
+++ b/src/providers/google/auth.ts
@@ -22,26 +22,42 @@ import type { CompletionOptions } from './types';
 const EXPECTED_GCP_METADATA_LOOKUP_WARNING =
   'received unexpected error = All promises were rejected code = UNKNOWN';
 
+let activeGcpMetadataLookupWarningSuppressions = 0;
+let restoreEmitWarning: (() => void) | undefined;
+
 // The optional ADC probe should stay quiet when gcp-metadata cannot reach its hosts,
 // while explicit Vertex authentication and unrelated process warnings remain visible.
 async function suppressExpectedGcpMetadataLookupWarning<T>(action: () => Promise<T>): Promise<T> {
-  const originalEmitWarning = process.emitWarning;
+  if (activeGcpMetadataLookupWarningSuppressions === 0) {
+    const originalEmitWarning = process.emitWarning;
+    const wrappedEmitWarning = ((warning: string | Error, ...args: unknown[]) => {
+      const message = warning instanceof Error ? warning.message : warning;
+      const type = warning instanceof Error ? warning.name : args[0];
 
-  process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
-    const message = warning instanceof Error ? warning.message : warning;
-    const type = warning instanceof Error ? warning.name : args[0];
+      if (type === 'MetadataLookupWarning' && message === EXPECTED_GCP_METADATA_LOOKUP_WARNING) {
+        return;
+      }
 
-    if (type === 'MetadataLookupWarning' && message === EXPECTED_GCP_METADATA_LOOKUP_WARNING) {
-      return;
-    }
+      Reflect.apply(originalEmitWarning, process, [warning, ...args]);
+    }) as typeof process.emitWarning;
 
-    Reflect.apply(originalEmitWarning, process, [warning, ...args]);
-  }) as typeof process.emitWarning;
+    process.emitWarning = wrappedEmitWarning;
+    restoreEmitWarning = () => {
+      if (process.emitWarning === wrappedEmitWarning) {
+        process.emitWarning = originalEmitWarning;
+      }
+    };
+  }
 
+  activeGcpMetadataLookupWarningSuppressions += 1;
   try {
     return await action();
   } finally {
-    process.emitWarning = originalEmitWarning;
+    activeGcpMetadataLookupWarningSuppressions -= 1;
+    if (activeGcpMetadataLookupWarningSuppressions === 0) {
+      restoreEmitWarning?.();
+      restoreEmitWarning = undefined;
+    }
   }
 }
 

--- a/src/providers/google/auth.ts
+++ b/src/providers/google/auth.ts
@@ -19,6 +19,8 @@ import type { GoogleAuthOptions } from 'google-auth-library';
 import type { EnvOverrides } from '../../types/env';
 import type { CompletionOptions } from './types';
 
+// gcp-metadata@8.1.2 emits this exact MetadataLookupWarning contract when optional host probes fail.
+// Keep the match narrow so new metadata errors and unrelated process warnings remain visible.
 const EXPECTED_GCP_METADATA_LOOKUP_WARNING =
   'received unexpected error = All promises were rejected code = UNKNOWN';
 

--- a/src/providers/google/auth.ts
+++ b/src/providers/google/auth.ts
@@ -19,10 +19,14 @@ import type { GoogleAuthOptions } from 'google-auth-library';
 import type { EnvOverrides } from '../../types/env';
 import type { CompletionOptions } from './types';
 
-// gcp-metadata@8.1.2 emits this exact MetadataLookupWarning contract when optional host probes fail.
-// Keep the match narrow so new metadata errors and unrelated process warnings remain visible.
-const EXPECTED_GCP_METADATA_LOOKUP_WARNING =
-  'received unexpected error = All promises were rejected code = UNKNOWN';
+// gcp-metadata (8.x) emits a `MetadataLookupWarning` of the form
+// `received unexpected error = ${err.message} code = ${code}` when the optional ADC probe cannot
+// reach the metadata host. Match the stable prefix (scoped by the warning type) rather than the
+// fully-interpolated string: the err.message/code suffix varies by failure mode (the codeless
+// `All promises were rejected`/`UNKNOWN` aggregate, plus non-allowlisted codes like ETIMEDOUT or
+// EAI_AGAIN), and a dependency reword of that suffix would otherwise silently defeat suppression.
+// Unrelated warnings and other warning types still surface.
+const EXPECTED_GCP_METADATA_LOOKUP_WARNING_PREFIX = 'received unexpected error = ';
 
 let activeGcpMetadataLookupWarningSuppressions = 0;
 let restoreEmitWarning: (() => void) | undefined;
@@ -36,7 +40,11 @@ async function suppressExpectedGcpMetadataLookupWarning<T>(action: () => Promise
       const message = warning instanceof Error ? warning.message : warning;
       const type = warning instanceof Error ? warning.name : args[0];
 
-      if (type === 'MetadataLookupWarning' && message === EXPECTED_GCP_METADATA_LOOKUP_WARNING) {
+      if (
+        type === 'MetadataLookupWarning' &&
+        typeof message === 'string' &&
+        message.startsWith(EXPECTED_GCP_METADATA_LOOKUP_WARNING_PREFIX)
+      ) {
         return;
       }
 

--- a/src/providers/google/auth.ts
+++ b/src/providers/google/auth.ts
@@ -19,6 +19,32 @@ import type { GoogleAuthOptions } from 'google-auth-library';
 import type { EnvOverrides } from '../../types/env';
 import type { CompletionOptions } from './types';
 
+const EXPECTED_GCP_METADATA_LOOKUP_WARNING =
+  'received unexpected error = All promises were rejected code = UNKNOWN';
+
+// The optional ADC probe should stay quiet when gcp-metadata cannot reach its hosts,
+// while explicit Vertex authentication and unrelated process warnings remain visible.
+async function suppressExpectedGcpMetadataLookupWarning<T>(action: () => Promise<T>): Promise<T> {
+  const originalEmitWarning = process.emitWarning;
+
+  process.emitWarning = ((warning: string | Error, ...args: unknown[]) => {
+    const message = warning instanceof Error ? warning.message : warning;
+    const type = warning instanceof Error ? warning.name : args[0];
+
+    if (type === 'MetadataLookupWarning' && message === EXPECTED_GCP_METADATA_LOOKUP_WARNING) {
+      return;
+    }
+
+    Reflect.apply(originalEmitWarning, process, [warning, ...args]);
+  }) as typeof process.emitWarning;
+
+  try {
+    return await action();
+  } finally {
+    process.emitWarning = originalEmitWarning;
+  }
+}
+
 /**
  * Configuration for Google authentication
  */
@@ -521,7 +547,7 @@ export class GoogleAuthManager {
     if (!this.pendingHasDefaultCredentials) {
       const probe = (async () => {
         try {
-          await this.getOAuthClient();
+          await suppressExpectedGcpMetadataLookupWarning(() => this.getOAuthClient());
           return true;
         } catch {
           return false;

--- a/test/providers/google/auth.test.ts
+++ b/test/providers/google/auth.test.ts
@@ -544,6 +544,45 @@ describe('GoogleAuthManager', () => {
       getOAuthClientSpy.mockRestore();
     });
 
+    it('should suppress expected metadata lookup warnings during optional probes', async () => {
+      const emitWarningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+      const getOAuthClientSpy = vi
+        .spyOn(GoogleAuthManager, 'getOAuthClient')
+        .mockImplementation(async () => {
+          process.emitWarning(
+            'received unexpected error = All promises were rejected code = UNKNOWN',
+            'MetadataLookupWarning',
+          );
+          throw new Error('no default credentials');
+        });
+
+      try {
+        await expect(GoogleAuthManager.hasDefaultCredentials()).resolves.toBe(false);
+        expect(emitWarningSpy).not.toHaveBeenCalled();
+      } finally {
+        getOAuthClientSpy.mockRestore();
+        emitWarningSpy.mockRestore();
+      }
+    });
+
+    it('should forward unrelated warnings during optional probes', async () => {
+      const emitWarningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+      const getOAuthClientSpy = vi
+        .spyOn(GoogleAuthManager, 'getOAuthClient')
+        .mockImplementation(async () => {
+          process.emitWarning('different warning', 'MetadataLookupWarning');
+          throw new Error('no default credentials');
+        });
+
+      try {
+        await expect(GoogleAuthManager.hasDefaultCredentials()).resolves.toBe(false);
+        expect(emitWarningSpy).toHaveBeenCalledWith('different warning', 'MetadataLookupWarning');
+      } finally {
+        getOAuthClientSpy.mockRestore();
+        emitWarningSpy.mockRestore();
+      }
+    });
+
     it('should clear cached default credential probe results', async () => {
       const getOAuthClientSpy = vi
         .spyOn(GoogleAuthManager, 'getOAuthClient')

--- a/test/providers/google/auth.test.ts
+++ b/test/providers/google/auth.test.ts
@@ -55,8 +55,15 @@ describe('GoogleAuthManager', () => {
     mockProcessEnv({ GOOGLE_CLOUD_LOCATION: undefined });
   });
 
+  // Captured once during collection so afterEach can guarantee no test leaks a patched
+  // process.emitWarning into the next one (the suppression helper swaps it process-globally).
+  const realEmitWarning = process.emitWarning;
+
   afterEach(() => {
     vi.clearAllMocks();
+    if (process.emitWarning !== realEmitWarning) {
+      process.emitWarning = realEmitWarning;
+    }
   });
 
   describe('getApiKey', () => {
@@ -551,6 +558,32 @@ describe('GoogleAuthManager', () => {
         .mockImplementation(async () => {
           process.emitWarning(
             'received unexpected error = All promises were rejected code = UNKNOWN',
+            'MetadataLookupWarning',
+          );
+          throw new Error('no default credentials');
+        });
+
+      try {
+        await expect(GoogleAuthManager.hasDefaultCredentials()).resolves.toBe(false);
+        expect(emitWarningSpy).not.toHaveBeenCalled();
+      } finally {
+        getOAuthClientSpy.mockRestore();
+        emitWarningSpy.mockRestore();
+      }
+    });
+
+    it('should suppress metadata lookup warnings for any unreachable-host error code', async () => {
+      // gcp-metadata interpolates the underlying error + code into the message, so the suffix
+      // varies by failure mode (the codeless `All promises were rejected`/`UNKNOWN` aggregate,
+      // plus non-allowlisted codes like ETIMEDOUT or EAI_AGAIN). All are the same optional probe
+      // failing to reach metadata, so the stable prefix must suppress every variant — and tolerate
+      // a dependency reword of the interpolated suffix.
+      const emitWarningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+      const getOAuthClientSpy = vi
+        .spyOn(GoogleAuthManager, 'getOAuthClient')
+        .mockImplementation(async () => {
+          process.emitWarning(
+            'received unexpected error = connect ETIMEDOUT 169.254.169.254:80 code = ETIMEDOUT',
             'MetadataLookupWarning',
           );
           throw new Error('no default credentials');

--- a/test/providers/google/auth.test.ts
+++ b/test/providers/google/auth.test.ts
@@ -583,6 +583,100 @@ describe('GoogleAuthManager', () => {
       }
     });
 
+    it('should forward matching metadata warning messages with a different warning type', async () => {
+      const emitWarningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+      const getOAuthClientSpy = vi
+        .spyOn(GoogleAuthManager, 'getOAuthClient')
+        .mockImplementation(async () => {
+          process.emitWarning(
+            'received unexpected error = All promises were rejected code = UNKNOWN',
+            'DeprecationWarning',
+          );
+          throw new Error('no default credentials');
+        });
+
+      try {
+        await expect(GoogleAuthManager.hasDefaultCredentials()).resolves.toBe(false);
+        expect(emitWarningSpy).toHaveBeenCalledWith(
+          'received unexpected error = All promises were rejected code = UNKNOWN',
+          'DeprecationWarning',
+        );
+      } finally {
+        getOAuthClientSpy.mockRestore();
+        emitWarningSpy.mockRestore();
+      }
+    });
+
+    it('should forward Error instance warnings during optional probes', async () => {
+      const emitWarningSpy = vi.spyOn(process, 'emitWarning').mockImplementation(() => {});
+      const warning = new Error('different warning');
+      warning.name = 'MetadataLookupWarning';
+      const getOAuthClientSpy = vi
+        .spyOn(GoogleAuthManager, 'getOAuthClient')
+        .mockImplementation(async () => {
+          process.emitWarning(warning);
+          throw new Error('no default credentials');
+        });
+
+      try {
+        await expect(GoogleAuthManager.hasDefaultCredentials()).resolves.toBe(false);
+        expect(emitWarningSpy).toHaveBeenCalledWith(warning);
+      } finally {
+        getOAuthClientSpy.mockRestore();
+        emitWarningSpy.mockRestore();
+      }
+    });
+
+    it('should restore process.emitWarning after an optional probe', async () => {
+      const originalEmitWarning = process.emitWarning;
+      const getOAuthClientSpy = vi
+        .spyOn(GoogleAuthManager, 'getOAuthClient')
+        .mockRejectedValue(new Error('no default credentials'));
+
+      try {
+        await expect(GoogleAuthManager.hasDefaultCredentials()).resolves.toBe(false);
+        expect(process.emitWarning).toBe(originalEmitWarning);
+      } finally {
+        getOAuthClientSpy.mockRestore();
+      }
+    });
+
+    it('should restore process.emitWarning after overlapping probes settle out of order', async () => {
+      const originalEmitWarning = process.emitWarning;
+      let rejectFirstProbe!: (reason?: unknown) => void;
+      let rejectSecondProbe!: (reason?: unknown) => void;
+      const firstProbeAuthCall = new Promise((_, reject) => {
+        rejectFirstProbe = reject;
+      });
+      const secondProbeAuthCall = new Promise((_, reject) => {
+        rejectSecondProbe = reject;
+      });
+      const getOAuthClientSpy = vi.spyOn(GoogleAuthManager, 'getOAuthClient');
+      getOAuthClientSpy
+        .mockImplementationOnce(() => firstProbeAuthCall as Promise<any>)
+        .mockImplementationOnce(() => secondProbeAuthCall as Promise<any>);
+
+      const firstProbe = GoogleAuthManager.hasDefaultCredentials();
+      GoogleAuthManager.clearCache();
+      const secondProbe = GoogleAuthManager.hasDefaultCredentials();
+
+      try {
+        rejectFirstProbe(new Error('first probe failed'));
+        await expect(firstProbe).resolves.toBe(false);
+        expect(process.emitWarning).not.toBe(originalEmitWarning);
+
+        rejectSecondProbe(new Error('second probe failed'));
+        await expect(secondProbe).resolves.toBe(false);
+        expect(process.emitWarning).toBe(originalEmitWarning);
+      } finally {
+        rejectFirstProbe(new Error('cleanup'));
+        rejectSecondProbe(new Error('cleanup'));
+        await Promise.allSettled([firstProbe, secondProbe]);
+        process.emitWarning = originalEmitWarning;
+        getOAuthClientSpy.mockRestore();
+      }
+    });
+
     it('should clear cached default credential probe results', async () => {
       const getOAuthClientSpy = vi
         .spyOn(GoogleAuthManager, 'getOAuthClient')

--- a/test/providers/google/auth.test.ts
+++ b/test/providers/google/auth.test.ts
@@ -641,6 +641,25 @@ describe('GoogleAuthManager', () => {
       }
     });
 
+    it('should preserve a newer process.emitWarning owner after an optional probe', async () => {
+      const originalEmitWarning = process.emitWarning;
+      const replacementEmitWarning = vi.fn() as typeof process.emitWarning;
+      const getOAuthClientSpy = vi
+        .spyOn(GoogleAuthManager, 'getOAuthClient')
+        .mockImplementation(async () => {
+          process.emitWarning = replacementEmitWarning;
+          throw new Error('no default credentials');
+        });
+
+      try {
+        await expect(GoogleAuthManager.hasDefaultCredentials()).resolves.toBe(false);
+        expect(process.emitWarning).toBe(replacementEmitWarning);
+      } finally {
+        process.emitWarning = originalEmitWarning;
+        getOAuthClientSpy.mockRestore();
+      }
+    });
+
     it('should restore process.emitWarning after overlapping probes settle out of order', async () => {
       const originalEmitWarning = process.emitWarning;
       let rejectFirstProbe!: (reason?: unknown) => void;


### PR DESCRIPTION
## Summary

- suppress the exact expected `MetadataLookupWarning` emitted when the optional Google ADC probe cannot reach metadata hosts
- preserve explicit Vertex authentication and forward unrelated process warnings
- add regression coverage for both suppression and forwarding behavior

## Testing

- `./node_modules/.bin/vitest run test/providers/defaults.test.ts test/providers/google/auth.test.ts --sequence.shuffle=false`
- `./node_modules/.bin/biome check src/providers/google/auth.ts test/providers/google/auth.test.ts`
- real `GoogleAuthManager.hasDefaultCredentials()` probe outside GCP
- real `getDefaultProviders()` fallback selection outside GCP

## Notes

- `tsc --noEmit` still reports pre-existing Anthropic usage-shape errors in unrelated test files.
