### PR TITLE
fix(eval): preserve --config ordering when expanding a directory entry

### DIFF
--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -261,8 +261,17 @@ export async function doEval(
           const { defaultConfig: dirConfig, defaultConfigPath: newConfigPath } =
             await loadDefaultConfig(configPath);
           if (newConfigPath) {
-            cmdObj.config = cmdObj.config.filter((path: string) => path !== configPath);
-            cmdObj.config.push(newConfigPath);
+            // Replace the directory entry in place so the original --config ordering is
+            // preserved. combineConfigs() applies configs in array order (later entries
+            // override earlier ones), so removing the directory and appending the resolved
+            // path to the end would change precedence when a directory is passed alongside
+            // other --config files (e.g. `--config base.yaml dir/ override.yaml`).
+            const configIndex = cmdObj.config.indexOf(configPath);
+            if (configIndex === -1) {
+              cmdObj.config.push(newConfigPath);
+            } else {
+              cmdObj.config[configIndex] = newConfigPath;
+            }
             defaultConfig = { ...defaultConfig, ...dirConfig };
           } else {
             logger.warn(

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -254,7 +254,11 @@ export async function doEval(
     }
 
     if (cmdObj.config !== undefined) {
+      // Normalize to an array up front (Commander's variadic --config already yields one) so
+      // the in-place directory resolution below — and the array operations on cmdObj.config
+      // later in this function — stay safe regardless of the caller's input shape.
       const configPaths: string[] = Array.isArray(cmdObj.config) ? cmdObj.config : [cmdObj.config];
+      cmdObj.config = configPaths;
       for (const configPath of configPaths) {
         const configStats = await fs.stat(configPath).catch(() => undefined);
         if (configStats?.isDirectory()) {

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -753,6 +753,29 @@ describe('evalCommand', () => {
     loadDefaultConfigSpy.mockRestore();
   });
 
+  it('should normalize a non-array config to an array before resolving a directory entry', async () => {
+    // Defensive: a non-Commander caller could pass config as a bare string. The directory
+    // resolution mutates the array in place, so a string must be normalized first (otherwise
+    // the in-place assignment throws in strict mode / corrupts the value).
+    const cmdObj = { config: '/suite' as unknown as string[], write: false };
+    const statSpy = vi.spyOn(fsPromises, 'stat').mockResolvedValue({
+      isDirectory: () => true,
+    } as any);
+    const loadDefaultConfigSpy = vi
+      .spyOn(defaultConfigModule, 'loadDefaultConfig')
+      .mockResolvedValueOnce({
+        defaultConfig: { prompts: ['from-dir'] },
+        defaultConfigPath: '/suite/promptfooconfig.yaml',
+      } as any);
+
+    await doEval(cmdObj, defaultConfig, undefined, {});
+
+    expect(cmdObj.config).toEqual(['/suite/promptfooconfig.yaml']);
+
+    statSpy.mockRestore();
+    loadDefaultConfigSpy.mockRestore();
+  });
+
   it('should warn when a directory config argument has no default config file', async () => {
     const cmdObj = { config: ['/empty-suite'], write: false };
     const loggerWarnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -720,6 +720,39 @@ describe('evalCommand', () => {
     loadDefaultConfigSpy.mockRestore();
   });
 
+  it('should preserve --config ordering when expanding a directory entry', async () => {
+    // combineConfigs applies configs in array order (later entries override earlier
+    // ones), so a directory must be resolved in place rather than moved to the end.
+    const cmdObj = { config: ['/base.yaml', '/suite', '/override.yaml'], write: false };
+    const statSpy = vi.spyOn(fsPromises, 'stat').mockImplementation(
+      async (target) =>
+        ({
+          isDirectory: () => target === '/suite',
+        }) as any,
+    );
+    const loadDefaultConfigSpy = vi
+      .spyOn(defaultConfigModule, 'loadDefaultConfig')
+      .mockResolvedValueOnce({
+        defaultConfig: { prompts: ['from-dir'] },
+        defaultConfigPath: '/suite/promptfooconfig.yaml',
+      } as any);
+
+    await doEval(cmdObj, defaultConfig, undefined, {});
+
+    // The resolved directory config stays in its original position, so /override.yaml
+    // still wins over it (regression: it used to be appended after /override.yaml).
+    expect(cmdObj.config).toEqual(['/base.yaml', '/suite/promptfooconfig.yaml', '/override.yaml']);
+    expect(resolveConfigs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: ['/base.yaml', '/suite/promptfooconfig.yaml', '/override.yaml'],
+      }),
+      expect.objectContaining({ prompts: ['from-dir'] }),
+    );
+
+    statSpy.mockRestore();
+    loadDefaultConfigSpy.mockRestore();
+  });
+
   it('should warn when a directory config argument has no default config file', async () => {
     const cmdObj = { config: ['/empty-suite'], write: false };
     const loggerWarnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => logger);


### PR DESCRIPTION
## Summary

Follow-up to #9566. Fixes a pre-existing `--config` precedence bug surfaced during that PR's review (Copilot flagged it on the moved code).

When a **directory** is passed to `--config`, `doEval` resolves it to the directory's `promptfooconfig` file. It did this by filtering the directory entry out of the array and **appending** the resolved path to the end:

```ts
cmdObj.config = cmdObj.config.filter((path) => path !== configPath);
cmdObj.config.push(newConfigPath);
```

`combineConfigs()` applies configs in **array order** (later entries override earlier ones), so moving the resolved path to the end silently changes precedence whenever a directory is passed alongside other `--config` files:

```
--config base.yaml dir/ override.yaml
  before → [base.yaml, override.yaml, dir/promptfooconfig.yaml]   # dir wrongly wins
  after  → [base.yaml, dir/promptfooconfig.yaml, override.yaml]   # override.yaml wins, as written
```

## Fix

Replace the directory entry **in place** so the original ordering — and therefore the precedence the user wrote on the command line — is preserved.

## Test

Adds a regression test (`should preserve --config ordering when expanding a directory entry`) that passes a directory between two files and asserts the resolved path keeps its position. Verified it **fails on the old remove+append code** and passes on the fix.

- `test/commands/eval.test.ts`: 106 passed
- `tsc`: clean
- Lint: only the pre-existing `runEvaluation` complexity warning (unchanged from `main`)
