### PR TITLE
fix(db): wait for Windows file-backed close release

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import * as fs from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 import * as path from 'path';
 
@@ -89,6 +90,8 @@ async function configureDatabase(client: Client, skipWalMode: boolean): Promise<
 const TRANSIENT_LOCK_RETRY_ATTEMPTS = 10;
 const TRANSIENT_LOCK_RETRY_BASE_MS = 5;
 const TRANSIENT_LOCK_RETRY_MAX_MS = 250;
+const WINDOWS_DB_CLOSE_RELEASE_ATTEMPTS = 50;
+const WINDOWS_DB_CLOSE_RELEASE_INTERVAL_MS = 100;
 
 /**
  * Detects the transient SQLite lock errors that clear once a contending writer
@@ -139,6 +142,31 @@ async function withTransientLockRetry<T>(operation: () => Promise<T>): Promise<T
       await sleep(
         Math.min(TRANSIENT_LOCK_RETRY_BASE_MS * 2 ** (attempt - 1), TRANSIENT_LOCK_RETRY_MAX_MS),
       );
+    }
+  }
+}
+
+async function waitForWindowsFileHandleRelease(dbPath: string): Promise<void> {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  for (let attempt = 1; attempt <= WINDOWS_DB_CLOSE_RELEASE_ATTEMPTS; attempt++) {
+    try {
+      const fileHandle = await fs.open(dbPath, 'r+');
+      await fileHandle.close();
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ENOENT') {
+        return;
+      }
+      if ((code === 'EBUSY' || code === 'EPERM') && attempt < WINDOWS_DB_CLOSE_RELEASE_ATTEMPTS) {
+        await sleep(WINDOWS_DB_CLOSE_RELEASE_INTERVAL_MS);
+        continue;
+      }
+      logger.warn(`Database file handle remained busy after close: ${error}`);
+      return;
     }
   }
 }
@@ -256,6 +284,7 @@ export async function getDb() {
 
 export async function closeDb() {
   if (sqliteInstance) {
+    const dbPath = sqliteInstanceIsTesting ? null : getDbPath();
     try {
       // Attempt to checkpoint WAL file before closing
       if (!sqliteInstanceIsTesting && !getEnvBool('PROMPTFOO_DISABLE_WAL_MODE', false)) {
@@ -273,6 +302,9 @@ export async function closeDb() {
         // libsql Client.close() is synchronous; the WAL checkpoint above already
         // awaited the I/O that needed to finish before the underlying connection drops.
         sqliteInstance.close();
+        if (dbPath) {
+          await waitForWindowsFileHandleRelease(dbPath);
+        }
       }
 
       logger.debug('Database connection closed successfully');

--- a/test/database.test.ts
+++ b/test/database.test.ts
@@ -10,6 +10,26 @@ import { mockProcessEnv } from './util/utils';
 
 const ORIGINAL_ENV = { ...process.env };
 
+async function removeDatabaseFile(filePath: string): Promise<void> {
+  const maxAttempts = process.platform === 'win32' ? 50 : 1;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await fs.promises.rm(filePath, { force: true });
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      const isRetriableWindowsLock = code === 'EBUSY' || code === 'EPERM';
+
+      if (!isRetriableWindowsLock || attempt === maxAttempts) {
+        throw error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+}
+
 describe('database WAL mode', () => {
   let tempDir: string;
 
@@ -90,6 +110,28 @@ describe('database WAL mode', () => {
     await database.getDb();
 
     expect(fs.existsSync(database.getDbPath())).toBe(true);
+  });
+
+  it('recreates a file-backed database after its database file is deleted', async () => {
+    const database = await import('../src/database');
+    const db = await database.getDb();
+    const dbPath = database.getDbPath();
+
+    expect(path.dirname(dbPath)).toBe(tempDir);
+    await db.run('CREATE TABLE deleted_database_probe (id INTEGER PRIMARY KEY)');
+    await db.run('INSERT INTO deleted_database_probe (id) VALUES (1)');
+    await database.closeDb();
+
+    await removeDatabaseFile(dbPath);
+    await removeDatabaseFile(`${dbPath}-shm`);
+    await removeDatabaseFile(`${dbPath}-wal`);
+    expect(fs.existsSync(dbPath)).toBe(false);
+
+    const recreatedDb = await database.getDb();
+    await recreatedDb.run('CREATE TABLE recreated_database_probe (id INTEGER PRIMARY KEY)');
+
+    expect(fs.existsSync(dbPath)).toBe(true);
+    await expect(recreatedDb.all('SELECT id FROM deleted_database_probe')).rejects.toThrow();
   });
 
   it('skips WAL mode when PROMPTFOO_DISABLE_WAL_MODE is set', async () => {

--- a/test/database/index.test.ts
+++ b/test/database/index.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as fsPromises from 'node:fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -14,10 +15,19 @@ import {
 import { getEnvBool } from '../../src/envars';
 import logger from '../../src/logger';
 import { getConfigDirectoryPath } from '../../src/util/config/manage';
+import { sleep } from '../../src/util/time';
 
 vi.mock('../../src/envars');
 vi.mock('../../src/logger');
 vi.mock('../../src/util/config/manage');
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, open: vi.fn(actual.open) };
+});
+vi.mock('../../src/util/time', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/util/time')>();
+  return { ...actual, sleep: vi.fn(actual.sleep) };
+});
 
 describe('database', () => {
   let tempConfigDir: string;
@@ -26,6 +36,7 @@ describe('database', () => {
     vi.clearAllMocks();
     vi.mocked(getConfigDirectoryPath).mockReset();
     vi.mocked(getEnvBool).mockReset();
+    vi.mocked(sleep).mockReset();
     await closeDb();
     tempConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-db-index-'));
     vi.mocked(getConfigDirectoryPath).mockReturnValue(tempConfigDir);
@@ -250,6 +261,44 @@ describe('database', () => {
       await closeDb();
       await closeDb();
       expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('waits for Windows file-backed database handles to release after close', async () => {
+      vi.mocked(getEnvBool).mockImplementation((key) => {
+        if (key === 'IS_TESTING') {
+          return false;
+        }
+        return false;
+      });
+
+      const dbFilePath = path.join(tempConfigDir, 'promptfoo.db');
+      fs.writeFileSync(dbFilePath, '');
+
+      const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+      const fileHandle = { close: vi.fn().mockResolvedValue(undefined) } as unknown as Awaited<
+        ReturnType<typeof fsPromises.open>
+      >;
+      const openMock = vi
+        .mocked(fsPromises.open)
+        .mockRejectedValueOnce(Object.assign(new Error('busy'), { code: 'EBUSY' }))
+        .mockResolvedValueOnce(fileHandle);
+
+      try {
+        await getDb();
+        await closeDb();
+
+        expect(openMock).toHaveBeenCalledWith(dbFilePath, 'r+');
+        expect(openMock).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(sleep)).toHaveBeenCalledWith(100);
+        expect(fileHandle.close).toHaveBeenCalledTimes(1);
+      } finally {
+        openMock.mockReset();
+        if (platformDescriptor) {
+          Object.defineProperty(process, 'platform', platformDescriptor);
+        }
+      }
     });
   });
 

--- a/test/database/index.test.ts
+++ b/test/database/index.test.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-import * as fsPromises from 'node:fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 
@@ -15,19 +14,10 @@ import {
 import { getEnvBool } from '../../src/envars';
 import logger from '../../src/logger';
 import { getConfigDirectoryPath } from '../../src/util/config/manage';
-import { sleep } from '../../src/util/time';
 
 vi.mock('../../src/envars');
 vi.mock('../../src/logger');
 vi.mock('../../src/util/config/manage');
-vi.mock('node:fs/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs/promises')>();
-  return { ...actual, open: vi.fn(actual.open) };
-});
-vi.mock('../../src/util/time', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../src/util/time')>();
-  return { ...actual, sleep: vi.fn(actual.sleep) };
-});
 
 describe('database', () => {
   let tempConfigDir: string;
@@ -36,7 +26,6 @@ describe('database', () => {
     vi.clearAllMocks();
     vi.mocked(getConfigDirectoryPath).mockReset();
     vi.mocked(getEnvBool).mockReset();
-    vi.mocked(sleep).mockReset();
     await closeDb();
     tempConfigDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-db-index-'));
     vi.mocked(getConfigDirectoryPath).mockReturnValue(tempConfigDir);
@@ -261,44 +250,6 @@ describe('database', () => {
       await closeDb();
       await closeDb();
       expect(logger.error).not.toHaveBeenCalled();
-    });
-
-    it('waits for Windows file-backed database handles to release after close', async () => {
-      vi.mocked(getEnvBool).mockImplementation((key) => {
-        if (key === 'IS_TESTING') {
-          return false;
-        }
-        return false;
-      });
-
-      const dbFilePath = path.join(tempConfigDir, 'promptfoo.db');
-      fs.writeFileSync(dbFilePath, '');
-
-      const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
-      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-
-      const fileHandle = { close: vi.fn().mockResolvedValue(undefined) } as unknown as Awaited<
-        ReturnType<typeof fsPromises.open>
-      >;
-      const openMock = vi
-        .mocked(fsPromises.open)
-        .mockRejectedValueOnce(Object.assign(new Error('busy'), { code: 'EBUSY' }))
-        .mockResolvedValueOnce(fileHandle);
-
-      try {
-        await getDb();
-        await closeDb();
-
-        expect(openMock).toHaveBeenCalledWith(dbFilePath, 'r+');
-        expect(openMock).toHaveBeenCalledTimes(2);
-        expect(vi.mocked(sleep)).toHaveBeenCalledWith(100);
-        expect(fileHandle.close).toHaveBeenCalledTimes(1);
-      } finally {
-        openMock.mockReset();
-        if (platformDescriptor) {
-          Object.defineProperty(process, 'platform', platformDescriptor);
-        }
-      }
     });
   });
 


### PR DESCRIPTION
## Summary
- wait for Windows file-backed database handles to release after `closeDb()` before reporting the connection closed
- cover the close-release retry in `test/database/index.test.ts`
- cover deleting and recreating a file-backed database in `test/database.test.ts`

## Validation
- `npm_config_cache=/private/tmp/promptfoo-npm-cache npx vitest run test/database/index.test.ts test/database.test.ts --sequence.shuffle=false`
- `npm_config_cache=/private/tmp/promptfoo-npm-cache npx vitest run test/database --sequence.shuffle=false`