### PR TITLE
fix(eval): compose metadata and result filters

### DIFF
--- a/scripts/generate_modelaudit_schema.py
+++ b/scripts/generate_modelaudit_schema.py
@@ -119,10 +119,7 @@ def write_text_atomic(path: Path, contents: str) -> None:
             tmp_file.write(contents)
         os.replace(tmp_name, path)
     except Exception:
-        try:
-            os.unlink(tmp_name)
-        except FileNotFoundError:
-            pass
+        Path(tmp_name).unlink(missing_ok=True)
         raise
 
 

--- a/site/docs/model-audit/usage.md
+++ b/site/docs/model-audit/usage.md
@@ -378,7 +378,7 @@ The result includes scan statistics, scanned assets, file metadata, `issues`, an
 
 Consumers should tolerate omitted optional fields and new scanner-specific fields, especially within `details` and `file_metadata`.
 
-Export the installed version's scanner catalog when you need the current scanner IDs and dependency metadata:
+Use the standalone ModelAudit CLI to export the installed version's scanner catalog when you need the current scanner IDs and dependency metadata:
 
 ```bash
 modelaudit scan --list-scanners --format json
@@ -613,6 +613,7 @@ class CustomModelScanner(BaseScanner):
     def scan(self, path: str) -> ScanResult:
         """Scan the model file for security issues"""
         result = self._create_result()
+        scan_success = True
 
         try:
             # Your custom scanning logic here
@@ -634,8 +635,9 @@ class CustomModelScanner(BaseScanner):
                 location=path,
                 details={"exception": str(e)}
             )
+            scan_success = False
 
-        result.finish(success=True)
+        result.finish(success=scan_success)
         return result
 ```
 

