### PR TITLE
fix(db): avoid SQLITE_LOCKED flakiness in shared-cache test database

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -6,6 +6,7 @@ import { DefaultLogger, type LogWriter } from 'drizzle-orm/logger';
 import { getEnvBool } from '../envars';
 import logger from '../logger';
 import { getConfigDirectoryPath } from '../util/config/manage';
+import { sleep } from '../util/time';
 import {
   closeTestDatabaseClient,
   registerTestDatabaseClient,
@@ -50,21 +51,6 @@ async function configureDatabase(client: Client, skipWalMode: boolean): Promise<
   // connection for the lock waits instead of erroring with SQLITE_BUSY.
   await client.execute('PRAGMA busy_timeout = 5000');
 
-  // The test database is a process-wide shared-cache in-memory DB
-  // (`file::memory:?cache=shared`). Shared-cache uses table-level locks, so a
-  // read that overlaps another connection's open write transaction fails
-  // immediately with SQLITE_LOCKED_SHAREDCACHE — and busy_timeout does NOT cover
-  // it (that only applies to SQLITE_BUSY). libsql also opens separate physical
-  // connections for interactive transactions, so the JS-level operation
-  // serialization cannot guarantee the prior writer's table lock is released the
-  // instant its promise settles. read_uncommitted lets readers proceed without
-  // taking a conflicting table lock, which removes the flaky lock errors. It is
-  // shared-cache-only (a no-op for the file-backed production DB) and we never
-  // reach this branch outside tests, so production isolation is unchanged.
-  if (skipWalMode) {
-    await client.execute('PRAGMA read_uncommitted = 1');
-  }
-
   // Configure WAL mode unless explicitly disabled or using in-memory database
   if (!skipWalMode && !getEnvBool('PROMPTFOO_DISABLE_WAL_MODE', false)) {
     try {
@@ -99,6 +85,66 @@ async function configureDatabase(client: Client, skipWalMode: boolean): Promise<
   }
 }
 
+// A statement that fails to acquire its lock never executed, so retrying it is
+// safe (no risk of double-applying a write). Shared-cache table locks surface as
+// SQLITE_LOCKED, which busy_timeout does NOT retry — it only covers SQLITE_BUSY.
+const TRANSIENT_LOCK_RETRY_ATTEMPTS = 10;
+const TRANSIENT_LOCK_RETRY_BASE_MS = 5;
+const TRANSIENT_LOCK_RETRY_MAX_MS = 250;
+
+/**
+ * Detects the transient SQLite lock errors that clear once a contending writer
+ * releases its lock. drizzle re-wraps the libsql error (its own message is just
+ * `Failed query: ...`), so walk the cause chain and match on code/message.
+ */
+function isTransientDatabaseLockError(error: unknown): boolean {
+  for (
+    let current = error as {
+        code?: unknown;
+        extendedCode?: unknown;
+        message?: unknown;
+        cause?: unknown;
+      } | null,
+      depth = 0;
+    current != null && depth < 6;
+    current = (current.cause ?? null) as typeof current, depth++
+  ) {
+    const code = typeof current.code === 'string' ? current.code : '';
+    const extendedCode = typeof current.extendedCode === 'string' ? current.extendedCode : '';
+    if (
+      code.startsWith('SQLITE_BUSY') ||
+      code.startsWith('SQLITE_LOCKED') ||
+      extendedCode.startsWith('SQLITE_BUSY') ||
+      extendedCode.startsWith('SQLITE_LOCKED')
+    ) {
+      return true;
+    }
+    const message = typeof current.message === 'string' ? current.message : '';
+    if (
+      /\bSQLITE_(?:BUSY|LOCKED)\b/.test(message) ||
+      /database (?:is|table is) locked/i.test(message)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function withTransientLockRetry<T>(operation: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= TRANSIENT_LOCK_RETRY_ATTEMPTS || !isTransientDatabaseLockError(error)) {
+        throw error;
+      }
+      await sleep(
+        Math.min(TRANSIENT_LOCK_RETRY_BASE_MS * 2 ** (attempt - 1), TRANSIENT_LOCK_RETRY_MAX_MS),
+      );
+    }
+  }
+}
+
 function serializeTopLevelOperations(client: Client, db: Drizzle): Drizzle {
   const transaction = db.transaction.bind(db);
   type TransactionCallback = Parameters<typeof transaction>[0];
@@ -122,11 +168,18 @@ function serializeTopLevelOperations(client: Client, db: Drizzle): Drizzle {
     return (...args: TArgs) => {
       // The outer transaction already owns the serialized queue. If a helper
       // called from that transaction uses the root db handle for a read, queueing
-      // it behind the outer transaction would deadlock.
+      // it behind the outer transaction would deadlock. Retrying here would also
+      // deadlock (the contending lock is the very transaction we are inside), so
+      // run it directly.
       if (activeTransaction.getStore()) {
         return method(...args);
       }
-      return runSerialized(() => method(...args));
+      // Statement-level methods are atomic, so a transient lock failure means
+      // nothing was applied. libsql runs interactive transactions on their own
+      // connection, so a prior writer's table lock can briefly outlive the JS
+      // promise that settled it; retry rides through that window without
+      // weakening isolation (reads still observe only committed rows).
+      return runSerialized(() => withTransientLockRetry(() => method(...args)));
     };
   };
 

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -50,6 +50,21 @@ async function configureDatabase(client: Client, skipWalMode: boolean): Promise<
   // connection for the lock waits instead of erroring with SQLITE_BUSY.
   await client.execute('PRAGMA busy_timeout = 5000');
 
+  // The test database is a process-wide shared-cache in-memory DB
+  // (`file::memory:?cache=shared`). Shared-cache uses table-level locks, so a
+  // read that overlaps another connection's open write transaction fails
+  // immediately with SQLITE_LOCKED_SHAREDCACHE — and busy_timeout does NOT cover
+  // it (that only applies to SQLITE_BUSY). libsql also opens separate physical
+  // connections for interactive transactions, so the JS-level operation
+  // serialization cannot guarantee the prior writer's table lock is released the
+  // instant its promise settles. read_uncommitted lets readers proceed without
+  // taking a conflicting table lock, which removes the flaky lock errors. It is
+  // shared-cache-only (a no-op for the file-backed production DB) and we never
+  // reach this branch outside tests, so production isolation is unchanged.
+  if (skipWalMode) {
+    await client.execute('PRAGMA read_uncommitted = 1');
+  }
+
   // Configure WAL mode unless explicitly disabled or using in-memory database
   if (!skipWalMode && !getEnvBool('PROMPTFOO_DISABLE_WAL_MODE', false)) {
     try {

--- a/test/database/isolation.test.ts
+++ b/test/database/isolation.test.ts
@@ -1,3 +1,4 @@
+import { createClient } from '@libsql/client/node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   closeTestDatabaseClient,
@@ -6,6 +7,10 @@ import {
   resetTestDatabaseClient,
 } from '../../src/database/testing';
 import { mockProcessEnv } from '../util/utils';
+
+// Mirror of the testing database URL in src/database/index.ts. The test database is a
+// process-wide shared-cache in-memory libsql DB so its internal connections see one schema.
+const SHARED_CACHE_MEMORY_URL = 'file::memory:?cache=shared';
 
 describe('database test isolation', () => {
   afterEach(async () => {
@@ -123,5 +128,37 @@ describe('database test isolation', () => {
     const secondDb = await secondDatabaseModule.getDb();
 
     await expect(secondDb.all('SELECT id FROM env_change_marker')).rejects.toThrow();
+  });
+
+  // Regression: shared-cache uses table-level locks, so a read that overlaps another
+  // connection's open write transaction fails immediately with SQLITE_LOCKED_SHAREDCACHE
+  // (busy_timeout only covers SQLITE_BUSY). libsql runs interactive transactions on their
+  // own connections, so a prior writer's lock can briefly outlive the JS promise that
+  // settled it — which is what made `import`'s collision check (Eval.findById's
+  // `SELECT ... FROM evals`) flake. configureDatabase enables read_uncommitted on the test
+  // DB so reads no longer take a conflicting lock.
+  it('reads while another connection holds a write lock instead of throwing SQLITE_LOCKED', async () => {
+    const databaseModule = await import('../../src/database/index');
+    const db = await databaseModule.getDb();
+    await db.run('CREATE TABLE lock_probe (id TEXT PRIMARY KEY)');
+    await db.run("INSERT INTO lock_probe VALUES ('committed')");
+
+    // Independent connection to the same shared cache, holding an open write lock on the
+    // probe table — standing in for libsql's lingering interactive-transaction connection.
+    const lockHolder = createClient({ url: SHARED_CACHE_MEMORY_URL });
+    const writeTx = await lockHolder.transaction('write');
+    await writeTx.execute("INSERT INTO lock_probe VALUES ('uncommitted')");
+
+    try {
+      // Top-level read through the serialized main connection, exactly like Eval.findById.
+      await expect(db.all("SELECT id FROM lock_probe WHERE id = 'committed'")).resolves.toEqual([
+        { id: 'committed' },
+      ]);
+    } finally {
+      await writeTx.rollback();
+      lockHolder.close();
+    }
+
+    await databaseModule.closeDb();
   });
 });

--- a/test/database/isolation.test.ts
+++ b/test/database/isolation.test.ts
@@ -6,6 +6,7 @@ import {
   registerTestDatabaseClient,
   resetTestDatabaseClient,
 } from '../../src/database/testing';
+import { sleep } from '../../src/util/time';
 import { mockProcessEnv } from '../util/utils';
 
 // Mirror of the testing database URL in src/database/index.ts. The test database is a
@@ -135,9 +136,9 @@ describe('database test isolation', () => {
   // (busy_timeout only covers SQLITE_BUSY). libsql runs interactive transactions on their
   // own connections, so a prior writer's lock can briefly outlive the JS promise that
   // settled it — which is what made `import`'s collision check (Eval.findById's
-  // `SELECT ... FROM evals`) flake. configureDatabase enables read_uncommitted on the test
-  // DB so reads no longer take a conflicting lock.
-  it('reads while another connection holds a write lock instead of throwing SQLITE_LOCKED', async () => {
+  // `SELECT ... FROM evals`) flake. Top-level statements now retry the transient lock
+  // instead of throwing, riding through the window without weakening isolation.
+  it('retries a read locked by another connection until the lock releases, without dirty reads', async () => {
     const databaseModule = await import('../../src/database/index');
     const db = await databaseModule.getDb();
     await db.run('CREATE TABLE lock_probe (id TEXT PRIMARY KEY)');
@@ -149,15 +150,22 @@ describe('database test isolation', () => {
     const writeTx = await lockHolder.transaction('write');
     await writeTx.execute("INSERT INTO lock_probe VALUES ('uncommitted')");
 
-    try {
-      // Top-level read through the serialized main connection, exactly like Eval.findById.
-      await expect(db.all("SELECT id FROM lock_probe WHERE id = 'committed'")).resolves.toEqual([
-        { id: 'committed' },
-      ]);
-    } finally {
-      await writeTx.rollback();
-      lockHolder.close();
-    }
+    // Top-level read through the serialized main connection (exactly like Eval.findById).
+    // It contends with the held lock; without the retry it rejects immediately with
+    // SQLITE_LOCKED. Capture the outcome so the still-pending read never rejects unhandled.
+    const readOutcome = db
+      .all('SELECT id FROM lock_probe ORDER BY id')
+      .then((rows) => ({ rows }))
+      .catch((error) => ({ error }));
+
+    // Release the lock — discarding the uncommitted row — while the read is still retrying.
+    await sleep(30);
+    await writeTx.rollback();
+    lockHolder.close();
+
+    // The read rode through the lock and observed only the committed row: the retry never
+    // exposed the rolled-back 'uncommitted' write, so isolation stays production-like.
+    expect(await readOutcome).toEqual({ rows: [{ id: 'committed' }] });
 
     await databaseModule.closeDb();
   });


### PR DESCRIPTION
## Summary

Fixes a flaky test surfaced in CI (`test/commands/import.test.ts > importCommand > collision handling > should reject import when eval already exists`, seen on Node 26.x / Windows). The second import's collision check intermittently failed with:

```
Failed to import eval: Failed query: select "id", "created_at", ..., "is_redteam" from "evals" where "evals"."id" = ?
params: eval-WJi-2025-10-01T20:08:11
```

instead of the expected `Eval <id> already exists` message.

## Root cause

The test database is a process-wide shared-cache in-memory libsql DB (`file::memory:?cache=shared`), introduced when we replaced better-sqlite3 with libsql (#9486).

- **Shared-cache mode uses table-level locks.** A read that overlaps another connection's open write transaction fails *immediately* with `SQLITE_LOCKED_SHAREDCACHE`.
- **`busy_timeout` does not cover this** — it only retries `SQLITE_BUSY`, not shared-cache `SQLITE_LOCKED`.
- **libsql runs interactive transactions on separate physical connections**, so the JS-level operation serialization in `serializeTopLevelOperations` cannot guarantee a prior writer's table lock is released the instant its promise settles. On a loaded runner that brief window is enough for `Eval.findById`'s `SELECT ... FROM evals` to hit the lingering lock.

I reproduced the exact error deterministically through the real `getDb()` layer (a top-level read on the main connection while a separate connection holds a write lock on `evals`) — same query text and `SQLITE_LOCKED_SHAREDCACHE` extended code as CI.

## Fix

Retry the transient lock at the serialization layer (`serializeTopLevelOperations`). A statement that fails to acquire its lock never executed, so retrying is safe (no double-applied writes), and it rides through the brief window where a prior writer's transaction connection still holds the table lock after its JS promise settled.

- **Isolation preserved:** unlike disabling read locks (`read_uncommitted`), retrying keeps the test DB production-like — reads still observe only committed rows.
- **Scoped narrowly:** retry wraps only the atomic statement methods (`execute`/`batch`/`migrate`/`executeMultiple`) on the serialized path. The in-transaction bypass is left direct (retrying there would deadlock against the enclosing transaction), and transaction callbacks are not retried (to avoid re-running side effects).
- **Bounded:** up to 10 attempts with capped exponential backoff; only triggers on `SQLITE_BUSY`/`SQLITE_LOCKED`, which is rare in production (WAL file DB) and covered by `busy_timeout` for the writer-vs-writer case.

> Replaces an earlier `PRAGMA read_uncommitted` approach after review feedback that it weakened test isolation by exposing uncommitted rows.

## Regression test

Added a test in `test/database/isolation.test.ts`: an independent connection holds a write lock, a top-level read through the main connection contends with it, the lock is released mid-read, and the read is asserted to succeed seeing **only the committed row**. It fails without the fix (the read rejects immediately with `SQLITE_LOCKED`) and confirms no dirty read with it.

## Verification

- `test/database/isolation.test.ts` — passes with fix; new test fails (`SQLITE_LOCKED`) without it.
- `test/commands/import.test.ts` — passes.
- `test/database/` + `test/models/` + `test/util/database*` — 353 pass (single fork, shuffled).
- `test/commands/` + `test/server/` + `test/util/` — 3253 pass (single fork, shuffled).
- `npm run l`, `npm run f`, and `npx tsc --noEmit` all clean.