### PR TITLE
feat(providers): add OpenAI GPT-5.5/5.4 frontier models + Codex on Amazon Bedrock

### DIFF
--- a/examples/amazon-bedrock/models/README.md
+++ b/examples/amazon-bedrock/models/README.md
@@ -38,6 +38,7 @@ This directory contains several example configurations for different Bedrock mod
 
 - [`promptfooconfig.claude.yaml`](promptfooconfig.claude.yaml) - Claude 4.6 Opus, Claude 4.1 Opus, Claude 4 Opus/Sonnet, Claude Haiku 4.5
 - [`promptfooconfig.openai.yaml`](promptfooconfig.openai.yaml) - OpenAI GPT-OSS models (120B and 20B) with reasoning effort
+- [`promptfooconfig.openai-frontier.yaml`](promptfooconfig.openai-frontier.yaml) - OpenAI frontier models (GPT-5.5 and GPT-5.4) with native reasoning effort and `showThinking`
 - [`promptfooconfig.llama.yaml`](promptfooconfig.llama.yaml) - Llama3
 - [`promptfooconfig.mistral.yaml`](promptfooconfig.mistral.yaml) - Mistral
 - [`promptfooconfig.nova.yaml`](promptfooconfig.nova.yaml) - Amazon's Nova models
@@ -239,6 +240,27 @@ Run the OpenAI example with:
 
 ```bash
 promptfoo eval -c examples/amazon-bedrock/models/promptfooconfig.openai.yaml
+```
+
+## OpenAI Frontier Models Example
+
+The frontier example (`promptfooconfig.openai-frontier.yaml`) demonstrates OpenAI's GPT-5.x frontier models on Bedrock:
+
+- **openai.gpt-5.5** - Flagship frontier reasoning model (available in `us-east-2`)
+- **openai.gpt-5.4** - Frontier reasoning model (available in `us-east-2` and `us-west-2`)
+
+### Key Features
+
+- **Native Reasoning Effort**: `reasoning_effort` is sent as a native request field; frontier models also support `minimal` and `none` in addition to `low`/`medium`/`high`
+- **`showThinking`**: Set `showThinking: false` to strip the `<reasoning>...</reasoning>` block and assert against the final answer only
+- **Region-gated**: Request model access in a supported region before running
+
+These are the same model IDs that back OpenAI's [Codex](https://developers.openai.com/codex/) coding agent when it is configured with the `amazon-bedrock` provider.
+
+Run the frontier example with:
+
+```bash
+promptfoo eval -c examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
 ```
 
 ## New Converse API Features (SDK 3.943+)

--- a/examples/amazon-bedrock/models/README.md
+++ b/examples/amazon-bedrock/models/README.md
@@ -38,7 +38,7 @@ This directory contains several example configurations for different Bedrock mod
 
 - [`promptfooconfig.claude.yaml`](promptfooconfig.claude.yaml) - Claude 4.6 Opus, Claude 4.1 Opus, Claude 4 Opus/Sonnet, Claude Haiku 4.5
 - [`promptfooconfig.openai.yaml`](promptfooconfig.openai.yaml) - OpenAI GPT-OSS models (120B and 20B) with reasoning effort
-- [`promptfooconfig.openai-frontier.yaml`](promptfooconfig.openai-frontier.yaml) - OpenAI frontier models (GPT-5.5 and GPT-5.4) with native reasoning effort and `showThinking`
+- [`promptfooconfig.openai-frontier.yaml`](promptfooconfig.openai-frontier.yaml) - OpenAI frontier models (GPT-5.5 and GPT-5.4) with native reasoning effort
 - [`promptfooconfig.llama.yaml`](promptfooconfig.llama.yaml) - Llama3
 - [`promptfooconfig.mistral.yaml`](promptfooconfig.mistral.yaml) - Mistral
 - [`promptfooconfig.nova.yaml`](promptfooconfig.nova.yaml) - Amazon's Nova models

--- a/examples/amazon-bedrock/models/README.md
+++ b/examples/amazon-bedrock/models/README.md
@@ -251,9 +251,15 @@ The frontier example (`promptfooconfig.openai-frontier.yaml`) demonstrates OpenA
 
 ### Key Features
 
-- **Native Reasoning Effort**: `reasoning_effort` is sent as a native request field; frontier models also support `minimal` and `none` in addition to `low`/`medium`/`high`
-- **`showThinking`**: Set `showThinking: false` to strip the `<reasoning>...</reasoning>` block and assert against the final answer only
-- **Region-gated**: Request model access in a supported region before running
+- **Responses API**: Frontier models are served through Bedrock's OpenAI-compatible Responses API (the mantle endpoint), not `InvokeModel`. promptfoo routes `bedrock:openai.gpt-5.x` there automatically, so output matches the `openai:responses` provider.
+- **Bedrock API key auth**: Unlike the gpt-oss models (AWS SDK credentials), the frontier models authenticate with an Amazon Bedrock API key. Export it first:
+
+  ```bash
+  export AWS_BEARER_TOKEN_BEDROCK="your_bedrock_api_key"
+  ```
+
+- **Native Reasoning Effort**: `reasoning_effort` supports `minimal`, `low`, `medium`, and `high`.
+- **Region-gated**: Request model access in a supported region before running.
 
 These are the same model IDs that back OpenAI's [Codex](https://developers.openai.com/codex/) coding agent when it is configured with the `amazon-bedrock` provider.
 

--- a/examples/amazon-bedrock/models/README.md
+++ b/examples/amazon-bedrock/models/README.md
@@ -258,7 +258,7 @@ The frontier example (`promptfooconfig.openai-frontier.yaml`) demonstrates OpenA
   export AWS_BEARER_TOKEN_BEDROCK="your_bedrock_api_key"
   ```
 
-- **Native Reasoning Effort**: `reasoning_effort` supports `minimal`, `low`, `medium`, and `high`.
+- **Native Reasoning Effort**: `reasoning_effort` supports `none`, `low`, `medium`, `high`, and `xhigh` (`minimal` is not supported by these Bedrock models).
 - **Region-gated**: Request model access in a supported region before running.
 
 These are the same model IDs that back OpenAI's [Codex](https://developers.openai.com/codex/) coding agent when it is configured with the `amazon-bedrock` provider.

--- a/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
+++ b/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
@@ -23,11 +23,12 @@ providers:
       max_output_tokens: 2048
   # GPT-5.4 is available in us-east-2 (Ohio) and us-west-2 (Oregon).
   - id: bedrock:openai.gpt-5.4
-    label: GPT-5.4 (minimal reasoning)
+    label: GPT-5.4 (low reasoning)
     config:
       region: us-east-2
       apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}'
-      reasoning_effort: minimal
+      # Valid: none | low | medium | high | xhigh (minimal is NOT supported)
+      reasoning_effort: low
       max_output_tokens: 1024
 
 tests:

--- a/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
+++ b/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'OpenAI frontier models (GPT-5.5 / GPT-5.4) via AWS Bedrock'
+
+prompts:
+  - |
+    Answer the following question concisely and accurately.
+
+    Question: {{question}}
+
+providers:
+  # GPT-5.5 is available in us-east-2 (Ohio).
+  - id: bedrock:openai.gpt-5.5
+    label: GPT-5.5 (high reasoning)
+    config:
+      region: us-east-2
+      max_completion_tokens: 2048
+      reasoning_effort: high
+      # Strip the <reasoning>...</reasoning> block so assertions run against the
+      # final answer only. Set to true to keep the model's chain-of-thought.
+      showThinking: false
+  # GPT-5.4 is available in us-east-2 (Ohio) and us-west-2 (Oregon).
+  - id: bedrock:openai.gpt-5.4
+    label: GPT-5.4 (minimal reasoning)
+    config:
+      region: us-east-2
+      max_completion_tokens: 1024
+      reasoning_effort: minimal
+      showThinking: false
+
+tests:
+  - vars:
+      question: What is the capital of France? Reply with only the city name.
+    assert:
+      - type: icontains
+        value: Paris
+  - vars:
+      question: 'If a train travels 120 miles in 2 hours, what is its average speed in mph? Reply with just the number and unit.'
+    assert:
+      - type: contains
+        value: '60'
+      - type: icontains-any
+        value: ['mph', 'miles per hour']
+  - vars:
+      question: 'Explain the concept of machine learning in two sentences.'
+    assert:
+      - type: llm-rubric
+        value: 'Response clearly and accurately explains machine learning in roughly two sentences.'

--- a/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
+++ b/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
@@ -47,5 +47,8 @@ tests:
   - vars:
       question: 'Explain the concept of machine learning in two sentences.'
     assert:
-      - type: llm-rubric
-        value: 'Response clearly and accurately explains machine learning in roughly two sentences.'
+      # Deterministic assertions keep this example runnable with only a Bedrock API key.
+      # (A model-graded assertion like `llm-rubric` would require a separate grader provider
+      # with its own credentials — see https://promptfoo.dev/docs/configuration/expected-outputs/model-graded/)
+      - type: icontains-any
+        value: ['data', 'model', 'train', 'learn', 'pattern']

--- a/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
+++ b/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
@@ -2,7 +2,8 @@
 description: 'OpenAI frontier models (GPT-5.5 / GPT-5.4) via AWS Bedrock'
 
 # Frontier models are served through Bedrock's OpenAI-compatible Responses API and
-# authenticate with an Amazon Bedrock API key. Export it before running:
+# authenticate with an Amazon Bedrock API key. Export it before running (promptfoo reads it
+# automatically — no apiKey field needed):
 #   export AWS_BEARER_TOKEN_BEDROCK="..."
 
 prompts:
@@ -18,7 +19,6 @@ providers:
     label: GPT-5.5 (high reasoning)
     config:
       region: us-east-2
-      apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}'
       reasoning_effort: high
       max_output_tokens: 2048
   # GPT-5.4 is available in us-east-2 (Ohio) and us-west-2 (Oregon).
@@ -26,7 +26,6 @@ providers:
     label: GPT-5.4 (low reasoning)
     config:
       region: us-east-2
-      apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}'
       # Valid: none | low | medium | high | xhigh (minimal is NOT supported)
       reasoning_effort: low
       max_output_tokens: 1024

--- a/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
+++ b/examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml
@@ -1,6 +1,10 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 description: 'OpenAI frontier models (GPT-5.5 / GPT-5.4) via AWS Bedrock'
 
+# Frontier models are served through Bedrock's OpenAI-compatible Responses API and
+# authenticate with an Amazon Bedrock API key. Export it before running:
+#   export AWS_BEARER_TOKEN_BEDROCK="..."
+
 prompts:
   - |
     Answer the following question concisely and accurately.
@@ -8,24 +12,23 @@ prompts:
     Question: {{question}}
 
 providers:
-  # GPT-5.5 is available in us-east-2 (Ohio).
+  # GPT-5.5 is available in us-east-2 (Ohio). promptfoo routes bedrock:openai.gpt-5.x to
+  # the OpenAI-compatible Responses API on the regional Bedrock mantle endpoint.
   - id: bedrock:openai.gpt-5.5
     label: GPT-5.5 (high reasoning)
     config:
       region: us-east-2
-      max_completion_tokens: 2048
+      apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}'
       reasoning_effort: high
-      # Strip the <reasoning>...</reasoning> block so assertions run against the
-      # final answer only. Set to true to keep the model's chain-of-thought.
-      showThinking: false
+      max_output_tokens: 2048
   # GPT-5.4 is available in us-east-2 (Ohio) and us-west-2 (Oregon).
   - id: bedrock:openai.gpt-5.4
     label: GPT-5.4 (minimal reasoning)
     config:
       region: us-east-2
-      max_completion_tokens: 1024
+      apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}'
       reasoning_effort: minimal
-      showThinking: false
+      max_output_tokens: 1024
 
 tests:
   - vars:

--- a/examples/openai-codex-sdk/README.md
+++ b/examples/openai-codex-sdk/README.md
@@ -129,6 +129,20 @@ This example runs Codex in `read-only` mode and asks it to create a file. The as
 
 If you run this config from the repo root, set `CODEX_SANDBOX_WORKING_DIR="$PWD/examples/openai-codex-sdk/sandbox/sample-workspace"`.
 
+### Run on Amazon Bedrock
+
+This example runs Codex against OpenAI frontier models hosted on Amazon Bedrock by setting `model_provider: amazon-bedrock` with a Bedrock model id (`openai.gpt-5.5`). It requires AWS credentials and Bedrock model access in a supported Region (`us-east-2` for GPT-5.5).
+
+**Location**: `./bedrock/`
+
+**Usage**:
+
+```bash
+(cd bedrock && promptfoo eval)
+```
+
+Export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` first; they are forwarded to the Codex CLI via `config.cli_env`.
+
 ## Key Features
 
 - **Thread Persistence**: Conversations saved to `~/.codex/sessions`

