### PR TITLE
fix(cli): preflight force imports before collision lookup

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -335,6 +335,30 @@ interface ImportedEvalContext {
   importAuthor: string | undefined;
 }
 
+function prepareImportArtifacts(
+  evalData: any,
+  importV3: boolean,
+): {
+  traces: TraceData[];
+  blobAssets: PreparedBlobAsset[];
+} {
+  const traces = importV3 ? prepareTraces(evalData.traces) : [];
+  const blobAssets =
+    importV3 && Array.isArray(evalData.blobAssets) && evalData.blobAssets.length > 0
+      ? prepareBlobAssets(
+          evalData.blobAssets,
+          // Bound the scan: imported files are untrusted, and deeply
+          // nested JSON would otherwise overflow the stack here.
+          collectBlobHashes(
+            { results: evalData.results, traces },
+            { maxDepth: 64, maxStringLength: 100_000 },
+          ),
+        )
+      : [];
+
+  return { traces, blobAssets };
+}
+
 async function createImportedV3Eval(
   evalData: any,
   traces: TraceData[],
@@ -400,6 +424,37 @@ export function importCommand(program: Command) {
         const importAuthor = extractAuthor(evalData);
         let existingEval: Eval | undefined;
 
+        let formatChecked = false;
+        let importV3 = false;
+        let importLegacy = false;
+        let artifactsPrepared = false;
+        let traces: TraceData[] = [];
+        let blobAssets: PreparedBlobAsset[] = [];
+        const validateImportFormat = () => {
+          if (!formatChecked) {
+            importV3 = isImportableV3Results(evalData.results);
+            importLegacy = isImportableLegacyResults(evalData.results);
+            if (!importV3 && !importLegacy) {
+              throw new Error('Unsupported eval export results format');
+            }
+            formatChecked = true;
+          }
+        };
+        const prepareArtifacts = () => {
+          if (!artifactsPrepared) {
+            validateImportFormat();
+            ({ traces, blobAssets } = prepareImportArtifacts(evalData, importV3));
+            artifactsPrepared = true;
+          }
+        };
+
+        // Validate replacement artifacts before consulting the database. A
+        // transient lock on the eval row should not mask a corrupt import file,
+        // and this preflight has no filesystem or database side effects.
+        if (cmdObj.force) {
+          prepareArtifacts();
+        }
+
         if (importId && !cmdObj.newId) {
           const existing = await Eval.findById(importId);
           if (existing) {
@@ -415,25 +470,7 @@ export function importCommand(program: Command) {
           }
         }
 
-        const importV3 = isImportableV3Results(evalData.results);
-        const importLegacy = isImportableLegacyResults(evalData.results);
-        if (!importV3 && !importLegacy) {
-          throw new Error('Unsupported eval export results format');
-        }
-
-        const traces = importV3 ? prepareTraces(evalData.traces) : [];
-        const blobAssets =
-          importV3 && Array.isArray(evalData.blobAssets) && evalData.blobAssets.length > 0
-            ? prepareBlobAssets(
-                evalData.blobAssets,
-                // Bound the scan: imported files are untrusted, and deeply
-                // nested JSON would otherwise overflow the stack here.
-                collectBlobHashes(
-                  { results: evalData.results, traces },
-                  { maxDepth: 64, maxStringLength: 100_000 },
-                ),
-              )
-            : [];
+        prepareArtifacts();
 
         // Restore embedded media before the destructive replace so a corrupt
         // artifact cannot delete the existing eval. blobAssets is empty for v2.

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
+import { createClient } from '@libsql/client/node';
 import { Command } from 'commander';
 import { sql } from 'drizzle-orm';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -43,6 +44,8 @@ vi.mock('../../src/database/signal', async () => {
     updateSignalFileForDeletedEvals: vi.fn(),
   };
 });
+
+const SHARED_CACHE_MEMORY_URL = 'file::memory:?cache=shared';
 
 describe('importCommand', () => {
   let program: Command;
@@ -1231,9 +1234,21 @@ describe('importCommand', () => {
       vi.clearAllMocks();
       process.exitCode = undefined;
 
-      const program2 = new Command();
-      importCommand(program2);
-      await program2.parseAsync(['node', 'test', 'import', '--force', filePath]);
+      const lockHolder = createClient({ url: SHARED_CACHE_MEMORY_URL });
+      const writeTx = await lockHolder.transaction('write');
+      try {
+        await writeTx.execute({
+          sql: 'UPDATE evals SET description = description WHERE id = ?',
+          args: [sampleData.evalId],
+        });
+
+        const program2 = new Command();
+        importCommand(program2);
+        await program2.parseAsync(['node', 'test', 'import', '--force', filePath]);
+      } finally {
+        await writeTx.rollback().catch(() => undefined);
+        lockHolder.close();
+      }
 
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('Embedded blob hash mismatch'),


### PR DESCRIPTION
## Summary

Preflight `promptfoo import --force` replacement artifacts before checking for an existing eval row. This keeps corrupt replacement exports on the validation path even when the shared-cache test database has a transient lock on `evals`, instead of letting the lock surface as a raw Drizzle query error.

The normal non-`--force` collision behavior is preserved: duplicate imports can still return the existing eval error before deeper artifact validation.

## Root cause

CI run 44368 failed on Windows Node 26 shard 3 when `Eval.findById(importId)` hit a transient shared-cache lock before the corrupt embedded blob in the replacement export was validated. The test expected `Embedded blob hash mismatch`, but the command logged the wrapped `select ... from evals` query error instead.

## Changes

- Extract side-effect-free import artifact preparation into a helper.
- Run that preflight before database collision lookup only for `--force` imports.
- Make the regression deterministic by holding a write lock on `evals` during the corrupt `--force` import test.

## Verification

- `npm run l && npm run f`
- `npx vitest run test/commands/import.test.ts -t "should keep the existing eval when a --force replacement fails preflight" --sequence.shuffle=false`
- `npx vitest run test/commands/import.test.ts --sequence.shuffle=false`
- `npm run tsc`
- `npm test -- --shard=3/3`