### PR TITLE
docs(site): fix modelaudit scanner catalog command

### DIFF
--- a/site/docs/model-audit/usage.md
+++ b/site/docs/model-audit/usage.md
@@ -378,7 +378,13 @@ The result envelope includes scan statistics, scanned assets, file metadata, `is
 
 Optional fields may be omitted, and scanner-specific fields may be added over time. Consumers should tolerate unknown fields, especially within `details` and `file_metadata`.
 
-Export the installed version's scanner catalog when you need the current scanner IDs and dependency metadata:
+Export the installed version's rule catalog when you need the current rule codes and descriptions:
+
+```bash
+modelaudit rules --list --format json
+```
+
+Export the scanner catalog separately when you need the current scanner IDs and dependency metadata:
 
 ```bash
 modelaudit scan --list-scanners --format json

--- a/site/docs/model-audit/usage.md
+++ b/site/docs/model-audit/usage.md
@@ -378,10 +378,10 @@ The result envelope includes scan statistics, scanned assets, file metadata, `is
 
 Optional fields may be omitted, and scanner-specific fields may be added over time. Consumers should tolerate unknown fields, especially within `details` and `file_metadata`.
 
-Export the installed version's rule catalog when you need the current rule codes and descriptions:
+Export the installed version's scanner catalog when you need the current scanner IDs and dependency metadata:
 
 ```bash
-modelaudit rules --list --format json
+modelaudit scan --list-scanners --format json
 ```
 
 ## SARIF Output Format

--- a/site/docs/model-audit/usage.md
+++ b/site/docs/model-audit/usage.md
@@ -378,13 +378,7 @@ The result envelope includes scan statistics, scanned assets, file metadata, `is
 
 Optional fields may be omitted, and scanner-specific fields may be added over time. Consumers should tolerate unknown fields, especially within `details` and `file_metadata`.
 
-Export the installed version's rule catalog when you need the current rule codes and descriptions:
-
-```bash
-modelaudit rules --list --format json
-```
-
-Export the scanner catalog separately when you need the current scanner IDs and dependency metadata:
+Export the installed version's scanner catalog when you need the current scanner IDs and dependency metadata:
 
 ```bash
 modelaudit scan --list-scanners --format json


### PR DESCRIPTION
## Summary

- replace the unsupported ModelAudit `rules --list` example with the published scanner catalog command
- describe the exported data as scanner IDs and dependency metadata

## Test plan

- `npx prettier --check site/docs/model-audit/usage.md`
- `cd site && SKIP_OG_GENERATION=true npm run build`
