### PR TITLE
chore(deps): downgrade anthropic sdk pins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "site"
       ],
       "dependencies": {
-        "@anthropic-ai/sdk": "0.100.0",
+        "@anthropic-ai/sdk": "0.97.1",
         "@apidevtools/json-schema-ref-parser": "^15.3.1",
         "@inquirer/checkbox": "^5.1.0",
         "@inquirer/confirm": "^6.0.8",
@@ -97,7 +97,7 @@
         "promptfoo": "dist/src/entrypoint.js"
       },
       "devDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk": "0.3.146",
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1045.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
@@ -158,7 +158,7 @@
         "node": "^20.20.0 || >=22.22.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.153",
+        "@anthropic-ai/claude-agent-sdk": "0.3.146",
         "@aws-sdk/client-bedrock-agent-runtime": "^3.1045.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
         "@aws-sdk/client-s3": "^3.1003.0",
@@ -554,23 +554,23 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.153",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.153.tgz",
-      "integrity": "sha512-+WYWQ5ih2dOuiJY4yql5pje3w8iA+aS7eZXJSFo6LZxmEiH4nV4n/fjhJCWPcqyo7TdvhAjS2cPqwIslNw3c7A==",
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.146.tgz",
+      "integrity": "sha512-hK9/Ng+hOyexUemTxdIUsSWJ9o2LFi2YNWzHwz8/YMCohUYOnFMZkBiENvUAb0WIc5hieOyBZrOIlg5OewuJMg==",
       "dev": true,
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.153",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.153",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.153",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.153",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.153",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.153",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.153",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.153"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.146",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.146"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -579,9 +579,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.153",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.153.tgz",
-      "integrity": "sha512-4K2K/n/qikp24ufO38owSEj5RPMWjBmf83BSUxLlzOhOXt7dHXs1CitmY9ZYM58Wmn3qhJs9DaS//ptO1siskQ==",
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.146.tgz",
+      "integrity": "sha512-0IIvlEaenq2CRSVx5Bo5BaCtHQXS87GancM35WKEYveGVLn6DI+5G7ikYuTE4AKRPkMnogFtY4BJt6LulWGj+A==",
       "cpu": [
         "arm64"
       ],
@@ -593,9 +593,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.153",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.153.tgz",
-      "integrity": "sha512-kY5DPMAK+ZkphoIUjOiP6sSB57Lw2H1RUNK2HVEDowagbl9T47DSbkjYE4NWYqfy22aebPj02VAIbFfFmYxnMw==",
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.146.tgz",
+      "integrity": "sha512-Dk5xJ03Ff1JXbMRP1t2wc/TyfY6xF/2Ysp31wMhFPjoNiKSPHMWaIg242+T3CHdxLWmJ8plWHL1HL5cyZ/LCkw==",
       "cpu": [
         "x64"
       ],
@@ -607,9 +607,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.153",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.153.tgz",
-      "integrity": "sha512-XoIP6xJn+QlfBta96yfxdtaeJ/BstA2S9abZJYeWs/wwNjQNWs83repg/v1VPuGn7i44teSzLtzoAv9t1w4Ybg==",
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.146.tgz",
+      "integrity": "sha512-mzBXDDWWBAC/vDtAYpO1G/dq5QvJtYSPXsqcb+sNdcDhiuf4IYnYp7ytRncYlsUNDkLmX6Gk2jkWAHUUA2Lozg==",
       "cpu": [
         "arm64"
       ],
@@ -624,9 +624,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.153",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.153.tgz",
-      "integrity": "sha512-5fD6MagyX+1tZdpVjZ6rN178pR7K10c+JyTsEh4HUJR3tnVO9uZYcmEcsKLX1TjWX+mz5+TW9rwDP5AMHXsjNA==",
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.146.tgz",
+      "integrity": "sha512-QlCid0ucdrmhUAOewfQjaofN2wlokWcfFTxSFePTSj1umk35JO7TDFP700F7jU49r1fPWIdvJpPwWGyB0DeFPA==",
       "cpu": [
         "arm64"
       ],
@@ -641,9 +641,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.153",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.153.tgz",
-      "integrity": "sha512-U2eY8iBLF0vrvuHnh33UA3LA/aIVgSk2Pw5KY7N5lH5fYzcnDBoT8bG32lelQIoaUDY0znOWIc0vqN5/Yih51w==",
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.146.tgz",
+      "integrity": "sha512-B2baXU1tCBT5CVlD7jJMKjpC4xdO45NUIWpqImmwuOfKvlM/PITjyTXyTY662mGZf1dBmdqBBsqirwFH/jhi8Q==",
       "cpu": [
         "x64"
       ],
@@ -658,9 +658,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.153",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.153.tgz",
-      "integrity": "sha512-4o+1RnNAL31iZDDT46AWl/t5lUSVJ5Gq8o2IxPgNBltPHAL3aUmTTDLxjDb+gFVEyegyy9FwK0yPJGpNp4CxKA==",
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.146.tgz",
+      "integrity": "sha512-E3coK1ThQT08KIX80RLcsq7DWXFllCKOzoOe32it/bdtY56TBgPY9xemwXhIJ+cVBHTI9/MpBSIlKBcFCt+yQA==",
       "cpu": [
         "x64"
       ],
