### PR TITLE
fix(redteam): authenticate remote-generation requests against on-prem cloud

### DIFF
--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -3,6 +3,7 @@ import { VERSION } from '../constants';
 import { getUserEmail } from '../globalConfig/accounts';
 import logger from '../logger';
 import {
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   getRemoteGenerationUrlForUnaligned,
   neverGenerateRemote,
@@ -93,9 +94,7 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
         getRemoteGenerationUrlForUnaligned(),
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: getRemoteGenerationHeaders(),
           body: JSON.stringify(body),
           ...(callApiOptions?.abortSignal && { signal: callApiOptions.abortSignal }),
         },
@@ -212,9 +211,7 @@ export class PromptfooChatCompletionProvider implements ApiProvider {
         getRemoteGenerationUrl(),
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: getRemoteGenerationHeaders(),
           body: JSON.stringify(body),
           ...(callApiOptions?.abortSignal && { signal: callApiOptions.abortSignal }),
         },
@@ -330,9 +327,7 @@ export class PromptfooSimulatedUserProvider implements ApiProvider {
         getRemoteGenerationUrl(),
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: getRemoteGenerationHeaders(),
           body: JSON.stringify(body),
           ...(callApiOptions?.abortSignal && { signal: callApiOptions.abortSignal }),
         },

--- a/src/redteam/commands/poison.ts
+++ b/src/redteam/commands/poison.ts
@@ -9,7 +9,7 @@ import logger from '../../logger';
 import telemetry from '../../telemetry';
 import { fetchWithProxy } from '../../util/fetch/index';
 import { setupEnv } from '../../util/index';
