### PR TITLE
fix(providers): require deployment name for no-default Azure provider types

### DIFF
--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -325,6 +325,11 @@ export const providerMap: ProviderFactory[] = [
             'azureopenai:image is not supported. MAI image models are Microsoft Foundry models — use azure:image:<deployment> instead.',
           );
         }
+        if (!deploymentName) {
+          throw new Error(
+            'Azure image provider requires a deployment name. Use azure:image:<deployment>.',
+          );
+        }
         return new AzureImageProvider(deploymentName, providerOptions);
       }
       if (modelType === 'embedding' || modelType === 'embeddings') {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -289,6 +289,18 @@ export const providerMap: ProviderFactory[] = [
       const modelType = splits[1];
       const deploymentName = splits[2];
 
+      // Azure model types that have no sensible default deployment must name one in
+      // the provider path (`azure:<type>:<name>`). Without this, the registry would
+      // build a provider with an undefined deployment that fails later with an opaque
+      // error (e.g. a `model: undefined` request body or `undefined.toLowerCase()`).
+      const requirePathSegment = (type: string, label: string, placeholder: string) => {
+        if (!deploymentName) {
+          throw new Error(
+            `Azure ${type} provider requires ${label}. Use azure:${type}:<${placeholder}>.`,
+          );
+        }
+      };
+
       if (modelType === 'moderation') {
         if (providerPath.startsWith('azureopenai:')) {
           throw new Error(
@@ -308,12 +320,15 @@ export const providerMap: ProviderFactory[] = [
         return new AzureModerationProvider(resolvedDeployment, providerOptions);
       }
       if (modelType === 'chat') {
+        requirePathSegment('chat', 'a deployment name', 'deployment');
         return new AzureChatCompletionProvider(deploymentName, providerOptions);
       }
       if (modelType === 'assistant') {
+        requirePathSegment('assistant', 'an assistant ID', 'assistant-id');
         return new AzureAssistantProvider(deploymentName, providerOptions);
       }
       if (modelType === 'foundry-agent') {
+        requirePathSegment('foundry-agent', 'an agent ID', 'agent-id');
         return new AzureFoundryAgentProvider(deploymentName, providerOptions);
       }
       if (modelType === 'image') {
@@ -325,11 +340,7 @@ export const providerMap: ProviderFactory[] = [
             'azureopenai:image is not supported. MAI image models are Microsoft Foundry models — use azure:image:<deployment> instead.',
           );
         }
-        if (!deploymentName) {
-          throw new Error(
-            'Azure image provider requires a deployment name. Use azure:image:<deployment>.',
-          );
-        }
+        requirePathSegment('image', 'a deployment name', 'deployment');
         return new AzureImageProvider(deploymentName, providerOptions);
       }
       if (modelType === 'embedding' || modelType === 'embeddings') {
@@ -339,6 +350,7 @@ export const providerMap: ProviderFactory[] = [
         );
       }
       if (modelType === 'completion') {
+        requirePathSegment('completion', 'a deployment name', 'deployment');
         return new AzureCompletionProvider(deploymentName, providerOptions);
       }
       if (modelType === 'responses') {

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -451,6 +451,38 @@ describe('Provider Registry', () => {
         factory!.create('azure:image:', mockProviderOptions, mockContext),
       ).rejects.toThrow(/Azure image provider requires a deployment name/);
 
+      // Model types without a default deployment must name one in the path. Cover both
+      // the missing (`azure:chat`) and empty (`azure:chat:`) third-segment variants.
+      for (const prefix of ['azure:chat', 'azure:completion']) {
+        await expect(factory!.create(prefix, mockProviderOptions, mockContext)).rejects.toThrow(
+          /requires a deployment name/,
+        );
+        await expect(
+          factory!.create(`${prefix}:`, mockProviderOptions, mockContext),
+        ).rejects.toThrow(/requires a deployment name/);
+      }
+      await expect(
+        factory!.create('azure:assistant', mockProviderOptions, mockContext),
+      ).rejects.toThrow(/Azure assistant provider requires an assistant ID/);
+      await expect(
+        factory!.create('azure:assistant:', mockProviderOptions, mockContext),
+      ).rejects.toThrow(/Azure assistant provider requires an assistant ID/);
+      await expect(
+        factory!.create('azure:foundry-agent', mockProviderOptions, mockContext),
+      ).rejects.toThrow(/Azure foundry-agent provider requires an agent ID/);
+      await expect(
+        factory!.create('azure:foundry-agent:', mockProviderOptions, mockContext),
+      ).rejects.toThrow(/Azure foundry-agent provider requires an agent ID/);
+
+      // Types with sensible defaults must still resolve without a deployment segment.
+      expect(
+        await factory!.create('azure:embedding', mockProviderOptions, mockContext),
+      ).toBeDefined();
+      expect(
+        await factory!.create('azure:responses', mockProviderOptions, mockContext),
+      ).toBeDefined();
+      expect(await factory!.create('azure:video', mockProviderOptions, mockContext)).toBeDefined();
+
       // MAI image models are Foundry-only; the Azure OpenAI prefix must reject them.
       await expect(
         factory!.create('azureopenai:image:mai-image-2-5', mockProviderOptions, mockContext),

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -444,6 +444,13 @@ describe('Provider Registry', () => {
       expect(imageProvider).toBeDefined();
       expect(imageProvider.toString()).toBe('[Azure Image Provider mai-image-2-5]');
 
+      await expect(
+        factory!.create('azure:image', mockProviderOptions, mockContext),
+      ).rejects.toThrow(/Azure image provider requires a deployment name/);
+      await expect(
+        factory!.create('azure:image:', mockProviderOptions, mockContext),
+      ).rejects.toThrow(/Azure image provider requires a deployment name/);
+
       // MAI image models are Foundry-only; the Azure OpenAI prefix must reject them.
       await expect(
         factory!.create('azureopenai:image:mai-image-2-5', mockProviderOptions, mockContext),


### PR DESCRIPTION
## Summary

- Reject Azure provider paths that omit the required deployment/identifier segment for every model type that has **no sensible default**: `chat`, `completion`, `assistant`, `foundry-agent`, and `image`.
- Previously the registry accepted `azure:image`/`azure:image:` (and the same for the other types), constructing a provider with an `undefined`/empty deployment.
- Use a shared `requirePathSegment` helper so each type reports an accurate identifier in its error (deployment name / assistant ID / agent ID).

## Problem

Azure providers take their deployment/identifier from the path's third segment (`azure:<type>:<name>`); `AzureGenericProvider` has no `config.deploymentName` fallback for these types. With the segment missing, the registry built a provider with an undefined deployment that failed later with an opaque error instead of reporting the misconfiguration up front — e.g.:

- image / completion: `model: undefined` in the request body
- chat: `undefined.toLowerCase()` in reasoning-model auto-detection
- assistant / foundry-agent: the id never matches, so the call fails downstream

Types that intentionally default (`embedding` → `text-embedding-ada-002`, `responses` → `gpt-4.1-2025-04-14`, `video` → `sora`, `moderation` → `text-content-safety`) are unchanged and still resolve without a path segment.

## Testing

- `npx vitest run test/providers/registry.test.ts test/providers/azure/image.test.ts --sequence.shuffle=false` — 99 passing (covers missing and empty third-segment variants for each no-default type, plus default-bearing types still resolving)
- `npm run tsc`, `npm run l`
- Real Azure verification via `az` CLI against a live MAI deployment (`mai-image-2-5` on an AIServices Foundry resource):
  - `azure:image` / `azure:image:` / `azure:chat` / `azure:foundry-agent` (no segment) → fail-fast with the type-specific error
  - `azure:image:mai-image-2-5` (valid) → real image generated successfully (PASS), confirming the guard does not regress valid usage