### PR TITLE
chore(deps): clarify renovate npm release-age buffer comment

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -259,7 +259,7 @@
       "minimumReleaseAge": "10 days"
     },
     {
-      "description": "All npm packages: wait 10 days to match the Socket minimum release age floor",
+      "description": "All npm packages: wait 10 days, a buffer above the 7-day Socket minimum release age floor",
       "matchDatasources": ["npm"],
       "minimumReleaseAge": "10 days"
     },


### PR DESCRIPTION
## Summary

Follow-up to #9560. That PR bumped Renovate's npm `minimumReleaseAge` from 7 to 10 days but left the "All npm packages" rule comment asserting that 10 days *matches* the Socket minimum release age floor. The Socket floor is **7 days**, so 10 days is a deliberate buffer, not a match.

This corrects the comment to describe the 10-day `minimumReleaseAge` as a buffer above the 7-day Socket floor.

- **No behavior change** — `minimumReleaseAge` stays `10 days` across all rules.
- Comment/`description` text only.

## Validation

- `npx renovate-config-validator` — Config validated successfully
- `npm run l && npm run f` — clean