--- a/src/util/eval/evalTableUtils.ts
+++ b/src/util/eval/evalTableUtils.ts
@@ -50,16 +50,11 @@ export class ComparisonEvalNotFoundError extends Error {
 }
 
 /**
- *
- *
- *
  * Keep this in its current order, as it is used to map the columns in the CSV, so it needs to be static.
- *
  *
  * The keys are the names of the columns in the metadata object, and the values are the names of the columns in the CSV.
  *
  * This is imported by enterprise so it doesn't need to be copied.
- *
  */
 export const REDTEAM_METADATA_KEYS_TO_CSV_COLUMN_NAMES = {
   messages: 'Messages',

--- a/src/util/eval/filterTests.ts
+++ b/src/util/eval/filterTests.ts
@@ -63,6 +63,13 @@ export interface FilterOptions {
 
 type Tests = NonNullable<TestSuite['tests']>;
 
+function restrictToCurrentTests(currentTests: Tests, resultFilteredTests: Tests): Tests {
+  const currentTestKeys = new Set(currentTests.map(getTestCaseDeduplicationKey));
+  return resultFilteredTests.filter((test) =>
+    currentTestKeys.has(getTestCaseDeduplicationKey(test)),
+  );
+}
+
 function createSeededRandom(seed: number): () => number {
   const stringSeed = String(seed);
   let state = 2166136261;
@@ -199,6 +206,13 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
     logger.debug(`After metadata filter: ${tests.length} tests remain`);
   }
 
+  const testsBeforeResultFilters = tests;
+  // Preserve runtime-generated tests unless an earlier filter already narrowed the config tests.
+  const restrictResultFilter = (resultFilteredTests: Tests): Tests =>
+    testsBeforeResultFilters === testSuite.tests
+      ? resultFilteredTests
+      : restrictToCurrentTests(testsBeforeResultFilters, resultFilteredTests);
+
   // Handle failing, failingOnly, and errorsOnly filters
   // - failing: all non-successful results (failures + errors)
   // - failingOnly: assertion failures only (excludes errors)
@@ -214,14 +228,16 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
     // Create a union of both sets, deduplicating by test identity
     const seen = new Set<string>();
 
-    tests = [...failingOnlyTests, ...errorTests].filter((test) => {
-      const key = getTestCaseDeduplicationKey(test);
-      if (seen.has(key)) {
-        return false;
-      }
-      seen.add(key);
-      return true;
-    });
+    tests = restrictResultFilter(
+      [...failingOnlyTests, ...errorTests].filter((test) => {
+        const key = getTestCaseDeduplicationKey(test);
+        if (seen.has(key)) {
+          return false;
+        }
+        seen.add(key);
+        return true;
+      }),
+    );
 
     logger.debug(
       `Combined failingOnly (${failingOnlyTests.length}) and errors (${errorTests.length}) filters: ${tests.length} unique tests`,
@@ -234,13 +250,13 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
     }
   } else if (options.failing) {
     // --filter-failing includes both failures and errors
-    tests = await filterFailingTests(testSuite, options.failing);
+    tests = restrictResultFilter(await filterFailingTests(testSuite, options.failing));
     if (tests.length === 0) {
       logNoTestsWarning('filter-failing', options.failing, 'no failures/errors');
     }
   } else if (options.failingOnly) {
     // --filter-failing-only includes only assertion failures (excludes errors)
-    tests = await filterFailingOnlyTests(testSuite, options.failingOnly);
+    tests = restrictResultFilter(await filterFailingOnlyTests(testSuite, options.failingOnly));
     if (tests.length === 0) {
       logNoTestsWarning(
         'filter-failing-only',
@@ -249,7 +265,7 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
       );
     }
   } else if (options.errorsOnly) {
-    tests = await filterErrorTests(testSuite, options.errorsOnly);
+    tests = restrictResultFilter(await filterErrorTests(testSuite, options.errorsOnly));
     if (tests.length === 0) {
       logNoTestsWarning('filter-errors-only', options.errorsOnly, 'no errors');
     }

--- a/src/util/eval/filterTests.ts
+++ b/src/util/eval/filterTests.ts
@@ -22,7 +22,7 @@ import { filterByRange } from '../../util/filterRange';
 import { warnEmptyFilterRange } from '../../util/filterRangeWarn';
 import { filterTestsByResults } from './filterTestsUtil';
 
-import type { TestSuite } from '../../types/index';
+import type { TestCase, TestSuite } from '../../types/index';
 
 /**
  * Logs a warning when a filter returns no tests.
@@ -62,13 +62,7 @@ export interface FilterOptions {
 }
 
 type Tests = NonNullable<TestSuite['tests']>;
-
-function restrictToCurrentTests(currentTests: Tests, resultFilteredTests: Tests): Tests {
-  const currentTestKeys = new Set(currentTests.map(getTestCaseDeduplicationKey));
-  return resultFilteredTests.filter((test) =>
-    currentTestKeys.has(getTestCaseDeduplicationKey(test)),
-  );
-}
+type TestFilterFn = (test: TestCase) => boolean;
 
 function createSeededRandom(seed: number): () => number {
   const stringSeed = String(seed);
@@ -92,9 +86,18 @@ function createSeededRandom(seed: number): () => number {
  * @param pathOrId - Either a file path to a JSON results file or an eval ID
  * @returns A filtered array of tests that failed in the specified eval
  */
-async function filterFailingTests(testSuite: TestSuite, pathOrId: string): Promise<Tests> {
+async function filterFailingTests(
+  testSuite: TestSuite,
+  pathOrId: string,
+  extractedTestFilter?: TestFilterFn,
+): Promise<Tests> {
   // Filter for all non-successful results (both assertion failures and errors)
-  return filterTestsByResults(testSuite, pathOrId, (result) => !result.success);
+  return filterTestsByResults(
+    testSuite,
+    pathOrId,
+    (result) => !result.success,
+    extractedTestFilter,
+  );
 }
 
 /**
@@ -103,12 +106,17 @@ async function filterFailingTests(testSuite: TestSuite, pathOrId: string): Promi
  * @param pathOrId - Either a file path to a JSON results file or an eval ID
  * @returns A filtered array of tests that failed assertions (not errors) in the specified eval
  */
-async function filterFailingOnlyTests(testSuite: TestSuite, pathOrId: string): Promise<Tests> {
+async function filterFailingOnlyTests(
+  testSuite: TestSuite,
+  pathOrId: string,
+  extractedTestFilter?: TestFilterFn,
+): Promise<Tests> {
   // Filter for assertion failures only, excluding errors
   return filterTestsByResults(
     testSuite,
     pathOrId,
     (result) => !result.success && result.failureReason !== ResultFailureReason.ERROR,
+    extractedTestFilter,
   );
 }
 
@@ -118,11 +126,16 @@ async function filterFailingOnlyTests(testSuite: TestSuite, pathOrId: string): P
  * @param pathOrId - Either a file path to a JSON results file or an eval ID
  * @returns A filtered array of tests that resulted in errors in the specified evaluation
  */
-async function filterErrorTests(testSuite: TestSuite, pathOrId: string): Promise<Tests> {
+async function filterErrorTests(
+  testSuite: TestSuite,
+  pathOrId: string,
+  extractedTestFilter?: TestFilterFn,
+): Promise<Tests> {
   return filterTestsByResults(
     testSuite,
     pathOrId,
     (result) => result.failureReason === ResultFailureReason.ERROR,
+    extractedTestFilter,
   );
 }
 
@@ -144,6 +157,7 @@ async function filterErrorTests(testSuite: TestSuite, pathOrId: string): Promise
  */
 export async function filterTests(testSuite: TestSuite, options: FilterOptions): Promise<Tests> {
   let tests = testSuite.tests || [];
+  let metadataFilter: TestFilterFn | undefined;
 
   logger.debug(`Starting filterTests with options: ${JSON.stringify(options)}`);
   logger.debug(`Initial test count: ${tests.length}`);
@@ -173,7 +187,7 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
     );
     logger.debug(`Before metadata filter: ${tests.length} tests`);
 
-    tests = tests.filter((test) => {
+    metadataFilter = (test) => {
       if (!test.metadata) {
         logger.debug(`Test has no metadata: ${test.description || 'unnamed test'}`);
         return false;
@@ -201,17 +215,13 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
       }
 
       return true;
-    });
+    };
+    tests = tests.filter(metadataFilter);
 
     logger.debug(`After metadata filter: ${tests.length} tests remain`);
   }
 
-  const testsBeforeResultFilters = tests;
-  // Preserve runtime-generated tests unless an earlier filter already narrowed the config tests.
-  const restrictResultFilter = (resultFilteredTests: Tests): Tests =>
-    testsBeforeResultFilters === testSuite.tests
-      ? resultFilteredTests
-      : restrictToCurrentTests(testsBeforeResultFilters, resultFilteredTests);
+  const resultFilterTestSuite = metadataFilter ? { ...testSuite, tests } : testSuite;
 
   // Handle failing, failingOnly, and errorsOnly filters
   // - failing: all non-successful results (failures + errors)
@@ -222,22 +232,28 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
     logger.debug(
       'Using both --filter-failing-only and --filter-errors-only together (equivalent to --filter-failing)',
     );
-    const failingOnlyTests = await filterFailingOnlyTests(testSuite, options.failingOnly);
-    const errorTests = await filterErrorTests(testSuite, options.errorsOnly);
+    const failingOnlyTests = await filterFailingOnlyTests(
+      resultFilterTestSuite,
+      options.failingOnly,
+      metadataFilter,
+    );
+    const errorTests = await filterErrorTests(
+      resultFilterTestSuite,
+      options.errorsOnly,
+      metadataFilter,
+    );
 
     // Create a union of both sets, deduplicating by test identity
     const seen = new Set<string>();
 
-    tests = restrictResultFilter(
-      [...failingOnlyTests, ...errorTests].filter((test) => {
-        const key = getTestCaseDeduplicationKey(test);
-        if (seen.has(key)) {
-          return false;
-        }
-        seen.add(key);
-        return true;
-      }),
-    );
+    tests = [...failingOnlyTests, ...errorTests].filter((test) => {
+      const key = getTestCaseDeduplicationKey(test);
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
 
     logger.debug(
       `Combined failingOnly (${failingOnlyTests.length}) and errors (${errorTests.length}) filters: ${tests.length} unique tests`,
@@ -250,13 +266,17 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
     }
   } else if (options.failing) {
     // --filter-failing includes both failures and errors
-    tests = restrictResultFilter(await filterFailingTests(testSuite, options.failing));
+    tests = await filterFailingTests(resultFilterTestSuite, options.failing, metadataFilter);
     if (tests.length === 0) {
       logNoTestsWarning('filter-failing', options.failing, 'no failures/errors');
     }
   } else if (options.failingOnly) {
     // --filter-failing-only includes only assertion failures (excludes errors)
-    tests = restrictResultFilter(await filterFailingOnlyTests(testSuite, options.failingOnly));
+    tests = await filterFailingOnlyTests(
+      resultFilterTestSuite,
+      options.failingOnly,
+      metadataFilter,
+    );
     if (tests.length === 0) {
       logNoTestsWarning(
         'filter-failing-only',
@@ -265,7 +285,7 @@ export async function filterTests(testSuite: TestSuite, options: FilterOptions):
       );
     }
   } else if (options.errorsOnly) {
-    tests = restrictResultFilter(await filterErrorTests(testSuite, options.errorsOnly));
+    tests = await filterErrorTests(resultFilterTestSuite, options.errorsOnly, metadataFilter);
     if (tests.length === 0) {
       logNoTestsWarning('filter-errors-only', options.errorsOnly, 'no errors');
     }

--- a/src/util/eval/filterTestsUtil.ts
+++ b/src/util/eval/filterTestsUtil.ts
@@ -175,9 +175,11 @@ export async function filterTestsByResults(
   const matchedResultKeys = new Set<string>();
 
   // Track which results matched config tests
+  const matchedTestsWithDefaults = matchedTests.map((test) =>
+    mergeDefaultVars(test, testSuite.defaultTest),
+  );
   for (const result of filteredResults) {
-    for (const test of matchedTests) {
-      const testWithDefaults = mergeDefaultVars(test, testSuite.defaultTest);
+    for (const testWithDefaults of matchedTestsWithDefaults) {
       if (resultIsForTestCase(result, testWithDefaults)) {
         matchedResultKeys.add(JSON.stringify(filterRuntimeVars(result.vars)));
         break;

--- a/src/util/eval/filterTestsUtil.ts
+++ b/src/util/eval/filterTestsUtil.ts
@@ -11,6 +11,7 @@ type Tests = NonNullable<TestSuite['tests']>;
  * Predicate function for filtering test results
  */
 type ResultFilterFn = (result: EvaluateResult) => boolean;
+type TestFilterFn = (test: TestCase) => boolean;
 
 /**
  * Merges defaultTest.vars into a test case's vars for comparison purposes.
@@ -36,12 +37,14 @@ function mergeDefaultVars(test: TestCase, defaultTest: TestSuite['defaultTest'])
  * @param testSuite - Test suite to filter
  * @param pathOrId - JSON results file path or eval ID
  * @param filterFn - Predicate to determine which results to include
+ * @param extractedTestFilter - Optional predicate for runtime-generated tests extracted from results
  * @returns Filtered array of tests
  */
 export async function filterTestsByResults(
   testSuite: TestSuite,
   pathOrId: string,
   filterFn: ResultFilterFn,
+  extractedTestFilter?: TestFilterFn,
 ): Promise<Tests> {
   if (!testSuite.tests) {
     logger.debug('[filterTestsByResults] No tests in test suite');
@@ -199,6 +202,10 @@ export async function filterTestsByResults(
     // Skip if no testCase data available
     if (!result.testCase) {
       logger.debug('[filterTestsByResults] Skipping result without testCase data for extraction');
+      continue;
+    }
+
+    if (extractedTestFilter && !extractedTestFilter(result.testCase)) {
       continue;
     }
 

--- a/test/assertions/google.test.ts
+++ b/test/assertions/google.test.ts
@@ -9,7 +9,7 @@ import { validateFunctionCall } from '../../src/providers/google/util';
 import { VertexChatProvider } from '../../src/providers/google/vertex';
 import { createMockProvider } from '../factories/provider';
 
-import type { Tool } from '../../src/providers/google//types';
+import type { Tool } from '../../src/providers/google/types';
 import type { ApiProvider, AtomicTestCase, GradingResult } from '../../src/types/index';
 
 // Create hoisted mocks for stable references

--- a/test/util/eval/filterTests.test.ts
+++ b/test/util/eval/filterTests.test.ts
@@ -658,5 +658,138 @@ describe('filterTests', () => {
       expect(result).toHaveLength(1);
       expect(result[0]?.vars?.var1).toBe('test1');
     });
+
+    it('should not reintroduce metadata-excluded tests with matching vars', async () => {
+      const excludedTest: TestCase = {
+        description: 'integration test',
+        vars: { prompt: 'shared input' },
+        metadata: { type: 'integration' },
+        provider: 'provider-integration',
+      };
+      const selectedTest: TestCase = {
+        description: 'unit test',
+        vars: { prompt: 'shared input' },
+        metadata: { type: 'unit' },
+        provider: 'provider-unit',
+      };
+      const testSuite: TestSuite = {
+        prompts: [],
+        providers: [],
+        tests: [excludedTest, selectedTest],
+      };
+      vi.mocked(Eval.findById).mockResolvedValue({
+        toEvaluateSummary: vi.fn().mockResolvedValue({
+          results: [
+            {
+              vars: excludedTest.vars,
+              provider: { id: 'provider-integration' },
+              success: false,
+              failureReason: ResultFailureReason.ASSERT,
+              testCase: excludedTest,
+            },
+            {
+              vars: selectedTest.vars,
+              provider: { id: 'provider-unit' },
+              success: false,
+              failureReason: ResultFailureReason.ASSERT,
+              testCase: selectedTest,
+            },
+          ],
+        }),
+      } as any);
+
+      const result = await filterTests(testSuite, {
+        metadata: 'type=unit',
+        failing: 'eval-123',
+      });
+
+      expect(result).toEqual([selectedTest]);
+    });
+
+    it('should preserve generated result tests when metadata matches all config tests', async () => {
+      const configTest: TestCase = {
+        description: 'configured test',
+        vars: { prompt: 'configured' },
+        metadata: { type: 'unit' },
+      };
+      const generatedTest: TestCase = {
+        description: 'generated test',
+        vars: { prompt: 'generated' },
+        metadata: { type: 'unit', pluginId: 'cipher-code' },
+      };
+      const testSuite: TestSuite = {
+        prompts: [],
+        providers: [],
+        tests: [configTest],
+      };
+      vi.mocked(Eval.findById).mockResolvedValue({
+        toEvaluateSummary: vi.fn().mockResolvedValue({
+          results: [
+            {
+              vars: configTest.vars,
+              success: false,
+              failureReason: ResultFailureReason.ASSERT,
+              testCase: configTest,
+            },
+            {
+              vars: generatedTest.vars,
+              success: false,
+              failureReason: ResultFailureReason.ASSERT,
+              testCase: generatedTest,
+            },
+          ],
+        }),
+      } as any);
+
+      const result = await filterTests(testSuite, {
+        metadata: 'type=unit',
+        failing: 'eval-123',
+      });
+
+      expect(result.map((test) => test.description)).toEqual(['configured test', 'generated test']);
+    });
+
+    it('should filter generated result tests by metadata before deduplication', async () => {
+      const excludedGeneratedTest: TestCase = {
+        description: 'excluded generated test',
+        vars: { prompt: 'shared generated input' },
+        metadata: { type: 'integration' },
+      };
+      const selectedGeneratedTest: TestCase = {
+        description: 'selected generated test',
+        vars: { prompt: 'shared generated input' },
+        metadata: { type: 'unit' },
+      };
+      const testSuite: TestSuite = {
+        prompts: [],
+        providers: [],
+        tests: [],
+      };
+      vi.mocked(Eval.findById).mockResolvedValue({
+        toEvaluateSummary: vi.fn().mockResolvedValue({
+          results: [
+            {
+              vars: excludedGeneratedTest.vars,
+              success: false,
+              failureReason: ResultFailureReason.ASSERT,
+              testCase: excludedGeneratedTest,
+            },
+            {
+              vars: selectedGeneratedTest.vars,
+              success: false,
+              failureReason: ResultFailureReason.ASSERT,
+              testCase: selectedGeneratedTest,
+            },
+          ],
+        }),
+      } as any);
+
+      const result = await filterTests(testSuite, {
+        metadata: 'type=unit',
+        failing: 'eval-123',
+      });
+
+      expect(result).toEqual([selectedGeneratedTest]);
+    });
   });
 });

--- a/test/util/eval/filterTests.test.ts
+++ b/test/util/eval/filterTests.test.ts
@@ -625,11 +625,34 @@ describe('filterTests', () => {
   });
 
   describe('multiple filters', () => {
-    it('should apply filters in correct order', async () => {
+    it('should compose metadata and failing filters', async () => {
+      vi.mocked(Eval.findById).mockResolvedValue({
+        toEvaluateSummary: vi.fn().mockResolvedValue({
+          results: [
+            {
+              vars: { var1: 'test1' },
+              success: false,
+              failureReason: ResultFailureReason.ASSERT,
+              testCase: mockTestSuite.tests![0],
+            },
+            {
+              vars: { var1: 'test2' },
+              success: false,
+              failureReason: ResultFailureReason.ASSERT,
+              testCase: mockTestSuite.tests![1],
+            },
+            {
+              vars: { var1: 'test3' },
+              success: true,
+              testCase: mockTestSuite.tests![2],
+            },
+          ],
+        }),
+      } as any);
+
       const result = await filterTests(mockTestSuite, {
         metadata: 'type=unit',
         failing: 'eval-123',
-        pattern: 'test1',
       });
 
       expect(result).toHaveLength(1);


### PR DESCRIPTION
## Summary

- compose metadata filters with failing/error result filters without reintroducing excluded tests
- precompute default-var merged tests and clean up the visible comment/import findings
- clarify the standalone ModelAudit scanner-catalog command and mark custom-scanner exceptions unsuccessful
- simplify ModelAudit schema temporary-file cleanup to remove the empty exception handler

## AI findings

Addresses all 6 visible AI findings across 5 files. The scanner-catalog command remains `modelaudit scan --list-scanners --format json` because it was intentionally fixed on `main`; the documentation now explicitly identifies it as the standalone ModelAudit CLI.

Also addresses the standard CodeQL `Empty except` finding in `scripts/generate_modelaudit_schema.py`.

## Validation

- `npm run f`
- `npm run l` (passes with existing cognitive-complexity warnings)
- `npm run tsc`
- `./node_modules/.bin/vitest run test/util/eval test/assertions/google.test.ts` (195 tests)
- `SKIP_OG_GENERATION=true npm run build` from `site/`
- real no-cache CLI eval composing `--filter-metadata type=unit` with `--filter-failing` selected only the expected unit failure
- Ruff 0.15.1 check/format and Python 3.12 atomic-write success/failure cleanup verification
- `npm run build`: core TypeScript and package bundling passed; the unrelated Web UI build was blocked by a missing `diff` package in the shared local dependency install
