### PR TITLE
fix(cloud): resolve on-prem API host correctly in checkEmailStatus, guardrails, and http-provider-generator

### DIFF
--- a/src/globalConfig/accounts.ts
+++ b/src/globalConfig/accounts.ts
@@ -14,6 +14,7 @@ import {
   UserEmailStatus,
 } from '../types/email';
 import { fetchWithTimeout } from '../util/fetch/index';
+import { cloudConfig } from './cloud';
 import { readGlobalConfig, writeGlobalConfig, writeGlobalConfigPartial } from './globalConfig';
 
 import type { GlobalConfig } from '../configTypes';
@@ -192,7 +193,9 @@ export async function checkEmailStatus(options?: {
       logger.info(`Checking email...`);
     }
 
-    const host = getEnvString('PROMPTFOO_CLOUD_API_URL', 'https://api.promptfoo.app');
+    const host = cloudConfig.isEnabled()
+      ? cloudConfig.getApiHost()
+      : getEnvString('PROMPTFOO_CLOUD_API_URL', 'https://api.promptfoo.app');
 
     const resp = await fetchWithTimeout(
       `${host}/api/users/status?email=${encodeURIComponent(userEmail)}${validateParam}`,

--- a/src/guardrails.ts
+++ b/src/guardrails.ts
@@ -1,8 +1,12 @@
 import { fetchWithCache } from './cache';
 import { getShareApiBaseUrl } from './constants';
+import { cloudConfig } from './globalConfig/cloud';
 import logger from './logger';
 
-const API_BASE_URL = `${getShareApiBaseUrl()}/v1`;
+function getApiBaseUrl(): string {
+  const base = cloudConfig.isEnabled() ? cloudConfig.getApiHost() : getShareApiBaseUrl();
+  return `${base}/v1`;
+}
 
 export interface GuardResult {
   model: string;
@@ -40,7 +44,7 @@ export interface AdaptiveResult {
 async function makeRequest(endpoint: string, input: string): Promise<GuardResult> {
   try {
     const response = await fetchWithCache(
-      `${API_BASE_URL}${endpoint}`,
+      `${getApiBaseUrl()}${endpoint}`,
       {
         method: 'POST',
         headers: {
@@ -66,7 +70,7 @@ async function makeRequest(endpoint: string, input: string): Promise<GuardResult
 async function makeAdaptiveRequest(request: AdaptiveRequest): Promise<AdaptiveResult> {
   try {
     const response = await fetchWithCache(
-      `${API_BASE_URL}/adaptive`,
+      `${getApiBaseUrl()}/adaptive`,
       {
         method: 'POST',
         headers: {

--- a/src/server/routes/providers.ts
+++ b/src/server/routes/providers.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { z } from 'zod';
 import { getEnvString } from '../../envars';
+import { cloudConfig } from '../../globalConfig/cloud';
 import logger from '../../logger';
 import { createTransformRequest, createTransformResponse } from '../../providers/httpTransforms';
 import { loadApiProvider } from '../../providers/index';
@@ -146,7 +147,9 @@ providersRouter.post('/http-generator', async (req: Request, res: Response): Pro
     return;
   }
 
-  const HOST = getEnvString('PROMPTFOO_CLOUD_API_URL', 'https://api.promptfoo.app');
+  const HOST = cloudConfig.isEnabled()
+    ? cloudConfig.getApiHost()
+    : getEnvString('PROMPTFOO_CLOUD_API_URL', 'https://api.promptfoo.app');
 
   try {
     logger.debug('[POST /providers/http-generator] Calling HTTP provider generator API', {


### PR DESCRIPTION
  ## Summary
  
  When a Promptfoo on-premises instance is configured via `promptfoo auth login`,
  the API host is saved to the local config file through `CloudConfig.setApiHost()`.
  However, three call-sites ignored the saved config and fell back to the public
  cloud API (`https://api.promptfoo.app`) because they checked only the
  `PROMPTFOO_CLOUD_API_URL` environment variable (or a module-level constant
  evaluated at import time):
  
  - `checkEmailStatus` in `src/globalConfig/accounts.ts` – called on every
    `promptfoo eval` and `promptfoo redteam generate`, so every run produced an
    unexpected request to the public cloud even for on-prem users
  - `src/guardrails.ts` – the base URL was a module-level constant resolved once
    at import time, so `cloudConfig` state was never consulted
  - `/providers/http-generator` route in `src/server/routes/providers.ts` – used
    the env-var-only path, missing the saved config-file host
    
  ## Changes

  | File | Change |
  |---|---|
  | `src/globalConfig/accounts.ts` | `checkEmailStatus` now prefers `cloudConfig.getApiHost()` when `cloudConfig.isEnabled()` |
  | `src/guardrails.ts` | Module-level `API_BASE_URL` constant replaced with `getApiBaseUrl()` function that consults `cloudConfig` at call time |
  | `src/server/routes/providers.ts` | `/api/v1/http-provider-generator` route prefers `cloudConfig.getApiHost()` when cloud is enabled |

  All three sites fall back to the existing `PROMPTFOO_CLOUD_API_URL` env-var /
  `https://api.promptfoo.app` default for non-cloud setups, so there is no
  behaviour change for standard (non-on-prem) users.
  
  ## Test plan
  
  - [x] Existing unit tests pass: `accounts.test.ts` (60 tests), `guardrails.test.ts` (14 tests)
  - [x] On-prem: after `promptfoo auth login --api-host https://your-onprem-host`,
    running `promptfoo eval` no longer sends requests to `api.promptfoo.app` for
    email status, guardrail assertions, or the HTTP provider generator
  - [x] Non-cloud: behaviour unchanged — requests still go to `PROMPTFOO_CLOUD_API_URL`
    env var or `https://api.promptfoo.app` when `cloudConfig` is not enabled