--- a/examples/openai-codex-sdk/bedrock/README.md
+++ b/examples/openai-codex-sdk/bedrock/README.md
@@ -1,0 +1,53 @@
+# openai-codex-sdk/bedrock (Codex SDK on Amazon Bedrock)
+
+Runs OpenAI's Codex coding agent against OpenAI frontier models hosted on **Amazon Bedrock**
+(`openai.gpt-5.5` / `openai.gpt-5.4`) instead of the OpenAI Platform.
+
+You can run this example with:
+
+```bash
+npx promptfoo@latest init --example openai-codex-sdk/bedrock
+```
+
+## Prerequisites
+
+1. Install the Codex SDK:
+
+   ```bash
+   npm install @openai/codex-sdk
+   ```
+
+2. Request access to the OpenAI frontier models in a supported AWS Region:
+   - GPT-5.5: `us-east-2`
+   - GPT-5.4: `us-east-2`, `us-west-2`
+
+3. Export AWS credentials (the Codex CLI reads them from its environment):
+
+   ```bash
+   export AWS_ACCESS_KEY_ID="your_access_key"
+   export AWS_SECRET_ACCESS_KEY="your_secret_key"
+   ```
+
+## How it works
+
+- `model_provider: amazon-bedrock` routes Codex through Bedrock's OpenAI-compatible
+  endpoint (`https://bedrock-mantle.<region>.api.aws/openai/v1`).
+- `model: openai.gpt-5.5` uses the Bedrock model id (note the `openai.` prefix).
+- AWS credentials and `AWS_REGION` are forwarded to the Codex CLI via `cli_env` because
+  promptfoo runs the CLI with a minimal environment by default. You may instead set
+  `AWS_BEARER_TOKEN_BEDROCK` (a Bedrock API key), `AWS_PROFILE`, or
+  `inherit_process_env: true`.
+
+> **Security note:** values placed in `cli_env` are exposed to the Codex agent's shell
+> environment. Scope the IAM permissions to Bedrock inference and prefer short-lived
+> credentials.
+
+For direct (non-agentic) inference against the same models, use the
+[`bedrock:` provider](https://www.promptfoo.dev/docs/providers/aws-bedrock/#openai-models)
+(`bedrock:openai.gpt-5.5`).
+
+## Run it
+
+```bash
+promptfoo eval -c examples/openai-codex-sdk/bedrock/promptfooconfig.yaml
+```

--- a/examples/openai-codex-sdk/bedrock/README.md
+++ b/examples/openai-codex-sdk/bedrock/README.md
@@ -43,6 +43,11 @@ npx promptfoo@latest init --example openai-codex-sdk/bedrock
 > environment. Scope the IAM permissions to Bedrock inference and prefer short-lived
 > credentials.
 
+> **Heads up:** export the AWS credentials before running. If `AWS_ACCESS_KEY_ID` /
+> `AWS_SECRET_ACCESS_KEY` are unset, the unresolved `{{env.*}}` template is forwarded to the
+> Codex CLI verbatim, and you'll get an opaque AWS auth error (e.g. `UnrecognizedClientException`)
+> rather than a clear "credentials not set" message.
+
 For direct (non-agentic) inference against the same models, use the
 [`bedrock:` provider](https://www.promptfoo.dev/docs/providers/aws-bedrock/#openai-models)
 (`bedrock:openai.gpt-5.5`).

--- a/examples/openai-codex-sdk/bedrock/README.md
+++ b/examples/openai-codex-sdk/bedrock/README.md
@@ -36,7 +36,8 @@ npx promptfoo@latest init --example openai-codex-sdk/bedrock
 - AWS credentials and `AWS_REGION` are forwarded to the Codex CLI via `cli_env` because
   promptfoo runs the CLI with a minimal environment by default. You may instead set
   `AWS_BEARER_TOKEN_BEDROCK` (a Bedrock API key), `AWS_PROFILE`, or
-  `inherit_process_env: true`.
+  `inherit_process_env: true`. If you use temporary credentials (SSO / STS / assumed
+  roles / MFA), also forward `AWS_SESSION_TOKEN` (uncomment it in the config).
 
 > **Security note:** values placed in `cli_env` are exposed to the Codex agent's shell
 > environment. Scope the IAM permissions to Bedrock inference and prefer short-lived

--- a/examples/openai-codex-sdk/bedrock/promptfooconfig.yaml
+++ b/examples/openai-codex-sdk/bedrock/promptfooconfig.yaml
@@ -21,6 +21,10 @@ providers:
         AWS_REGION: us-east-2
         AWS_ACCESS_KEY_ID: '{{env.AWS_ACCESS_KEY_ID}}'
         AWS_SECRET_ACCESS_KEY: '{{env.AWS_SECRET_ACCESS_KEY}}'
+        # Using temporary credentials (SSO / STS / assumed role / MFA)? Also forward the
+        # session token (leave it out for long-lived IAM keys). Or set AWS_BEARER_TOKEN_BEDROCK
+        # / AWS_PROFILE instead.
+        # AWS_SESSION_TOKEN: '{{env.AWS_SESSION_TOKEN}}'
 
 tests:
   - assert:

--- a/examples/openai-codex-sdk/bedrock/promptfooconfig.yaml
+++ b/examples/openai-codex-sdk/bedrock/promptfooconfig.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'Codex SDK running OpenAI frontier models on Amazon Bedrock'
+
+prompts:
+  - 'Write a Python function that calculates the factorial of a number. Output only the code.'
+
+providers:
+  # GPT-5.5 on Bedrock (us-east-2). Codex routes through Bedrock's OpenAI-compatible
+  # endpoint, so the model id uses the openai. prefix.
+  - id: openai:codex-sdk
+    label: codex-gpt-5.5-bedrock
+    config:
+      model: openai.gpt-5.5
+      model_provider: amazon-bedrock
+      model_reasoning_effort: low
+      sandbox_mode: read-only
+      skip_git_repo_check: true
+      # The Codex CLI reads AWS credentials from its own environment. promptfoo runs
+      # the CLI with a minimal env by default, so forward credentials + region here.
+      cli_env:
+        AWS_REGION: us-east-2
+        AWS_ACCESS_KEY_ID: '{{env.AWS_ACCESS_KEY_ID}}'
+        AWS_SECRET_ACCESS_KEY: '{{env.AWS_SECRET_ACCESS_KEY}}'
+
+tests:
+  - assert:
+      - type: contains
+        value: 'def factorial'

--- a/examples/openai-codex-sdk/bedrock/promptfooconfig.yaml
+++ b/examples/openai-codex-sdk/bedrock/promptfooconfig.yaml
@@ -22,9 +22,11 @@ providers:
         AWS_ACCESS_KEY_ID: '{{env.AWS_ACCESS_KEY_ID}}'
         AWS_SECRET_ACCESS_KEY: '{{env.AWS_SECRET_ACCESS_KEY}}'
         # Using temporary credentials (SSO / STS / assumed role / MFA)? Also forward the
-        # session token (leave it out for long-lived IAM keys). Or set AWS_BEARER_TOKEN_BEDROCK
-        # / AWS_PROFILE instead.
+        # session token (leave it out for long-lived IAM keys):
         # AWS_SESSION_TOKEN: '{{env.AWS_SESSION_TOKEN}}'
+        # Or authenticate another way instead of static keys — forward one of:
+        # AWS_BEARER_TOKEN_BEDROCK: '{{env.AWS_BEARER_TOKEN_BEDROCK}}' # a Bedrock API key
+        # AWS_PROFILE: '{{env.AWS_PROFILE}}'                           # a named profile
 
 tests:
   - assert:

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -510,11 +510,12 @@ providers:
       region: 'us-east-1'
       temperature: 0.7
       max_tokens: 256
-  - id: bedrock:openai.gpt-5.5
+  - id: bedrock:openai.gpt-5.5 # frontier: Responses API, needs a Bedrock API key
     config:
       region: 'us-east-2'
-      max_completion_tokens: 256
+      apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}'
       reasoning_effort: 'medium'
+      max_output_tokens: 256
   - id: bedrock:openai.gpt-oss-120b-1:0
     config:
       region: 'us-west-2'
@@ -978,105 +979,99 @@ requests and return the final assistant message directly.
 
 ### OpenAI Models
 
-OpenAI models on Bedrock use OpenAI-style request parameters. Available model IDs
-include:
+Amazon Bedrock hosts two families of OpenAI models, and they are served by **different
+APIs**. promptfoo routes each `bedrock:openai.*` id to the correct one automatically.
 
-**Frontier models** (reasoning models, region-gated):
+#### Frontier models (GPT-5.x)
 
 - **`openai.gpt-5.5`**: Flagship frontier model (US East / Ohio `us-east-2`)
 - **`openai.gpt-5.4`**: Frontier model (US East / Ohio `us-east-2` and US West / Oregon `us-west-2`)
 
-**Open-weight (GPT OSS) models:**
+The frontier models are served only through Bedrock's **OpenAI-compatible Responses API**
+on the regional "mantle" endpoint (`https://bedrock-mantle.<region>.api.aws/openai/v1`) —
+not the native `InvokeModel` API. promptfoo routes `bedrock:openai.gpt-5.5` to its OpenAI
+Responses provider pointed at that endpoint, so the output is **identical to the
+[`openai:responses:gpt-5.5`](/docs/providers/openai/) provider** (the clean final answer;
+chain-of-thought is hidden).
+
+Authentication uses an **Amazon Bedrock API key**, not the AWS SDK credential chain. Set
+`AWS_BEARER_TOKEN_BEDROCK` (or `config.apiKey`):
+
+```yaml
+providers:
+  - id: bedrock:openai.gpt-5.5
+    config:
+      region: us-east-2 # gpt-5.5: us-east-2; gpt-5.4: us-east-2 or us-west-2
+      apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}' # or just export AWS_BEARER_TOKEN_BEDROCK
+      reasoning_effort: low # minimal | low | medium | high
+      max_output_tokens: 2048
+```
+
+This is also equivalent to configuring the OpenAI Responses provider directly:
+
+```yaml
+providers:
+  - id: openai:responses:openai.gpt-5.5
+    config:
+      apiBaseUrl: https://bedrock-mantle.us-east-2.api.aws/openai/v1
+      apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}'
+```
+
+#### Open-weight models (GPT OSS)
 
 - **`openai.gpt-oss-120b-1:0`**: 120 billion parameter general-purpose model
 - **`openai.gpt-oss-20b-1:0`**: 20 billion parameter general-purpose model
 - **`openai.gpt-oss-safeguard-120b`**: 120 billion parameter safety model
 - **`openai.gpt-oss-safeguard-20b`**: 20 billion parameter safety model
 
+The open-weight models are served through Bedrock's native `InvokeModel` API and use the
+standard AWS SDK credential chain, with OpenAI-style request parameters:
+
 ```yaml
-config:
-  region: 'us-east-2' # Frontier models are region-gated (see list above)
-  max_completion_tokens: 1024 # Maximum tokens for response (OpenAI-style parameter)
-  temperature: 0.7 # Controls randomness (0.0 to 1.0)
-  top_p: 0.9 # Nucleus sampling parameter
-  frequency_penalty: 0.1 # Reduces repetition of frequent tokens
-  presence_penalty: 0.1 # Reduces repetition of any tokens
-  stop: ['END', 'STOP'] # Stop sequences
-  reasoning_effort: 'medium' # Native reasoning depth (values vary by model)
-  showThinking: true # Keep (true) or strip (false) the <reasoning> block
+providers:
+  - id: bedrock:openai.gpt-oss-120b-1:0
+    config:
+      region: us-west-2
+      max_completion_tokens: 1024 # OpenAI-style parameter (not max_tokens)
+      temperature: 0.7
+      top_p: 0.9
+      frequency_penalty: 0.1
+      presence_penalty: 0.1
+      stop: ['END', 'STOP']
+      reasoning_effort: medium # low | medium | high
+      showThinking: false # see below
 ```
 
 #### Reasoning Effort
 
-OpenAI reasoning models accept the native `reasoning_effort` request parameter, which
-promptfoo forwards as-is so Bedrock validates it for the specific model:
+Both families accept the native `reasoning_effort` request parameter, which promptfoo
+forwards as-is so the API validates it for the specific model:
 
 - **GPT OSS** (`openai.gpt-oss-*`): `low`, `medium`, `high`
-- **Frontier** (`openai.gpt-5.5`, `openai.gpt-5.4`): also support `minimal` and `none`
+- **Frontier** (`openai.gpt-5.x`): also support `minimal` and `none`
 
 Higher effort produces more thorough reasoning at the cost of latency and output tokens.
 
-#### Reasoning Output and `showThinking`
+#### Reasoning Output and `showThinking` (GPT OSS only)
 
-When invoked through Bedrock's `InvokeModel` API, OpenAI reasoning models prepend their
-chain-of-thought wrapped in `<reasoning>...</reasoning>` before the final answer. By
-default promptfoo preserves the full output (`showThinking: true`). Set
-`showThinking: false` to strip the reasoning block and assert against the final answer
-only:
+When invoked through `InvokeModel`, the open-weight models prepend their chain-of-thought
+wrapped in `<reasoning>...</reasoning>` before the final answer. This differs from OpenAI's
+first-party API, which hides chain-of-thought.
 
-```yaml
-providers:
-  - id: bedrock:openai.gpt-5.5
-    config:
-      region: 'us-east-2'
-      reasoning_effort: 'high'
-      showThinking: false # output is just the final answer
-```
-
-#### Usage Example
-
-```yaml
-providers:
-  - id: bedrock:openai.gpt-5.5
-    config:
-      region: 'us-east-2'
-      max_completion_tokens: 2048
-      reasoning_effort: 'high'
-  - id: bedrock:openai.gpt-oss-120b-1:0
-    config:
-      region: 'us-west-2'
-      max_completion_tokens: 2048
-      temperature: 0.3
-      top_p: 0.95
-      reasoning_effort: 'high'
-  - id: bedrock:openai.gpt-oss-20b-1:0
-    config:
-      region: 'us-west-2'
-      max_completion_tokens: 1024
-      temperature: 0.5
-      reasoning_effort: 'medium'
-      stop: ['END', 'FINAL']
-```
-
-:::note
-
-OpenAI models use `max_completion_tokens` instead of `max_tokens` like other Bedrock models. This aligns with OpenAI's API specification and allows for more precise control over response length.
-
-:::
+To keep results consistent with the [`openai:` providers](/docs/providers/openai/),
+promptfoo **strips the reasoning block by default**, so `output` is the clean final
+answer. Set `showThinking: true` to surface it, formatted as
+`Thinking: <reasoning>\n\n<answer>` (the same format the OpenAI chat provider uses). The
+frontier models return clean output already, so this option does not apply to them.
 
 :::note Codex on Bedrock
 
 OpenAI's [Codex](https://developers.openai.com/codex/) coding agent uses these same
-frontier model IDs (`openai.gpt-5.5`, `openai.gpt-5.4`) when configured with the
-`amazon-bedrock` provider. There are two distinct ways to use OpenAI-on-Bedrock in
-promptfoo:
-
-- **`bedrock:openai.gpt-5.5`** (this page) — direct single-turn inference via Bedrock's
-  `InvokeModel` API, authenticated with the standard AWS SDK credential chain.
-- **`openai:codex-sdk` with `model_provider: amazon-bedrock`** — runs the full Codex
-  coding agent against the same models through Bedrock's OpenAI-compatible endpoint. See
-  [Run on Amazon Bedrock](/docs/providers/openai-codex-sdk/#option-3-run-on-amazon-bedrock)
-  in the Codex SDK docs.
+frontier model IDs (`openai.gpt-5.5`, `openai.gpt-5.4`). To run the full coding agent
+against Bedrock, use `openai:codex-sdk` with `model_provider: amazon-bedrock` — see
+[Run on Amazon Bedrock](/docs/providers/openai-codex-sdk/#option-3-run-on-amazon-bedrock)
+in the Codex SDK docs. For direct (non-agentic) inference, use `bedrock:openai.gpt-5.5`
+as shown above.
 
 :::
 

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -188,19 +188,19 @@ Do not set `temperature`, `topP`, or `topK` when using extended thinking. These 
 
 ### Configuration Options
 
-| Option                | Description                                                                   |
-| --------------------- | ----------------------------------------------------------------------------- |
-| `maxTokens`           | Maximum output tokens                                                         |
-| `temperature`         | Sampling temperature (0-1)                                                    |
-| `topP`                | Nucleus sampling parameter                                                    |
-| `stopSequences`       | Array of stop sequences                                                       |
-| `thinking`            | Extended thinking configuration (Claude models)                               |
-| `reasoningConfig`     | Reasoning configuration (Amazon Nova 2 models)                                |
-| `showThinking`        | Include thinking in output (default: true; gpt-oss models default to `false`) |
-| `performanceConfig`   | Performance settings (`latency: optimized`)                                   |
-| `serviceTier`         | Service tier (`priority`, `default`, or `flex`)                               |
-| `guardrailIdentifier` | Guardrail ID for content filtering                                            |
-| `guardrailVersion`    | Guardrail version (default: DRAFT)                                            |
+| Option                | Description                                     |
+| --------------------- | ----------------------------------------------- |
+| `maxTokens`           | Maximum output tokens                           |
+| `temperature`         | Sampling temperature (0-1)                      |
+| `topP`                | Nucleus sampling parameter                      |
+| `stopSequences`       | Array of stop sequences                         |
+| `thinking`            | Extended thinking configuration (Claude models) |
+| `reasoningConfig`     | Reasoning configuration (Amazon Nova 2 models)  |
+| `showThinking`        | Include thinking in output (default: true)      |
+| `performanceConfig`   | Performance settings (`latency: optimized`)     |
+| `serviceTier`         | Service tier (`priority`, `default`, or `flex`) |
+| `guardrailIdentifier` | Guardrail ID for content filtering              |
+| `guardrailVersion`    | Guardrail version (default: DRAFT)              |
 
 ### Performance Configuration
 
@@ -1036,7 +1036,7 @@ providers:
       presence_penalty: 0.1
       stop: ['END', 'STOP']
       reasoning_effort: medium # low | medium | high
-      showThinking: false # see below
+      showThinking: false # strip the <reasoning> block from output (see below)
 ```
 
 #### Reasoning Effort
@@ -1056,19 +1056,16 @@ When invoked through `InvokeModel`, the open-weight models prepend their chain-o
 wrapped in `<reasoning>...</reasoning>` before the final answer. This differs from OpenAI's
 first-party API, which hides chain-of-thought.
 
-To keep results consistent with the [`openai:` providers](/docs/providers/openai/),
-promptfoo **strips the reasoning block by default**, so `output` is the clean final
-answer. Set `showThinking: true` to surface it, formatted as
-`Thinking: <reasoning>\n\n<answer>` (the same format the OpenAI chat provider uses). The
-frontier models return clean output already, so this option does not apply to them.
+By default promptfoo returns this output **verbatim**, so the reasoning stays visible to your
+assertions and red-team graders — an eval framework should not hide model-returned content by
+default. Use `showThinking` to transform it:
 
-:::note Behavior change
+- **`showThinking: false`** — strip the reasoning block so `output` is the clean final answer,
+  matching the [`openai:` providers](/docs/providers/openai/) (which hide chain-of-thought).
+- **`showThinking: true`** — surface the reasoning in the `Thinking: <reasoning>\n\n<answer>`
+  format the OpenAI chat provider uses.
 
-Earlier versions returned the raw `<reasoning>...</reasoning>` block in gpt-oss `output`.
-It now defaults to the clean final answer; set `showThinking: true` to restore the reasoning
-in the output.
-
-:::
+The frontier models return clean output already, so this option does not apply to them.
 
 :::note Codex on Bedrock
 

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1003,7 +1003,7 @@ providers:
     config:
       region: us-east-2 # gpt-5.5: us-east-2; gpt-5.4: us-east-2 or us-west-2
       apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}' # or just export AWS_BEARER_TOKEN_BEDROCK
-      reasoning_effort: low # minimal | low | medium | high
+      reasoning_effort: low # none | low | medium | high | xhigh
       max_output_tokens: 2048
 ```
 
@@ -1048,8 +1048,9 @@ Both families accept the native `reasoning_effort` request parameter, which prom
 forwards as-is so the API validates it for the specific model:
 
 - **GPT OSS** (`openai.gpt-oss-*`): `low`, `medium`, `high`
-- **Frontier** (`openai.gpt-5.x`): also support `minimal` and `none`
+- **Frontier** (`openai.gpt-5.x`): `none`, `low`, `medium`, `high`, `xhigh`
 
+Note that `minimal` is **not** a valid value for these Bedrock models (the API rejects it).
 Higher effort produces more thorough reasoning at the cost of latency and output tokens.
 
 #### Reasoning Output and `showThinking` (GPT OSS only)

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -510,6 +510,11 @@ providers:
       region: 'us-east-1'
       temperature: 0.7
       max_tokens: 256
+  - id: bedrock:openai.gpt-5.5
+    config:
+      region: 'us-east-2'
+      max_completion_tokens: 256
+      reasoning_effort: 'medium'
   - id: bedrock:openai.gpt-oss-120b-1:0
     config:
       region: 'us-west-2'
@@ -976,6 +981,13 @@ requests and return the final assistant message directly.
 OpenAI models on Bedrock use OpenAI-style request parameters. Available model IDs
 include:
 
+**Frontier models** (reasoning models, region-gated):
+
+- **`openai.gpt-5.5`**: Flagship frontier model (US East / Ohio `us-east-2`)
+- **`openai.gpt-5.4`**: Frontier model (US East / Ohio `us-east-2` and US West / Oregon `us-west-2`)
+
+**Open-weight (GPT OSS) models:**
+
 - **`openai.gpt-oss-120b-1:0`**: 120 billion parameter general-purpose model
 - **`openai.gpt-oss-20b-1:0`**: 20 billion parameter general-purpose model
 - **`openai.gpt-oss-safeguard-120b`**: 120 billion parameter safety model
@@ -983,29 +995,53 @@ include:
 
 ```yaml
 config:
+  region: 'us-east-2' # Frontier models are region-gated (see list above)
   max_completion_tokens: 1024 # Maximum tokens for response (OpenAI-style parameter)
   temperature: 0.7 # Controls randomness (0.0 to 1.0)
   top_p: 0.9 # Nucleus sampling parameter
   frequency_penalty: 0.1 # Reduces repetition of frequent tokens
   presence_penalty: 0.1 # Reduces repetition of any tokens
   stop: ['END', 'STOP'] # Stop sequences
-  reasoning_effort: 'medium' # Controls reasoning depth: 'low', 'medium', 'high'
+  reasoning_effort: 'medium' # Native reasoning depth (values vary by model)
+  showThinking: true # Keep (true) or strip (false) the <reasoning> block
 ```
 
 #### Reasoning Effort
 
-General-purpose GPT OSS models support adjustable reasoning effort through the `reasoning_effort` parameter:
+OpenAI reasoning models accept the native `reasoning_effort` request parameter, which
+promptfoo forwards as-is so Bedrock validates it for the specific model:
 
-- **`low`**: Faster responses with basic reasoning
-- **`medium`**: Balanced performance and reasoning depth
-- **`high`**: Thorough reasoning, slower but more accurate responses
+- **GPT OSS** (`openai.gpt-oss-*`): `low`, `medium`, `high`
+- **Frontier** (`openai.gpt-5.5`, `openai.gpt-5.4`): also support `minimal` and `none`
 
-The reasoning effort is implemented via system prompt instructions, allowing the model to adjust its cognitive processing depth.
+Higher effort produces more thorough reasoning at the cost of latency and output tokens.
+
+#### Reasoning Output and `showThinking`
+
+When invoked through Bedrock's `InvokeModel` API, OpenAI reasoning models prepend their
+chain-of-thought wrapped in `<reasoning>...</reasoning>` before the final answer. By
+default promptfoo preserves the full output (`showThinking: true`). Set
+`showThinking: false` to strip the reasoning block and assert against the final answer
+only:
+
+```yaml
+providers:
+  - id: bedrock:openai.gpt-5.5
+    config:
+      region: 'us-east-2'
+      reasoning_effort: 'high'
+      showThinking: false # output is just the final answer
+```
 
 #### Usage Example
 
 ```yaml
 providers:
+  - id: bedrock:openai.gpt-5.5
+    config:
+      region: 'us-east-2'
+      max_completion_tokens: 2048
+      reasoning_effort: 'high'
   - id: bedrock:openai.gpt-oss-120b-1:0
     config:
       region: 'us-west-2'
@@ -1025,6 +1061,15 @@ providers:
 :::note
 
 OpenAI models use `max_completion_tokens` instead of `max_tokens` like other Bedrock models. This aligns with OpenAI's API specification and allows for more precise control over response length.
+
+:::
+
+:::note Codex on Bedrock
+
+OpenAI's [Codex](https://developers.openai.com/codex/) coding agent uses these same
+frontier model IDs (`openai.gpt-5.5`, `openai.gpt-5.4`) when configured with the
+`amazon-bedrock` provider. Evaluating those model IDs in promptfoo exercises the same
+models that back Codex on Bedrock.
 
 :::
 

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -188,19 +188,19 @@ Do not set `temperature`, `topP`, or `topK` when using extended thinking. These 
 
 ### Configuration Options
 
-| Option                | Description                                     |
-| --------------------- | ----------------------------------------------- |
-| `maxTokens`           | Maximum output tokens                           |
-| `temperature`         | Sampling temperature (0-1)                      |
-| `topP`                | Nucleus sampling parameter                      |
-| `stopSequences`       | Array of stop sequences                         |
-| `thinking`            | Extended thinking configuration (Claude models) |
-| `reasoningConfig`     | Reasoning configuration (Amazon Nova 2 models)  |
-| `showThinking`        | Include thinking in output (default: true)      |
-| `performanceConfig`   | Performance settings (`latency: optimized`)     |
-| `serviceTier`         | Service tier (`priority`, `default`, or `flex`) |
-| `guardrailIdentifier` | Guardrail ID for content filtering              |
-| `guardrailVersion`    | Guardrail version (default: DRAFT)              |
+| Option                | Description                                                                   |
+| --------------------- | ----------------------------------------------------------------------------- |
+| `maxTokens`           | Maximum output tokens                                                         |
+| `temperature`         | Sampling temperature (0-1)                                                    |
+| `topP`                | Nucleus sampling parameter                                                    |
+| `stopSequences`       | Array of stop sequences                                                       |
+| `thinking`            | Extended thinking configuration (Claude models)                               |
+| `reasoningConfig`     | Reasoning configuration (Amazon Nova 2 models)                                |
+| `showThinking`        | Include thinking in output (default: true; gpt-oss models default to `false`) |
+| `performanceConfig`   | Performance settings (`latency: optimized`)                                   |
+| `serviceTier`         | Service tier (`priority`, `default`, or `flex`)                               |
+| `guardrailIdentifier` | Guardrail ID for content filtering                                            |
+| `guardrailVersion`    | Guardrail version (default: DRAFT)                                            |
 
 ### Performance Configuration
 
@@ -1061,6 +1061,14 @@ promptfoo **strips the reasoning block by default**, so `output` is the clean fi
 answer. Set `showThinking: true` to surface it, formatted as
 `Thinking: <reasoning>\n\n<answer>` (the same format the OpenAI chat provider uses). The
 frontier models return clean output already, so this option does not apply to them.
+
+:::note Behavior change
+
+Earlier versions returned the raw `<reasoning>...</reasoning>` block in gpt-oss `output`.
+It now defaults to the clean final answer; set `showThinking: true` to restore the reasoning
+in the output.
+
+:::
 
 :::note Codex on Bedrock
 

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1068,8 +1068,15 @@ OpenAI models use `max_completion_tokens` instead of `max_tokens` like other Bed
 
 OpenAI's [Codex](https://developers.openai.com/codex/) coding agent uses these same
 frontier model IDs (`openai.gpt-5.5`, `openai.gpt-5.4`) when configured with the
-`amazon-bedrock` provider. Evaluating those model IDs in promptfoo exercises the same
-models that back Codex on Bedrock.
+`amazon-bedrock` provider. There are two distinct ways to use OpenAI-on-Bedrock in
+promptfoo:
+
+- **`bedrock:openai.gpt-5.5`** (this page) — direct single-turn inference via Bedrock's
+  `InvokeModel` API, authenticated with the standard AWS SDK credential chain.
+- **`openai:codex-sdk` with `model_provider: amazon-bedrock`** — runs the full Codex
+  coding agent against the same models through Bedrock's OpenAI-compatible endpoint. See
+  [Run on Amazon Bedrock](/docs/providers/openai-codex-sdk/#option-3-run-on-amazon-bedrock)
+  in the Codex SDK docs.
 
 :::
 

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -196,7 +196,7 @@ Do not set `temperature`, `topP`, or `topK` when using extended thinking. These 
 | `stopSequences`       | Array of stop sequences                         |
 | `thinking`            | Extended thinking configuration (Claude models) |
 | `reasoningConfig`     | Reasoning configuration (Amazon Nova 2 models)  |
-| `showThinking`        | Include thinking in output (default: false)     |
+| `showThinking`        | Include thinking in output (default: true)      |
 | `performanceConfig`   | Performance settings (`latency: optimized`)     |
 | `serviceTier`         | Service tier (`priority`, `default`, or `flex`) |
 | `guardrailIdentifier` | Guardrail ID for content filtering              |
@@ -1007,15 +1007,12 @@ providers:
       max_output_tokens: 2048
 ```
 
-This is also equivalent to configuring the OpenAI Responses provider directly:
-
-```yaml
-providers:
-  - id: openai:responses:openai.gpt-5.5
-    config:
-      apiBaseUrl: https://bedrock-mantle.us-east-2.api.aws/openai/v1
-      apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}'
-```
+Prefer the `bedrock:openai.gpt-5.5` form above. It wraps the OpenAI Responses provider,
+points it at the mantle endpoint, and normalizes the `openai.`-prefixed id for GPT-5
+capability detection (reasoning effort, verbosity) and billing. Using
+`openai:responses:openai.gpt-5.5` directly is **not** equivalent — the base provider does
+not recognize the `openai.` prefix as a GPT-5 model, so reasoning/verbosity controls would
+be dropped.
 
 #### Open-weight models (GPT OSS)
 

--- a/site/docs/providers/openai-codex-app-server.md
+++ b/site/docs/providers/openai-codex-app-server.md
@@ -69,6 +69,26 @@ export OPENAI_API_KEY=your_api_key_here
 
 Promptfoo also accepts `CODEX_API_KEY` or `config.apiKey`. For reproducible evals, prefer API-key-backed runs or set `cli_env.CODEX_HOME` to a fixture home directory that already contains the intended Codex login state.
 
+### Run on Amazon Bedrock
+
+Set `model_provider: amazon-bedrock` with a Bedrock model id to run OpenAI's frontier models on [Amazon Bedrock](/docs/providers/aws-bedrock/#openai-models). Provide AWS credentials and a Region to the Codex CLI through `cli_env`:
+
+```yaml title="promptfooconfig.yaml"
+providers:
+  - id: openai:codex-app-server
+    config:
+      model: openai.gpt-5.5 # Bedrock model id (note the openai. prefix)
+      model_provider: amazon-bedrock
+      sandbox_mode: read-only
+      approval_policy: never
+      cli_env:
+        AWS_REGION: us-east-2
+        AWS_ACCESS_KEY_ID: '{{env.AWS_ACCESS_KEY_ID}}'
+        AWS_SECRET_ACCESS_KEY: '{{env.AWS_SECRET_ACCESS_KEY}}'
+```
+
+The same notes as the [Codex SDK Bedrock setup](/docs/providers/openai-codex-sdk/#option-3-run-on-amazon-bedrock) apply: use the `openai.`-prefixed model ids, request model access in a supported Region (`us-east-2` for GPT-5.5), and remember that credentials in `cli_env` are exposed to the agent's shell environment.
+
 ## Basic Usage
 
 ```yaml title="promptfooconfig.yaml"

--- a/site/docs/providers/openai-codex-app-server.md
+++ b/site/docs/providers/openai-codex-app-server.md
@@ -87,7 +87,7 @@ providers:
         AWS_SECRET_ACCESS_KEY: '{{env.AWS_SECRET_ACCESS_KEY}}'
 ```
 
-The same notes as the [Codex SDK Bedrock setup](/docs/providers/openai-codex-sdk/#option-3-run-on-amazon-bedrock) apply: use the `openai.`-prefixed model ids, request model access in a supported Region (`us-east-2` for GPT-5.5), and remember that credentials in `cli_env` are exposed to the agent's shell environment.
+The same notes as the [Codex SDK Bedrock setup](/docs/providers/openai-codex-sdk/#option-3-run-on-amazon-bedrock) apply: use the `openai.`-prefixed model ids, request model access in a supported Region (`us-east-2` for GPT-5.5), forward `AWS_SESSION_TOKEN` as well when using temporary/SSO credentials, and remember that credentials in `cli_env` are exposed to the agent's shell environment.
 
 ## Basic Usage
 

--- a/site/docs/providers/openai-codex-sdk.md
+++ b/site/docs/providers/openai-codex-sdk.md
@@ -950,6 +950,7 @@ See the [examples directory](https://github.com/promptfoo/promptfoo/tree/main/ex
 - [Skills testing](https://github.com/promptfoo/promptfoo/tree/main/examples/openai-codex-sdk/skills) - Evaluate local Codex skills with `skill-used` and traced skill evidence
 - [Thread persistence](https://github.com/promptfoo/promptfoo/tree/main/examples/openai-codex-sdk/thread-persistence) - Reuse one prompt-template thread across multiple tests
 - [Sandbox enforcement](https://github.com/promptfoo/promptfoo/tree/main/examples/openai-codex-sdk/sandbox) - Verify `read-only` mode blocks writes in a sample workspace
+- [Amazon Bedrock](https://github.com/promptfoo/promptfoo/tree/main/examples/openai-codex-sdk/bedrock) - Run Codex against OpenAI frontier models (gpt-5.5 / gpt-5.4) on Amazon Bedrock
 - [Agentic SDK comparison](https://github.com/promptfoo/promptfoo/tree/main/examples/compare-agentic-sdks) - Side-by-side comparison with Claude Agent SDK
 
 ### Verified end-to-end example runs

--- a/site/docs/providers/openai-codex-sdk.md
+++ b/site/docs/providers/openai-codex-sdk.md
@@ -97,6 +97,38 @@ ChatGPT login support is specific to the Codex SDK provider. Promptfoo can now u
 
 :::
 
+### Option 3: Run on Amazon Bedrock
+
+Codex can run OpenAI's frontier models hosted on [Amazon Bedrock](/docs/providers/aws-bedrock/#openai-models) instead of the OpenAI Platform. Set `model_provider: amazon-bedrock`, use the Bedrock model id (the `openai.`-prefixed form), and provide AWS credentials and a Region to the Codex CLI through `cli_env`:
+
+```yaml title="promptfooconfig.yaml"
+providers:
+  - id: openai:codex-sdk
+    config:
+      model: openai.gpt-5.5 # Bedrock model id (note the openai. prefix)
+      model_provider: amazon-bedrock
+      sandbox_mode: read-only
+      cli_env:
+        AWS_REGION: us-east-2
+        AWS_ACCESS_KEY_ID: '{{env.AWS_ACCESS_KEY_ID}}'
+        AWS_SECRET_ACCESS_KEY: '{{env.AWS_SECRET_ACCESS_KEY}}'
+
+prompts:
+  - 'Write a Python function that calculates the factorial of a number'
+```
+
+Notes:
+
+- **Model ids are Bedrock ids**: use `openai.gpt-5.5` / `openai.gpt-5.4`, not the bare `gpt-5.5`. The Codex Bedrock provider serves frontier models through Bedrock's OpenAI-compatible endpoint (`https://bedrock-mantle.<region>.api.aws/openai/v1`), which is separate from the classic `bedrock-runtime` `InvokeModel` API used by the [`bedrock:` provider](/docs/providers/aws-bedrock/).
+- **Region matters**: GPT-5.5 is available in `us-east-2`; GPT-5.4 in `us-east-2` and `us-west-2`. Request model access first.
+- **Credentials must reach the Codex CLI**: the Codex CLI reads AWS credentials from its own environment. Because promptfoo runs the CLI with a minimal environment by default, pass `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` (or `AWS_BEARER_TOKEN_BEDROCK`, or `AWS_PROFILE`) and `AWS_REGION` via `cli_env`, or set `inherit_process_env: true`. The `bedrock:` provider, by contrast, uses the AWS SDK credential chain directly and does not need this.
+
+:::warning
+
+Credentials placed in `cli_env` are exposed to the Codex agent's shell environment. Scope the IAM permissions to Bedrock inference and prefer short-lived credentials.
+
+:::
+
 ## Quick Start
 
 ### Basic Usage
@@ -185,6 +217,7 @@ The provider validates top-level provider config strictly. If you mistype a prov
 | `working_dir`            | string   | Directory for Codex to operate in                                                                    | Current directory    |
 | `additional_directories` | string[] | Additional directories the agent can access. Relative values resolve from the config file directory. | None                 |
 | `model`                  | string   | Model to use                                                                                         | SDK default          |
+| `model_provider`         | string   | Codex model provider to route through (e.g. `amazon-bedrock`). Maps to `cli_config.model_provider`.  | `openai`             |
 | `sandbox_mode`           | string   | Sandbox access level (see below)                                                                     | `workspace-write`    |
 | `model_reasoning_effort` | string   | Reasoning intensity (see below)                                                                      | SDK default          |
 | `network_access_enabled` | boolean  | Allow network requests                                                                               | false                |

--- a/site/docs/providers/openai-codex-sdk.md
+++ b/site/docs/providers/openai-codex-sdk.md
@@ -121,7 +121,7 @@ Notes:
 
 - **Model ids are Bedrock ids**: use `openai.gpt-5.5` / `openai.gpt-5.4`, not the bare `gpt-5.5`. The Codex Bedrock provider serves frontier models through Bedrock's OpenAI-compatible endpoint (`https://bedrock-mantle.<region>.api.aws/openai/v1`), which is separate from the classic `bedrock-runtime` `InvokeModel` API used by the [`bedrock:` provider](/docs/providers/aws-bedrock/).
 - **Region matters**: GPT-5.5 is available in `us-east-2`; GPT-5.4 in `us-east-2` and `us-west-2`. Request model access first.
-- **Credentials must reach the Codex CLI**: the Codex CLI reads AWS credentials from its own environment. Because promptfoo runs the CLI with a minimal environment by default, pass `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` (or `AWS_BEARER_TOKEN_BEDROCK`, or `AWS_PROFILE`) and `AWS_REGION` via `cli_env`, or set `inherit_process_env: true`. The `bedrock:` provider, by contrast, uses the AWS SDK credential chain directly and does not need this.
+- **Credentials must reach the Codex CLI**: the Codex CLI reads AWS credentials from its own environment. Because promptfoo runs the CLI with a minimal environment by default, pass `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` (or `AWS_BEARER_TOKEN_BEDROCK`, or `AWS_PROFILE`) and `AWS_REGION` via `cli_env`, or set `inherit_process_env: true`. If you use **temporary credentials** (SSO, STS, assumed roles, or MFA), also forward `AWS_SESSION_TOKEN` — without it the credentials are incomplete and Codex will fail to authenticate. The `bedrock:` provider, by contrast, uses the AWS SDK credential chain directly and does not need this.
 
 :::warning
 

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -191,6 +191,9 @@
         "ATLASCLOUD_API_KEY": {
           "type": "string"
         },
+        "AWS_BEARER_TOKEN_BEDROCK": {
+          "type": "string"
+        },
         "AWS_BEDROCK_REGION": {
           "type": "string"
         },
@@ -1646,6 +1649,9 @@
                       "type": "string"
                     },
                     "ATLASCLOUD_API_KEY": {
+                      "type": "string"
+                    },
+                    "AWS_BEARER_TOKEN_BEDROCK": {
                       "type": "string"
                     },
                     "AWS_BEDROCK_REGION": {

--- a/src/contracts/env.ts
+++ b/src/contracts/env.ts
@@ -9,6 +9,7 @@ export const ProviderEnvOverridesSchema = z.object({
   ANTHROPIC_API_KEY: z.string().optional(),
   ANTHROPIC_BASE_URL: z.string().optional(),
   ATLASCLOUD_API_KEY: z.string().optional(),
+  AWS_BEARER_TOKEN_BEDROCK: z.string().optional(),
   AWS_BEDROCK_REGION: z.string().optional(),
   AZURE_API_BASE_URL: z.string().optional(),
   AZURE_API_HOST: z.string().optional(),

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -214,13 +214,11 @@ const BEDROCK_CONVERSE_PRICING: Record<string, { input: number; output: number }
   // Writer Palmyra
   'writer.palmyra-x5': { input: 0.6, output: 6 },
   'writer.palmyra-x4': { input: 2.5, output: 10 },
-  // OpenAI GPT-OSS
+  // OpenAI GPT-OSS (open-weight models served via InvokeModel/Converse). The frontier
+  // gpt-5.x models are not available through Converse — they use the OpenAI-compatible
+  // Responses API (see src/providers/bedrock/openaiResponses.ts).
   'openai.gpt-oss-120b': { input: 1.0, output: 3.0 },
   'openai.gpt-oss-20b': { input: 0.3, output: 0.9 },
-  // OpenAI frontier models - Bedrock matches OpenAI first-party rates per the GA
-  // announcement; verify at aws.amazon.com/bedrock/pricing
-  'openai.gpt-5.5': { input: 5.0, output: 30.0 },
-  'openai.gpt-5.4': { input: 2.5, output: 15.0 },
 };
 
 /**

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -217,6 +217,10 @@ const BEDROCK_CONVERSE_PRICING: Record<string, { input: number; output: number }
   // OpenAI GPT-OSS
   'openai.gpt-oss-120b': { input: 1.0, output: 3.0 },
   'openai.gpt-oss-20b': { input: 0.3, output: 0.9 },
+  // OpenAI frontier models - Bedrock matches OpenAI first-party rates per the GA
+  // announcement; verify at aws.amazon.com/bedrock/pricing
+  'openai.gpt-5.5': { input: 5.0, output: 30.0 },
+  'openai.gpt-5.4': { input: 2.5, output: 15.0 },
 };
 
 /**

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -2568,10 +2568,19 @@ export function getHandlerForModel(
   if (modelName.startsWith('qwen.')) {
     return BEDROCK_MODEL.QWEN;
   }
-  // Route any OpenAI model id (including future frontier releases and cross-region
-  // inference profiles such as `us.openai.gpt-5.5`) through the OpenAI handler.
-  if (modelName.includes('openai.')) {
+  // Open-weight gpt-oss models are the only OpenAI models served via InvokeModel. The
+  // frontier gpt-5.x models use the OpenAI-compatible Responses API and are routed to the
+  // OpenAI Responses provider in src/providers/families/aws.ts before reaching this handler.
+  if (modelName.includes('openai.gpt-oss')) {
     return BEDROCK_MODEL.OPENAI;
+  }
+  if (modelName.includes('openai.')) {
+    throw new Error(
+      `OpenAI model "${modelName}" is not served by Bedrock's InvokeModel API. Frontier ` +
+        `models (gpt-5.x) use the OpenAI-compatible Responses API — use "bedrock:${modelName}" ` +
+        `(promptfoo routes it automatically) and set AWS_BEARER_TOKEN_BEDROCK. See ` +
+        `https://www.promptfoo.dev/docs/providers/aws-bedrock/#openai-models`,
+    );
   }
   throw new Error(`Unknown Amazon Bedrock model: ${modelName}`);
 }
@@ -2587,20 +2596,18 @@ export class AwsBedrockCompletionProvider extends AwsBedrockGenericProvider impl
       throw new Error(`BEDROCK_STOP is not a valid JSON string: ${err}`);
     }
 
-    let model = getHandlerForModel(this.modelName, { ...this.config, ...context?.prompt.config });
+    // Merge prompt-level config over provider config once so the same effective config
+    // drives handler selection, request params, AND output parsing (e.g. showThinking).
+    const mergedConfig = { ...this.config, ...context?.prompt.config };
+
+    let model = getHandlerForModel(this.modelName, mergedConfig);
     if (!model) {
       logger.warn(
         `Unknown Amazon Bedrock model: ${this.modelName}. Assuming its API is Claude-like.`,
       );
       model = BEDROCK_MODEL.CLAUDE_MESSAGES;
     }
-    const params = await model.params(
-      { ...this.config, ...context?.prompt.config },
-      prompt,
-      stop,
-      this.modelName,
-      context?.vars,
-    );
+    const params = await model.params(mergedConfig, prompt, stop, this.modelName, context?.vars);
 
     logger.debug('Calling Amazon Bedrock API', { params });
 
@@ -2618,7 +2625,7 @@ export class AwsBedrockCompletionProvider extends AwsBedrockGenericProvider impl
       if (cachedResponse) {
         logger.debug(`Returning cached response for ${prompt}: ${cachedResponse}`);
         return {
-          output: model.output(this.config, JSON.parse(cachedResponse as string)),
+          output: model.output(mergedConfig, JSON.parse(cachedResponse as string)),
           tokenUsage: createEmptyTokenUsage(),
           cached: true,
         };
@@ -2730,7 +2737,7 @@ export class AwsBedrockCompletionProvider extends AwsBedrockGenericProvider impl
       }
 
       return {
-        output: model.output(this.config, output),
+        output: model.output(mergedConfig, output),
         tokenUsage,
         ...(output['amazon-bedrock-guardrailAction']
           ? {

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -2079,9 +2079,9 @@ ${prompt}
         0.1,
       );
       addConfigParam(params, 'top_p', config?.top_p, getEnvFloat('AWS_BEDROCK_TOP_P'), 1.0);
-      // OpenAI reasoning models (gpt-oss, gpt-5.x) accept `reasoning_effort` as a
-      // native request field on Bedrock. Forward it as-is and let the API validate
-      // the value for the specific model.
+      // The open-weight gpt-oss models accept `reasoning_effort` as a native request field on
+      // Bedrock's InvokeModel API. Forward it as-is and let the API validate the value.
+      // (Frontier gpt-5.x models don't reach this handler — see the OpenAI Responses provider.)
       addConfigParam(params, 'reasoning_effort', config?.reasoning_effort);
       if ((stop && stop.length > 0) || config?.stop) {
         addConfigParam(params, 'stop', stop || config?.stop, getEnvString('AWS_BEDROCK_STOP'));

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -391,7 +391,21 @@ export interface BedrockOpenAIGenerationOptions extends BedrockOptions {
   frequency_penalty?: number;
   presence_penalty?: number;
   stop?: string[];
-  reasoning_effort?: 'low' | 'medium' | 'high';
+  /**
+   * Reasoning depth for OpenAI reasoning models on Bedrock, passed through as the
+   * native `reasoning_effort` request field. Valid values depend on the model:
+   * gpt-oss accepts `low`/`medium`/`high`, while the frontier GPT-5.x models also
+   * support `minimal` and `none`. The value is forwarded as-is so the Bedrock API
+   * validates it per-model.
+   */
+  reasoning_effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
+  /**
+   * When `false`, strip the `<reasoning>...</reasoning>` block that OpenAI reasoning
+   * models (gpt-oss, gpt-5.x) prepend to the response content via `InvokeModel`,
+   * leaving only the final answer. Defaults to `true`, which preserves the model's
+   * full output including its chain-of-thought.
+   */
+  showThinking?: boolean;
 }
 
 interface BedrockQwenGenerationOptions extends BedrockOptions {
@@ -2040,21 +2054,6 @@ ${prompt}
     ) => {
       const messages = parseChatPrompt(prompt, [{ role: 'user', content: prompt }]);
 
-      // Handle reasoning_effort by adding it to system message
-      if (config?.reasoning_effort) {
-        const reasoningInstruction = `Reasoning: ${config.reasoning_effort}`;
-
-        // Find existing system message or create one
-        const systemMessageIndex = messages.findIndex((msg) => msg.role === 'system');
-        if (systemMessageIndex >= 0) {
-          // Append to existing system message
-          messages[systemMessageIndex].content += `\n\n${reasoningInstruction}`;
-        } else {
-          // Add new system message at the beginning
-          messages.unshift({ role: 'system', content: reasoningInstruction });
-        }
-      }
-
       const params: any = {
         messages,
       };
@@ -2074,6 +2073,10 @@ ${prompt}
         0.1,
       );
       addConfigParam(params, 'top_p', config?.top_p, getEnvFloat('AWS_BEDROCK_TOP_P'), 1.0);
+      // OpenAI reasoning models (gpt-oss, gpt-5.x) accept `reasoning_effort` as a
+      // native request field on Bedrock. Forward it as-is and let the API validate
+      // the value for the specific model.
+      addConfigParam(params, 'reasoning_effort', config?.reasoning_effort);
       if ((stop && stop.length > 0) || config?.stop) {
         addConfigParam(params, 'stop', stop || config?.stop, getEnvString('AWS_BEDROCK_STOP'));
       }
@@ -2092,11 +2095,21 @@ ${prompt}
 
       return params;
     },
-    output: (_config: BedrockOptions, responseJson: any) => {
+    output: (config: BedrockOptions, responseJson: any) => {
       if (responseJson.error) {
         throw new Error(`OpenAI API error: ${responseJson.error}`);
       }
-      return responseJson.choices?.[0]?.message?.content;
+      const content = responseJson.choices?.[0]?.message?.content;
+      // Reasoning models prepend their chain-of-thought wrapped in
+      // <reasoning>...</reasoning> before the final answer when invoked via
+      // InvokeModel. Strip that prefix when the caller opts out of seeing it.
+      if (
+        typeof content === 'string' &&
+        (config as BedrockOpenAIGenerationOptions)?.showThinking === false
+      ) {
+        return content.replace(/^\s*<reasoning>[\s\S]*?<\/reasoning>\s*/, '');
+      }
+      return content;
     },
     tokenUsage: (responseJson: any, _promptText: string): TokenUsage => {
       if (responseJson?.usage) {
@@ -2388,6 +2401,12 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   'openai.gpt-oss-20b-1:0': BEDROCK_MODEL.OPENAI,
   'openai.gpt-oss-safeguard-120b': BEDROCK_MODEL.OPENAI,
   'openai.gpt-oss-safeguard-20b': BEDROCK_MODEL.OPENAI,
+  // OpenAI frontier models via Bedrock (GA June 2026). These reasoning models also
+  // back the Codex coding agent when it is configured with the amazon-bedrock
+  // provider. Availability is region-gated: gpt-5.5 in us-east-2; gpt-5.4 in
+  // us-east-2 and us-west-2 (see https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html).
+  'openai.gpt-5.5': BEDROCK_MODEL.OPENAI,
+  'openai.gpt-5.4': BEDROCK_MODEL.OPENAI,
 
   // Qwen Models via Bedrock
   'qwen.qwen3-coder-next': BEDROCK_MODEL.QWEN,
@@ -2414,7 +2433,10 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
 };
 
 // See https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
-function getHandlerForModel(modelName: string, config?: BedrockInvokeModelOptions): IBedrockModel {
+export function getHandlerForModel(
+  modelName: string,
+  config?: BedrockInvokeModelOptions,
+): IBedrockModel {
   // Check if it's an inference profile ARN
   if (modelName.includes('arn:') && modelName.includes('inference-profile')) {
     // For inference profiles, use the model type from config to determine handler
@@ -2521,6 +2543,11 @@ function getHandlerForModel(modelName: string, config?: BedrockInvokeModelOption
   }
   if (modelName.startsWith('qwen.')) {
     return BEDROCK_MODEL.QWEN;
+  }
+  // Route any OpenAI model id (including future frontier releases and cross-region
+  // inference profiles such as `us.openai.gpt-5.5`) through the OpenAI handler.
+  if (modelName.includes('openai.')) {
+    return BEDROCK_MODEL.OPENAI;
   }
   throw new Error(`Unknown Amazon Bedrock model: ${modelName}`);
 }

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -400,8 +400,10 @@ export interface BedrockOpenAIGenerationOptions extends BedrockOptions {
    */
   reasoning_effort?: 'low' | 'medium' | 'high';
   /**
-   * Controls how the `<reasoning>...</reasoning>` block that OpenAI reasoning models
-   * (gpt-oss, gpt-5.x) prepend to the response content via `InvokeModel` is surfaced.
+   * Controls how the `<reasoning>...</reasoning>` block that the open-weight gpt-oss models
+   * prepend to the response content via `InvokeModel` is surfaced. (Frontier gpt-5.x models
+   * do not use this handler — they go through the OpenAI Responses provider, which returns the
+   * final answer only.)
    *
    * Defaults to `false`: the reasoning block is stripped and `output` is the clean
    * final answer, matching OpenAI's first-party Chat Completions API (which hides
@@ -2121,30 +2123,32 @@ ${prompt}
       if ((config as BedrockOpenAIGenerationOptions)?.showThinking === true) {
         return `Thinking: ${reasoning.trim()}\n\n${answer}`;
       }
-      return answer;
+      // If the model returned only a reasoning block with no final answer, stripping would
+      // collapse `output` to an empty string. Fall back to the original content so the whole
+      // response is never silently dropped.
+      return answer.trim() === '' ? content : answer;
     },
     tokenUsage: (responseJson: any, _promptText: string): TokenUsage => {
       if (responseJson?.usage) {
         const usage = responseJson.usage;
-        // Frontier reasoning models report reasoning tokens the same way OpenAI does;
-        // surface them under completionDetails for parity with the OpenAI provider.
+        // gpt-oss reports usage the same way OpenAI's Chat Completions API does; surface
+        // reasoning and cached-input token counts (when present) under completionDetails for
+        // parity with the openai: provider.
         const reasoningTokens = coerceStrToNum(usage.completion_tokens_details?.reasoning_tokens);
         const cachedInputTokens = coerceStrToNum(usage.prompt_tokens_details?.cached_tokens);
-        const completionDetails =
-          reasoningTokens !== undefined || (cachedInputTokens ?? 0) > 0
-            ? {
-                ...(reasoningTokens === undefined ? {} : { reasoning: reasoningTokens }),
-                ...((cachedInputTokens ?? 0) > 0
-                  ? { cacheReadInputTokens: cachedInputTokens }
-                  : {}),
-              }
-            : undefined;
+        const completionDetails: { reasoning?: number; cacheReadInputTokens?: number } = {};
+        if (reasoningTokens !== undefined) {
+          completionDetails.reasoning = reasoningTokens;
+        }
+        if ((cachedInputTokens ?? 0) > 0) {
+          completionDetails.cacheReadInputTokens = cachedInputTokens;
+        }
         return {
           prompt: coerceStrToNum(usage.prompt_tokens),
           completion: coerceStrToNum(usage.completion_tokens),
           total: coerceStrToNum(usage.total_tokens),
           numRequests: 1,
-          ...(completionDetails ? { completionDetails } : {}),
+          ...(Object.keys(completionDetails).length > 0 ? { completionDetails } : {}),
         };
       }
 

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -400,10 +400,14 @@ export interface BedrockOpenAIGenerationOptions extends BedrockOptions {
    */
   reasoning_effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
   /**
-   * When `false`, strip the `<reasoning>...</reasoning>` block that OpenAI reasoning
-   * models (gpt-oss, gpt-5.x) prepend to the response content via `InvokeModel`,
-   * leaving only the final answer. Defaults to `true`, which preserves the model's
-   * full output including its chain-of-thought.
+   * Controls how the `<reasoning>...</reasoning>` block that OpenAI reasoning models
+   * (gpt-oss, gpt-5.x) prepend to the response content via `InvokeModel` is surfaced.
+   *
+   * Defaults to `false`: the reasoning block is stripped and `output` is the clean
+   * final answer, matching OpenAI's first-party Chat Completions API (which hides
+   * chain-of-thought) and the `openai:` providers. Set to `true` to surface the
+   * reasoning, formatted as `Thinking: <reasoning>\n\n<answer>` for consistency with
+   * the OpenAI chat provider.
    */
   showThinking?: boolean;
 }
@@ -2100,24 +2104,47 @@ ${prompt}
         throw new Error(`OpenAI API error: ${responseJson.error}`);
       }
       const content = responseJson.choices?.[0]?.message?.content;
-      // Reasoning models prepend their chain-of-thought wrapped in
-      // <reasoning>...</reasoning> before the final answer when invoked via
-      // InvokeModel. Strip that prefix when the caller opts out of seeing it.
-      if (
-        typeof content === 'string' &&
-        (config as BedrockOpenAIGenerationOptions)?.showThinking === false
-      ) {
-        return content.replace(/^\s*<reasoning>[\s\S]*?<\/reasoning>\s*/, '');
+      if (typeof content !== 'string') {
+        return content;
       }
-      return content;
+      // Unlike OpenAI's first-party Chat Completions API (which hides chain-of-thought
+      // and returns only the final answer), Bedrock's InvokeModel prepends the model
+      // reasoning wrapped in <reasoning>...</reasoning>. Split it out so that, by
+      // default, `output` is the clean final answer — matching the OpenAI provider.
+      const reasoningMatch = content.match(/^\s*<reasoning>([\s\S]*?)<\/reasoning>\s*([\s\S]*)$/);
+      if (!reasoningMatch) {
+        return content;
+      }
+      const [, reasoning, answer] = reasoningMatch;
+      // Opt in to surfacing reasoning. Format it the same way the OpenAI chat provider
+      // does (`Thinking: ...`) so outputs stay consistent across providers.
+      if ((config as BedrockOpenAIGenerationOptions)?.showThinking === true) {
+        return `Thinking: ${reasoning.trim()}\n\n${answer}`;
+      }
+      return answer;
     },
     tokenUsage: (responseJson: any, _promptText: string): TokenUsage => {
       if (responseJson?.usage) {
+        const usage = responseJson.usage;
+        // Frontier reasoning models report reasoning tokens the same way OpenAI does;
+        // surface them under completionDetails for parity with the OpenAI provider.
+        const reasoningTokens = coerceStrToNum(usage.completion_tokens_details?.reasoning_tokens);
+        const cachedInputTokens = coerceStrToNum(usage.prompt_tokens_details?.cached_tokens);
+        const completionDetails =
+          reasoningTokens !== undefined || (cachedInputTokens ?? 0) > 0
+            ? {
+                ...(reasoningTokens === undefined ? {} : { reasoning: reasoningTokens }),
+                ...((cachedInputTokens ?? 0) > 0
+                  ? { cacheReadInputTokens: cachedInputTokens }
+                  : {}),
+              }
+            : undefined;
         return {
-          prompt: coerceStrToNum(responseJson.usage.prompt_tokens),
-          completion: coerceStrToNum(responseJson.usage.completion_tokens),
-          total: coerceStrToNum(responseJson.usage.total_tokens),
+          prompt: coerceStrToNum(usage.prompt_tokens),
+          completion: coerceStrToNum(usage.completion_tokens),
+          total: coerceStrToNum(usage.total_tokens),
           numRequests: 1,
+          ...(completionDetails ? { completionDetails } : {}),
         };
       }
 
@@ -2396,17 +2423,14 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   'us.meta.llama4-maverick-17b-instruct-v1:0': BEDROCK_MODEL.LLAMA4,
   'us.mistral.pixtral-large-2502-v1:0': BEDROCK_MODEL.MISTRAL_CHAT,
 
-  // OpenAI Models via Bedrock
+  // OpenAI open-weight (gpt-oss) models via Bedrock InvokeModel. The frontier models
+  // (openai.gpt-5.x) are NOT InvokeModel models — they are served through Bedrock's
+  // OpenAI-compatible Responses API and are routed to the OpenAI Responses provider in
+  // src/providers/families/aws.ts (see src/providers/bedrock/openaiResponses.ts).
   'openai.gpt-oss-120b-1:0': BEDROCK_MODEL.OPENAI,
   'openai.gpt-oss-20b-1:0': BEDROCK_MODEL.OPENAI,
   'openai.gpt-oss-safeguard-120b': BEDROCK_MODEL.OPENAI,
   'openai.gpt-oss-safeguard-20b': BEDROCK_MODEL.OPENAI,
-  // OpenAI frontier models via Bedrock (GA June 2026). These reasoning models also
-  // back the Codex coding agent when it is configured with the amazon-bedrock
-  // provider. Availability is region-gated: gpt-5.5 in us-east-2; gpt-5.4 in
-  // us-east-2 and us-west-2 (see https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html).
-  'openai.gpt-5.5': BEDROCK_MODEL.OPENAI,
-  'openai.gpt-5.4': BEDROCK_MODEL.OPENAI,
 
   // Qwen Models via Bedrock
   'qwen.qwen3-coder-next': BEDROCK_MODEL.QWEN,

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -405,11 +405,14 @@ export interface BedrockOpenAIGenerationOptions extends BedrockOptions {
    * do not use this handler — they go through the OpenAI Responses provider, which returns the
    * final answer only.)
    *
-   * Defaults to `false`: the reasoning block is stripped and `output` is the clean
-   * final answer, matching OpenAI's first-party Chat Completions API (which hides
-   * chain-of-thought) and the `openai:` providers. Set to `true` to surface the
-   * reasoning, formatted as `Thinking: <reasoning>\n\n<answer>` for consistency with
-   * the OpenAI chat provider.
+   * - **unset (default):** the model output is returned verbatim (reasoning block included).
+   *   An eval framework should not hide application-visible content by default, so the raw
+   *   response stays available to assertions and red-team graders.
+   * - **`true`:** the reasoning is surfaced in the `Thinking: <reasoning>\n\n<answer>` format
+   *   the OpenAI chat provider uses, for consistency across providers.
+   * - **`false`:** the reasoning block is stripped and `output` is the clean final answer,
+   *   matching OpenAI's first-party Chat Completions API (which hides chain-of-thought) and
+   *   the `openai:` providers.
    */
   showThinking?: boolean;
 }
@@ -2106,26 +2109,28 @@ ${prompt}
         throw new Error(`OpenAI API error: ${responseJson.error}`);
       }
       const content = responseJson.choices?.[0]?.message?.content;
-      if (typeof content !== 'string') {
+      const showThinking = (config as BedrockOpenAIGenerationOptions)?.showThinking;
+      // Bedrock's InvokeModel surfaces the model's chain-of-thought inline, wrapped in
+      // <reasoning>...</reasoning> before the final answer. By DEFAULT promptfoo returns the
+      // model output verbatim so nothing the API returned is hidden from assertions or
+      // red-team graders — an eval framework should not silently drop application-visible
+      // content. `showThinking` makes the two transformations opt-in.
+      if (typeof content !== 'string' || showThinking === undefined) {
         return content;
       }
-      // Unlike OpenAI's first-party Chat Completions API (which hides chain-of-thought
-      // and returns only the final answer), Bedrock's InvokeModel prepends the model
-      // reasoning wrapped in <reasoning>...</reasoning>. Split it out so that, by
-      // default, `output` is the clean final answer — matching the OpenAI provider.
       const reasoningMatch = content.match(/^\s*<reasoning>([\s\S]*?)<\/reasoning>\s*([\s\S]*)$/);
       if (!reasoningMatch) {
         return content;
       }
       const [, reasoning, answer] = reasoningMatch;
-      // Opt in to surfacing reasoning. Format it the same way the OpenAI chat provider
-      // does (`Thinking: ...`) so outputs stay consistent across providers.
-      if ((config as BedrockOpenAIGenerationOptions)?.showThinking === true) {
+      // showThinking: true → surface the reasoning in the OpenAI chat provider's `Thinking: ...`
+      // format so outputs read consistently across providers.
+      if (showThinking) {
         return `Thinking: ${reasoning.trim()}\n\n${answer}`;
       }
-      // If the model returned only a reasoning block with no final answer, stripping would
-      // collapse `output` to an empty string. Fall back to the original content so the whole
-      // response is never silently dropped.
+      // showThinking: false → strip the reasoning to the clean final answer (parity with the
+      // openai: providers, which hide chain-of-thought). If the model returned only a reasoning
+      // block, fall back to the original content so the whole response is never silently dropped.
       return answer.trim() === '' ? content : answer;
     },
     tokenUsage: (responseJson: any, _promptText: string): TokenUsage => {
@@ -2576,13 +2581,30 @@ export function getHandlerForModel(
   // frontier gpt-5.x models use the OpenAI-compatible Responses API and are routed to the
   // OpenAI Responses provider in src/providers/families/aws.ts before reaching this handler.
   if (modelName.includes('openai.gpt-oss')) {
-    return BEDROCK_MODEL.OPENAI;
+    // The registered runtime ids (e.g. openai.gpt-oss-120b-1:0, openai.gpt-oss-safeguard-120b)
+    // are resolved by the exact-match lookup above. Any gpt-oss id reaching here is
+    // unregistered: a versioned id (…-N:M) is still an InvokeModel runtime id (forward-compat
+    // for new versions), but a bare id such as `openai.gpt-oss-120b` is the Bedrock Mantle id,
+    // which the InvokeModel (bedrock-runtime) API does not serve — reject it with the runtime
+    // id to use instead of silently sending the wrong id.
+    if (/-\d+:\d+$/.test(modelName)) {
+      return BEDROCK_MODEL.OPENAI;
+    }
+    throw new Error(
+      `Amazon Bedrock model "${modelName}" looks like the Bedrock Mantle id for an open-weight ` +
+        `gpt-oss model. promptfoo's bedrock: provider calls the InvokeModel (bedrock-runtime) ` +
+        `API, which uses the versioned runtime id — e.g. "bedrock:openai.gpt-oss-120b-1:0". See ` +
+        `https://www.promptfoo.dev/docs/providers/aws-bedrock/#openai-models`,
+    );
   }
   if (modelName.includes('openai.')) {
+    // Suggest the bare frontier id: AWS does not offer region/geo/global inference profiles for
+    // the gpt-5.x frontier models, so a prefixed id like `us.openai.gpt-5.5` is not valid.
+    const bareFrontierId = modelName.replace(/^[a-z]+\.(?=openai\.)/, '');
     throw new Error(
       `OpenAI model "${modelName}" is not served by Bedrock's InvokeModel API. Frontier ` +
-        `models (gpt-5.x) use the OpenAI-compatible Responses API — use "bedrock:${modelName}" ` +
-        `(promptfoo routes it automatically) and set AWS_BEARER_TOKEN_BEDROCK. See ` +
+        `models (gpt-5.x) use the OpenAI-compatible Responses API — use ` +
+        `"bedrock:${bareFrontierId}" and set AWS_BEARER_TOKEN_BEDROCK. See ` +
         `https://www.promptfoo.dev/docs/providers/aws-bedrock/#openai-models`,
     );
   }

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -392,13 +392,13 @@ export interface BedrockOpenAIGenerationOptions extends BedrockOptions {
   presence_penalty?: number;
   stop?: string[];
   /**
-   * Reasoning depth for OpenAI reasoning models on Bedrock, passed through as the
-   * native `reasoning_effort` request field. Valid values depend on the model:
-   * gpt-oss accepts `low`/`medium`/`high`, while the frontier GPT-5.x models also
-   * support `minimal` and `none`. The value is forwarded as-is so the Bedrock API
-   * validates it per-model.
+   * Reasoning depth for the open-weight gpt-oss models (served via InvokeModel), passed
+   * through as the native `reasoning_effort` request field. gpt-oss accepts `low`, `medium`,
+   * and `high` (the Harmony runtime rejects `none`); `minimal` is not supported. The value is
+   * forwarded as-is so the Bedrock API validates it. Frontier gpt-5.x models do not use this
+   * handler — they go through the OpenAI Responses provider (see openaiResponses.ts).
    */
-  reasoning_effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high';
+  reasoning_effort?: 'low' | 'medium' | 'high';
   /**
    * Controls how the `<reasoning>...</reasoning>` block that OpenAI reasoning models
    * (gpt-oss, gpt-5.x) prepend to the response content via `InvokeModel` is surfaced.

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -41,9 +41,26 @@ export function isBedrockOpenAiResponsesModel(modelName: string): boolean {
  * those return 400 on `/openai/v1`. Do not "simplify" this to `/v1`.
  */
 export function getBedrockMantleBaseUrl(region: string): string {
+  // Guard against a malformed region silently producing a bogus host: a value like
+  // `evil.com/x` would yield host `bedrock-mantle.evil.com`, redirecting the Bedrock bearer
+  // token. region is operator-controlled (config/env), never request-derived, so this is
+  // defense-in-depth plus a clearer failure than the opaque TLS/DNS error a bad region causes.
+  if (!/^[a-z]{2}(?:-[a-z]+)+-\d+$/.test(region)) {
+    throw new Error(
+      `Invalid AWS region "${region}" for the Bedrock mantle endpoint. Expected a region like ` +
+        `"us-east-2". Set a valid region via config.region, AWS_BEDROCK_REGION, or AWS_REGION ` +
+        `(or supply config.apiBaseUrl to target a custom endpoint).`,
+    );
+  }
   return `https://bedrock-mantle.${region}.api.aws/openai/v1`;
 }
 
+// Region precedence for the frontier provider. This intentionally extends
+// AwsBedrockGenericProvider.getRegion() (src/providers/bedrock/base.ts): the same
+// config.region → AWS_BEDROCK_REGION head, plus AWS_REGION/AWS_DEFAULT_REGION fallbacks and a
+// us-east-2 default (the frontier GA region) instead of base.ts's us-east-1. The frontier
+// provider wraps OpenAiResponsesProvider rather than extending AwsBedrockGenericProvider, so it
+// can't reuse getRegion() directly — keep this chain in sync if the canonical one changes.
 function resolveRegion(config: Record<string, any>, env?: EnvOverrides): string {
   return (
     config.region ||

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -23,10 +23,12 @@ export const DEFAULT_BEDROCK_OPENAI_REGION = 'us-east-2';
 
 /**
  * Whether a Bedrock OpenAI model id is a frontier model served through the Responses API
- * (everything under the `openai.` namespace except the open-weight `gpt-oss` models).
+ * (everything in the `openai.` namespace except the open-weight `gpt-oss` models). Matches
+ * region-prefixed ids too (e.g. `us.openai.gpt-5.5`) so they don't fall through to the
+ * InvokeModel path.
  */
 export function isBedrockOpenAiResponsesModel(modelName: string): boolean {
-  return modelName.startsWith('openai.') && !modelName.includes('gpt-oss');
+  return modelName.includes('openai.') && !modelName.includes('gpt-oss');
 }
 
 /**
@@ -47,6 +49,8 @@ function resolveRegion(config: Record<string, any>, env?: EnvOverrides): string 
     config.region ||
     env?.AWS_BEDROCK_REGION ||
     getEnvString('AWS_BEDROCK_REGION') ||
+    env?.AWS_REGION ||
+    env?.AWS_DEFAULT_REGION ||
     process.env.AWS_REGION ||
     process.env.AWS_DEFAULT_REGION ||
     DEFAULT_BEDROCK_OPENAI_REGION
@@ -70,12 +74,22 @@ function resolveApiKey(config: Record<string, any>, env?: EnvOverrides): string 
  */
 export class BedrockOpenAiResponsesProvider extends OpenAiResponsesProvider {
   /**
-   * Strip the Bedrock `openai.` prefix so the base provider's GPT-5 / o-series capability
-   * detection and the OpenAI billing tables match. The request still sends the real
-   * `this.modelName` (e.g. `openai.gpt-5.5`) as the model id.
+   * Strip the Bedrock `openai.` prefix (and any region prefix such as `us.`) so the base
+   * provider's GPT-5 / o-series capability detection and the OpenAI billing tables match.
+   * The request still sends the real `this.modelName` (e.g. `openai.gpt-5.5`) as the model id.
    */
   protected getCapabilityModelName(): string {
-    return this.modelName.replace(/^openai\./, '');
+    return this.modelName.replace(/^.*?openai\./, '');
+  }
+
+  /**
+   * Pin requests to the Bedrock mantle endpoint configured on this provider. The base
+   * `getApiUrl()` prefers `apiHost`/`OPENAI_API_HOST` over `apiBaseUrl`, so without this an
+   * ambient `OPENAI_API_HOST` (set for an unrelated OpenAI-compatible provider) would hijack
+   * Bedrock calls and send the Bedrock bearer token to the wrong host.
+   */
+  getApiUrl(): string {
+    return this.config.apiBaseUrl || super.getApiUrl();
   }
 }
 

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -59,12 +59,6 @@ function resolveApiKey(config: Record<string, any>, env?: EnvOverrides): string 
 }
 
 /**
- * Construct an OpenAI Responses provider configured for a Bedrock frontier model. Resolves
- * the region (config → AWS_BEDROCK_REGION → AWS_REGION → default) and the Amazon Bedrock
- * API key (config.apiKey → AWS_BEARER_TOKEN_BEDROCK), and targets the mantle endpoint
- * unless the caller supplies an explicit `apiBaseUrl`.
- */
-/**
  * OpenAI Responses provider for Bedrock frontier models. Behaves exactly like the OpenAI
  * Platform provider (shared request/response/usage handling) but strips the `openai.`
  * prefix from the model id when resolving billing rates, so cost is computed from the
@@ -76,6 +70,12 @@ export class BedrockOpenAiResponsesProvider extends OpenAiResponsesProvider {
   }
 }
 
+/**
+ * Construct an OpenAI Responses provider configured for a Bedrock frontier model. Resolves
+ * the region (config → AWS_BEDROCK_REGION → AWS_REGION → default) and the Amazon Bedrock
+ * API key (config.apiKey → AWS_BEARER_TOKEN_BEDROCK), and targets the mantle endpoint
+ * unless the caller supplies an explicit `apiBaseUrl`.
+ */
 export function createBedrockOpenAiResponsesProvider(
   modelName: string,
   providerOptions: ProviderOptions & { id?: string } = {},

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -29,7 +29,15 @@ export function isBedrockOpenAiResponsesModel(modelName: string): boolean {
   return modelName.startsWith('openai.') && !modelName.includes('gpt-oss');
 }
 
-/** Build the regional Bedrock mantle base URL for the OpenAI-compatible Responses API. */
+/**
+ * Build the regional Bedrock mantle base URL for the OpenAI frontier models.
+ *
+ * NOTE: the path is `/openai/v1`, not `/v1`. Verified live against gpt-5.5/gpt-5.4: the
+ * frontier models are served under the `/openai/v1/responses` path and return HTTP 400
+ * ("does not support the '/v1/responses' API") on the bare `/v1` path. The bare `/v1` path
+ * documented in the AWS Mantle guide serves the open-weight `gpt-oss` models instead — and
+ * those return 400 on `/openai/v1`. Do not "simplify" this to `/v1`.
+ */
 export function getBedrockMantleBaseUrl(region: string): string {
   return `https://bedrock-mantle.${region}.api.aws/openai/v1`;
 }

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -23,12 +23,16 @@ export const DEFAULT_BEDROCK_OPENAI_REGION = 'us-east-2';
 
 /**
  * Whether a Bedrock OpenAI model id is a frontier model served through the Responses API
- * (everything in the `openai.` namespace except the open-weight `gpt-oss` models). Matches
- * region-prefixed ids too (e.g. `us.openai.gpt-5.5`) so they don't fall through to the
- * InvokeModel path.
+ * (a bare `openai.` id that is not an open-weight `gpt-oss` model, e.g. `openai.gpt-5.5`).
+ *
+ * Only the bare ids are accepted. AWS's GPT-5.5 / GPT-5.4 model cards list just the bare model
+ * ids and explicitly mark the Geo and Global inference IDs as "Not supported", so a
+ * region/geo-prefixed id such as `us.openai.gpt-5.5` is not a real Bedrock model. Matching it
+ * here would route an invalid id to the mantle endpoint; instead it falls through to a clear
+ * error (see `getHandlerForModel` in ./index.ts) that points at the supported bare id.
  */
 export function isBedrockOpenAiResponsesModel(modelName: string): boolean {
-  return modelName.includes('openai.') && !modelName.includes('gpt-oss');
+  return modelName.startsWith('openai.') && !modelName.includes('gpt-oss');
 }
 
 /**
@@ -96,12 +100,13 @@ function resolveApiKey(config: Record<string, any>, env?: EnvOverrides): string 
  */
 export class BedrockOpenAiResponsesProvider extends OpenAiResponsesProvider {
   /**
-   * Strip the Bedrock `openai.` prefix (and any region prefix such as `us.`) so the base
-   * provider's GPT-5 / o-series capability detection and the OpenAI billing tables match.
-   * The request still sends the real `this.modelName` (e.g. `openai.gpt-5.5`) as the model id.
+   * Strip the Bedrock `openai.` prefix so the base provider's GPT-5 / o-series capability
+   * detection and the OpenAI billing tables match. The request still sends the real
+   * `this.modelName` (e.g. `openai.gpt-5.5`) as the model id. Only bare `openai.` ids reach
+   * this provider (see {@link isBedrockOpenAiResponsesModel}), so no region prefix is expected.
    */
   protected getCapabilityModelName(): string {
-    return this.modelName.replace(/^.*?openai\./, '');
+    return this.modelName.replace(/^openai\./, '');
   }
 
   /**

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -60,13 +60,28 @@ function resolveApiKey(config: Record<string, any>, env?: EnvOverrides): string 
 
 /**
  * OpenAI Responses provider for Bedrock frontier models. Behaves exactly like the OpenAI
- * Platform provider (shared request/response/usage handling) but strips the `openai.`
- * prefix from the model id when resolving billing rates, so cost is computed from the
- * OpenAI billing tables (Bedrock mirrors OpenAI first-party rates).
+ * Platform provider (shared request/response/usage handling).
+ *
+ * Bedrock model ids carry an `openai.` prefix (e.g. `openai.gpt-5.5`), which the base
+ * provider's GPT-5 detection (`gpt-5*` / `/gpt-5`) and billing lookups don't recognize.
+ * Without this, GPT-5 controls (reasoning effort, verbosity) would be dropped and a
+ * `temperature` default wrongly applied. We strip the prefix for those capability/billing
+ * checks while still sending the real `openai.gpt-5.5` id as the request `model` — Bedrock
+ * mirrors OpenAI first-party rates, so the OpenAI billing tables apply.
  */
 export class BedrockOpenAiResponsesProvider extends OpenAiResponsesProvider {
-  protected getBillingModelName(config: OpenAiCompletionOptions): string {
-    return super.getBillingModelName(config).replace(/^openai\./, '');
+  /** Model id without the Bedrock `openai.` prefix, for OpenAI capability/billing lookups. */
+  private bareModelName(): string {
+    return this.modelName.replace(/^openai\./, '');
+  }
+
+  protected getBillingModelName(_config: OpenAiCompletionOptions): string {
+    return this.bareModelName();
+  }
+
+  protected isGPT5Model(): boolean {
+    const model = this.bareModelName();
+    return model.startsWith('gpt-5') || model.includes('/gpt-5');
   }
 }
 

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -3,7 +3,6 @@ import { OpenAiResponsesProvider } from '../openai/responses';
 
 import type { EnvOverrides } from '../../types/env';
 import type { ProviderOptions } from '../../types/providers';
-import type { OpenAiCompletionOptions } from '../openai/types';
 
 /**
  * OpenAI's frontier models on Amazon Bedrock (gpt-5.5, gpt-5.4, ...) are NOT served
@@ -70,18 +69,13 @@ function resolveApiKey(config: Record<string, any>, env?: EnvOverrides): string 
  * mirrors OpenAI first-party rates, so the OpenAI billing tables apply.
  */
 export class BedrockOpenAiResponsesProvider extends OpenAiResponsesProvider {
-  /** Model id without the Bedrock `openai.` prefix, for OpenAI capability/billing lookups. */
-  private bareModelName(): string {
+  /**
+   * Strip the Bedrock `openai.` prefix so the base provider's GPT-5 / o-series capability
+   * detection and the OpenAI billing tables match. The request still sends the real
+   * `this.modelName` (e.g. `openai.gpt-5.5`) as the model id.
+   */
+  protected getCapabilityModelName(): string {
     return this.modelName.replace(/^openai\./, '');
-  }
-
-  protected getBillingModelName(_config: OpenAiCompletionOptions): string {
-    return this.bareModelName();
-  }
-
-  protected isGPT5Model(): boolean {
-    const model = this.bareModelName();
-    return model.startsWith('gpt-5') || model.includes('/gpt-5');
   }
 }
 

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -1,0 +1,81 @@
+import { getEnvString } from '../../envars';
+import { OpenAiResponsesProvider } from '../openai/responses';
+
+import type { EnvOverrides } from '../../types/env';
+import type { ProviderOptions } from '../../types/providers';
+
+/**
+ * OpenAI's frontier models on Amazon Bedrock (gpt-5.5, gpt-5.4, ...) are NOT served
+ * through the native `InvokeModel` / `Converse` APIs that back the rest of the `bedrock:`
+ * provider. They are only available through Bedrock's OpenAI-compatible **Responses API**
+ * on the regional "mantle" endpoint:
+ *
+ *   https://bedrock-mantle.<region>.api.aws/openai/v1/responses
+ *
+ * This module routes those model ids to promptfoo's OpenAI Responses provider pointed at
+ * that endpoint, so `bedrock:openai.gpt-5.5` produces output identical to the OpenAI
+ * Platform `openai:responses:gpt-5.5` provider. The open-weight `gpt-oss` models, by
+ * contrast, are served via `InvokeModel` and continue to use the standard Bedrock path.
+ */
+
+/** GA region for the OpenAI frontier models on Bedrock; used when none is configured. */
+export const DEFAULT_BEDROCK_OPENAI_REGION = 'us-east-2';
+
+/**
+ * Whether a Bedrock OpenAI model id is a frontier model served through the Responses API
+ * (everything under the `openai.` namespace except the open-weight `gpt-oss` models).
+ */
+export function isBedrockOpenAiResponsesModel(modelName: string): boolean {
+  return modelName.startsWith('openai.') && !modelName.includes('gpt-oss');
+}
+
+/** Build the regional Bedrock mantle base URL for the OpenAI-compatible Responses API. */
+export function getBedrockMantleBaseUrl(region: string): string {
+  return `https://bedrock-mantle.${region}.api.aws/openai/v1`;
+}
+
+function resolveRegion(config: Record<string, any>, env?: EnvOverrides): string {
+  return (
+    config.region ||
+    env?.AWS_BEDROCK_REGION ||
+    getEnvString('AWS_BEDROCK_REGION') ||
+    process.env.AWS_REGION ||
+    process.env.AWS_DEFAULT_REGION ||
+    DEFAULT_BEDROCK_OPENAI_REGION
+  );
+}
+
+function resolveApiKey(config: Record<string, any>, env?: EnvOverrides): string | undefined {
+  return config.apiKey || env?.AWS_BEARER_TOKEN_BEDROCK || getEnvString('AWS_BEARER_TOKEN_BEDROCK');
+}
+
+/**
+ * Construct an OpenAI Responses provider configured for a Bedrock frontier model. Resolves
+ * the region (config → AWS_BEDROCK_REGION → AWS_REGION → default) and the Amazon Bedrock
+ * API key (config.apiKey → AWS_BEARER_TOKEN_BEDROCK), and targets the mantle endpoint
+ * unless the caller supplies an explicit `apiBaseUrl`.
+ */
+export function createBedrockOpenAiResponsesProvider(
+  modelName: string,
+  providerOptions: ProviderOptions & { id?: string } = {},
+): OpenAiResponsesProvider {
+  const config: Record<string, any> = providerOptions.config ?? {};
+  const region = resolveRegion(config, providerOptions.env);
+  const apiKey = resolveApiKey(config, providerOptions.env);
+
+  if (!apiKey) {
+    throw new Error(
+      `Amazon Bedrock model "${modelName}" is an OpenAI frontier model served through ` +
+        `Bedrock's OpenAI-compatible Responses API, which authenticates with an Amazon ` +
+        `Bedrock API key. Set the AWS_BEARER_TOKEN_BEDROCK environment variable (or ` +
+        `config.apiKey). See https://www.promptfoo.dev/docs/providers/aws-bedrock/#openai-models`,
+    );
+  }
+
+  const apiBaseUrl = config.apiBaseUrl || getBedrockMantleBaseUrl(region);
+
+  return new OpenAiResponsesProvider(modelName, {
+    ...providerOptions,
+    config: { ...config, apiBaseUrl, apiKey },
+  });
+}

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -58,7 +58,12 @@ function resolveRegion(config: Record<string, any>, env?: EnvOverrides): string 
 }
 
 function resolveApiKey(config: Record<string, any>, env?: EnvOverrides): string | undefined {
-  return config.apiKey || env?.AWS_BEARER_TOKEN_BEDROCK || getEnvString('AWS_BEARER_TOKEN_BEDROCK');
+  // Ignore an unresolved `{{ env.* }}` template (the referenced var wasn't set). Otherwise the
+  // literal would be sent as the bearer token and the eval would fail with a confusing 401
+  // instead of the actionable missing-key error below; fall through to the env var instead.
+  const explicitKey =
+    typeof config.apiKey === 'string' && !config.apiKey.includes('{{') ? config.apiKey : undefined;
+  return explicitKey || env?.AWS_BEARER_TOKEN_BEDROCK || getEnvString('AWS_BEARER_TOKEN_BEDROCK');
 }
 
 /**

--- a/src/providers/bedrock/openaiResponses.ts
+++ b/src/providers/bedrock/openaiResponses.ts
@@ -3,6 +3,7 @@ import { OpenAiResponsesProvider } from '../openai/responses';
 
 import type { EnvOverrides } from '../../types/env';
 import type { ProviderOptions } from '../../types/providers';
+import type { OpenAiCompletionOptions } from '../openai/types';
 
 /**
  * OpenAI's frontier models on Amazon Bedrock (gpt-5.5, gpt-5.4, ...) are NOT served
@@ -63,6 +64,18 @@ function resolveApiKey(config: Record<string, any>, env?: EnvOverrides): string 
  * API key (config.apiKey → AWS_BEARER_TOKEN_BEDROCK), and targets the mantle endpoint
  * unless the caller supplies an explicit `apiBaseUrl`.
  */
+/**
+ * OpenAI Responses provider for Bedrock frontier models. Behaves exactly like the OpenAI
+ * Platform provider (shared request/response/usage handling) but strips the `openai.`
+ * prefix from the model id when resolving billing rates, so cost is computed from the
+ * OpenAI billing tables (Bedrock mirrors OpenAI first-party rates).
+ */
+export class BedrockOpenAiResponsesProvider extends OpenAiResponsesProvider {
+  protected getBillingModelName(config: OpenAiCompletionOptions): string {
+    return super.getBillingModelName(config).replace(/^openai\./, '');
+  }
+}
+
 export function createBedrockOpenAiResponsesProvider(
   modelName: string,
   providerOptions: ProviderOptions & { id?: string } = {},
@@ -82,7 +95,7 @@ export function createBedrockOpenAiResponsesProvider(
 
   const apiBaseUrl = config.apiBaseUrl || getBedrockMantleBaseUrl(region);
 
-  return new OpenAiResponsesProvider(modelName, {
+  return new BedrockOpenAiResponsesProvider(modelName, {
     ...providerOptions,
     config: { ...config, apiBaseUrl, apiKey },
   });

--- a/src/providers/families/aws.ts
+++ b/src/providers/families/aws.ts
@@ -16,14 +16,23 @@ export const awsProviderFactories: ProviderFactory[] = [
       // APIs. Route them before the per-type handlers so `bedrock:openai.gpt-5.5`,
       // `bedrock:converse:openai.gpt-5.5`, and `bedrock:completion:openai.gpt-5.5` all resolve
       // correctly. Open-weight gpt-oss models fall through to InvokeModel/Converse below.
+      //
+      // Only those three forms carry a frontier model id, so restrict the candidate to the
+      // bare id (`bedrock:openai.gpt-5.5`, i.e. exactly two segments) and the explicit
+      // `converse:`/`completion:` forms. Frontier ids contain no colon, so the bare form is
+      // always two segments. This prevents sub-typed forms whose id merely contains `openai.`
+      // (`bedrock:kb:...openai...`, `:embeddings:`, `:agents:`, `:video:`, inference-profile
+      // ARNs, ...) from being hijacked here instead of reaching their own handlers below.
       const { isBedrockOpenAiResponsesModel, createBedrockOpenAiResponsesProvider } = await import(
         '../bedrock/openaiResponses'
       );
       const candidateOpenAiModel =
         modelType === 'converse' || modelType === 'completion'
           ? modelName
-          : splits.slice(1).join(':');
-      if (isBedrockOpenAiResponsesModel(candidateOpenAiModel)) {
+          : splits.length === 2
+            ? splits[1]
+            : undefined;
+      if (candidateOpenAiModel && isBedrockOpenAiResponsesModel(candidateOpenAiModel)) {
         return createBedrockOpenAiResponsesProvider(candidateOpenAiModel, {
           ...providerOptions,
           id: providerOptions.id ?? providerPath,

--- a/src/providers/families/aws.ts
+++ b/src/providers/families/aws.ts
@@ -23,20 +23,27 @@ export const awsProviderFactories: ProviderFactory[] = [
       // always two segments. This prevents sub-typed forms whose id merely contains `openai.`
       // (`bedrock:kb:...openai...`, `:embeddings:`, `:agents:`, `:video:`, inference-profile
       // ARNs, ...) from being hijacked here instead of reaching their own handlers below.
-      const { isBedrockOpenAiResponsesModel, createBedrockOpenAiResponsesProvider } = await import(
-        '../bedrock/openaiResponses'
-      );
       const candidateOpenAiModel =
         modelType === 'converse' || modelType === 'completion'
           ? modelName
           : splits.length === 2
             ? splits[1]
             : undefined;
-      if (candidateOpenAiModel && isBedrockOpenAiResponsesModel(candidateOpenAiModel)) {
-        return createBedrockOpenAiResponsesProvider(candidateOpenAiModel, {
-          ...providerOptions,
-          id: providerOptions.id ?? providerPath,
-        });
+      // Gate the (heavy) openaiResponses import — which pulls in the OpenAI Responses stack —
+      // behind a cheap `openai.` prefix check, like every other handler import below, so the
+      // common non-OpenAI bedrock: models don't load it at construction. The prefix is a
+      // necessary condition; isBedrockOpenAiResponsesModel remains the source of truth for the
+      // frontier-vs-gpt-oss decision (a gpt-oss id passes the prefix gate but is rejected there
+      // and falls through to InvokeModel below).
+      if (candidateOpenAiModel?.startsWith('openai.')) {
+        const { isBedrockOpenAiResponsesModel, createBedrockOpenAiResponsesProvider } =
+          await import('../bedrock/openaiResponses');
+        if (isBedrockOpenAiResponsesModel(candidateOpenAiModel)) {
+          return createBedrockOpenAiResponsesProvider(candidateOpenAiModel, {
+            ...providerOptions,
+            id: providerOptions.id ?? providerPath,
+          });
+        }
       }
 
       // Handle Converse API

--- a/src/providers/families/aws.ts
+++ b/src/providers/families/aws.ts
@@ -16,13 +16,14 @@ export const awsProviderFactories: ProviderFactory[] = [
       // APIs. Route them before the per-type handlers so `bedrock:openai.gpt-5.5`,
       // `bedrock:converse:openai.gpt-5.5`, and `bedrock:completion:openai.gpt-5.5` all resolve
       // correctly. Open-weight gpt-oss models fall through to InvokeModel/Converse below.
-      const { isBedrockOpenAiResponsesModel } = await import('../bedrock/openaiResponses');
+      const { isBedrockOpenAiResponsesModel, createBedrockOpenAiResponsesProvider } = await import(
+        '../bedrock/openaiResponses'
+      );
       const candidateOpenAiModel =
         modelType === 'converse' || modelType === 'completion'
           ? modelName
           : splits.slice(1).join(':');
       if (isBedrockOpenAiResponsesModel(candidateOpenAiModel)) {
-        const { createBedrockOpenAiResponsesProvider } = await import('../bedrock/openaiResponses');
         return createBedrockOpenAiResponsesProvider(candidateOpenAiModel, {
           ...providerOptions,
           id: providerOptions.id ?? providerPath,

--- a/src/providers/families/aws.ts
+++ b/src/providers/families/aws.ts
@@ -11,6 +11,24 @@ export const awsProviderFactories: ProviderFactory[] = [
       const modelType = splits[1];
       const modelName = splits.slice(2).join(':');
 
+      // OpenAI frontier models (gpt-5.x) are served only through Bedrock's OpenAI-compatible
+      // Responses API on the regional mantle endpoint — never the native InvokeModel/Converse
+      // APIs. Route them before the per-type handlers so `bedrock:openai.gpt-5.5`,
+      // `bedrock:converse:openai.gpt-5.5`, and `bedrock:completion:openai.gpt-5.5` all resolve
+      // correctly. Open-weight gpt-oss models fall through to InvokeModel/Converse below.
+      const { isBedrockOpenAiResponsesModel } = await import('../bedrock/openaiResponses');
+      const candidateOpenAiModel =
+        modelType === 'converse' || modelType === 'completion'
+          ? modelName
+          : splits.slice(1).join(':');
+      if (isBedrockOpenAiResponsesModel(candidateOpenAiModel)) {
+        const { createBedrockOpenAiResponsesProvider } = await import('../bedrock/openaiResponses');
+        return createBedrockOpenAiResponsesProvider(candidateOpenAiModel, {
+          ...providerOptions,
+          id: providerOptions.id ?? providerPath,
+        });
+      }
+
       // Handle Converse API
       if (modelType === 'converse') {
         return new AwsBedrockConverseProvider(modelName, providerOptions);
@@ -68,20 +86,9 @@ export const awsProviderFactories: ProviderFactory[] = [
         const { AwsBedrockKnowledgeBaseProvider } = await import('../bedrock/knowledgeBase');
         return new AwsBedrockKnowledgeBaseProvider(modelName, providerOptions);
       }
-      // Reconstruct the full model name preserving the original format
+      // Reconstruct the full model name preserving the original format. Frontier OpenAI
+      // models were already routed to the Responses provider near the top of this factory.
       const fullModelName = splits.slice(1).join(':');
-      // OpenAI frontier models (gpt-5.x) are served only through Bedrock's
-      // OpenAI-compatible Responses API on the regional mantle endpoint, not the native
-      // InvokeModel API. Route them to the OpenAI Responses provider. Open-weight gpt-oss
-      // models stay on InvokeModel via AwsBedrockCompletionProvider below.
-      const { isBedrockOpenAiResponsesModel } = await import('../bedrock/openaiResponses');
-      if (isBedrockOpenAiResponsesModel(fullModelName)) {
-        const { createBedrockOpenAiResponsesProvider } = await import('../bedrock/openaiResponses');
-        return createBedrockOpenAiResponsesProvider(fullModelName, {
-          ...providerOptions,
-          id: providerOptions.id ?? providerPath,
-        });
-      }
       return new AwsBedrockCompletionProvider(fullModelName, providerOptions);
     },
   },

--- a/src/providers/families/aws.ts
+++ b/src/providers/families/aws.ts
@@ -70,6 +70,18 @@ export const awsProviderFactories: ProviderFactory[] = [
       }
       // Reconstruct the full model name preserving the original format
       const fullModelName = splits.slice(1).join(':');
+      // OpenAI frontier models (gpt-5.x) are served only through Bedrock's
+      // OpenAI-compatible Responses API on the regional mantle endpoint, not the native
+      // InvokeModel API. Route them to the OpenAI Responses provider. Open-weight gpt-oss
+      // models stay on InvokeModel via AwsBedrockCompletionProvider below.
+      const { isBedrockOpenAiResponsesModel } = await import('../bedrock/openaiResponses');
+      if (isBedrockOpenAiResponsesModel(fullModelName)) {
+        const { createBedrockOpenAiResponsesProvider } = await import('../bedrock/openaiResponses');
+        return createBedrockOpenAiResponsesProvider(fullModelName, {
+          ...providerOptions,
+          id: providerOptions.id ?? providerPath,
+        });
+      }
       return new AwsBedrockCompletionProvider(fullModelName, providerOptions);
     },
   },

--- a/src/providers/openai/codex-app-server.ts
+++ b/src/providers/openai/codex-app-server.ts
@@ -1434,10 +1434,7 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
       }
     }
 
-    if (apiKey) {
-      sortedEnv.OPENAI_API_KEY = apiKey;
-      sortedEnv.CODEX_API_KEY = apiKey;
-    }
+    this.applyApiKeyToCliEnv(sortedEnv, config, apiKey);
 
     if (config.base_url) {
       sortedEnv.OPENAI_BASE_URL = config.base_url;
@@ -1493,6 +1490,55 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
     return {
       ...(config.cli_config ?? {}),
     };
+  }
+
+  /**
+   * Whether this provider routes inference through a non-OpenAI Codex model provider
+   * (e.g. `amazon-bedrock`). When it does, an ambient OpenAI/Codex API key is unrelated to the
+   * backend, so it must not be injected into the agent env or used for `account/login`.
+   */
+  private usesCustomModelProvider(config: CodexAppServerConfig = this.config): boolean {
+    const cliConfigProvider = config.cli_config?.model_provider;
+    const provider =
+      config.model_provider ??
+      (typeof cliConfigProvider === 'string' ? cliConfigProvider : undefined);
+    // Compare case-insensitively so `OpenAI`/`OPENAI` aren't treated as a custom provider.
+    const normalized = typeof provider === 'string' ? provider.trim().toLowerCase() : '';
+    return normalized.length > 0 && normalized !== 'openai';
+  }
+
+  /**
+   * Whether the resolved API key should be presented to the Codex CLI (env + login). Mirrors
+   * the codex-sdk gating: inject only when the key belongs to the active backend, i.e. the
+   * default OpenAI provider, or a custom provider where the user set `config.apiKey` explicitly.
+   */
+  private shouldInjectApiKey(config: CodexAppServerConfig, apiKey: string | undefined): boolean {
+    return Boolean(apiKey) && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey));
+  }
+
+  /**
+   * Apply the resolved API key to the Codex CLI environment. Inject it only when it belongs to
+   * the active backend (see {@link shouldInjectApiKey}); when routing to a non-OpenAI
+   * model_provider without an explicit key, strip any OpenAI/Codex key inherited via
+   * `inherit_process_env`, unless the user passed it explicitly through cli_env.
+   */
+  private applyApiKeyToCliEnv(
+    sortedEnv: Record<string, string>,
+    config: CodexAppServerConfig,
+    apiKey: string | undefined,
+  ): void {
+    if (this.shouldInjectApiKey(config, apiKey)) {
+      sortedEnv.OPENAI_API_KEY = apiKey as string;
+      sortedEnv.CODEX_API_KEY = apiKey as string;
+      return;
+    }
+    if (this.usesCustomModelProvider(config)) {
+      for (const key of ['OPENAI_API_KEY', 'CODEX_API_KEY'] as const) {
+        if (!(key in (config.cli_env ?? {}))) {
+          delete sortedEnv[key];
+        }
+      }
+    }
   }
 
   private getRequestTimeoutMs(config: CodexAppServerConfig): number {
@@ -1555,7 +1601,9 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
     try {
       await connection.initialize(config);
       const apiKey = this.getApiKey(config);
-      if (apiKey) {
+      // Don't log in with an ambient OpenAI/Codex key when routing to a custom model_provider
+      // (e.g. amazon-bedrock) — it's unrelated to the backend. Gate it like the env injection.
+      if (this.shouldInjectApiKey(config, apiKey)) {
         try {
           await connection.request(
             'account/login/start',

--- a/src/providers/openai/codex-app-server.ts
+++ b/src/providers/openai/codex-app-server.ts
@@ -24,6 +24,7 @@ import { VERSION } from '../../version';
 import { resolveAgenticWorkingDir } from '../agentic-utils';
 import { providerRegistry } from '../providerRegistry';
 import { calculateOpenAIUsageCostFromTokenUsage } from './billing';
+import { applyApiKeyToCliEnv, shouldInjectApiKey } from './codexApiKeyGating';
 import {
   buildCodexSkillMetadata,
   getCodexSkillMetadataFields,
@@ -1434,7 +1435,7 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
       }
     }
 
-    this.applyApiKeyToCliEnv(sortedEnv, config, apiKey);
+    applyApiKeyToCliEnv(sortedEnv, config, apiKey);
 
     if (config.base_url) {
       sortedEnv.OPENAI_BASE_URL = config.base_url;
@@ -1490,55 +1491,6 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
     return {
       ...(config.cli_config ?? {}),
     };
-  }
-
-  /**
-   * Whether this provider routes inference through a non-OpenAI Codex model provider
-   * (e.g. `amazon-bedrock`). When it does, an ambient OpenAI/Codex API key is unrelated to the
-   * backend, so it must not be injected into the agent env or used for `account/login`.
-   */
-  private usesCustomModelProvider(config: CodexAppServerConfig = this.config): boolean {
-    const cliConfigProvider = config.cli_config?.model_provider;
-    const provider =
-      config.model_provider ??
-      (typeof cliConfigProvider === 'string' ? cliConfigProvider : undefined);
-    // Compare case-insensitively so `OpenAI`/`OPENAI` aren't treated as a custom provider.
-    const normalized = typeof provider === 'string' ? provider.trim().toLowerCase() : '';
-    return normalized.length > 0 && normalized !== 'openai';
-  }
-
-  /**
-   * Whether the resolved API key should be presented to the Codex CLI (env + login). Mirrors
-   * the codex-sdk gating: inject only when the key belongs to the active backend, i.e. the
-   * default OpenAI provider, or a custom provider where the user set `config.apiKey` explicitly.
-   */
-  private shouldInjectApiKey(config: CodexAppServerConfig, apiKey: string | undefined): boolean {
-    return Boolean(apiKey) && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey));
-  }
-
-  /**
-   * Apply the resolved API key to the Codex CLI environment. Inject it only when it belongs to
-   * the active backend (see {@link shouldInjectApiKey}); when routing to a non-OpenAI
-   * model_provider without an explicit key, strip any OpenAI/Codex key inherited via
-   * `inherit_process_env`, unless the user passed it explicitly through cli_env.
-   */
-  private applyApiKeyToCliEnv(
-    sortedEnv: Record<string, string>,
-    config: CodexAppServerConfig,
-    apiKey: string | undefined,
-  ): void {
-    if (this.shouldInjectApiKey(config, apiKey)) {
-      sortedEnv.OPENAI_API_KEY = apiKey as string;
-      sortedEnv.CODEX_API_KEY = apiKey as string;
-      return;
-    }
-    if (this.usesCustomModelProvider(config)) {
-      for (const key of ['OPENAI_API_KEY', 'CODEX_API_KEY'] as const) {
-        if (!(key in (config.cli_env ?? {}))) {
-          delete sortedEnv[key];
-        }
-      }
-    }
   }
 
   private getRequestTimeoutMs(config: CodexAppServerConfig): number {
@@ -1603,7 +1555,7 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
       const apiKey = this.getApiKey(config);
       // Don't log in with an ambient OpenAI/Codex key when routing to a custom model_provider
       // (e.g. amazon-bedrock) — it's unrelated to the backend. Gate it like the env injection.
-      if (this.shouldInjectApiKey(config, apiKey)) {
+      if (shouldInjectApiKey(config, apiKey)) {
         try {
           await connection.request(
             'account/login/start',

--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -24,6 +24,11 @@ import { resolveAgenticWorkingDir } from '../agentic-utils';
 import { providerRegistry } from '../providerRegistry';
 import { calculateOpenAIUsageCostFromTokenUsage } from './billing';
 import {
+  applyApiKeyToCliEnv,
+  shouldInjectApiKey,
+  usesCustomModelProvider,
+} from './codexApiKeyGating';
+import {
   buildCodexSkillMetadata,
   extractCodexSkillPathCandidates,
   getCodexSkillMetadataFields,
@@ -645,7 +650,7 @@ export class OpenAICodexSDKProvider implements ApiProvider {
 
     if (
       this.config.model &&
-      !this.usesCustomModelProvider() &&
+      !usesCustomModelProvider(this.config) &&
       !OpenAICodexSDKProvider.OPENAI_MODELS.includes(this.config.model)
     ) {
       logger.warn(`Using unknown model for OpenAI Codex SDK: ${this.config.model}`);
@@ -763,7 +768,7 @@ export class OpenAICodexSDKProvider implements ApiProvider {
       }
     }
 
-    this.applyApiKeyToCliEnv(sortedEnv, config, apiKey);
+    applyApiKeyToCliEnv(sortedEnv, config, apiKey);
 
     // Inject OpenTelemetry configuration for deep tracing
     // This allows the Codex CLI to export its internal traces to our OTLP receiver
@@ -834,60 +839,6 @@ export class OpenAICodexSDKProvider implements ApiProvider {
       ...(config.model_provider ? { model_provider: config.model_provider } : {}),
       ...(config.collaboration_mode ? { collaboration_mode: config.collaboration_mode } : {}),
     };
-  }
-
-  /**
-   * Whether this provider routes inference through a non-OpenAI Codex model provider
-   * (e.g. `amazon-bedrock`). When it does, the model id belongs to that provider's
-   * namespace, so promptfoo's OpenAI model allowlist no longer applies.
-   */
-  private usesCustomModelProvider(config: OpenAICodexSDKConfig = this.config): boolean {
-    const cliConfigProvider = config.cli_config?.model_provider;
-    const provider =
-      config.model_provider ??
-      (typeof cliConfigProvider === 'string' ? cliConfigProvider : undefined);
-    // Compare case-insensitively so `OpenAI`/`OPENAI` aren't treated as a custom provider.
-    const normalized = typeof provider === 'string' ? provider.trim().toLowerCase() : '';
-    return normalized.length > 0 && normalized !== 'openai';
-  }
-
-  /**
-   * Apply the resolved Codex/OpenAI API key to the Codex CLI environment.
-   *
-   * Inject it only when it belongs to the active backend — the default OpenAI provider, or a
-   * custom `model_provider` where the user set `config.apiKey` explicitly. When routing to a
-   * non-OpenAI provider (e.g. `amazon-bedrock`) without an explicit key, an ambient
-   * OPENAI_API_KEY / CODEX_API_KEY is unrelated to the backend (Bedrock authenticates via AWS
-   * credentials in cli_env); never inject one, and also strip any inherited via
-   * `inherit_process_env`, unless the user passed it explicitly through cli_env.
-   */
-  /**
-   * Whether the resolved API key should be presented to the Codex CLI/SDK. Single source of
-   * truth so the CLI-env injection ({@link applyApiKeyToCliEnv}) and the SDK constructor
-   * `apiKey` ({@link buildCodexOptions}) can never diverge — the SDK forwards a constructor
-   * `apiKey` into the spawned CLI as CODEX_API_KEY, so both must agree.
-   */
-  private shouldInjectApiKey(config: OpenAICodexSDKConfig, apiKey: string | undefined): boolean {
-    return Boolean(apiKey) && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey));
-  }
-
-  private applyApiKeyToCliEnv(
-    sortedEnv: Record<string, string>,
-    config: OpenAICodexSDKConfig,
-    apiKey: string | undefined,
-  ): void {
-    if (apiKey && this.shouldInjectApiKey(config, apiKey)) {
-      sortedEnv.OPENAI_API_KEY = apiKey;
-      sortedEnv.CODEX_API_KEY = apiKey;
-      return;
-    }
-    if (this.usesCustomModelProvider(config)) {
-      for (const key of ['OPENAI_API_KEY', 'CODEX_API_KEY'] as const) {
-        if (!(key in (config.cli_env ?? {}))) {
-          delete sortedEnv[key];
-        }
-      }
-    }
   }
 
   private getSkillRootPrefixes(env: Record<string, string>, workingDir?: string): string[] {
@@ -995,7 +946,7 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     // non-OpenAI model_provider (Bedrock authenticates via AWS credentials in cli_env).
     return {
       env,
-      ...(this.shouldInjectApiKey(config, apiKey) ? { apiKey } : {}),
+      ...(shouldInjectApiKey(config, apiKey) ? { apiKey } : {}),
       ...(config.codex_path_override ? { codexPathOverride: config.codex_path_override } : {}),
       ...(config.base_url ? { baseUrl: config.base_url } : {}),
       ...(cliConfig ? { config: cliConfig } : {}),

--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -766,7 +766,14 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     // Inject only the resolved Codex/OpenAI API key from provider env/config.
     // Other promptfoo env overrides should be passed explicitly via cli_env so
     // unrelated secrets are not exposed to shell commands.
-    if (apiKey) {
+    //
+    // When routing through a non-OpenAI model provider (e.g. `amazon-bedrock`), an
+    // OPENAI_API_KEY / CODEX_API_KEY inherited from the ambient environment is unrelated to
+    // the actual backend (Bedrock authenticates via AWS credentials in cli_env). Don't leak
+    // it into the agent's shell unless it was set explicitly via config.apiKey.
+    const injectApiKey =
+      apiKey && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey));
+    if (injectApiKey) {
       sortedEnv.OPENAI_API_KEY = apiKey;
       sortedEnv.CODEX_API_KEY = apiKey;
     }

--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -763,20 +763,7 @@ export class OpenAICodexSDKProvider implements ApiProvider {
       }
     }
 
-    // Inject only the resolved Codex/OpenAI API key from provider env/config.
-    // Other promptfoo env overrides should be passed explicitly via cli_env so
-    // unrelated secrets are not exposed to shell commands.
-    //
-    // When routing through a non-OpenAI model provider (e.g. `amazon-bedrock`), an
-    // OPENAI_API_KEY / CODEX_API_KEY inherited from the ambient environment is unrelated to
-    // the actual backend (Bedrock authenticates via AWS credentials in cli_env). Don't leak
-    // it into the agent's shell unless it was set explicitly via config.apiKey.
-    const injectApiKey =
-      apiKey && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey));
-    if (injectApiKey) {
-      sortedEnv.OPENAI_API_KEY = apiKey;
-      sortedEnv.CODEX_API_KEY = apiKey;
-    }
+    this.applyApiKeyToCliEnv(sortedEnv, config, apiKey);
 
     // Inject OpenTelemetry configuration for deep tracing
     // This allows the Codex CLI to export its internal traces to our OTLP receiver
@@ -859,7 +846,38 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     const provider =
       config.model_provider ??
       (typeof cliConfigProvider === 'string' ? cliConfigProvider : undefined);
-    return typeof provider === 'string' && provider.length > 0 && provider !== 'openai';
+    // Compare case-insensitively so `OpenAI`/`OPENAI` aren't treated as a custom provider.
+    const normalized = typeof provider === 'string' ? provider.trim().toLowerCase() : '';
+    return normalized.length > 0 && normalized !== 'openai';
+  }
+
+  /**
+   * Apply the resolved Codex/OpenAI API key to the Codex CLI environment.
+   *
+   * Inject it only when it belongs to the active backend — the default OpenAI provider, or a
+   * custom `model_provider` where the user set `config.apiKey` explicitly. When routing to a
+   * non-OpenAI provider (e.g. `amazon-bedrock`) without an explicit key, an ambient
+   * OPENAI_API_KEY / CODEX_API_KEY is unrelated to the backend (Bedrock authenticates via AWS
+   * credentials in cli_env); never inject one, and also strip any inherited via
+   * `inherit_process_env`, unless the user passed it explicitly through cli_env.
+   */
+  private applyApiKeyToCliEnv(
+    sortedEnv: Record<string, string>,
+    config: OpenAICodexSDKConfig,
+    apiKey: string | undefined,
+  ): void {
+    if (apiKey && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey))) {
+      sortedEnv.OPENAI_API_KEY = apiKey;
+      sortedEnv.CODEX_API_KEY = apiKey;
+      return;
+    }
+    if (this.usesCustomModelProvider(config)) {
+      for (const key of ['OPENAI_API_KEY', 'CODEX_API_KEY'] as const) {
+        if (!(key in (config.cli_env ?? {}))) {
+          delete sortedEnv[key];
+        }
+      }
+    }
   }
 
   private getSkillRootPrefixes(env: Record<string, string>, workingDir?: string): string[] {
@@ -961,9 +979,18 @@ export class OpenAICodexSDKProvider implements ApiProvider {
   ): Record<string, any> {
     const cliConfig = this.getResolvedCliConfig(config);
 
+    // The Codex SDK forwards a constructor `apiKey` into the spawned CLI process as
+    // CODEX_API_KEY. Gate it exactly like the env injection in `prepareEnvironment`: when
+    // routing through a non-OpenAI model_provider (e.g. amazon-bedrock), an ambient
+    // OPENAI_API_KEY / CODEX_API_KEY is unrelated to the backend (Bedrock authenticates via
+    // AWS credentials in cli_env), so don't leak it into the agent shell unless it was set
+    // explicitly via config.apiKey.
+    const injectApiKey =
+      apiKey && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey));
+
     return {
       env,
-      ...(apiKey ? { apiKey } : {}),
+      ...(injectApiKey ? { apiKey } : {}),
       ...(config.codex_path_override ? { codexPathOverride: config.codex_path_override } : {}),
       ...(config.base_url ? { baseUrl: config.base_url } : {}),
       ...(cliConfig ? { config: cliConfig } : {}),

--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -223,9 +223,21 @@ export interface OpenAICodexSDKConfig {
   codex_path_override?: string;
 
   /**
-   * Model to use (e.g., 'gpt-5.5', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.1-codex-mini')
+   * Model to use (e.g., 'gpt-5.5', 'gpt-5.4', 'gpt-5.3-codex', 'gpt-5.2-codex', 'gpt-5.1-codex-mini').
+   * When routing through a non-OpenAI `model_provider` (such as `amazon-bedrock`), use that
+   * provider's model id instead (e.g., 'openai.gpt-5.5' for Amazon Bedrock).
    */
   model?: string;
+
+  /**
+   * Codex model provider to route through, mapped to the CLI's `model_provider` config.
+   * Defaults to OpenAI. Set to `amazon-bedrock` to run inference against OpenAI models hosted
+   * on Amazon Bedrock (combine with `model: 'openai.gpt-5.5'` and AWS credentials in `cli_env`).
+   * Equivalent to setting `cli_config: { model_provider: '<value>' }`.
+   *
+   * @see https://www.promptfoo.dev/docs/providers/aws-bedrock/
+   */
+  model_provider?: string;
 
   /**
    * Sandbox access level controlling filesystem permissions
@@ -352,6 +364,7 @@ const OpenAICodexSDKConfigShape = {
   skip_git_repo_check: z.boolean().optional(),
   codex_path_override: z.string().min(1).optional(),
   model: z.string().min(1).optional(),
+  model_provider: z.string().min(1).optional(),
   sandbox_mode: z.enum(['read-only', 'workspace-write', 'danger-full-access']).optional(),
   model_reasoning_effort: z.enum(['minimal', 'low', 'medium', 'high', 'xhigh']).optional(),
   network_access_enabled: z.boolean().optional(),
@@ -630,7 +643,11 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     this.providerId = id ?? this.providerId;
     providerRegistry.register(this);
 
-    if (this.config.model && !OpenAICodexSDKProvider.OPENAI_MODELS.includes(this.config.model)) {
+    if (
+      this.config.model &&
+      !this.usesCustomModelProvider() &&
+      !OpenAICodexSDKProvider.OPENAI_MODELS.includes(this.config.model)
+    ) {
       logger.warn(`Using unknown model for OpenAI Codex SDK: ${this.config.model}`);
     }
   }
@@ -812,14 +829,30 @@ export class OpenAICodexSDKProvider implements ApiProvider {
   }
 
   private getResolvedCliConfig(config: OpenAICodexSDKConfig): Record<string, unknown> | undefined {
-    if (!config.cli_config && !config.collaboration_mode) {
+    if (!config.cli_config && !config.collaboration_mode && !config.model_provider) {
       return undefined;
     }
 
     return {
       ...(config.cli_config ?? {}),
+      // The first-class `model_provider` option takes precedence over any value
+      // supplied through raw `cli_config`.
+      ...(config.model_provider ? { model_provider: config.model_provider } : {}),
       ...(config.collaboration_mode ? { collaboration_mode: config.collaboration_mode } : {}),
     };
+  }
+
+  /**
+   * Whether this provider routes inference through a non-OpenAI Codex model provider
+   * (e.g. `amazon-bedrock`). When it does, the model id belongs to that provider's
+   * namespace, so promptfoo's OpenAI model allowlist no longer applies.
+   */
+  private usesCustomModelProvider(config: OpenAICodexSDKConfig = this.config): boolean {
+    const cliConfigProvider = config.cli_config?.model_provider;
+    const provider =
+      config.model_provider ??
+      (typeof cliConfigProvider === 'string' ? cliConfigProvider : undefined);
+    return typeof provider === 'string' && provider.length > 0 && provider !== 'openai';
   }
 
   private getSkillRootPrefixes(env: Record<string, string>, workingDir?: string): string[] {

--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -861,12 +861,22 @@ export class OpenAICodexSDKProvider implements ApiProvider {
    * credentials in cli_env); never inject one, and also strip any inherited via
    * `inherit_process_env`, unless the user passed it explicitly through cli_env.
    */
+  /**
+   * Whether the resolved API key should be presented to the Codex CLI/SDK. Single source of
+   * truth so the CLI-env injection ({@link applyApiKeyToCliEnv}) and the SDK constructor
+   * `apiKey` ({@link buildCodexOptions}) can never diverge — the SDK forwards a constructor
+   * `apiKey` into the spawned CLI as CODEX_API_KEY, so both must agree.
+   */
+  private shouldInjectApiKey(config: OpenAICodexSDKConfig, apiKey: string | undefined): boolean {
+    return Boolean(apiKey) && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey));
+  }
+
   private applyApiKeyToCliEnv(
     sortedEnv: Record<string, string>,
     config: OpenAICodexSDKConfig,
     apiKey: string | undefined,
   ): void {
-    if (apiKey && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey))) {
+    if (apiKey && this.shouldInjectApiKey(config, apiKey)) {
       sortedEnv.OPENAI_API_KEY = apiKey;
       sortedEnv.CODEX_API_KEY = apiKey;
       return;
@@ -980,17 +990,12 @@ export class OpenAICodexSDKProvider implements ApiProvider {
     const cliConfig = this.getResolvedCliConfig(config);
 
     // The Codex SDK forwards a constructor `apiKey` into the spawned CLI process as
-    // CODEX_API_KEY. Gate it exactly like the env injection in `prepareEnvironment`: when
-    // routing through a non-OpenAI model_provider (e.g. amazon-bedrock), an ambient
-    // OPENAI_API_KEY / CODEX_API_KEY is unrelated to the backend (Bedrock authenticates via
-    // AWS credentials in cli_env), so don't leak it into the agent shell unless it was set
-    // explicitly via config.apiKey.
-    const injectApiKey =
-      apiKey && (!this.usesCustomModelProvider(config) || Boolean(config.apiKey));
-
+    // CODEX_API_KEY. Gate it with the same predicate as the env injection so an ambient
+    // OPENAI_API_KEY / CODEX_API_KEY isn't leaked to the agent shell when routing through a
+    // non-OpenAI model_provider (Bedrock authenticates via AWS credentials in cli_env).
     return {
       env,
-      ...(injectApiKey ? { apiKey } : {}),
+      ...(this.shouldInjectApiKey(config, apiKey) ? { apiKey } : {}),
       ...(config.codex_path_override ? { codexPathOverride: config.codex_path_override } : {}),
       ...(config.base_url ? { baseUrl: config.base_url } : {}),
       ...(cliConfig ? { config: cliConfig } : {}),

--- a/src/providers/openai/codexApiKeyGating.ts
+++ b/src/providers/openai/codexApiKeyGating.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared API-key gating for the two Codex providers (`openai:codex-sdk` and
+ * `openai:codex-app-server`). Both spawn the Codex CLI and must decide identically whether the
+ * resolved Codex/OpenAI API key belongs to the active backend. When routing through a
+ * non-OpenAI `model_provider` (e.g. `amazon-bedrock`), an ambient `OPENAI_API_KEY` /
+ * `CODEX_API_KEY` is unrelated to the backend (Bedrock authenticates via AWS credentials) and
+ * must never reach the agent shell. Keeping this logic in one place stops the two providers
+ * from drifting apart.
+ */
+
+/** Minimal structural shape that both Codex provider configs satisfy. */
+export interface CodexApiKeyGatingConfig {
+  model_provider?: string;
+  cli_config?: Record<string, unknown>;
+  apiKey?: string;
+  cli_env?: Record<string, unknown>;
+}
+
+/**
+ * Whether the provider routes inference through a non-OpenAI Codex model provider
+ * (e.g. `amazon-bedrock`). When it does, the model id belongs to that provider's namespace and
+ * an ambient OpenAI/Codex key is unrelated to the active backend, so promptfoo's OpenAI model
+ * allowlist no longer applies and the key must not be injected.
+ */
+export function usesCustomModelProvider(config: CodexApiKeyGatingConfig): boolean {
+  const cliConfigProvider = config.cli_config?.model_provider;
+  const provider =
+    config.model_provider ??
+    (typeof cliConfigProvider === 'string' ? cliConfigProvider : undefined);
+  // Compare case-insensitively so `OpenAI`/`OPENAI` aren't treated as a custom provider.
+  const normalized = typeof provider === 'string' ? provider.trim().toLowerCase() : '';
+  return normalized.length > 0 && normalized !== 'openai';
+}
+
+/**
+ * Whether the resolved API key should be presented to the Codex CLI/SDK across every channel
+ * (the spawned process env, the SDK constructor `apiKey`, and `account/login`). Single source
+ * of truth so the channels can never disagree: inject only when the key belongs to the active
+ * backend — the default OpenAI provider, or a custom `model_provider` where the user set
+ * `config.apiKey` explicitly.
+ */
+export function shouldInjectApiKey(
+  config: CodexApiKeyGatingConfig,
+  apiKey: string | undefined,
+): boolean {
+  return Boolean(apiKey) && (!usesCustomModelProvider(config) || Boolean(config.apiKey));
+}
+
+/**
+ * Apply the resolved Codex/OpenAI API key to the spawned Codex CLI environment.
+ *
+ * Inject it only when {@link shouldInjectApiKey} allows (the key belongs to the active
+ * backend). When routing to a non-OpenAI provider without an explicit key, an ambient
+ * OPENAI_API_KEY / CODEX_API_KEY is unrelated to the backend; never inject one, and also strip
+ * any inherited via `inherit_process_env` — unless the user passed it explicitly through
+ * cli_env.
+ */
+export function applyApiKeyToCliEnv(
+  sortedEnv: Record<string, string>,
+  config: CodexApiKeyGatingConfig,
+  apiKey: string | undefined,
+): void {
+  // The `apiKey &&` guard narrows `apiKey` to `string` for the assignments below;
+  // `shouldInjectApiKey` already short-circuits on a falsy key.
+  if (apiKey && shouldInjectApiKey(config, apiKey)) {
+    sortedEnv.OPENAI_API_KEY = apiKey;
+    sortedEnv.CODEX_API_KEY = apiKey;
+    return;
+  }
+  if (usesCustomModelProvider(config)) {
+    for (const key of ['OPENAI_API_KEY', 'CODEX_API_KEY'] as const) {
+      if (!(key in (config.cli_env ?? {}))) {
+        delete sortedEnv[key];
+      }
+    }
+  }
+}

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -477,8 +477,10 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
   ): Promise<ProviderResponse> {
     const { body, config } = prepared;
 
-    // Validate deep research models have required tools
-    const isDeepResearchModel = this.modelName.includes('deep-research');
+    // Validate deep research models have required tools. Use the capability model name so
+    // detection stays consistent with the other capability checks (isGPT5Model, isReasoningModel,
+    // the gpt-5-pro timeout regex) for subclasses that strip a vendor prefix.
+    const isDeepResearchModel = this.getCapabilityModelName().includes('deep-research');
     if (isDeepResearchModel) {
       const hasWebSearchTool = config.tools?.some(
         (tool: any) => tool.type === 'web_search_preview',

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -149,20 +149,32 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     });
   }
 
+  /**
+   * Model id used for OpenAI capability and billing lookups. Defaults to the request model
+   * name. Subclasses (e.g. Bedrock frontier models, which carry an `openai.` prefix) override
+   * this to strip a vendor prefix so gpt-5 / o-series detection and the billing tables still
+   * match, while the request itself still sends the real `this.modelName`.
+   */
+  protected getCapabilityModelName(): string {
+    return this.modelName;
+  }
+
   protected isGPT5Model(): boolean {
     // Handle both direct model names (gpt-5-mini) and prefixed names (openai/gpt-5-mini)
-    return this.modelName.startsWith('gpt-5') || this.modelName.includes('/gpt-5');
+    const model = this.getCapabilityModelName();
+    return model.startsWith('gpt-5') || model.includes('/gpt-5');
   }
 
   protected isReasoningModel(): boolean {
+    const model = this.getCapabilityModelName();
     return (
-      this.modelName.startsWith('o1') ||
-      this.modelName.startsWith('o3') ||
-      this.modelName.startsWith('o4') ||
-      this.modelName.includes('/o1') ||
-      this.modelName.includes('/o3') ||
-      this.modelName.includes('/o4') ||
-      this.modelName === 'codex-mini-latest' ||
+      model.startsWith('o1') ||
+      model.startsWith('o3') ||
+      model.startsWith('o4') ||
+      model.includes('/o1') ||
+      model.includes('/o3') ||
+      model.includes('/o4') ||
+      model === 'codex-mini-latest' ||
       this.isGPT5Model()
     );
   }
@@ -174,7 +186,7 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
   }
 
   protected getBillingModelName(_config: OpenAiCompletionOptions): string {
-    return this.modelName;
+    return this.getCapabilityModelName();
   }
 
   protected getBillingUsage(data: any, _config: OpenAiCompletionOptions): any {
@@ -399,13 +411,8 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
       body.reasoning = { ...body.reasoning, ...renderedReasoning };
     }
 
-    // The Responses API uses max_output_tokens; prevent passthrough from reintroducing max_tokens.
-    if ('max_tokens' in body) {
-      delete body.max_tokens;
-    }
-
-    // Sanitize body: strip max_tokens if it leaked via passthrough or YAML anchors.
-    // The responses API uses max_output_tokens, never max_tokens.
+    // The Responses API uses max_output_tokens, never max_tokens; strip max_tokens if it
+    // leaked in via passthrough or YAML anchors.
     if ('max_tokens' in body) {
       delete body.max_tokens;
     }
@@ -495,7 +502,7 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
 
     // Calculate timeout for long-running models (deep research and GPT-5-pro variants)
     let timeout = getRequestTimeoutMs();
-    const isGpt5ProModel = /(^|\/)gpt-5(?:\.\d+)?-pro(?:-|$)/.test(this.modelName);
+    const isGpt5ProModel = /(^|\/)gpt-5(?:\.\d+)?-pro(?:-|$)/.test(this.getCapabilityModelName());
     const isLongRunningModel = isDeepResearchModel || isGpt5ProModel;
     if (isLongRunningModel) {
       const evalTimeout = getEnvInt('PROMPTFOO_EVAL_TIMEOUT_MS', 0);

--- a/test/contracts/index.test.ts
+++ b/test/contracts/index.test.ts
@@ -45,6 +45,18 @@ describe('contracts leaf surface', () => {
       }
     });
 
+    it('preserves AWS_BEARER_TOKEN_BEDROCK (used by the Bedrock OpenAI Responses path)', () => {
+      const parsed = ProviderEnvOverridesSchema.safeParse({
+        AWS_BEARER_TOKEN_BEDROCK: 'bedrock-api-key',
+        AWS_BEDROCK_REGION: 'us-east-2',
+      });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.AWS_BEARER_TOKEN_BEDROCK).toBe('bedrock-api-key');
+        expect(parsed.data.AWS_BEDROCK_REGION).toBe('us-east-2');
+      }
+    });
+
     it('strips unknown keys at parse time (strict z.object)', () => {
       const parsed = ProviderEnvOverridesSchema.safeParse({
         OPENAI_API_KEY: 'sk-known',

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -2104,6 +2104,43 @@ Third line`;
       expect(result.cost).toBeCloseTo(0.01485, 4);
     });
 
+    it('should calculate cost for OpenAI frontier models', async () => {
+      // Model ID needs to contain 'openai.gpt-5.5' for pricing lookup
+      const provider = new AwsBedrockConverseProvider('openai.gpt-5.5', {
+        config: { region: 'us-east-2' },
+      });
+
+      mockSend.mockResolvedValueOnce(
+        createMockConverseResponse('Response', {
+          usage: { inputTokens: 10000, outputTokens: 5000, totalTokens: 15000 },
+        }),
+      );
+
+      const result = await provider.callApi('Test');
+
+      // GPT-5.5: $5/MTok input, $30/MTok output
+      // (10000/1M * 5) + (5000/1M * 30) = 0.05 + 0.15 = 0.2
+      expect(result.cost).toBeCloseTo(0.2, 4);
+    });
+
+    it('should not mistake gpt-5.5 pricing for gpt-5.4', async () => {
+      const provider = new AwsBedrockConverseProvider('openai.gpt-5.4', {
+        config: { region: 'us-east-2' },
+      });
+
+      mockSend.mockResolvedValueOnce(
+        createMockConverseResponse('Response', {
+          usage: { inputTokens: 10000, outputTokens: 5000, totalTokens: 15000 },
+        }),
+      );
+
+      const result = await provider.callApi('Test');
+
+      // GPT-5.4: $2.5/MTok input, $15/MTok output
+      // (10000/1M * 2.5) + (5000/1M * 15) = 0.025 + 0.075 = 0.1
+      expect(result.cost).toBeCloseTo(0.1, 4);
+    });
+
     it('should return undefined cost for unknown models', async () => {
       const provider = new AwsBedrockConverseProvider('unknown.model-v1:0', {
         config: { region: 'us-east-1' },
@@ -3295,6 +3332,9 @@ describe('Model coverage parity', () => {
     // OpenAI GPT-OSS models
     { id: 'openai.gpt-oss-120b-1:0', family: 'openai' },
     { id: 'openai.gpt-oss-20b-1:0', family: 'openai' },
+    // OpenAI frontier models
+    { id: 'openai.gpt-5.5', family: 'openai' },
+    { id: 'openai.gpt-5.4', family: 'openai' },
   ];
 
   // Use describe.each for proper test isolation - each test gets its own beforeEach

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -2104,43 +2104,6 @@ Third line`;
       expect(result.cost).toBeCloseTo(0.01485, 4);
     });
 
-    it('should calculate cost for OpenAI frontier models', async () => {
-      // Model ID needs to contain 'openai.gpt-5.5' for pricing lookup
-      const provider = new AwsBedrockConverseProvider('openai.gpt-5.5', {
-        config: { region: 'us-east-2' },
-      });
-
-      mockSend.mockResolvedValueOnce(
-        createMockConverseResponse('Response', {
-          usage: { inputTokens: 10000, outputTokens: 5000, totalTokens: 15000 },
-        }),
-      );
-
-      const result = await provider.callApi('Test');
-
-      // GPT-5.5: $5/MTok input, $30/MTok output
-      // (10000/1M * 5) + (5000/1M * 30) = 0.05 + 0.15 = 0.2
-      expect(result.cost).toBeCloseTo(0.2, 4);
-    });
-
-    it('should not mistake gpt-5.5 pricing for gpt-5.4', async () => {
-      const provider = new AwsBedrockConverseProvider('openai.gpt-5.4', {
-        config: { region: 'us-east-2' },
-      });
-
-      mockSend.mockResolvedValueOnce(
-        createMockConverseResponse('Response', {
-          usage: { inputTokens: 10000, outputTokens: 5000, totalTokens: 15000 },
-        }),
-      );
-
-      const result = await provider.callApi('Test');
-
-      // GPT-5.4: $2.5/MTok input, $15/MTok output
-      // (10000/1M * 2.5) + (5000/1M * 15) = 0.025 + 0.075 = 0.1
-      expect(result.cost).toBeCloseTo(0.1, 4);
-    });
-
     it('should return undefined cost for unknown models', async () => {
       const provider = new AwsBedrockConverseProvider('unknown.model-v1:0', {
         config: { region: 'us-east-1' },
@@ -3329,12 +3292,9 @@ describe('Model coverage parity', () => {
     // Writer Palmyra models
     { id: 'writer.palmyra-x5-v1:0', family: 'writer' },
     { id: 'writer.palmyra-x4-v1:0', family: 'writer' },
-    // OpenAI GPT-OSS models
+    // OpenAI GPT-OSS models (frontier gpt-5.x models are not served via Converse)
     { id: 'openai.gpt-oss-120b-1:0', family: 'openai' },
     { id: 'openai.gpt-oss-20b-1:0', family: 'openai' },
-    // OpenAI frontier models
-    { id: 'openai.gpt-5.5', family: 'openai' },
-    { id: 'openai.gpt-5.4', family: 'openai' },
   ];
 
   // Use describe.each for proper test isolation - each test gets its own beforeEach

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -2134,15 +2134,15 @@ describe('BEDROCK_MODEL OPENAI', () => {
       });
     });
 
-    it('should forward frontier-only reasoning_effort values verbatim', async () => {
+    it('should forward the configured reasoning_effort verbatim', async () => {
       const config = {
-        reasoning_effort: 'minimal' as const,
+        reasoning_effort: 'low' as const,
       };
       const prompt = 'Test prompt';
 
       const params = await modelHandler.params(config, prompt);
 
-      expect(params.reasoning_effort).toBe('minimal');
+      expect(params.reasoning_effort).toBe('low');
     });
 
     it('should not include reasoning_effort when it is not specified', async () => {

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -2177,25 +2177,25 @@ describe('BEDROCK_MODEL OPENAI', () => {
       );
     });
 
-    it('should keep the <reasoning> block by default', async () => {
+    it('should strip the <reasoning> block by default to match the OpenAI provider', async () => {
       const mockResponse = {
         choices: [{ message: { content: '<reasoning>Think think</reasoning>The answer is 42.' } }],
       };
 
-      expect(modelHandler.output({}, mockResponse)).toBe(
-        '<reasoning>Think think</reasoning>The answer is 42.',
+      expect(modelHandler.output({}, mockResponse)).toBe('The answer is 42.');
+    });
+
+    it('should surface reasoning as Thinking: when showThinking is true', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: '<reasoning>Think think</reasoning>The answer is 42.' } }],
+      };
+
+      expect(modelHandler.output({ showThinking: true }, mockResponse)).toBe(
+        'Thinking: Think think\n\nThe answer is 42.',
       );
     });
 
-    it('should strip the <reasoning> block when showThinking is false', async () => {
-      const mockResponse = {
-        choices: [{ message: { content: '<reasoning>Think think</reasoning>The answer is 42.' } }],
-      };
-
-      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe('The answer is 42.');
-    });
-
-    it('should strip a multi-line <reasoning> block and leading whitespace', async () => {
+    it('should strip a multi-line <reasoning> block and leading whitespace by default', async () => {
       const mockResponse = {
         choices: [
           {
@@ -2206,15 +2206,16 @@ describe('BEDROCK_MODEL OPENAI', () => {
         ],
       };
 
-      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe('Final answer');
+      expect(modelHandler.output({}, mockResponse)).toBe('Final answer');
     });
 
-    it('should leave content untouched when showThinking is false but no reasoning is present', async () => {
+    it('should leave content untouched when no reasoning block is present', async () => {
       const mockResponse = {
         choices: [{ message: { content: 'Just the answer.' } }],
       };
 
-      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe('Just the answer.');
+      expect(modelHandler.output({}, mockResponse)).toBe('Just the answer.');
+      expect(modelHandler.output({ showThinking: true }, mockResponse)).toBe('Just the answer.');
     });
 
     it('should throw an error for API errors', async () => {
@@ -2265,6 +2266,27 @@ describe('BEDROCK_MODEL OPENAI', () => {
         completion: 60,
         total: 90,
         numRequests: 1,
+      });
+    });
+
+    it('should surface reasoning and cached token details for parity with the OpenAI provider', async () => {
+      const mockResponse = {
+        usage: {
+          prompt_tokens: 19,
+          completion_tokens: 22,
+          total_tokens: 41,
+          completion_tokens_details: { reasoning_tokens: 12 },
+          prompt_tokens_details: { cached_tokens: 8 },
+        },
+      };
+
+      const result = modelHandler.tokenUsage!(mockResponse, 'Test prompt');
+      expect(result).toEqual({
+        prompt: 19,
+        completion: 22,
+        total: 41,
+        numRequests: 1,
+        completionDetails: { reasoning: 12, cacheReadInputTokens: 8 },
       });
     });
 
@@ -3109,25 +3131,17 @@ describe('AWS_BEDROCK_MODELS mapping', () => {
     expect(AWS_BEDROCK_MODELS['openai.gpt-oss-safeguard-20b']).toBe(BEDROCK_MODEL.OPENAI);
   });
 
-  it('should map OpenAI frontier models correctly', async () => {
-    expect(AWS_BEDROCK_MODELS['openai.gpt-5.5']).toBe(BEDROCK_MODEL.OPENAI);
-    expect(AWS_BEDROCK_MODELS['openai.gpt-5.4']).toBe(BEDROCK_MODEL.OPENAI);
+  it('should not register frontier gpt-5.x models for the InvokeModel path', async () => {
+    // Frontier models are served via the OpenAI-compatible Responses API, not InvokeModel,
+    // so they must not appear in the InvokeModel model map.
+    expect(AWS_BEDROCK_MODELS['openai.gpt-5.5']).toBeUndefined();
+    expect(AWS_BEDROCK_MODELS['openai.gpt-5.4']).toBeUndefined();
   });
 
   describe('getHandlerForModel OpenAI routing', () => {
-    it('should resolve registered OpenAI model ids to the OpenAI handler', () => {
-      expect(getHandlerForModel('openai.gpt-5.5')).toBe(BEDROCK_MODEL.OPENAI);
+    it('should resolve gpt-oss OpenAI model ids to the InvokeModel OpenAI handler', () => {
       expect(getHandlerForModel('openai.gpt-oss-120b-1:0')).toBe(BEDROCK_MODEL.OPENAI);
-    });
-
-    it('should fall back to the OpenAI handler for unregistered openai.* model ids', () => {
-      // Future frontier releases that are not yet in the static map should still route
-      // through the OpenAI handler instead of throwing.
-      expect(getHandlerForModel('openai.gpt-5.6')).toBe(BEDROCK_MODEL.OPENAI);
-    });
-
-    it('should route region-prefixed OpenAI inference profiles to the OpenAI handler', () => {
-      expect(getHandlerForModel('us.openai.gpt-5.5')).toBe(BEDROCK_MODEL.OPENAI);
+      expect(getHandlerForModel('openai.gpt-oss-20b-1:0')).toBe(BEDROCK_MODEL.OPENAI);
     });
 
     it('should still throw for genuinely unknown models', () => {

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -2177,12 +2177,25 @@ describe('BEDROCK_MODEL OPENAI', () => {
       );
     });
 
-    it('should strip the <reasoning> block by default to match the OpenAI provider', async () => {
+    it('should return the model output verbatim by default (reasoning preserved for assertions/red-team)', async () => {
+      // An eval framework must not hide application-visible content by default. The raw
+      // <reasoning>...</reasoning> block the API returned stays in `output` unless the user
+      // explicitly opts into a transformation via showThinking.
       const mockResponse = {
         choices: [{ message: { content: '<reasoning>Think think</reasoning>The answer is 42.' } }],
       };
 
-      expect(modelHandler.output({}, mockResponse)).toBe('The answer is 42.');
+      expect(modelHandler.output({}, mockResponse)).toBe(
+        '<reasoning>Think think</reasoning>The answer is 42.',
+      );
+    });
+
+    it('should strip the <reasoning> block when showThinking is false (parity with the openai: providers)', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: '<reasoning>Think think</reasoning>The answer is 42.' } }],
+      };
+
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe('The answer is 42.');
     });
 
     it('should surface reasoning as Thinking: when showThinking is true', async () => {
@@ -2195,7 +2208,7 @@ describe('BEDROCK_MODEL OPENAI', () => {
       );
     });
 
-    it('should strip a multi-line <reasoning> block and leading whitespace by default', async () => {
+    it('should strip a multi-line <reasoning> block and leading whitespace when showThinking is false', async () => {
       const mockResponse = {
         choices: [
           {
@@ -2206,32 +2219,38 @@ describe('BEDROCK_MODEL OPENAI', () => {
         ],
       };
 
-      expect(modelHandler.output({}, mockResponse)).toBe('Final answer');
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe('Final answer');
     });
 
-    it('should leave content untouched when no reasoning block is present', async () => {
+    it('should leave content untouched when no reasoning block is present (any showThinking value)', async () => {
       const mockResponse = {
         choices: [{ message: { content: 'Just the answer.' } }],
       };
 
       expect(modelHandler.output({}, mockResponse)).toBe('Just the answer.');
       expect(modelHandler.output({ showThinking: true }, mockResponse)).toBe('Just the answer.');
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe('Just the answer.');
     });
 
-    it('should fall back to the full content when only a reasoning block is present (no final answer)', async () => {
-      // Stripping a reasoning-only response would collapse output to '' — fall back instead.
+    it('should handle a reasoning-only response across all showThinking values', async () => {
       const mockResponse = {
         choices: [{ message: { content: '<reasoning>just thinking</reasoning>' } }],
       };
 
+      // Default: verbatim.
       expect(modelHandler.output({}, mockResponse)).toBe('<reasoning>just thinking</reasoning>');
-      // showThinking still surfaces the reasoning even when the answer is empty.
+      // showThinking:false would strip to '', so it falls back to the full content instead of
+      // silently dropping the whole response.
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe(
+        '<reasoning>just thinking</reasoning>',
+      );
+      // showThinking:true still surfaces the reasoning even when the answer is empty.
       expect(modelHandler.output({ showThinking: true }, mockResponse)).toBe(
         'Thinking: just thinking\n\n',
       );
     });
 
-    it('should not strip an unterminated <reasoning> tag (returns content verbatim, no data loss)', async () => {
+    it('should return content verbatim for an unterminated <reasoning> tag (no data loss)', async () => {
       const mockResponse = {
         choices: [{ message: { content: '<reasoning>oops no closing tag, the answer is 42' } }],
       };
@@ -2239,9 +2258,12 @@ describe('BEDROCK_MODEL OPENAI', () => {
       expect(modelHandler.output({}, mockResponse)).toBe(
         '<reasoning>oops no closing tag, the answer is 42',
       );
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe(
+        '<reasoning>oops no closing tag, the answer is 42',
+      );
     });
 
-    it('should only strip a leading <reasoning> block, leaving later ones as answer content', async () => {
+    it('should only strip the leading <reasoning> block when showThinking is false, leaving later ones as answer content', async () => {
       const mockResponse = {
         choices: [
           {
@@ -2254,18 +2276,17 @@ describe('BEDROCK_MODEL OPENAI', () => {
       };
 
       // Non-greedy match strips only the first block; subsequent ones are part of the answer.
-      expect(modelHandler.output({}, mockResponse)).toBe(
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe(
         'answer with <reasoning>literal</reasoning> data',
       );
     });
 
-    it('should not strip a <reasoning> block that does not start the content', async () => {
+    it('should not strip a mid-content <reasoning> block when showThinking is false (regex is start-anchored)', async () => {
       const mockResponse = {
         choices: [{ message: { content: 'The answer <reasoning>is</reasoning> here.' } }],
       };
 
-      // The regex is anchored to the start, so mid-content reasoning-as-data is preserved.
-      expect(modelHandler.output({}, mockResponse)).toBe(
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe(
         'The answer <reasoning>is</reasoning> here.',
       );
     });
@@ -3279,9 +3300,19 @@ describe('AWS_BEDROCK_MODELS mapping', () => {
   });
 
   describe('getHandlerForModel OpenAI routing', () => {
-    it('should resolve gpt-oss OpenAI model ids to the InvokeModel OpenAI handler', () => {
+    it('should resolve versioned gpt-oss runtime ids to the InvokeModel OpenAI handler', () => {
       expect(getHandlerForModel('openai.gpt-oss-120b-1:0')).toBe(BEDROCK_MODEL.OPENAI);
       expect(getHandlerForModel('openai.gpt-oss-20b-1:0')).toBe(BEDROCK_MODEL.OPENAI);
+      // Registered bare safeguard ids resolve via the exact-match lookup.
+      expect(getHandlerForModel('openai.gpt-oss-safeguard-120b')).toBe(BEDROCK_MODEL.OPENAI);
+    });
+
+    it('should reject the bare Mantle gpt-oss id instead of sending it to InvokeModel', () => {
+      // `openai.gpt-oss-120b` (no version suffix) is the Bedrock Mantle id; the bedrock:
+      // provider uses the InvokeModel runtime API, so it must reject it with the runtime id.
+      expect(() => getHandlerForModel('openai.gpt-oss-120b')).toThrow(/Mantle id/);
+      expect(() => getHandlerForModel('openai.gpt-oss-120b')).toThrow(/openai\.gpt-oss-120b-1:0/);
+      expect(() => getHandlerForModel('openai.gpt-oss-20b')).toThrow(/Mantle id/);
     });
 
     it('should throw a clear error for frontier gpt-5.x ids on the InvokeModel path', () => {
@@ -3289,6 +3320,13 @@ describe('AWS_BEDROCK_MODELS mapping', () => {
       // a direct/forced InvokeModel resolution should explain that rather than silently try.
       expect(() => getHandlerForModel('openai.gpt-5.5')).toThrow(/Responses API/);
       expect(() => getHandlerForModel('openai.gpt-5.4')).toThrow(/Responses API/);
+    });
+
+    it('should suggest the bare frontier id when a region/geo-prefixed frontier id is forced down InvokeModel', () => {
+      // AWS offers no Geo/Global inference profiles for the frontier models; the error should
+      // point at the supported bare id rather than echo the invalid prefixed one.
+      expect(() => getHandlerForModel('us.openai.gpt-5.5')).toThrow(/bedrock:openai\.gpt-5\.5/);
+      expect(() => getHandlerForModel('global.openai.gpt-5.4')).toThrow(/bedrock:openai\.gpt-5\.4/);
     });
 
     it('should still throw for genuinely unknown models', () => {

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -2218,6 +2218,58 @@ describe('BEDROCK_MODEL OPENAI', () => {
       expect(modelHandler.output({ showThinking: true }, mockResponse)).toBe('Just the answer.');
     });
 
+    it('should fall back to the full content when only a reasoning block is present (no final answer)', async () => {
+      // Stripping a reasoning-only response would collapse output to '' — fall back instead.
+      const mockResponse = {
+        choices: [{ message: { content: '<reasoning>just thinking</reasoning>' } }],
+      };
+
+      expect(modelHandler.output({}, mockResponse)).toBe('<reasoning>just thinking</reasoning>');
+      // showThinking still surfaces the reasoning even when the answer is empty.
+      expect(modelHandler.output({ showThinking: true }, mockResponse)).toBe(
+        'Thinking: just thinking\n\n',
+      );
+    });
+
+    it('should not strip an unterminated <reasoning> tag (returns content verbatim, no data loss)', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: '<reasoning>oops no closing tag, the answer is 42' } }],
+      };
+
+      expect(modelHandler.output({}, mockResponse)).toBe(
+        '<reasoning>oops no closing tag, the answer is 42',
+      );
+    });
+
+    it('should only strip a leading <reasoning> block, leaving later ones as answer content', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content:
+                '<reasoning>first</reasoning>answer with <reasoning>literal</reasoning> data',
+            },
+          },
+        ],
+      };
+
+      // Non-greedy match strips only the first block; subsequent ones are part of the answer.
+      expect(modelHandler.output({}, mockResponse)).toBe(
+        'answer with <reasoning>literal</reasoning> data',
+      );
+    });
+
+    it('should not strip a <reasoning> block that does not start the content', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'The answer <reasoning>is</reasoning> here.' } }],
+      };
+
+      // The regex is anchored to the start, so mid-content reasoning-as-data is preserved.
+      expect(modelHandler.output({}, mockResponse)).toBe(
+        'The answer <reasoning>is</reasoning> here.',
+      );
+    });
+
     it('should throw an error for API errors', async () => {
       const mockErrorResponse = { error: 'API Error occurred' };
       expect(() => modelHandler.output({}, mockErrorResponse)).toThrow(
@@ -3501,6 +3553,38 @@ describe('AwsBedrockCompletionProvider', () => {
         raw: 'test prompt',
         label: 'test',
         // Prompt-level override should reach output(), not just params().
+        config: { showThinking: true } as any,
+      },
+      vars: {},
+    };
+
+    await provider.callApi('test prompt', context as any);
+
+    expect(
+      AWS_BEDROCK_MODELS['us.anthropic.claude-3-7-sonnet-20250219-v1:0'].output,
+    ).toHaveBeenCalledWith(expect.objectContaining({ showThinking: true }), expect.anything());
+  });
+
+  it('should pass merged prompt-level config to model.output on the live (non-cached) path', async () => {
+    // Default beforeEach has caching disabled, so this exercises the live InvokeModel path.
+    // The live path both logs via body.transformToString() and decodes via TextDecoder, so the
+    // mock body must be a real byte view that also carries transformToString().
+    const liveBytes = new TextEncoder().encode(JSON.stringify({ completion: 'live' }));
+    (liveBytes as any).transformToString = () => JSON.stringify({ completion: 'live' });
+    mockInvokeModel.mockResolvedValueOnce({ body: liveBytes });
+
+    const provider = new (class extends AwsBedrockCompletionProvider {
+      constructor() {
+        super('us.anthropic.claude-3-7-sonnet-20250219-v1:0', {
+          config: { region: 'us-east-1', showThinking: false } as any,
+        });
+      }
+    })();
+
+    const context = {
+      prompt: {
+        raw: 'test prompt',
+        label: 'test',
         config: { showThinking: true } as any,
       },
       vars: {},

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -3144,6 +3144,13 @@ describe('AWS_BEDROCK_MODELS mapping', () => {
       expect(getHandlerForModel('openai.gpt-oss-20b-1:0')).toBe(BEDROCK_MODEL.OPENAI);
     });
 
+    it('should throw a clear error for frontier gpt-5.x ids on the InvokeModel path', () => {
+      // Frontier models are routed to the Responses provider before reaching this handler;
+      // a direct/forced InvokeModel resolution should explain that rather than silently try.
+      expect(() => getHandlerForModel('openai.gpt-5.5')).toThrow(/Responses API/);
+      expect(() => getHandlerForModel('openai.gpt-5.4')).toThrow(/Responses API/);
+    });
+
     it('should still throw for genuinely unknown models', () => {
       expect(() => getHandlerForModel('totally.unknown-model')).toThrow(
         'Unknown Amazon Bedrock model',
@@ -3474,6 +3481,36 @@ describe('AwsBedrockCompletionProvider', () => {
       'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
       {}, // vars from context
     );
+  });
+
+  it('should pass merged prompt-level config to model.output (e.g. showThinking)', async () => {
+    // Exercise the cached path, which reaches model.output with the effective config.
+    mockCache.get = vi.fn().mockResolvedValue(JSON.stringify({ completion: 'cached' }));
+    vi.mocked(isCacheEnabled).mockImplementation(() => true);
+
+    const provider = new (class extends AwsBedrockCompletionProvider {
+      constructor() {
+        super('us.anthropic.claude-3-7-sonnet-20250219-v1:0', {
+          config: { region: 'us-east-1', showThinking: false } as any,
+        });
+      }
+    })();
+
+    const context = {
+      prompt: {
+        raw: 'test prompt',
+        label: 'test',
+        // Prompt-level override should reach output(), not just params().
+        config: { showThinking: true } as any,
+      },
+      vars: {},
+    };
+
+    await provider.callApi('test prompt', context as any);
+
+    expect(
+      AWS_BEDROCK_MODELS['us.anthropic.claude-3-7-sonnet-20250219-v1:0'].output,
+    ).toHaveBeenCalledWith(expect.objectContaining({ showThinking: true }), expect.anything());
   });
 
   it('should set cached flag when returning cached response', async () => {

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -20,6 +20,7 @@ import {
   formatPromptLlama3Instruct,
   formatPromptLlama4,
   formatPromptLlama32Vision,
+  getHandlerForModel,
   getLlamaModelHandler,
   LlamaVersion,
   parseValue,
@@ -2093,7 +2094,7 @@ describe('BEDROCK_MODEL OPENAI', () => {
       });
     });
 
-    it('should handle reasoning_effort by adding it to system message', async () => {
+    it('should pass reasoning_effort as a native parameter without modifying messages', async () => {
       const config = {
         temperature: 0.7,
         reasoning_effort: 'high' as const,
@@ -2103,16 +2104,14 @@ describe('BEDROCK_MODEL OPENAI', () => {
       const params = await modelHandler.params(config, prompt);
 
       expect(params).toEqual({
-        messages: [
-          { role: 'system', content: 'Reasoning: high' },
-          { role: 'user', content: 'Test prompt' },
-        ],
+        messages: [{ role: 'user', content: 'Test prompt' }],
         temperature: 0.7,
         top_p: 1.0,
+        reasoning_effort: 'high',
       });
     });
 
-    it('should append reasoning_effort to existing system message', async () => {
+    it('should keep an existing system message intact when reasoning_effort is set', async () => {
       const config = {
         temperature: 0.7,
         reasoning_effort: 'medium' as const,
@@ -2126,15 +2125,27 @@ describe('BEDROCK_MODEL OPENAI', () => {
 
       expect(params).toEqual({
         messages: [
-          { role: 'system', content: 'You are a helpful assistant.\n\nReasoning: medium' },
+          { role: 'system', content: 'You are a helpful assistant.' },
           { role: 'user', content: 'What is machine learning?' },
         ],
         temperature: 0.7,
         top_p: 1.0,
+        reasoning_effort: 'medium',
       });
     });
 
-    it('should not modify messages when reasoning_effort is not specified', async () => {
+    it('should forward frontier-only reasoning_effort values verbatim', async () => {
+      const config = {
+        reasoning_effort: 'minimal' as const,
+      };
+      const prompt = 'Test prompt';
+
+      const params = await modelHandler.params(config, prompt);
+
+      expect(params.reasoning_effort).toBe('minimal');
+    });
+
+    it('should not include reasoning_effort when it is not specified', async () => {
       const config = { temperature: 0.5 };
       const prompt = 'Test prompt';
 
@@ -2145,6 +2156,7 @@ describe('BEDROCK_MODEL OPENAI', () => {
         temperature: 0.5,
         top_p: 1.0,
       });
+      expect(params).not.toHaveProperty('reasoning_effort');
     });
   });
 
@@ -2163,6 +2175,46 @@ describe('BEDROCK_MODEL OPENAI', () => {
       expect(modelHandler.output({}, mockResponse)).toBe(
         'This is a test response from OpenAI model.',
       );
+    });
+
+    it('should keep the <reasoning> block by default', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: '<reasoning>Think think</reasoning>The answer is 42.' } }],
+      };
+
+      expect(modelHandler.output({}, mockResponse)).toBe(
+        '<reasoning>Think think</reasoning>The answer is 42.',
+      );
+    });
+
+    it('should strip the <reasoning> block when showThinking is false', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: '<reasoning>Think think</reasoning>The answer is 42.' } }],
+      };
+
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe('The answer is 42.');
+    });
+
+    it('should strip a multi-line <reasoning> block and leading whitespace', async () => {
+      const mockResponse = {
+        choices: [
+          {
+            message: {
+              content: '<reasoning>line one\nline two</reasoning>\n\nFinal answer',
+            },
+          },
+        ],
+      };
+
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe('Final answer');
+    });
+
+    it('should leave content untouched when showThinking is false but no reasoning is present', async () => {
+      const mockResponse = {
+        choices: [{ message: { content: 'Just the answer.' } }],
+      };
+
+      expect(modelHandler.output({ showThinking: false }, mockResponse)).toBe('Just the answer.');
     });
 
     it('should throw an error for API errors', async () => {
@@ -3055,6 +3107,34 @@ describe('AWS_BEDROCK_MODELS mapping', () => {
     expect(AWS_BEDROCK_MODELS['openai.gpt-oss-20b-1:0']).toBe(BEDROCK_MODEL.OPENAI);
     expect(AWS_BEDROCK_MODELS['openai.gpt-oss-safeguard-120b']).toBe(BEDROCK_MODEL.OPENAI);
     expect(AWS_BEDROCK_MODELS['openai.gpt-oss-safeguard-20b']).toBe(BEDROCK_MODEL.OPENAI);
+  });
+
+  it('should map OpenAI frontier models correctly', async () => {
+    expect(AWS_BEDROCK_MODELS['openai.gpt-5.5']).toBe(BEDROCK_MODEL.OPENAI);
+    expect(AWS_BEDROCK_MODELS['openai.gpt-5.4']).toBe(BEDROCK_MODEL.OPENAI);
+  });
+
+  describe('getHandlerForModel OpenAI routing', () => {
+    it('should resolve registered OpenAI model ids to the OpenAI handler', () => {
+      expect(getHandlerForModel('openai.gpt-5.5')).toBe(BEDROCK_MODEL.OPENAI);
+      expect(getHandlerForModel('openai.gpt-oss-120b-1:0')).toBe(BEDROCK_MODEL.OPENAI);
+    });
+
+    it('should fall back to the OpenAI handler for unregistered openai.* model ids', () => {
+      // Future frontier releases that are not yet in the static map should still route
+      // through the OpenAI handler instead of throwing.
+      expect(getHandlerForModel('openai.gpt-5.6')).toBe(BEDROCK_MODEL.OPENAI);
+    });
+
+    it('should route region-prefixed OpenAI inference profiles to the OpenAI handler', () => {
+      expect(getHandlerForModel('us.openai.gpt-5.5')).toBe(BEDROCK_MODEL.OPENAI);
+    });
+
+    it('should still throw for genuinely unknown models', () => {
+      expect(() => getHandlerForModel('totally.unknown-model')).toThrow(
+        'Unknown Amazon Bedrock model',
+      );
+    });
   });
 
   it('should map APAC regional models correctly', async () => {

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -2342,6 +2342,94 @@ describe('BEDROCK_MODEL OPENAI', () => {
       });
     });
 
+    it('should surface reasoning alone when no cached-token detail is present', async () => {
+      const result = modelHandler.tokenUsage!(
+        {
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            total_tokens: 30,
+            completion_tokens_details: { reasoning_tokens: 7 },
+          },
+        },
+        'Test prompt',
+      );
+      // No prompt_tokens_details => cacheReadInputTokens must be absent (not 0).
+      expect(result).toEqual({
+        prompt: 10,
+        completion: 20,
+        total: 30,
+        numRequests: 1,
+        completionDetails: { reasoning: 7 },
+      });
+    });
+
+    it('should surface cached input tokens alone when no reasoning detail is present', async () => {
+      const result = modelHandler.tokenUsage!(
+        {
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            total_tokens: 30,
+            prompt_tokens_details: { cached_tokens: 5 },
+          },
+        },
+        'Test prompt',
+      );
+      // No completion_tokens_details => reasoning must be absent.
+      expect(result).toEqual({
+        prompt: 10,
+        completion: 20,
+        total: 30,
+        numRequests: 1,
+        completionDetails: { cacheReadInputTokens: 5 },
+      });
+    });
+
+    it('should include reasoning:0 but drop cached_tokens:0 (asymmetric guards: !== undefined vs > 0)', async () => {
+      const result = modelHandler.tokenUsage!(
+        {
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            total_tokens: 30,
+            completion_tokens_details: { reasoning_tokens: 0 },
+            prompt_tokens_details: { cached_tokens: 0 },
+          },
+        },
+        'Test prompt',
+      );
+      // reasoning:0 is reported (guard is `!== undefined`); cached:0 is dropped (guard is `> 0`).
+      expect(result).toEqual({
+        prompt: 10,
+        completion: 20,
+        total: 30,
+        numRequests: 1,
+        completionDetails: { reasoning: 0 },
+      });
+    });
+
+    it('should omit completionDetails entirely when only cached_tokens:0 is present', async () => {
+      const result = modelHandler.tokenUsage!(
+        {
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 20,
+            total_tokens: 30,
+            prompt_tokens_details: { cached_tokens: 0 },
+          },
+        },
+        'Test prompt',
+      );
+      // cached:0 dropped and no reasoning => no completionDetails key at all.
+      expect(result).toEqual({
+        prompt: 10,
+        completion: 20,
+        total: 30,
+        numRequests: 1,
+      });
+    });
+
     it('should return undefined token counts when usage is not provided', async () => {
       const mockResponse = {
         choices: [

--- a/test/providers/bedrock/openaiResponses.test.ts
+++ b/test/providers/bedrock/openaiResponses.test.ts
@@ -33,10 +33,14 @@ describe('bedrock openaiResponses helper', () => {
       expect(isBedrockOpenAiResponsesModel('qwen.qwen3-32b-v1:0')).toBe(false);
     });
 
-    it('matches region-prefixed frontier ids', () => {
-      expect(isBedrockOpenAiResponsesModel('us.openai.gpt-5.5')).toBe(true);
-      expect(isBedrockOpenAiResponsesModel('eu.openai.gpt-5.4')).toBe(true);
-      // ...but still excludes region-prefixed gpt-oss
+    it('rejects region/geo-prefixed frontier ids (AWS offers only the bare ids)', () => {
+      // AWS's GPT-5.5 / GPT-5.4 model cards mark Geo and Global inference IDs as "Not
+      // supported", so a prefixed id is not a real Bedrock model — it must not be routed to the
+      // mantle endpoint; it falls through to a clear error instead.
+      expect(isBedrockOpenAiResponsesModel('us.openai.gpt-5.5')).toBe(false);
+      expect(isBedrockOpenAiResponsesModel('eu.openai.gpt-5.4')).toBe(false);
+      expect(isBedrockOpenAiResponsesModel('global.openai.gpt-5.5')).toBe(false);
+      // ...and region-prefixed gpt-oss is likewise not a Responses model.
       expect(isBedrockOpenAiResponsesModel('us.openai.gpt-oss-120b')).toBe(false);
     });
   });
@@ -140,7 +144,6 @@ describe('bedrock openaiResponses helper', () => {
     it.each([
       'openai.gpt-5.5',
       'openai.gpt-5.4',
-      'us.openai.gpt-5.5',
     ])('computes a finite, non-zero cost end-to-end for %s via the OpenAI billing tables', (modelId) => {
       restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
       const provider = createBedrockOpenAiResponsesProvider(modelId, {});
@@ -228,13 +231,6 @@ describe('bedrock openaiResponses helper', () => {
       expect(direct.getApiUrl()).toBe(
         new OpenAiResponsesProvider('gpt-5.5', { config: { apiKey: 'k' } }).getApiUrl(),
       );
-    });
-
-    it('strips a region prefix for capability detection on profile ids', () => {
-      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
-      const provider = createBedrockOpenAiResponsesProvider('us.openai.gpt-5.5', {});
-      expect((provider as any).getBillingModelName({})).toBe('gpt-5.5');
-      expect((provider as any).isGPT5Model()).toBe(true);
     });
   });
 });

--- a/test/providers/bedrock/openaiResponses.test.ts
+++ b/test/providers/bedrock/openaiResponses.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  BedrockOpenAiResponsesProvider,
   createBedrockOpenAiResponsesProvider,
   getBedrockMantleBaseUrl,
   isBedrockOpenAiResponsesModel,
@@ -48,6 +49,22 @@ describe('bedrock openaiResponses helper', () => {
       expect(getBedrockMantleBaseUrl('us-west-2')).toBe(
         'https://bedrock-mantle.us-west-2.api.aws/openai/v1',
       );
+    });
+
+    it('accepts non-standard but well-formed AWS region shapes', () => {
+      expect(getBedrockMantleBaseUrl('us-gov-west-1')).toBe(
+        'https://bedrock-mantle.us-gov-west-1.api.aws/openai/v1',
+      );
+      expect(getBedrockMantleBaseUrl('ap-southeast-4')).toBe(
+        'https://bedrock-mantle.ap-southeast-4.api.aws/openai/v1',
+      );
+    });
+
+    it('rejects a malformed region instead of building a bogus host (defense-in-depth)', () => {
+      // A value like `evil.com/x` would otherwise yield host `bedrock-mantle.evil.com`.
+      expect(() => getBedrockMantleBaseUrl('evil.com/x')).toThrow(/Invalid AWS region/);
+      expect(() => getBedrockMantleBaseUrl('us_east_2')).toThrow(/Invalid AWS region/);
+      expect(() => getBedrockMantleBaseUrl('')).toThrow(/Invalid AWS region/);
     });
   });
 
@@ -193,6 +210,24 @@ describe('bedrock openaiResponses helper', () => {
       });
       // Base getApiUrl() would prefer OPENAI_API_HOST; the subclass must override that.
       expect(provider.getApiUrl()).toBe('https://bedrock-mantle.us-east-2.api.aws/openai/v1');
+    });
+
+    it('falls back to the base OpenAI URL when constructed directly without apiBaseUrl', () => {
+      // The factory always sets config.apiBaseUrl, so the `|| super.getApiUrl()` fallback in the
+      // override is only reachable by a direct caller. Exercise it: with no apiBaseUrl, getApiUrl()
+      // must delegate to the base provider (never the mantle endpoint).
+      restoreEnv = mockProcessEnv({
+        OPENAI_API_HOST: undefined,
+        OPENAI_BASE_URL: undefined,
+        OPENAI_API_BASE_URL: undefined,
+      });
+      const direct = new BedrockOpenAiResponsesProvider('openai.gpt-5.5', {
+        config: { apiKey: 'k' },
+      });
+      expect(direct.getApiUrl()).not.toContain('bedrock-mantle');
+      expect(direct.getApiUrl()).toBe(
+        new OpenAiResponsesProvider('gpt-5.5', { config: { apiKey: 'k' } }).getApiUrl(),
+      );
     });
 
     it('strips a region prefix for capability detection on profile ids', () => {

--- a/test/providers/bedrock/openaiResponses.test.ts
+++ b/test/providers/bedrock/openaiResponses.test.ts
@@ -92,5 +92,31 @@ describe('bedrock openaiResponses helper', () => {
       // billing key so cost is computed (Bedrock mirrors OpenAI first-party rates).
       expect((provider as any).getBillingModelName({})).toBe('gpt-5.5');
     });
+
+    it('detects the prefixed frontier id as a GPT-5 / reasoning model', () => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
+      const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {});
+      // Without prefix-stripping these would be false (the id starts with "openai.").
+      expect((provider as any).isGPT5Model()).toBe(true);
+      expect((provider as any).isReasoningModel()).toBe(true);
+      expect((provider as any).supportsTemperature()).toBe(false);
+    });
+
+    it('sends GPT-5 controls in the request body and preserves the openai. model id', async () => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
+      const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {
+        config: { reasoning_effort: 'high', verbosity: 'low' } as any,
+      });
+
+      const { body } = await (provider as any).getOpenAiBody('hello');
+
+      // Real Bedrock model id is sent to the mantle endpoint...
+      expect(body.model).toBe('openai.gpt-5.5');
+      // ...while GPT-5 capability detection applies: reasoning effort + verbosity are sent,
+      // and no temperature default leaks in (reasoning models don't support it).
+      expect(body.reasoning).toEqual({ effort: 'high' });
+      expect(body.text?.verbosity).toBe('low');
+      expect(body.temperature).toBeUndefined();
+    });
   });
 });

--- a/test/providers/bedrock/openaiResponses.test.ts
+++ b/test/providers/bedrock/openaiResponses.test.ts
@@ -58,6 +58,25 @@ describe('bedrock openaiResponses helper', () => {
       );
     });
 
+    it('treats an unresolved {{env.*}} apiKey template as missing (helpful error)', () => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
+      // Simulates the env var being unset: the template literal must NOT be sent as a bearer
+      // token (which would 401); the user should get the actionable missing-key error.
+      expect(() =>
+        createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {
+          config: { apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}' },
+        }),
+      ).toThrow(/AWS_BEARER_TOKEN_BEDROCK/);
+    });
+
+    it('falls back to the env var when apiKey is an unresolved template but the env is set', () => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'real-key' });
+      const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {
+        config: { apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}' },
+      });
+      expect((provider.config as any).apiKey).toBe('real-key');
+    });
+
     it('targets the mantle endpoint for the configured region with config.apiKey', () => {
       restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
       const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {

--- a/test/providers/bedrock/openaiResponses.test.ts
+++ b/test/providers/bedrock/openaiResponses.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createBedrockOpenAiResponsesProvider,
+  getBedrockMantleBaseUrl,
+  isBedrockOpenAiResponsesModel,
+} from '../../../src/providers/bedrock/openaiResponses';
+import { OpenAiResponsesProvider } from '../../../src/providers/openai/responses';
+import { mockProcessEnv } from '../../util/utils';
+
+describe('bedrock openaiResponses helper', () => {
+  let restoreEnv: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreEnv?.();
+    restoreEnv = undefined;
+  });
+
+  describe('isBedrockOpenAiResponsesModel', () => {
+    it('treats frontier gpt-5.x ids as Responses models', () => {
+      expect(isBedrockOpenAiResponsesModel('openai.gpt-5.5')).toBe(true);
+      expect(isBedrockOpenAiResponsesModel('openai.gpt-5.4')).toBe(true);
+    });
+
+    it('excludes open-weight gpt-oss ids (served via InvokeModel)', () => {
+      expect(isBedrockOpenAiResponsesModel('openai.gpt-oss-120b-1:0')).toBe(false);
+      expect(isBedrockOpenAiResponsesModel('openai.gpt-oss-safeguard-20b')).toBe(false);
+    });
+
+    it('excludes non-openai ids', () => {
+      expect(isBedrockOpenAiResponsesModel('anthropic.claude-opus-4-8')).toBe(false);
+      expect(isBedrockOpenAiResponsesModel('qwen.qwen3-32b-v1:0')).toBe(false);
+    });
+  });
+
+  describe('getBedrockMantleBaseUrl', () => {
+    it('builds the regional mantle endpoint', () => {
+      expect(getBedrockMantleBaseUrl('us-east-2')).toBe(
+        'https://bedrock-mantle.us-east-2.api.aws/openai/v1',
+      );
+      expect(getBedrockMantleBaseUrl('us-west-2')).toBe(
+        'https://bedrock-mantle.us-west-2.api.aws/openai/v1',
+      );
+    });
+  });
+
+  describe('createBedrockOpenAiResponsesProvider', () => {
+    it('throws a helpful error when no Bedrock API key is configured', () => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
+      expect(() => createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {})).toThrow(
+        /AWS_BEARER_TOKEN_BEDROCK/,
+      );
+    });
+
+    it('targets the mantle endpoint for the configured region with config.apiKey', () => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
+      const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {
+        config: { region: 'us-west-2', apiKey: 'bedrock-key' },
+      });
+      expect(provider).toBeInstanceOf(OpenAiResponsesProvider);
+      expect((provider.config as any).apiBaseUrl).toBe(
+        'https://bedrock-mantle.us-west-2.api.aws/openai/v1',
+      );
+      expect((provider.config as any).apiKey).toBe('bedrock-key');
+    });
+
+    it('falls back to AWS_BEARER_TOKEN_BEDROCK and the default region', () => {
+      restoreEnv = mockProcessEnv({
+        AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key',
+        AWS_BEDROCK_REGION: undefined,
+        AWS_REGION: undefined,
+        AWS_DEFAULT_REGION: undefined,
+      });
+      const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {});
+      expect((provider.config as any).apiBaseUrl).toBe(
+        'https://bedrock-mantle.us-east-2.api.aws/openai/v1',
+      );
+      expect((provider.config as any).apiKey).toBe('env-bedrock-key');
+    });
+
+    it('respects an explicit apiBaseUrl override', () => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
+      const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {
+        config: { apiBaseUrl: 'https://example.test/openai/v1' },
+      });
+      expect((provider.config as any).apiBaseUrl).toBe('https://example.test/openai/v1');
+    });
+  });
+});

--- a/test/providers/bedrock/openaiResponses.test.ts
+++ b/test/providers/bedrock/openaiResponses.test.ts
@@ -30,6 +30,13 @@ describe('bedrock openaiResponses helper', () => {
       expect(isBedrockOpenAiResponsesModel('anthropic.claude-opus-4-8')).toBe(false);
       expect(isBedrockOpenAiResponsesModel('qwen.qwen3-32b-v1:0')).toBe(false);
     });
+
+    it('matches region-prefixed frontier ids', () => {
+      expect(isBedrockOpenAiResponsesModel('us.openai.gpt-5.5')).toBe(true);
+      expect(isBedrockOpenAiResponsesModel('eu.openai.gpt-5.4')).toBe(true);
+      // ...but still excludes region-prefixed gpt-oss
+      expect(isBedrockOpenAiResponsesModel('us.openai.gpt-oss-120b')).toBe(false);
+    });
   });
 
   describe('getBedrockMantleBaseUrl', () => {
@@ -117,6 +124,41 @@ describe('bedrock openaiResponses helper', () => {
       expect(body.reasoning).toEqual({ effort: 'high' });
       expect(body.text?.verbosity).toBe('low');
       expect(body.temperature).toBeUndefined();
+    });
+
+    it('honors AWS_BEARER_TOKEN_BEDROCK and AWS_REGION supplied via promptfoo env overrides', () => {
+      restoreEnv = mockProcessEnv({
+        AWS_BEARER_TOKEN_BEDROCK: undefined,
+        AWS_BEDROCK_REGION: undefined,
+        AWS_REGION: undefined,
+        AWS_DEFAULT_REGION: undefined,
+      });
+      const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.4', {
+        env: { AWS_BEARER_TOKEN_BEDROCK: 'override-key', AWS_REGION: 'us-west-2' } as any,
+      });
+      expect((provider.config as any).apiKey).toBe('override-key');
+      expect((provider.config as any).apiBaseUrl).toBe(
+        'https://bedrock-mantle.us-west-2.api.aws/openai/v1',
+      );
+    });
+
+    it('pins the mantle endpoint even when OPENAI_API_HOST is set', () => {
+      restoreEnv = mockProcessEnv({
+        AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key',
+        OPENAI_API_HOST: 'unrelated.example.com',
+      });
+      const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {
+        config: { region: 'us-east-2' },
+      });
+      // Base getApiUrl() would prefer OPENAI_API_HOST; the subclass must override that.
+      expect(provider.getApiUrl()).toBe('https://bedrock-mantle.us-east-2.api.aws/openai/v1');
+    });
+
+    it('strips a region prefix for capability detection on profile ids', () => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
+      const provider = createBedrockOpenAiResponsesProvider('us.openai.gpt-5.5', {});
+      expect((provider as any).getBillingModelName({})).toBe('gpt-5.5');
+      expect((provider as any).isGPT5Model()).toBe(true);
     });
   });
 });

--- a/test/providers/bedrock/openaiResponses.test.ts
+++ b/test/providers/bedrock/openaiResponses.test.ts
@@ -84,5 +84,13 @@ describe('bedrock openaiResponses helper', () => {
       });
       expect((provider.config as any).apiBaseUrl).toBe('https://example.test/openai/v1');
     });
+
+    it('strips the openai. prefix for billing so OpenAI cost rates apply', () => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
+      const provider = createBedrockOpenAiResponsesProvider('openai.gpt-5.5', {});
+      // getBillingModelName is protected; the Bedrock id must resolve to the OpenAI
+      // billing key so cost is computed (Bedrock mirrors OpenAI first-party rates).
+      expect((provider as any).getBillingModelName({})).toBe('gpt-5.5');
+    });
   });
 });

--- a/test/providers/bedrock/openaiResponses.test.ts
+++ b/test/providers/bedrock/openaiResponses.test.ts
@@ -4,6 +4,7 @@ import {
   getBedrockMantleBaseUrl,
   isBedrockOpenAiResponsesModel,
 } from '../../../src/providers/bedrock/openaiResponses';
+import { calculateOpenAIUsageCost } from '../../../src/providers/openai/billing';
 import { OpenAiResponsesProvider } from '../../../src/providers/openai/responses';
 import { mockProcessEnv } from '../../util/utils';
 
@@ -117,6 +118,27 @@ describe('bedrock openaiResponses helper', () => {
       // getBillingModelName is protected; the Bedrock id must resolve to the OpenAI
       // billing key so cost is computed (Bedrock mirrors OpenAI first-party rates).
       expect((provider as any).getBillingModelName({})).toBe('gpt-5.5');
+    });
+
+    it.each([
+      'openai.gpt-5.5',
+      'openai.gpt-5.4',
+      'us.openai.gpt-5.5',
+    ])('computes a finite, non-zero cost end-to-end for %s via the OpenAI billing tables', (modelId) => {
+      restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
+      const provider = createBedrockOpenAiResponsesProvider(modelId, {});
+      const billingModelName = (provider as any).getBillingModelName({});
+      // The stripped id must actually resolve in the OpenAI cost map, not just be a string.
+      const cost = calculateOpenAIUsageCost(
+        billingModelName,
+        {},
+        {
+          input_tokens: 1000,
+          output_tokens: 500,
+        },
+      );
+      expect(cost).toBeGreaterThan(0);
+      expect(Number.isFinite(cost)).toBe(true);
     });
 
     it('detects the prefixed frontier id as a GPT-5 / reasoning model', () => {

--- a/test/providers/families/aws.test.ts
+++ b/test/providers/families/aws.test.ts
@@ -98,4 +98,18 @@ describe('aws bedrock provider factory routing', () => {
     expect(provider).not.toBeInstanceOf(OpenAiResponsesProvider);
     expect(provider.constructor.name).toBe(expectedClass);
   });
+
+  it.each([
+    'bedrock:us.openai.gpt-5.5',
+    'bedrock:eu.openai.gpt-5.4',
+    'bedrock:global.openai.gpt-5.5',
+  ])('rejects region/geo-prefixed frontier id %s with a clear error pointing at the bare id', async (providerPath) => {
+    // AWS does not offer Geo/Global inference profiles for the frontier models, so these are
+    // not real Bedrock ids. They must not be routed to the mantle endpoint; instead the
+    // InvokeModel fallback throws an actionable error suggesting the supported bare id.
+    restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
+    const provider = await bedrockFactory.create(providerPath, { config: {} }, ctx);
+    expect(provider).not.toBeInstanceOf(OpenAiResponsesProvider);
+    await expect(provider.callApi('hi')).rejects.toThrow(/Responses API.*bedrock:openai\.gpt-5\./s);
+  });
 });

--- a/test/providers/families/aws.test.ts
+++ b/test/providers/families/aws.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { AwsBedrockCompletionProvider } from '../../../src/providers/bedrock/index';
+import { awsProviderFactories } from '../../../src/providers/families/aws';
+import { OpenAiResponsesProvider } from '../../../src/providers/openai/responses';
+import { mockProcessEnv } from '../../util/utils';
+
+const bedrockFactory = awsProviderFactories.find((f) => f.test('bedrock:openai.gpt-5.5'))!;
+
+// The aws factories ignore the context argument; an empty object satisfies the type.
+const ctx = {} as any;
+
+describe('aws bedrock provider factory routing', () => {
+  let restoreEnv: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreEnv?.();
+    restoreEnv = undefined;
+  });
+
+  it('routes frontier gpt-5.x ids to the OpenAI Responses provider on the mantle endpoint', async () => {
+    const provider = await bedrockFactory.create(
+      'bedrock:openai.gpt-5.5',
+      { config: { region: 'us-east-2', apiKey: 'bedrock-key' } },
+      ctx,
+    );
+    expect(provider).toBeInstanceOf(OpenAiResponsesProvider);
+    expect((provider as any).config.apiBaseUrl).toBe(
+      'https://bedrock-mantle.us-east-2.api.aws/openai/v1',
+    );
+    expect(provider.id()).toBe('bedrock:openai.gpt-5.5');
+  });
+
+  it('routes gpt-oss ids to the InvokeModel completion provider', async () => {
+    const provider = await bedrockFactory.create(
+      'bedrock:openai.gpt-oss-120b-1:0',
+      { config: { region: 'us-east-2' } },
+      ctx,
+    );
+    expect(provider).toBeInstanceOf(AwsBedrockCompletionProvider);
+  });
+
+  it('throws a helpful error for frontier ids without a Bedrock API key', async () => {
+    restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: undefined });
+    await expect(
+      bedrockFactory.create('bedrock:openai.gpt-5.5', { config: { region: 'us-east-2' } }, ctx),
+    ).rejects.toThrow(/AWS_BEARER_TOKEN_BEDROCK/);
+  });
+});

--- a/test/providers/families/aws.test.ts
+++ b/test/providers/families/aws.test.ts
@@ -45,4 +45,57 @@ describe('aws bedrock provider factory routing', () => {
       bedrockFactory.create('bedrock:openai.gpt-5.5', { config: { region: 'us-east-2' } }, ctx),
     ).rejects.toThrow(/AWS_BEARER_TOKEN_BEDROCK/);
   });
+
+  it('routes the converse: form of a frontier id to the Responses provider on the mantle endpoint', async () => {
+    const provider = await bedrockFactory.create(
+      'bedrock:converse:openai.gpt-5.5',
+      { config: { region: 'us-east-2', apiKey: 'bedrock-key' } },
+      ctx,
+    );
+    expect(provider).toBeInstanceOf(OpenAiResponsesProvider);
+    expect((provider as any).config.apiBaseUrl).toBe(
+      'https://bedrock-mantle.us-east-2.api.aws/openai/v1',
+    );
+  });
+
+  it('routes the completion: form of a frontier id to the Responses provider on the mantle endpoint', async () => {
+    const provider = await bedrockFactory.create(
+      'bedrock:completion:openai.gpt-5.4',
+      { config: { region: 'us-west-2', apiKey: 'bedrock-key' } },
+      ctx,
+    );
+    expect(provider).toBeInstanceOf(OpenAiResponsesProvider);
+    expect((provider as any).config.apiBaseUrl).toBe(
+      'https://bedrock-mantle.us-west-2.api.aws/openai/v1',
+    );
+  });
+
+  it('routes the completion: form of a gpt-oss id to the InvokeModel completion provider (not Responses)', async () => {
+    const provider = await bedrockFactory.create(
+      'bedrock:completion:openai.gpt-oss-120b-1:0',
+      { config: { region: 'us-east-2' } },
+      ctx,
+    );
+    expect(provider).toBeInstanceOf(AwsBedrockCompletionProvider);
+    expect(provider).not.toBeInstanceOf(OpenAiResponsesProvider);
+  });
+
+  // The frontier check must not hijack sub-typed forms whose model segment merely contains
+  // "openai." — they must reach their own handlers (kb / embeddings / agents), not Responses.
+  it.each([
+    ['bedrock:kb:openai.gpt-5.5', 'AwsBedrockKnowledgeBaseProvider'],
+    ['bedrock:knowledge-base:openai.gpt-5.5', 'AwsBedrockKnowledgeBaseProvider'],
+    ['bedrock:embeddings:openai.embed-foo', 'AwsBedrockEmbeddingProvider'],
+    ['bedrock:embedding:openai.embed-foo', 'AwsBedrockEmbeddingProvider'],
+    ['bedrock:agents:my-openai.agent', 'AwsBedrockAgentsProvider'],
+  ])('does not hijack %s to the Responses provider', async (providerPath, expectedClass) => {
+    restoreEnv = mockProcessEnv({ AWS_BEARER_TOKEN_BEDROCK: 'env-bedrock-key' });
+    const provider = await bedrockFactory.create(
+      providerPath,
+      { config: { region: 'us-east-2', knowledgeBaseId: 'KB123', apiKey: 'bedrock-key' } },
+      ctx,
+    );
+    expect(provider).not.toBeInstanceOf(OpenAiResponsesProvider);
+    expect(provider.constructor.name).toBe(expectedClass);
+  });
 });

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -974,6 +974,131 @@ describe('OpenAICodexAppServerProvider', () => {
     expect(spawnEnv.CODEX_API_KEY).toBe('explicit-bedrock-key');
   });
 
+  it('strips an inherited OpenAI/Codex key from the CLI env when inherit_process_env is set with a custom model_provider', async () => {
+    // Highest-risk path: with inherit_process_env the whole process env is spread into the CLI
+    // env, so an ambient OPENAI_API_KEY/CODEX_API_KEY would reach the Bedrock-routed agent shell
+    // unless the strip loop removes it. Mirrors openai-codex-sdk.test.ts's inherit-path test.
+    const restore = mockProcessEnv({
+      OPENAI_API_KEY: 'sk-process-unrelated',
+      CODEX_API_KEY: 'codex-process-unrelated',
+    });
+    const server = createMockAppServer();
+    mocks.spawn.mockReturnValue(server.proc);
+
+    try {
+      const provider = new OpenAICodexAppServerProvider({
+        config: {
+          model: 'openai.gpt-5.5',
+          model_provider: 'amazon-bedrock',
+          inherit_process_env: true,
+          thread_cleanup: 'none',
+        },
+      });
+
+      const resultPromise = provider.callApi('Run on Bedrock with inherited env');
+
+      const initialize = await waitForMessage(server, (message) => message.method === 'initialize');
+      server.send({ id: initialize.id, result: {} });
+
+      // No login for the unrelated ambient key — straight to thread/start.
+      const threadStart = await waitForMessage(
+        server,
+        (message) => message.method === 'thread/start',
+      );
+      server.send({ id: threadStart.id, result: { thread: { id: 'thr_bedrock_inherit' } } });
+      const turnStart = await waitForMessage(server, (message) => message.method === 'turn/start');
+      server.send({
+        id: turnStart.id,
+        result: { turn: { id: 'turn_bedrock_inherit', status: 'inProgress' } },
+      });
+      server.send({
+        method: 'item/agentMessage/delta',
+        params: {
+          threadId: 'thr_bedrock_inherit',
+          turnId: 'turn_bedrock_inherit',
+          itemId: 'msg_bedrock_inherit',
+          delta: 'Inherited env ok',
+        },
+      });
+      server.send({
+        method: 'turn/completed',
+        params: {
+          threadId: 'thr_bedrock_inherit',
+          turn: { id: 'turn_bedrock_inherit', status: 'completed', items: [], error: null },
+        },
+      });
+
+      await expect(resultPromise).resolves.toMatchObject({ output: 'Inherited env ok' });
+
+      const spawnEnv = mocks.spawn.mock.calls[0][2].env as Record<string, string>;
+      expect(spawnEnv.OPENAI_API_KEY).toBeUndefined();
+      expect(spawnEnv.CODEX_API_KEY).toBeUndefined();
+      expect(
+        server.messages().some((message: any) => message.method === 'account/login/start'),
+      ).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('preserves an OPENAI_API_KEY supplied explicitly via cli_env under a custom model_provider', async () => {
+    // The strip loop must not delete a key the user placed in cli_env on purpose (the
+    // `!(key in cli_env)` exception). No config.apiKey -> no login, mirroring the no-leak flow.
+    const restore = mockProcessEnv({ OPENAI_API_KEY: undefined, CODEX_API_KEY: undefined });
+    const server = createMockAppServer();
+    mocks.spawn.mockReturnValue(server.proc);
+
+    try {
+      const provider = new OpenAICodexAppServerProvider({
+        config: {
+          model: 'openai.gpt-5.5',
+          model_provider: 'amazon-bedrock',
+          cli_env: { OPENAI_API_KEY: 'cli-env-key' },
+          thread_cleanup: 'none',
+        },
+      });
+
+      const resultPromise = provider.callApi('Run on Bedrock with cli_env key');
+
+      const initialize = await waitForMessage(server, (message) => message.method === 'initialize');
+      server.send({ id: initialize.id, result: {} });
+      const threadStart = await waitForMessage(
+        server,
+        (message) => message.method === 'thread/start',
+      );
+      server.send({ id: threadStart.id, result: { thread: { id: 'thr_bedrock_clienv' } } });
+      const turnStart = await waitForMessage(server, (message) => message.method === 'turn/start');
+      server.send({
+        id: turnStart.id,
+        result: { turn: { id: 'turn_bedrock_clienv', status: 'inProgress' } },
+      });
+      server.send({
+        method: 'item/agentMessage/delta',
+        params: {
+          threadId: 'thr_bedrock_clienv',
+          turnId: 'turn_bedrock_clienv',
+          itemId: 'msg_bedrock_clienv',
+          delta: 'cli_env key ok',
+        },
+      });
+      server.send({
+        method: 'turn/completed',
+        params: {
+          threadId: 'thr_bedrock_clienv',
+          turn: { id: 'turn_bedrock_clienv', status: 'completed', items: [], error: null },
+        },
+      });
+
+      await expect(resultPromise).resolves.toMatchObject({ output: 'cli_env key ok' });
+
+      const spawnEnv = mocks.spawn.mock.calls[0][2].env as Record<string, string>;
+      // The cli_env-supplied key survives the custom-provider strip loop.
+      expect(spawnEnv.OPENAI_API_KEY).toBe('cli-env-key');
+    } finally {
+      restore();
+    }
+  });
+
   it('maps legacy approval requests by conversation id and legacy decision names', async () => {
     const server = createMockAppServer();
     mocks.spawn.mockReturnValue(server.proc);

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -855,6 +855,125 @@ describe('OpenAICodexAppServerProvider', () => {
     await expect(resultPromise).resolves.toMatchObject({ output: 'Legacy auth ok' });
   });
 
+  it('does not leak an ambient OpenAI key to the CLI (env or login) when routing to a custom model_provider', async () => {
+    const restore = mockProcessEnv({ OPENAI_API_KEY: 'sk-ambient-unrelated' });
+    const server = createMockAppServer();
+    mocks.spawn.mockReturnValue(server.proc);
+
+    try {
+      const provider = new OpenAICodexAppServerProvider({
+        config: {
+          model: 'openai.gpt-5.5',
+          model_provider: 'amazon-bedrock',
+          thread_cleanup: 'none',
+        },
+      });
+
+      const resultPromise = provider.callApi('Run on Bedrock');
+
+      const initialize = await waitForMessage(server, (message) => message.method === 'initialize');
+      server.send({ id: initialize.id, result: {} });
+
+      // No account/login/start should be issued for the ambient OpenAI key; the next request
+      // is thread/start (mirrors the no-key flow).
+      const threadStart = await waitForMessage(
+        server,
+        (message) => message.method === 'thread/start',
+      );
+      server.send({ id: threadStart.id, result: { thread: { id: 'thr_bedrock_noleak' } } });
+      const turnStart = await waitForMessage(server, (message) => message.method === 'turn/start');
+      server.send({
+        id: turnStart.id,
+        result: { turn: { id: 'turn_bedrock_noleak', status: 'inProgress' } },
+      });
+      server.send({
+        method: 'item/agentMessage/delta',
+        params: {
+          threadId: 'thr_bedrock_noleak',
+          turnId: 'turn_bedrock_noleak',
+          itemId: 'msg_bedrock_noleak',
+          delta: 'On Bedrock',
+        },
+      });
+      server.send({
+        method: 'turn/completed',
+        params: {
+          threadId: 'thr_bedrock_noleak',
+          turn: { id: 'turn_bedrock_noleak', status: 'completed', items: [], error: null },
+        },
+      });
+
+      await expect(resultPromise).resolves.toMatchObject({ output: 'On Bedrock' });
+
+      const spawnEnv = mocks.spawn.mock.calls[0][2].env as Record<string, string>;
+      expect(spawnEnv.OPENAI_API_KEY).toBeUndefined();
+      expect(spawnEnv.CODEX_API_KEY).toBeUndefined();
+      // No account/login/start was ever sent for the unrelated ambient key.
+      expect(
+        server.messages().some((message: any) => message.method === 'account/login/start'),
+      ).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('still injects an explicit config.apiKey when routing to a custom model_provider', async () => {
+    const server = createMockAppServer();
+    mocks.spawn.mockReturnValue(server.proc);
+
+    const provider = new OpenAICodexAppServerProvider({
+      config: {
+        model: 'openai.gpt-5.5',
+        model_provider: 'amazon-bedrock',
+        apiKey: 'explicit-bedrock-key',
+        thread_cleanup: 'none',
+      },
+    });
+
+    const resultPromise = provider.callApi('Run on Bedrock with explicit key');
+
+    const initialize = await waitForMessage(server, (message) => message.method === 'initialize');
+    server.send({ id: initialize.id, result: {} });
+    const loginStart = await waitForMessage(
+      server,
+      (message) => message.method === 'account/login/start',
+    );
+    expect(loginStart.params).toEqual({ type: 'apiKey', apiKey: 'explicit-bedrock-key' });
+    server.send({ id: loginStart.id, result: { type: 'apiKey' } });
+    const threadStart = await waitForMessage(
+      server,
+      (message) => message.method === 'thread/start',
+    );
+    server.send({ id: threadStart.id, result: { thread: { id: 'thr_bedrock_explicit' } } });
+    const turnStart = await waitForMessage(server, (message) => message.method === 'turn/start');
+    server.send({
+      id: turnStart.id,
+      result: { turn: { id: 'turn_bedrock_explicit', status: 'inProgress' } },
+    });
+    server.send({
+      method: 'item/agentMessage/delta',
+      params: {
+        threadId: 'thr_bedrock_explicit',
+        turnId: 'turn_bedrock_explicit',
+        itemId: 'msg_bedrock_explicit',
+        delta: 'Explicit key ok',
+      },
+    });
+    server.send({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thr_bedrock_explicit',
+        turn: { id: 'turn_bedrock_explicit', status: 'completed', items: [], error: null },
+      },
+    });
+
+    await expect(resultPromise).resolves.toMatchObject({ output: 'Explicit key ok' });
+
+    const spawnEnv = mocks.spawn.mock.calls[0][2].env as Record<string, string>;
+    expect(spawnEnv.OPENAI_API_KEY).toBe('explicit-bedrock-key');
+    expect(spawnEnv.CODEX_API_KEY).toBe('explicit-bedrock-key');
+  });
+
   it('maps legacy approval requests by conversation id and legacy decision names', async () => {
     const server = createMockAppServer();
     mocks.spawn.mockReturnValue(server.proc);

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -245,6 +245,21 @@ describe('OpenAICodexSDKProvider', () => {
       warnSpy.mockRestore();
     });
 
+    it('should treat model_provider case-insensitively (OpenAI is not a custom provider)', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      // `OpenAI` normalizes to the default provider, so an unknown model still warns.
+      new OpenAICodexSDKProvider({
+        config: { model: 'unknown-model', model_provider: 'OpenAI' },
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Using unknown model for OpenAI Codex SDK: unknown-model',
+      );
+
+      warnSpy.mockRestore();
+    });
+
     it('should reject malformed provider config', () => {
       expect(
         () =>
@@ -2525,6 +2540,50 @@ describe('OpenAICodexSDKProvider', () => {
         const codexCall = MockCodex.mock.calls.at(-1)?.[0];
         expect(codexCall?.env?.OPENAI_API_KEY).toBeUndefined();
         expect(codexCall?.env?.CODEX_API_KEY).toBeUndefined();
+        // The SDK forwards a constructor `apiKey` into the spawned CLI as CODEX_API_KEY, so it
+        // must also be withheld — otherwise the env gating above is silently defeated.
+        expect(codexCall?.apiKey).toBeUndefined();
+      });
+
+      it('should not pass an inherited OpenAI key as the SDK constructor apiKey for a custom provider', async () => {
+        mockRun.mockResolvedValue(createMockResponse('Response'));
+
+        const provider = new OpenAICodexSDKProvider({
+          config: { model: 'openai.gpt-5.5', model_provider: 'amazon-bedrock' },
+          env: { OPENAI_API_KEY: 'sk-unrelated' },
+        });
+
+        await provider.callApi('Test prompt');
+
+        const codexCall = MockCodex.mock.calls.at(-1)?.[0];
+        expect(codexCall?.apiKey).toBeUndefined();
+      });
+
+      it('should strip an inherited OpenAI key from the CLI env when inherit_process_env is set with a custom provider', async () => {
+        mockRun.mockResolvedValue(createMockResponse('Response'));
+        const restore = mockProcessEnv({
+          OPENAI_API_KEY: 'sk-process-unrelated',
+          CODEX_API_KEY: 'codex-process-unrelated',
+        });
+
+        try {
+          const provider = new OpenAICodexSDKProvider({
+            config: {
+              model: 'openai.gpt-5.5',
+              model_provider: 'amazon-bedrock',
+              inherit_process_env: true,
+            },
+          });
+
+          await provider.callApi('Test prompt');
+
+          const codexCall = MockCodex.mock.calls.at(-1)?.[0];
+          expect(codexCall?.env?.OPENAI_API_KEY).toBeUndefined();
+          expect(codexCall?.env?.CODEX_API_KEY).toBeUndefined();
+          expect(codexCall?.apiKey).toBeUndefined();
+        } finally {
+          restore();
+        }
       });
 
       it('should still inject an explicit config.apiKey when routing to a custom provider', async () => {
@@ -2542,6 +2601,8 @@ describe('OpenAICodexSDKProvider', () => {
 
         const codexCall = MockCodex.mock.calls.at(-1)?.[0];
         expect(codexCall?.env?.OPENAI_API_KEY).toBe('explicit-key');
+        // Explicit key is the active backend credential, so it IS passed to the SDK too.
+        expect(codexCall?.apiKey).toBe('explicit-key');
       });
 
       it('should warn when CODEX_HOME from process.env is omitted from the default minimal CLI env', async () => {

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -214,6 +214,37 @@ describe('OpenAICodexSDKProvider', () => {
       warnSpy.mockRestore();
     });
 
+    it('should not warn about provider-specific model ids when routing through a custom model_provider', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      // Amazon Bedrock model ids live in a different namespace than OpenAI's allowlist.
+      new OpenAICodexSDKProvider({
+        config: { model: 'openai.gpt-5.5', model_provider: 'amazon-bedrock' },
+      });
+      // Same when the provider is supplied through raw cli_config.
+      new OpenAICodexSDKProvider({
+        config: { model: 'openai.gpt-5.4', cli_config: { model_provider: 'amazon-bedrock' } },
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it('should still warn about unknown models when model_provider is openai', () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      new OpenAICodexSDKProvider({
+        config: { model: 'unknown-model', model_provider: 'openai' },
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Using unknown model for OpenAI Codex SDK: unknown-model',
+      );
+
+      warnSpy.mockRestore();
+    });
+
     it('should reject malformed provider config', () => {
       expect(
         () =>
@@ -2384,6 +2415,46 @@ describe('OpenAICodexSDKProvider', () => {
         expect(MockCodex).toHaveBeenCalledWith(
           expect.objectContaining({
             config: { collaboration_mode: 'coding', model_provider: { timeout: 30 } },
+          }),
+        );
+      });
+
+      it('should map the first-class model_provider into the Codex CLI config object', async () => {
+        mockRun.mockResolvedValue(createMockResponse('Response'));
+
+        const provider = new OpenAICodexSDKProvider({
+          config: {
+            model: 'openai.gpt-5.5',
+            model_provider: 'amazon-bedrock',
+          },
+          env: { OPENAI_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('Test prompt');
+
+        expect(MockCodex).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: { model_provider: 'amazon-bedrock' },
+          }),
+        );
+      });
+
+      it('should let the first-class model_provider take precedence over cli_config', async () => {
+        mockRun.mockResolvedValue(createMockResponse('Response'));
+
+        const provider = new OpenAICodexSDKProvider({
+          config: {
+            model_provider: 'amazon-bedrock',
+            cli_config: { model_provider: 'openai', model_providers: { 'amazon-bedrock': {} } },
+          },
+          env: { OPENAI_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('Test prompt');
+
+        expect(MockCodex).toHaveBeenCalledWith(
+          expect.objectContaining({
+            config: { model_provider: 'amazon-bedrock', model_providers: { 'amazon-bedrock': {} } },
           }),
         );
       });

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -2511,6 +2511,39 @@ describe('OpenAICodexSDKProvider', () => {
         }
       });
 
+      it('should not leak an inherited OpenAI key into the CLI env when routing to a custom provider', async () => {
+        mockRun.mockResolvedValue(createMockResponse('Response'));
+
+        const provider = new OpenAICodexSDKProvider({
+          config: { model: 'openai.gpt-5.5', model_provider: 'amazon-bedrock' },
+          // Ambient OpenAI key unrelated to the Bedrock backend.
+          env: { OPENAI_API_KEY: 'sk-unrelated' },
+        });
+
+        await provider.callApi('Test prompt');
+
+        const codexCall = MockCodex.mock.calls.at(-1)?.[0];
+        expect(codexCall?.env?.OPENAI_API_KEY).toBeUndefined();
+        expect(codexCall?.env?.CODEX_API_KEY).toBeUndefined();
+      });
+
+      it('should still inject an explicit config.apiKey when routing to a custom provider', async () => {
+        mockRun.mockResolvedValue(createMockResponse('Response'));
+
+        const provider = new OpenAICodexSDKProvider({
+          config: {
+            model: 'openai.gpt-5.5',
+            model_provider: 'amazon-bedrock',
+            apiKey: 'explicit-key',
+          },
+        });
+
+        await provider.callApi('Test prompt');
+
+        const codexCall = MockCodex.mock.calls.at(-1)?.[0];
+        expect(codexCall?.env?.OPENAI_API_KEY).toBe('explicit-key');
+      });
+
       it('should warn when CODEX_HOME from process.env is omitted from the default minimal CLI env', async () => {
         const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
         mockRun.mockResolvedValue(createMockResponse('Response'));


### PR DESCRIPTION
## Summary

OpenAI's frontier models ([GPT-5.5 / GPT-5.4](https://aws.amazon.com/blogs/machine-learning/openai-models-and-codex-on-amazon-bedrock-are-now-generally-available/)) and Codex are GA on Amazon Bedrock. This PR adds first-class support across every way promptfoo can reach them, and aligns output/usage/cost with the `openai:` and `azure:` providers.

Bedrock serves the two OpenAI families through **different APIs** (verified live), so they're wired differently:

| Family | Bedrock API | promptfoo route | Auth |
| --- | --- | --- | --- |
| Frontier `gpt-5.5` / `gpt-5.4` | OpenAI-compatible **Responses API** on the `bedrock-mantle` endpoint (`/openai/v1`) | `bedrock:openai.gpt-5.5` → OpenAI Responses provider | Bedrock API key (`AWS_BEARER_TOKEN_BEDROCK`) |
| Open-weight `gpt-oss-*` | native **InvokeModel** | `bedrock:openai.gpt-oss-120b-1:0` | AWS SDK credential chain |

> **Codex is not a separate model** — it uses these same frontier IDs. Run the agent with `openai:codex-sdk` + `model_provider: amazon-bedrock`.

## What changed

**Frontier (`bedrock:openai.gpt-5.x`)**
- The AWS factory routes all forms (`bedrock:`, `bedrock:converse:`, `bedrock:completion:`) of a frontier id to a new `BedrockOpenAiResponsesProvider` pointed at `https://bedrock-mantle.<region>.api.aws/openai/v1`. Output, token usage, and metadata are produced by the **same shared `ResponsesProcessor`** as `openai:responses` and `azure:responses` — identical by construction.
- Cost is computed from the OpenAI billing tables by stripping the `openai.` prefix for billing lookup (Bedrock mirrors OpenAI first-party rates).
- These models are **not** registered for InvokeModel/Converse; `getHandlerForModel` throws a clear, actionable error if a frontier id is forced down the InvokeModel path.
- The mantle endpoint pins to `apiBaseUrl` (so an ambient `OPENAI_API_HOST` can't hijack the call and leak the Bedrock bearer token to the wrong host), and the region is shape-validated before it's interpolated into the endpoint URL.

**Open-weight (`bedrock:openai.gpt-oss-*`, InvokeModel)**
- `reasoning_effort` is sent as the native request field (was an inert system-message hack). Values: `low|medium|high`, forwarded for the API to validate.
- InvokeModel returns reasoning inline as `<reasoning>…</reasoning>`. promptfoo returns this **verbatim by default** so nothing the API surfaced is hidden from assertions/red-team graders (an eval framework shouldn't drop application-visible content by default). `showThinking: false` strips it to the clean answer (parity with the `openai:` providers, which hide chain-of-thought); `showThinking: true` reformats it as `Thinking: <reasoning>\n\n<answer>`.
- Only valid Bedrock ids are routed: bare frontier ids (`openai.gpt-5.x`) go to the Responses API, versioned runtime ids (`openai.gpt-oss-*-N:M`) go to InvokeModel. Region/geo-prefixed frontier ids (`us.openai.gpt-5.5`) and the bare Mantle gpt-oss id (`openai.gpt-oss-120b`) are **rejected with an actionable error** rather than sent to an API that would reject them — AWS offers neither for these models.
- `reasoning`/cached token counts are mapped into `completionDetails` for usage parity.
- Prompt-level config (incl. `showThinking`) is now threaded into `output()` (previously only provider-level config reached it).

**Codex (`openai:codex-sdk` / `openai:codex-app-server`)**
- First-class `model_provider` option on codex-sdk (parity with app-server) → `model_provider: amazon-bedrock`.
- No more spurious "unknown model" warning when routing through a non-OpenAI provider.
- An ambient `OPENAI_API_KEY` / `CODEX_API_KEY` is never leaked to the Codex agent shell when routing to a custom `model_provider` (gated across the process env, the SDK constructor `apiKey`, and `account/login`; inherited keys are stripped unless passed explicitly via `cli_env`). This gating now lives in one shared `codexApiKeyGating` helper so the SDK and app-server providers can't drift apart.
- Docs note that temporary/SSO credentials must also forward `AWS_SESSION_TOKEN`.

Plus docs, runnable examples, and tests.

## Verification (live against AWS)

3-way parity for the same prompt (`17 * 23`) — **byte-identical output, consistent usage/cost**:

| source | output | cost | reasoning tokens |
| --- | --- | --- | --- |
| `bedrock:openai.gpt-5.5` | `391` | 0.00085 | 18 |
| `openai:responses:gpt-5-mini` | `391` | 0.000085 | — |
| `azure:responses:gpt-5` | `391` | — | — |

- Confirmed the mantle path is `/openai/v1` for frontier (the bare `/v1` 400s for frontier and serves gpt-oss instead).
- Ran end-to-end in `us-east-2`: `bedrock:openai.gpt-5.5`, `bedrock:openai.gpt-5.4`, and the `bedrock:converse:openai.gpt-5.5` form (routes to Responses). `reasoning_effort: minimal` is rejected by the API (`400 "Unsupported value: 'minimal'"`) — matching the docs.
- gpt-oss: default → model output verbatim (reasoning preserved); `showThinking:false` → clean answer; `showThinking:true` → `Thinking:` prefix (live-verified).
- `openai:codex-sdk` + `model_provider: amazon-bedrock` + `openai.gpt-5.5` → passing agent run on Bedrock.
- The shipped frontier example (`examples/amazon-bedrock/models/promptfooconfig.openai-frontier.yaml`) passes 6/6; the codex-on-bedrock example runs the agent end-to-end.

## Availability (per AWS)

- `openai.gpt-5.5`: `us-east-2`
- `openai.gpt-5.4`: `us-east-2`, `us-west-2`

Request model access and create a Bedrock API key first.

## Test plan

- [x] Unit: native `reasoning_effort`; gpt-oss output verbatim-by-default + `showThinking` strip/surface; bare-Mantle-id (`openai.gpt-oss-120b`) rejection + versioned-runtime routing; region/geo-prefixed frontier id rejection (matcher + factory); token-detail parity (incl. the asymmetric `reasoning`/`cacheReadInputTokens` guards: reasoning reported at 0, cached dropped at 0, each side alone); merged-config output; frontier routing (3 forms) + error; billing-prefix strip; region/auth resolution; region shape-validation; `getApiUrl` mantle-pin + super-fallback; codex `model_provider` mapping + warning suppression; codex apiKey gating (env, SDK constructor `apiKey`, and `account/login`) for both providers — including the `inherit_process_env` strip path and the `cli_env` opt-in exception
- [x] Live: bedrock/openai output+cost parity; bedrock gpt-5.5 / gpt-5.4 / `converse:` form; `reasoning_effort: minimal` rejection; gpt-oss verbatim/showThinking; codex-sdk on Bedrock; shipped examples 6/6
- [x] tsc, lint, format; PR review + code-simplifier passes; full adversarial QA audit (shared apiKey-gating helper extracted, mantle region validated, app-server credential-strip + gpt-oss token-detail coverage added); addressed bot/reviewer threads (gpt-oss output visibility, region-prefixed id rejection, bare Mantle id rejection)
