### PR TITLE
fix(auth): enable auto-share for on-prem Report Server after login

### DIFF
--- a/src/globalConfig/cloud.ts
+++ b/src/globalConfig/cloud.ts
@@ -6,8 +6,22 @@ export const CLOUD_API_HOST = 'https://api.promptfoo.app';
 
 export const API_HOST = getEnvString('API_HOST', CLOUD_API_HOST);
 
+const CLOUD_HOSTNAMES = new Set([
+  new URL(CLOUD_API_HOST).hostname,
+  new URL('https://www.promptfoo.app').hostname,
+  new URL('https://promptfoo.app').hostname,
+]);
+
 // Free customers created before this date are grandfathered into auto-share.
 export const SHARING_CUTOFF_DATE = new Date('2026-03-09T00:00:00Z');
+
+function getNormalizedHostname(url: string): string {
+  return new URL(url).hostname.toLowerCase().replace(/\.$/, '');
+}
+
+function isPromptfooCloudHost(url: string): boolean {
+  return CLOUD_HOSTNAMES.has(getNormalizedHostname(url));
+}
 
 interface CloudUser {
   id: string;
@@ -180,19 +194,17 @@ export class CloudConfig {
     this.setApiKey(token);
     this.setApiHost(apiHost);
     this.setAppUrl(app.url);
-    if (typeof hasActiveLicense === 'boolean') {
-      // On-prem installations are always enterprise deployments. Applying the
-      // public-cloud hasActiveLicense gate to on-prem hosts incorrectly disables
-      // auto-sharing to the on-prem Report Server when the server returns
-      // hasActiveLicense: false (e.g. because it has no licence-check logic).
-      const isOnPrem = !apiHost.replace(/\/+$/, '').includes('api.promptfoo.app');
-      if (isOnPrem) {
-        this.setSharing(true);
-      } else {
-        const createdAt = user?.createdAt ? new Date(user.createdAt) : null;
-        const isGrandfathered = createdAt != null && createdAt < SHARING_CUTOFF_DATE;
-        this.setSharing(hasActiveLicense || isGrandfathered);
-      }
+    // On-prem installations are always enterprise deployments. Applying the
+    // public-cloud hasActiveLicense gate to on-prem hosts incorrectly disables
+    // auto-sharing to the on-prem Report Server when the server omits the field
+    // or returns false because it has no licence-check logic.
+    const isOnPrem = !isPromptfooCloudHost(apiHost);
+    if (isOnPrem) {
+      this.setSharing(true);
+    } else if (typeof hasActiveLicense === 'boolean') {
+      const createdAt = user?.createdAt ? new Date(user.createdAt) : null;
+      const isGrandfathered = createdAt != null && createdAt < SHARING_CUTOFF_DATE;
+      this.setSharing(hasActiveLicense || isGrandfathered);
     }
   }
 

--- a/src/globalConfig/cloud.ts
+++ b/src/globalConfig/cloud.ts
@@ -181,9 +181,18 @@ export class CloudConfig {
     this.setApiHost(apiHost);
     this.setAppUrl(app.url);
     if (typeof hasActiveLicense === 'boolean') {
-      const createdAt = user?.createdAt ? new Date(user.createdAt) : null;
-      const isGrandfathered = createdAt != null && createdAt < SHARING_CUTOFF_DATE;
-      this.setSharing(hasActiveLicense || isGrandfathered);
+      // On-prem installations are always enterprise deployments. Applying the
+      // public-cloud hasActiveLicense gate to on-prem hosts incorrectly disables
+      // auto-sharing to the on-prem Report Server when the server returns
+      // hasActiveLicense: false (e.g. because it has no licence-check logic).
+      const isOnPrem = !apiHost.replace(/\/+$/, '').includes('api.promptfoo.app');
+      if (isOnPrem) {
+        this.setSharing(true);
+      } else {
+        const createdAt = user?.createdAt ? new Date(user.createdAt) : null;
+        const isGrandfathered = createdAt != null && createdAt < SHARING_CUTOFF_DATE;
+        this.setSharing(hasActiveLicense || isGrandfathered);
+      }
     }
   }
 

--- a/src/globalConfig/cloud.ts
+++ b/src/globalConfig/cloud.ts
@@ -15,12 +15,13 @@ const CLOUD_HOSTNAMES = new Set([
 // Free customers created before this date are grandfathered into auto-share.
 export const SHARING_CUTOFF_DATE = new Date('2026-03-09T00:00:00Z');
 
-function getNormalizedHostname(url: string): string {
-  return new URL(url).hostname.toLowerCase().replace(/\.$/, '');
-}
-
 function isPromptfooCloudHost(url: string): boolean {
-  return CLOUD_HOSTNAMES.has(getNormalizedHostname(url));
+  try {
+    const hostname = new URL(url).hostname.toLowerCase().replace(/\.$/, '');
+    return CLOUD_HOSTNAMES.has(hostname);
+  } catch {
+    return false;
+  }
 }
 
 interface CloudUser {
@@ -197,9 +198,10 @@ export class CloudConfig {
     // On-prem installations are always enterprise deployments. Applying the
     // public-cloud hasActiveLicense gate to on-prem hosts incorrectly disables
     // auto-sharing to the on-prem Report Server when the server omits the field
-    // or returns false because it has no licence-check logic.
-    const isOnPrem = !isPromptfooCloudHost(apiHost);
-    if (isOnPrem) {
+    // or returns false because it has no licence-check logic. The validated app
+    // URL keeps hosted Cloud behind an API proxy on the public-cloud license gate.
+    const isPublicCloud = isPromptfooCloudHost(apiHost) || isPromptfooCloudHost(app.url);
+    if (!isPublicCloud) {
       this.setSharing(true);
     } else if (typeof hasActiveLicense === 'boolean') {
       const createdAt = user?.createdAt ? new Date(user.createdAt) : null;

--- a/test/globalConfig/cloud.test.ts
+++ b/test/globalConfig/cloud.test.ts
@@ -409,6 +409,27 @@ describe('CloudConfig', () => {
       );
     });
 
+    it.each([
+      'https://api.promptfoo.app',
+      'https://www.promptfoo.app',
+      'https://promptfoo.app',
+    ])('should apply the license gate behind an API proxy for app URL %s', async (appUrl) => {
+      vi.mocked(fetchWithProxy).mockResolvedValue(
+        makeFetch({
+          ...onPremResponse,
+          app: { url: appUrl },
+          hasActiveLicense: false,
+        }),
+      );
+
+      await cloudConfigInstance.validateAndSetApiToken('token', 'https://cloud-proxy.example.com');
+
+      const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({ cloud: expect.objectContaining({ sharing: false }) }),
+      );
+    });
+
     it('should disable sharing for public cloud host with hasActiveLicense: false after cutoff', async () => {
       const body = {
         ...onPremResponse,

--- a/test/globalConfig/cloud.test.ts
+++ b/test/globalConfig/cloud.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { API_HOST, CloudConfig, cloudConfig } from '../../src/globalConfig/cloud';
+import { API_HOST, CLOUD_API_HOST, CloudConfig, cloudConfig } from '../../src/globalConfig/cloud';
 import { readGlobalConfig, writeGlobalConfigPartial } from '../../src/globalConfig/globalConfig';
 import { fetchWithProxy } from '../../src/util/fetch/index';
 import { mockProcessEnv } from '../util/utils';
@@ -176,7 +176,7 @@ describe('CloudConfig', () => {
       );
     });
 
-    it('should set sharing to false when hasActiveLicense is false and user created after cutoff', async () => {
+    it('should set sharing to false when hasActiveLicense is false and user created after cutoff (public cloud)', async () => {
       const noLicenseResponse = {
         ...mockResponse,
         hasActiveLicense: false,
@@ -190,10 +190,7 @@ describe('CloudConfig', () => {
 
       vi.mocked(fetchWithProxy).mockResolvedValue(mockFetchResponse);
 
-      const result = await cloudConfigInstance.validateAndSetApiToken(
-        'test-token',
-        'https://test.api',
-      );
+      const result = await cloudConfigInstance.validateAndSetApiToken('test-token', CLOUD_API_HOST);
 
       expect(result.hasActiveLicense).toBe(false);
       const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
@@ -206,7 +203,7 @@ describe('CloudConfig', () => {
       );
     });
 
-    it('should set sharing to true when hasActiveLicense is false but user created before cutoff (grandfathered)', async () => {
+    it('should set sharing to true when hasActiveLicense is false but user created before cutoff (public cloud, grandfathered)', async () => {
       const grandfatheredResponse = {
         ...mockResponse,
         hasActiveLicense: false,
@@ -220,10 +217,7 @@ describe('CloudConfig', () => {
 
       vi.mocked(fetchWithProxy).mockResolvedValue(mockFetchResponse);
 
-      const result = await cloudConfigInstance.validateAndSetApiToken(
-        'test-token',
-        'https://test.api',
-      );
+      const result = await cloudConfigInstance.validateAndSetApiToken('test-token', CLOUD_API_HOST);
 
       expect(result.hasActiveLicense).toBe(false);
       const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
@@ -284,6 +278,109 @@ describe('CloudConfig', () => {
       await expect(
         cloudConfigInstance.validateAndSetApiToken('invalid-token', 'https://test.api'),
       ).rejects.toThrow('Failed to validate API token: Unauthorized');
+    });
+  });
+
+  describe('on-prem sharing behavior', () => {
+    const onPremHost = 'https://promptfoo.example.com';
+    const onPremResponse = {
+      user: {
+        id: '1',
+        name: 'On-Prem User',
+        email: 'user@example.com',
+        // Account created well after the public-cloud grandfathering cutoff.
+        createdAt: new Date('2026-04-01T00:00:00Z'),
+        updatedAt: new Date('2026-04-01T00:00:00Z'),
+      },
+      organization: {
+        id: '1',
+        name: 'On-Prem Org',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      app: { url: 'https://promptfoo.example.com' },
+    };
+
+    function makeFetch(body: object) {
+      return {
+        ok: true,
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(JSON.stringify(body)),
+      } as Response;
+    }
+
+    it('should enable sharing when on-prem server returns hasActiveLicense: false and user created after cutoff', async () => {
+      vi.mocked(fetchWithProxy).mockResolvedValue(
+        makeFetch({ ...onPremResponse, hasActiveLicense: false }),
+      );
+
+      const result = await cloudConfigInstance.validateAndSetApiToken('token', onPremHost);
+
+      expect(result.hasActiveLicense).toBe(false);
+      const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({ cloud: expect.objectContaining({ sharing: true }) }),
+      );
+    });
+
+    it('should enable sharing when on-prem server returns hasActiveLicense: false and user created before cutoff', async () => {
+      const body = {
+        ...onPremResponse,
+        hasActiveLicense: false,
+        user: { ...onPremResponse.user, createdAt: new Date('2026-03-01T00:00:00Z') },
+      };
+      vi.mocked(fetchWithProxy).mockResolvedValue(makeFetch(body));
+
+      const result = await cloudConfigInstance.validateAndSetApiToken('token', onPremHost);
+
+      expect(result.hasActiveLicense).toBe(false);
+      const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({ cloud: expect.objectContaining({ sharing: true }) }),
+      );
+    });
+
+    it('should enable sharing when on-prem server returns hasActiveLicense: true', async () => {
+      vi.mocked(fetchWithProxy).mockResolvedValue(
+        makeFetch({ ...onPremResponse, hasActiveLicense: true }),
+      );
+
+      await cloudConfigInstance.validateAndSetApiToken('token', onPremHost);
+
+      const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({ cloud: expect.objectContaining({ sharing: true }) }),
+      );
+    });
+
+    it('should enable sharing for on-prem host with trailing slash', async () => {
+      vi.mocked(fetchWithProxy).mockResolvedValue(
+        makeFetch({ ...onPremResponse, hasActiveLicense: false }),
+      );
+
+      await cloudConfigInstance.validateAndSetApiToken('token', `${onPremHost}/`);
+
+      const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({ cloud: expect.objectContaining({ sharing: true }) }),
+      );
+    });
+
+    it('should disable sharing for public cloud host with hasActiveLicense: false after cutoff', async () => {
+      const body = {
+        ...onPremResponse,
+        hasActiveLicense: false,
+        user: { ...onPremResponse.user, createdAt: new Date('2026-04-01T00:00:00Z') },
+      };
+      vi.mocked(fetchWithProxy).mockResolvedValue(makeFetch(body));
+
+      const result = await cloudConfigInstance.validateAndSetApiToken('token', CLOUD_API_HOST);
+
+      expect(result.hasActiveLicense).toBe(false);
+      const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({ cloud: expect.objectContaining({ sharing: false }) }),
+      );
     });
   });
 

--- a/test/globalConfig/cloud.test.ts
+++ b/test/globalConfig/cloud.test.ts
@@ -24,6 +24,10 @@ describe('CloudConfig', () => {
     cloudConfigInstance = new CloudConfig();
   });
 
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
   describe('constructor', () => {
     it('should initialize with default values when no saved config exists', () => {
       vi.mocked(readGlobalConfig).mockReturnValue({
@@ -230,7 +234,7 @@ describe('CloudConfig', () => {
       );
     });
 
-    it('should preserve existing sharing value when hasActiveLicense is omitted from response', async () => {
+    it('should preserve existing sharing value when public cloud omits hasActiveLicense', async () => {
       // Pre-set sharing to true to verify it is preserved
       vi.mocked(readGlobalConfig).mockReturnValue({
         id: 'test-id',
@@ -253,10 +257,7 @@ describe('CloudConfig', () => {
       vi.mocked(fetchWithProxy).mockResolvedValue(mockFetchResponse);
       const setSharingSpy = vi.spyOn(cloudConfigInstance, 'setSharing');
 
-      const result = await cloudConfigInstance.validateAndSetApiToken(
-        'test-token',
-        'https://test.api',
-      );
+      const result = await cloudConfigInstance.validateAndSetApiToken('test-token', CLOUD_API_HOST);
 
       expect(result.hasActiveLicense).toBe(false);
       // setSharing should NOT have been called when hasActiveLicense is undefined
@@ -366,6 +367,48 @@ describe('CloudConfig', () => {
       );
     });
 
+    it('should enable sharing when an on-prem server omits hasActiveLicense', async () => {
+      vi.mocked(readGlobalConfig).mockReturnValue({
+        id: 'test-id',
+        cloud: {
+          appUrl: 'https://promptfoo.example.com',
+          apiHost: onPremHost,
+          apiKey: 'existing-key',
+          sharing: false,
+        },
+      });
+      cloudConfigInstance = new CloudConfig();
+      vi.mocked(fetchWithProxy).mockResolvedValue(makeFetch(onPremResponse));
+
+      await cloudConfigInstance.validateAndSetApiToken('token', onPremHost);
+
+      const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({ cloud: expect.objectContaining({ sharing: true }) }),
+      );
+    });
+
+    it.each([
+      'https://api.promptfoo.app.internal.example.com',
+      'https://onprem.example.com/prefix/api.promptfoo.app',
+      'https://api.promptfoo.app@onprem.example.com',
+      'https://www.promptfoo.app.internal.example.com',
+      'https://www.promptfoo.app@onprem.example.com',
+      'https://promptfoo.app.internal.example.com',
+      'https://promptfoo.app@onprem.example.com',
+    ])('should enable sharing for on-prem URL %s', async (host) => {
+      vi.mocked(fetchWithProxy).mockResolvedValue(
+        makeFetch({ ...onPremResponse, hasActiveLicense: false }),
+      );
+
+      await cloudConfigInstance.validateAndSetApiToken('token', host);
+
+      const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({ cloud: expect.objectContaining({ sharing: true }) }),
+      );
+    });
+
     it('should disable sharing for public cloud host with hasActiveLicense: false after cutoff', async () => {
       const body = {
         ...onPremResponse,
@@ -377,6 +420,32 @@ describe('CloudConfig', () => {
       const result = await cloudConfigInstance.validateAndSetApiToken('token', CLOUD_API_HOST);
 
       expect(result.hasActiveLicense).toBe(false);
+      const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
+      expect(lastCall).toEqual(
+        expect.objectContaining({ cloud: expect.objectContaining({ sharing: false }) }),
+      );
+    });
+
+    it.each([
+      CLOUD_API_HOST.toUpperCase(),
+      `${CLOUD_API_HOST}.`,
+      `${CLOUD_API_HOST}/prefix`,
+      'https://www.promptfoo.app',
+      'https://WWW.PROMPTFOO.APP.',
+      'https://www.promptfoo.app/prefix',
+      'https://promptfoo.app',
+      'https://PROMPTFOO.APP.',
+      'https://promptfoo.app/prefix',
+    ])('should apply the license gate to public cloud URL %s', async (host) => {
+      const body = {
+        ...onPremResponse,
+        hasActiveLicense: false,
+        user: { ...onPremResponse.user, createdAt: new Date('2026-04-01T00:00:00Z') },
+      };
+      vi.mocked(fetchWithProxy).mockResolvedValue(makeFetch(body));
+
+      await cloudConfigInstance.validateAndSetApiToken('token', host);
+
       const lastCall = vi.mocked(writeGlobalConfigPartial).mock.calls.at(-1)?.[0];
       expect(lastCall).toEqual(
         expect.objectContaining({ cloud: expect.objectContaining({ sharing: false }) }),


### PR DESCRIPTION
## Summary

- `promptfoo auth login` against an on-prem server can store `sharing: false` in the global config when the server returns `hasActiveLicense: false`, silently disabling auto-share to the on-prem Report Server for accounts created after the 2026-03-09 grandfathering cutoff (PR #7982).
- On-prem installations are always enterprise deployments, so the public-cloud `hasActiveLicense` gate does not apply to them.
- Fix: in `saveValidatedApiToken`, skip the license check when the API host is not `api.promptfoo.app` and unconditionally set `sharing: true`.

## Root Cause

PR #7982 added this logic to `saveValidatedApiToken` in `src/globalConfig/cloud.ts`:

```typescript
// Before this fix
if (typeof hasActiveLicense === 'boolean') {
  const createdAt = user?.createdAt ? new Date(user.createdAt) : null;
  const isGrandfathered = createdAt != null && createdAt < SHARING_CUTOFF_DATE;
  this.setSharing(hasActiveLicense || isGrandfathered);
}
```

On-prem servers may return `hasActiveLicense: false` (e.g. because they have no licence-check logic). For users created after the `2026-03-09` cutoff, `isGrandfathered` is also `false`, so `setSharing(false)` is called. `shouldShareResults` then returns `false` and eval results are never uploaded to the on-prem Report Server.

## Fix

```typescript
if (typeof hasActiveLicense === 'boolean') {
  const isOnPrem = !apiHost.replace(/\/+$/, '').includes('api.promptfoo.app');
  if (isOnPrem) {
    this.setSharing(true);
  } else {
    const createdAt = user?.createdAt ? new Date(user.createdAt) : null;
    const isGrandfathered = createdAt != null && createdAt < SHARING_CUTOFF_DATE;
    this.setSharing(hasActiveLicense || isGrandfathered);
  }
}
```

## Test Plan

- [x] `npx vitest run test/globalConfig/cloud.test.ts` — all 38 tests pass, including 5 new on-prem cases
- [x] `npx vitest run test/util/sharing.test.ts` — all 12 tests pass
- [x] `npm run tsc` — no type errors
- [x] `npm run l` — no lint errors