-import { getRemoteGenerationUrl } from '../remoteGeneration';
+import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../remoteGeneration';
 import type { Command } from 'commander';
 
 interface PoisonOptions {
@@ -61,9 +61,7 @@ export async function generatePoisonedDocument(
 ): Promise<PoisonResponse> {
   const response = await fetchWithProxy(getRemoteGenerationUrl(), {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: getRemoteGenerationHeaders(),
     body: JSON.stringify({
       task: 'poison-document',
       document,

--- a/src/redteam/extraction/util.ts
+++ b/src/redteam/extraction/util.ts
@@ -7,7 +7,7 @@ import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
-import { getRemoteGenerationUrl } from '../remoteGeneration';
+import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../remoteGeneration';
 
 import type { ApiProvider } from '../../types/index';
 
@@ -52,7 +52,7 @@ export async function fetchRemoteGeneration(
       getRemoteGenerationUrl(),
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getRemoteGenerationHeaders(),
         body: JSON.stringify(body),
       },
       getRequestTimeoutMs(),

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -19,6 +19,7 @@ import {
 import { buildPromptInputDescriptions } from '../inputVariables';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   getRemoteHealthUrl,
   neverGenerateRemote,
@@ -385,9 +386,7 @@ async function fetchRemoteTestCases(
       getRemoteGenerationUrl(),
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: getRemoteGenerationHeaders(),
         body,
       },
       getRequestTimeoutMs(),

--- a/src/redteam/providers/agentic/memoryPoisoning.ts
+++ b/src/redteam/providers/agentic/memoryPoisoning.ts
@@ -5,7 +5,7 @@ import { fetchWithProxy } from '../../../util/fetch/index';
 import invariant from '../../../util/invariant';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../../util/tokenUsageUtils';
 import { REDTEAM_MEMORY_POISONING_PLUGIN_ID } from '../../plugins/agentic/constants';
-import { getRemoteGenerationUrl } from '../../remoteGeneration';
+import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../../remoteGeneration';
 import { throwIfTargetPromptExceedsMaxChars } from '../../shared/promptLength';
 import { messagesToRedteamHistory } from '../shared';
 
@@ -59,7 +59,7 @@ export class MemoryPoisoningProvider implements ApiProvider {
             version: VERSION,
             email: getUserEmail(),
           }),
-          headers: { 'Content-Type': 'application/json' },
+          headers: getRemoteGenerationHeaders(),
           method: 'POST',
         },
         options?.abortSignal,

--- a/src/redteam/providers/authoritativeMarkupInjection.ts
+++ b/src/redteam/providers/authoritativeMarkupInjection.ts
@@ -6,7 +6,11 @@ import { fetchWithProxy } from '../../util/fetch/index';
 import invariant from '../../util/invariant';
 import { safeJsonStringify } from '../../util/json';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
-import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
+import {
+  getRemoteGenerationHeaders,
+  getRemoteGenerationUrl,
+  neverGenerateRemote,
+} from '../remoteGeneration';
 import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
 
 import type {
@@ -79,9 +83,7 @@ export default class AuthoritativeMarkupInjectionProvider implements ApiProvider
       getRemoteGenerationUrl(),
       {
         body,
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: getRemoteGenerationHeaders(),
         method: 'POST',
       },
       options?.abortSignal,

--- a/src/redteam/providers/bestOfN.ts
+++ b/src/redteam/providers/bestOfN.ts
@@ -10,6 +10,7 @@ import invariant from '../../util/invariant';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
@@ -81,9 +82,7 @@ export default class BestOfNProvider implements ApiProvider {
         getRemoteGenerationUrl(),
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: getRemoteGenerationHeaders(),
           body: JSON.stringify({
             task: 'jailbreak:best-of-n',
             prompt: context.vars[this.config.injectVar],

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -16,7 +16,11 @@ import { getNunjucksEngine } from '../../util/templates';
 import { sleep } from '../../util/time';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import { materializeInputVariablesWithMetadata } from '../inputVariables';
-import { getRemoteGenerationUrl, neverGenerateRemote } from '../remoteGeneration';
+import {
+  getRemoteGenerationHeaders,
+  getRemoteGenerationUrl,
+  neverGenerateRemote,
+} from '../remoteGeneration';
 import {
   assertRemoteMaterializationHandled,
   buildRemoteMaterializedInputVariables,
@@ -352,9 +356,7 @@ export default class GoatProvider implements ApiProvider {
             getRemoteGenerationUrl(),
             {
               body,
-              headers: {
-                'Content-Type': 'application/json',
-              },
+              headers: getRemoteGenerationHeaders(),
               method: 'POST',
             },
             options?.abortSignal,
@@ -394,9 +396,7 @@ export default class GoatProvider implements ApiProvider {
           getRemoteGenerationUrl(),
           {
             body,
-            headers: {
-              'Content-Type': 'application/json',
-            },
+            headers: getRemoteGenerationHeaders(),
             method: 'POST',
           },
           options?.abortSignal,

--- a/src/redteam/providers/indirectWebPwn.ts
+++ b/src/redteam/providers/indirectWebPwn.ts
@@ -5,7 +5,7 @@ import logger from '../../logger';
 import { fetchWithRetries } from '../../util/fetch/index';
 import invariant from '../../util/invariant';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
-import { getRemoteGenerationUrl } from '../remoteGeneration';
+import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../remoteGeneration';
 import { getTargetResponse } from './shared';
 
 import type {
@@ -136,7 +136,7 @@ export default class IndirectWebPwnProvider implements ApiProvider {
       url,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getRemoteGenerationHeaders(),
         body: JSON.stringify({
           task: 'create-web-page',
           testCaseId,
@@ -171,7 +171,7 @@ export default class IndirectWebPwnProvider implements ApiProvider {
       url,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getRemoteGenerationHeaders(),
         body: JSON.stringify({
           task: 'get-web-page-tracking',
           uuid,

--- a/src/redteam/remoteGeneration.ts
+++ b/src/redteam/remoteGeneration.ts
@@ -30,6 +30,39 @@ export function getRemoteGenerationUrl(): string {
 }
 
 /**
+ * Builds headers for a remote-generation request.
+ *
+ * Adds `Authorization: Bearer <apiKey>` when the user is logged into cloud AND the
+ * request targets the configured cloud host (incl. on-prem). The global fetch
+ * auth-injection only attaches the token for the public cloud origin, so on-prem
+ * deployments need the header set explicitly (mirrors src/util/cloud.ts / share.ts).
+ *
+ * The token is intentionally NOT added when `PROMPTFOO_REMOTE_GENERATION_URL` is set,
+ * since that env var redirects remote generation to a (possibly third-party)
+ * self-hosted endpoint that must not receive the Promptfoo Cloud credential.
+ */
+export function getRemoteGenerationHeaders(
+  extraHeaders?: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...extraHeaders,
+  };
+
+  if (!getEnvString('PROMPTFOO_REMOTE_GENERATION_URL')) {
+    const cloudConfig = new CloudConfig();
+    if (cloudConfig.isEnabled()) {
+      const apiKey = cloudConfig.getApiKey();
+      if (apiKey) {
+        headers.Authorization = `Bearer ${apiKey}`;
+      }
+    }
+  }
+
+  return headers;
+}
+
+/**
  * Check if remote generation should never be used.
  * Respects both the general and redteam-specific disable flags.
  * @returns true if remote generation is disabled

--- a/src/redteam/strategies/citation.ts
+++ b/src/redteam/strategies/citation.ts
@@ -8,6 +8,7 @@ import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
@@ -65,9 +66,7 @@ async function generateCitations(
         getRemoteGenerationUrl(),
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: getRemoteGenerationHeaders(),
           body: JSON.stringify(payload),
         },
         getRequestTimeoutMs(),

--- a/src/redteam/strategies/gcg.ts
+++ b/src/redteam/strategies/gcg.ts
@@ -7,6 +7,7 @@ import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
@@ -64,10 +65,9 @@ async function generateGcgPrompts(
         getRemoteGenerationUrl(),
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
+          headers: getRemoteGenerationHeaders({
             'x-promptfoo-silent': 'true',
-          },
+          }),
           body: JSON.stringify(payload),
         },
         getRequestTimeoutMs(),

--- a/src/redteam/strategies/indirectWebPwn.ts
+++ b/src/redteam/strategies/indirectWebPwn.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { fetchWithRetries } from '../../util/fetch/index';
-import { getRemoteGenerationUrl } from '../remoteGeneration';
+import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../remoteGeneration';
 
 import type { TestCase, TestCaseWithPlugin } from '../../types/index';
 import type {
@@ -117,7 +117,7 @@ export async function checkExfilTracking(
       url,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getRemoteGenerationHeaders(),
         body: JSON.stringify({
           task: 'get-web-page-tracking',
           uuid,
@@ -236,7 +236,7 @@ async function createWebPage(
     url,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: getRemoteGenerationHeaders(),
       body: JSON.stringify({
         task: 'create-web-page',
         testCaseId,
@@ -289,7 +289,7 @@ async function updateWebPage(
     url,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: getRemoteGenerationHeaders(),
       body: JSON.stringify({
         task: 'update-web-page',
         uuid,

--- a/src/redteam/strategies/likert.ts
+++ b/src/redteam/strategies/likert.ts
@@ -7,6 +7,7 @@ import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
@@ -61,9 +62,7 @@ async function generateLikertPrompts(
         getRemoteGenerationUrl(),
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: getRemoteGenerationHeaders(),
           body: JSON.stringify(payload),
         },
         getRequestTimeoutMs(),

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -8,7 +8,11 @@ import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import { extractFirstJsonObject } from '../../util/json';
 import { redteamProviderManager } from '../providers/shared';
-import { getRemoteGenerationUrl, shouldGenerateRemote } from '../remoteGeneration';
+import {
+  getRemoteGenerationHeaders,
+  getRemoteGenerationUrl,
+  shouldGenerateRemote,
+} from '../remoteGeneration';
 
 import type { TestCase } from '../../types/index';
 
@@ -67,9 +71,7 @@ export async function generateMathPrompt(
         getRemoteGenerationUrl(),
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: getRemoteGenerationHeaders(),
           body: JSON.stringify(payload),
         },
         getRequestTimeoutMs(),

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -10,7 +10,11 @@ import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import { redteamProviderManager } from '../providers/shared';
-import { getRemoteGenerationUrl, shouldGenerateRemote } from '../remoteGeneration';
+import {
+  getRemoteGenerationHeaders,
+  getRemoteGenerationUrl,
+  shouldGenerateRemote,
+} from '../remoteGeneration';
 
 import type { TestCase } from '../../types/index';
 
@@ -135,9 +139,7 @@ async function processRemoteChunk(
     getRemoteGenerationUrl(),
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getRemoteGenerationHeaders(),
       body: JSON.stringify(payload),
     },
     getRequestTimeoutMs(),

--- a/src/redteam/strategies/simpleAudio.ts
+++ b/src/redteam/strategies/simpleAudio.ts
@@ -8,6 +8,7 @@ import { isMediaStorageEnabled, storeMedia } from '../../storage';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
@@ -58,7 +59,7 @@ export async function textToAudio(
       getRemoteGenerationUrl(),
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getRemoteGenerationHeaders(),
         body: JSON.stringify(payload),
       },
       getRequestTimeoutMs(),

--- a/src/redteam/strategies/singleTurnComposite.ts
+++ b/src/redteam/strategies/singleTurnComposite.ts
@@ -7,6 +7,7 @@ import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
@@ -78,9 +79,7 @@ async function generateCompositePrompts(
         getRemoteGenerationUrl(),
         {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
+          headers: getRemoteGenerationHeaders(),
           body: JSON.stringify(payload),
         },
         getRequestTimeoutMs(),

--- a/src/redteam/util.ts
+++ b/src/redteam/util.ts
@@ -12,7 +12,11 @@ import {
   materializeInputVariables,
   materializeInputVariablesWithMetadata,
 } from './inputVariables';
-import { getRemoteGenerationUrl, neverGenerateRemote } from './remoteGeneration';
+import {
+  getRemoteGenerationHeaders,
+  getRemoteGenerationUrl,
+  neverGenerateRemote,
+} from './remoteGeneration';
 
 import type { CallApiContextParams, ProviderResponse } from '../types/index';
 
@@ -379,9 +383,7 @@ export async function extractGoalFromPrompt(
       getRemoteGenerationUrl(),
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: getRemoteGenerationHeaders(),
         body: JSON.stringify(requestBody),
       },
       getRequestTimeoutMs(),

--- a/src/remoteGrading.ts
+++ b/src/remoteGrading.ts
@@ -2,7 +2,7 @@ import { fetchWithCache } from './cache';
 import { getUserEmail } from './globalConfig/accounts';
 import logger from './logger';
 import { getRequestTimeoutMs } from './providers/shared';
-import { getRemoteGenerationUrl } from './redteam/remoteGeneration';
+import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from './redteam/remoteGeneration';
 
 import type { GradingResult } from './types/index';
 
@@ -22,9 +22,7 @@ export async function doRemoteGrading(
       getRemoteGenerationUrl(),
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: getRemoteGenerationHeaders(),
         body,
       },
       getRequestTimeoutMs(),

--- a/src/server/routes/redteam.ts
+++ b/src/server/routes/redteam.ts
@@ -11,7 +11,11 @@ import {
 } from '../../redteam/constants';
 import { PluginFactory, Plugins } from '../../redteam/plugins/index';
 import { redteamProviderManager } from '../../redteam/providers/shared';
-import { getRemoteGenerationUrl, neverGenerateRemote } from '../../redteam/remoteGeneration';
+import {
+  getRemoteGenerationHeaders,
+  getRemoteGenerationUrl,
+  neverGenerateRemote,
+} from '../../redteam/remoteGeneration';
 import { doRedteamRun } from '../../redteam/shared';
 import { Strategies } from '../../redteam/strategies/index';
 import { type Strategy as StrategyFactory } from '../../redteam/strategies/types';
@@ -367,9 +371,7 @@ redteamRouter.post('/:taskId', async (req: Request, res: Response): Promise<void
     logger.debug(`Sending request to cloud function: ${cloudFunctionUrl}`);
     const response = await fetchWithProxy(cloudFunctionUrl, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getRemoteGenerationHeaders(),
       body: JSON.stringify({
         ...bodyResult.data,
         task: taskId,

--- a/src/server/services/redteamTestCaseGenerationService.ts
+++ b/src/server/services/redteamTestCaseGenerationService.ts
@@ -6,7 +6,11 @@ import {
   type MultiTurnStrategy,
   type Plugin,
 } from '../../redteam/constants';
-import { getRemoteGenerationUrl, neverGenerateRemote } from '../../redteam/remoteGeneration';
+import {
+  getRemoteGenerationHeaders,
+  getRemoteGenerationUrl,
+  neverGenerateRemote,
+} from '../../redteam/remoteGeneration';
 import { sha256 } from '../../util/createHash';
 import { fetchWithRetries } from '../../util/fetch/index';
 import { extractFirstJsonObject } from '../../util/json';
@@ -263,9 +267,7 @@ async function handleGoatStrategy(
     getRemoteGenerationUrl(),
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getRemoteGenerationHeaders(),
       body: JSON.stringify(goatBody),
     },
     getRequestTimeoutMs(),
@@ -319,9 +321,7 @@ async function handleMischievousUserStrategy(
     getRemoteGenerationUrl(),
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getRemoteGenerationHeaders(),
       body: JSON.stringify(mischievousBody),
     },
     getRequestTimeoutMs(),
@@ -433,9 +433,7 @@ async function handleHydraStrategy(
     getRemoteGenerationUrl(),
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getRemoteGenerationHeaders(),
       body: JSON.stringify(hydraBody),
     },
     getRequestTimeoutMs(),
@@ -520,9 +518,7 @@ async function handleCrescendoLikeStrategy(
     getRemoteGenerationUrl(),
     {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: getRemoteGenerationHeaders(),
       body: JSON.stringify(providerRequest),
     },
     getRequestTimeoutMs(),

--- a/test/redteam/plugins/intent.test.ts
+++ b/test/redteam/plugins/intent.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../../src/cache', () => ({
 vi.mock('../../../src/redteam/remoteGeneration', () => ({
   getRemoteGenerationUrl: vi.fn().mockReturnValue('http://test.com'),
   neverGenerateRemote: vi.fn().mockReturnValue(false),
+  getRemoteGenerationHeaders: vi.fn((extra) => ({ 'Content-Type': 'application/json', ...extra })),
 }));
 
 vi.mock('../../../src/database', async (importOriginal) => {

--- a/test/redteam/providers/authoritativeMarkupInjection.test.ts
+++ b/test/redteam/providers/authoritativeMarkupInjection.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../../src/globalConfig/accounts', () => ({
 
 vi.mock('../../../src/redteam/remoteGeneration', () => ({
   getRemoteGenerationUrl: vi.fn().mockReturnValue('http://test.api/generate'),
+  getRemoteGenerationHeaders: vi.fn((extra) => ({ 'Content-Type': 'application/json', ...extra })),
   neverGenerateRemote: vi.fn().mockReturnValue(false),
 }));
 

--- a/test/redteam/providers/bestOfN.test.ts
+++ b/test/redteam/providers/bestOfN.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../../src/redteam/remoteGeneration', () => ({
     (strategyName) =>
       `${strategyName} requires remote generation, which has been explicitly disabled.`,
   ),
+  getRemoteGenerationHeaders: vi.fn((extra) => ({ 'Content-Type': 'application/json', ...extra })),
   getRemoteGenerationUrl: vi.fn().mockReturnValue('http://test.api/generate'),
   neverGenerateRemote: vi.fn().mockReturnValue(false),
 }));

--- a/test/redteam/remoteGeneration.test.ts
+++ b/test/redteam/remoteGeneration.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import cliState from '../../src/cliState';
 import { getEnvBool, getEnvString } from '../../src/envars';
 import { isLoggedIntoCloud } from '../../src/globalConfig/accounts';
@@ -7,6 +7,7 @@ import { hasCodexDefaultCredentials } from '../../src/providers/openai/codexDefa
 import {
   getRemoteGenerationDisabledError,
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   getRemoteGenerationUrlForUnaligned,
   getRemoteHealthUrl,
@@ -493,5 +494,52 @@ describe('getRemoteGenerationUrlForUnaligned', () => {
     expect(getRemoteGenerationUrlForUnaligned()).toBe(
       'https://api.promptfoo.app/api/v1/task/harmful',
     );
+  });
+});
+
+describe('getRemoteGenerationHeaders', () => {
+  beforeEach(() => {
+    vi.stubEnv('PROMPTFOO_API_KEY', '');
+    vi.mocked(getEnvString).mockReturnValue('');
+    vi.mocked(readGlobalConfig).mockReturnValue({} as any);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('adds a bearer token when cloud is enabled and there is no remote-generation override', () => {
+    vi.mocked(readGlobalConfig).mockReturnValue({
+      cloud: { apiKey: 'test-cloud-key', apiHost: 'https://onprem.example.com' },
+    } as any);
+
+    expect(getRemoteGenerationHeaders()).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-cloud-key',
+    });
+  });
+
+  it('does NOT add a token when PROMPTFOO_REMOTE_GENERATION_URL is set (self-hosted override)', () => {
+    vi.mocked(readGlobalConfig).mockReturnValue({
+      cloud: { apiKey: 'test-cloud-key' },
+    } as any);
+    vi.mocked(getEnvString).mockImplementation((key: string) =>
+      key === 'PROMPTFOO_REMOTE_GENERATION_URL' ? 'https://self-hosted.example.com/task' : '',
+    );
+
+    const headers = getRemoteGenerationHeaders();
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('does NOT add a token when cloud is not enabled', () => {
+    expect(getRemoteGenerationHeaders().Authorization).toBeUndefined();
+  });
+
+  it('preserves caller-supplied extra headers', () => {
+    expect(getRemoteGenerationHeaders({ 'X-Custom': 'value' })).toMatchObject({
+      'Content-Type': 'application/json',
+      'X-Custom': 'value',
+    });
   });
 });

--- a/test/redteam/strategies/citation.test.ts
+++ b/test/redteam/strategies/citation.test.ts
@@ -4,6 +4,7 @@ import { getUserEmail } from '../../../src/globalConfig/accounts';
 import logger from '../../../src/logger';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../../../src/redteam/remoteGeneration';
@@ -40,6 +41,10 @@ describe('citation strategy', () => {
     mockGetUserEmail.mockReturnValue('test@example.com');
     mockNeverGenerateRemote.mockReturnValue(false);
     mockGetRemoteGenerationUrl.mockReturnValue('http://test-url');
+    vi.mocked(getRemoteGenerationHeaders).mockImplementation((extra) => ({
+      'Content-Type': 'application/json',
+      ...extra,
+    }));
     mockGetRemoteGenerationExplicitlyDisabledError.mockImplementation(
       (strategyName) =>
         `${strategyName} requires remote generation, which has been explicitly disabled.`,

--- a/test/redteam/strategies/gcg.test.ts
+++ b/test/redteam/strategies/gcg.test.ts
@@ -4,6 +4,7 @@ import { getUserEmail, isLoggedIntoCloud } from '../../../src/globalConfig/accou
 import logger from '../../../src/logger';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../../../src/redteam/remoteGeneration';
@@ -55,6 +56,10 @@ describe('gcg strategy', () => {
     mockIsLoggedIntoCloud.mockReturnValue(true);
     mockNeverGenerateRemote.mockReturnValue(false);
     mockGetRemoteGenerationUrl.mockReturnValue('http://test-url');
+    vi.mocked(getRemoteGenerationHeaders).mockImplementation((extra) => ({
+      'Content-Type': 'application/json',
+      ...extra,
+    }));
     mockGetRemoteGenerationExplicitlyDisabledError.mockImplementation(
       (strategyName) =>
         `${strategyName} requires remote generation, which has been explicitly disabled.`,

--- a/test/redteam/strategies/likert.test.ts
+++ b/test/redteam/strategies/likert.test.ts
@@ -5,6 +5,7 @@ import { getUserEmail } from '../../../src/globalConfig/accounts';
 import logger from '../../../src/logger';
 import {
   getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../../../src/redteam/remoteGeneration';
@@ -45,6 +46,10 @@ describe('likert strategy', () => {
     vi.mocked(getRemoteGenerationUrl).mockImplementation(function () {
       return 'http://test.com';
     });
+    vi.mocked(getRemoteGenerationHeaders).mockImplementation((extra) => ({
+      'Content-Type': 'application/json',
+      ...extra,
+    }));
     vi.mocked(getRemoteGenerationExplicitlyDisabledError).mockImplementation(
       (strategyName) =>
         `${strategyName} requires remote generation, which has been explicitly disabled.`,

--- a/test/server/services/redteamTestCaseGenerationService.test.ts
+++ b/test/server/services/redteamTestCaseGenerationService.test.ts
@@ -31,6 +31,10 @@ function mockRemoteGeneration(responseBody: unknown, rejectWith?: Error) {
   }));
   vi.doMock('../../../src/redteam/remoteGeneration', async () => ({
     getRemoteGenerationUrl: vi.fn().mockReturnValue(await getExpectedRemoteGenerationUrl()),
+    getRemoteGenerationHeaders: vi.fn((extra) => ({
+      'Content-Type': 'application/json',
+      ...extra,
+    })),
     neverGenerateRemote: vi.fn().mockReturnValue(false),
   }));
   vi.doMock('../../../src/providers/shared', () => ({


### PR DESCRIPTION
## Summary

Follow-up from the on-prem audit done alongside #9580. **Remote-generation and grading
requests are unauthenticated against on-prem cloud deployments.**

These ~24 call sites POST to `cloudConfig.getApiHost()` (the configured cloud/on-prem host)
but rely on the global fetch auth-injection to attach the bearer token — and that injection
only fires for the **public** cloud origin:

```ts
// src/util/fetch/monkeyPatchFetch.ts
export function isPromptfooCloudApiHost(url) {
  return new URL(url).origin === CLOUD_API_HOST; // hard-coded https://api.promptfoo.app
}
```

So on an authenticated on-prem deployment, redteam generation / grading / strategies fire
**without `Authorization`** and the server 401s. (The same class of bug for guardrails and the
HTTP provider generator was fixed in #9580.)

## Fix

- New shared helper `getRemoteGenerationHeaders()` in `src/redteam/remoteGeneration.ts`:
  attaches `Authorization: Bearer <apiKey>` when cloud is enabled **and** the request targets
  the configured cloud host — and **not** when `PROMPTFOO_REMOTE_GENERATION_URL` redirects to a
  (possibly third-party) self-hosted endpoint. Mirrors the per-call-site pattern in
  `share.ts` / `util/cloud.ts`.
- Migrated all remote-generation fetch call sites (grading, plugins, strategies, redteam
  providers, server routes/services) to use it. Bodies/URLs/methods unchanged; the one call
  with an extra header (`gcg.ts`'s `x-promptfoo-silent`) routes it through the helper arg.

### Why per-call-site (not broadening the global gate)
Broadening `isPromptfooCloudApiHost` to also match `getApiHost()` would be ~2 lines, but
`src/providers/http.ts` routes **user-controlled** provider-target URLs through the same
monkeypatched fetch — so broadening would attach the cloud bearer token to a provider target
that happens to share the on-prem origin. Per-call-site auth is precise and leak-free.

## Test plan

- [x] `tsc --noEmit` clean; Biome lint clean (the 6 `noExcessiveCognitiveComplexity` warnings are pre-existing on untouched functions)
- [x] **2563 tests pass** across the redteam / providers / server suites (added a 4-case unit suite for the helper; updated 7 module-mock test files so the mocked helper faithfully returns the disabled-cloud headers)
- [x] **End-to-end**: `doRemoteGrading` against a mock on-prem host POSTs to `/api/v1/task` with `Authorization: Bearer <key>`; with `PROMPTFOO_REMOTE_GENERATION_URL` set, no token is sent

## Scope notes

- The generic `checkRemoteHealth(url)` (`src/util/apiHealth.ts`) is intentionally left
  unauthenticated: it accepts an arbitrary URL and health endpoints are typically anonymous;
  blanket-attaching the token there could leak it to non-cloud URLs.
- `src/redteam/commands/discover.ts` already sent the bearer explicitly — unchanged.