@@ -675,9 +675,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.153",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.153.tgz",
-      "integrity": "sha512-GQsZTvf4pJVVAgaXwpN/W7RpO7dtUd3VCM3zxD7RQ1X+Dc8tUNPMWr7JCHEYwrUWiS1jeSjLOsrAuRFopSP43Q==",
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.146.tgz",
+      "integrity": "sha512-CIwQxGX2r/yWpjCJ6ahB3smKXhghWgGTxL98+LGW52TUwqTiBnlNrH9DPqqgv1/+Hyquw6xfLrKU+StyfMgiLw==",
       "cpu": [
         "arm64"
       ],
@@ -689,9 +689,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.153",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.153.tgz",
-      "integrity": "sha512-t/+IEFLsp+fY1G5EZhzVBNKI1mm28rPNcyrlJHy3wCbl1aA/Myd7mWnNCRckDGENZz4V7KyqCslLsCt5gT2iPg==",
+      "version": "0.3.146",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.146.tgz",
+      "integrity": "sha512-qmxrsyaqA8s4HShqJls7ZCRjdoqN66Jo/hbjQNB3uHepD8tEO1iD19aPV4+osdLT7feMkhDBfLT07Q30R2NB5w==",
       "cpu": [
         "x64"
       ],
@@ -703,9 +703,9 @@
       ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.100.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.0.tgz",
-      "integrity": "sha512-cAm3aXm6qAiHIvHxyIIGd6tVmsD2gDqlc2h0R20ijNUzGgVnIN822bit4mKbF6CkuV7qIrLQIPoAepHEpanrQQ==",
+      "version": "0.97.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.97.1.tgz",
+      "integrity": "sha512-wOf7AUeJPitcVpvKO4UMu63mWH5SaVipkGd7OOQJt/G6VYGlV8D2Gp9dLxOrttDJh/9gqPqdaBwDGcBevumeAg==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     }
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk": "0.3.146",
     "@asteasolutions/zod-to-openapi": "^8.5.0",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1045.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
@@ -230,7 +230,7 @@
     "winston-transport": "^4.9.0"
   },
   "optionalDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.153",
+    "@anthropic-ai/claude-agent-sdk": "0.3.146",
     "@aws-sdk/client-bedrock-agent-runtime": "^3.1045.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1045.0",
     "@aws-sdk/client-s3": "^3.1003.0",
@@ -275,7 +275,7 @@
     "sharp": "^0.34.5"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "0.100.0",
+    "@anthropic-ai/sdk": "0.97.1",
     "@apidevtools/json-schema-ref-parser": "^15.3.1",
     "@inquirer/checkbox": "^5.1.0",
     "@inquirer/confirm": "^6.0.8",

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -2330,7 +2330,6 @@ describe('AnthropicMessagesProvider', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -397,7 +397,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 
@@ -425,7 +424,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 
@@ -456,7 +454,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 
@@ -499,7 +496,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 
@@ -539,7 +535,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 
@@ -585,7 +580,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 
@@ -621,7 +615,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 
@@ -659,7 +652,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 
@@ -694,7 +686,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 
@@ -729,7 +720,6 @@ describe('Anthropic utilities', () => {
           server_tool_use: null,
           service_tier: null,
           inference_geo: null,
-          output_tokens_details: null,
         },
       };
 

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -115,7 +115,6 @@ const createMockUsage = (input = 0, output = 0): NonNullableUsage => ({
   speed: 'standard',
   inference_geo: '',
   iterations: [],
-  output_tokens_details: { thinking_tokens: 0 },
 });
 
 // Helper to create a mock BetaMessage with required fields
@@ -146,7 +145,6 @@ const createMockBetaMessage = (
     server_tool_use: null,
     service_tier: 'standard' as const,
     speed: 'standard' as const,
-    output_tokens_details: null,
   },
 });
 


### PR DESCRIPTION
## Summary

- downgrade `@anthropic-ai/claude-agent-sdk` to `0.3.146`
- downgrade `@anthropic-ai/sdk` to `0.97.1`
- remove newer-only Anthropic usage mock fields so tests typecheck against the older SDK types

## Validation

- `npm install`
- `npm ls @anthropic-ai/claude-agent-sdk @anthropic-ai/sdk`
- `npx vitest run test/providers/claude-agent-sdk.test.ts test/providers/anthropic/messages.test.ts test/providers/anthropic/util.test.ts`
- `npm run tsc`
- `npx vitest run test/providers/azure/chat.test.ts test/providers/bedrock/converse.test.ts test/providers/bedrock/index.test.ts test/providers/google/vertex.test.ts test/providers/webSearchUtils.test.ts`
- `npm run build`
- `npx check-dependency-version-consistency`
- `npm run l`
- `npx @biomejs/biome check --write package.json package-lock.json test/providers/anthropic/messages.test.ts test/providers/anthropic/util.test.ts test/providers/claude-agent-sdk.test.ts`
- `git diff --check`

`npm run f` ran Biome successfully, then exited on the repo script's empty Prettier file-list case because this branch does not touch any CSS/Markdown/YAML files.
