### PR TITLE
fix: harden validation and target discovery

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -18,12 +18,14 @@ import { setupEnv } from '../util/index';
 import { isUuid } from '../util/uuid';
 import type { Command } from 'commander';
 
-import type { ProviderTestResult, SessionTestResult } from '../node/testProvider';
 import type { UnifiedConfig } from '../types/index';
 import type { ApiProvider } from '../types/providers';
 
 const VALIDATE_FAILURE_PREFIX = 'Failed to validate configuration: ';
 const LOAD_FAILURE_PREFIX = 'Failed to load configuration: ';
+
+type ProviderTestResult = Awaited<ReturnType<typeof testProviderConnectivity>>;
+type SessionTestResult = Awaited<ReturnType<typeof testProviderSession>>;
 
 interface ValidateOptions {
   config?: string[];

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -23,9 +23,11 @@ import type { ApiProvider } from '../types/providers';
 
 const VALIDATE_FAILURE_PREFIX = 'Failed to validate configuration: ';
 const LOAD_FAILURE_PREFIX = 'Failed to load configuration: ';
+const TEST_RESULT_INDENT = '    ';
 
 type ProviderTestResult = Awaited<ReturnType<typeof testProviderConnectivity>>;
 type SessionTestResult = Awaited<ReturnType<typeof testProviderSession>>;
+type TestResult = ProviderTestResult | SessionTestResult;
 
 interface ValidateOptions {
   config?: string[];
@@ -83,84 +85,125 @@ async function testBasicConnectivity(provider: ApiProvider): Promise<{
 }
 
 /**
- * Display detailed test results with suggestions
+ * Display a successful test result.
  */
-function displayTestResult(result: ProviderTestResult | SessionTestResult, testName: string): void {
-  const indent = '    ';
+function displaySuccessfulTestResult(
+  result: TestResult,
+  testName: string,
+  sessionId: string | undefined,
+): void {
+  logger.info(chalk.green(`  ✓ ${testName}`));
+  if (result.message && result.message !== 'Test completed') {
+    logger.info(chalk.dim(`${TEST_RESULT_INDENT}${result.message}`));
+  }
+  if (sessionId) {
+    logger.info(chalk.dim(`${TEST_RESULT_INDENT}Session ID: ${sessionId}`));
+  }
+}
+
+/**
+ * Display a failed test result.
+ */
+function displayFailedTestResult(
+  result: TestResult,
+  testName: string,
+  analysis: ProviderTestResult['analysis'],
+  reason: string | undefined,
+): void {
+  const hasSuggestions = analysis?.changes_needed;
+  const isHardError = result.error && !hasSuggestions;
+
+  if (isHardError) {
+    logger.error(chalk.red(`  ✗ ${testName}`));
+    if (result.message) {
+      logger.error(chalk.red(`${TEST_RESULT_INDENT}${result.message}`));
+    }
+    if (result.error && result.error !== result.message) {
+      logger.error(chalk.red(`${TEST_RESULT_INDENT}${result.error}`));
+    }
+  } else if (hasSuggestions) {
+    logger.warn(chalk.yellow(`  ⚠ ${testName}`));
+    if (result.message) {
+      logger.info(`${TEST_RESULT_INDENT}${result.message}`);
+    }
+  } else {
+    logger.warn(chalk.yellow(`  ✗ ${testName}`));
+    if (result.message) {
+      logger.info(`${TEST_RESULT_INDENT}${result.message}`);
+    }
+  }
+
+  if (reason) {
+    logger.info(chalk.dim(`${TEST_RESULT_INDENT}Reason: ${reason}`));
+  }
+}
+
+/**
+ * Display API analysis feedback from testAnalyzerResponse.
+ */
+function displayAnalysisFeedback(analysis: ProviderTestResult['analysis']): void {
+  if (!analysis?.changes_needed) {
+    return;
+  }
+
+  logger.info('');
+  logger.info(chalk.cyan(`${TEST_RESULT_INDENT}Suggestions:`));
+  if (analysis.changes_needed_reason) {
+    logger.info(`${TEST_RESULT_INDENT}${analysis.changes_needed_reason}`);
+  }
+  if (Array.isArray(analysis.changes_needed_suggestions)) {
+    logger.info('');
+    analysis.changes_needed_suggestions.forEach((suggestion, idx) => {
+      logger.info(`${TEST_RESULT_INDENT}${chalk.cyan(`${idx + 1}.`)} ${suggestion}`);
+    });
+  }
+}
+
+function getTransformedRequest(result: TestResult): Record<string, unknown> | undefined {
+  if (
+    !('transformedRequest' in result) ||
+    result.transformedRequest === null ||
+    typeof result.transformedRequest !== 'object'
+  ) {
+    return undefined;
+  }
+  return result.transformedRequest as Record<string, unknown>;
+}
+
+/**
+ * Show transformed request details when available.
+ */
+function displayTransformedRequest(transformedRequest: Record<string, unknown> | undefined): void {
+  if (!transformedRequest) {
+    return;
+  }
+
+  logger.debug('');
+  logger.debug(chalk.dim(`${TEST_RESULT_INDENT}Request details:`));
+  if (transformedRequest.url) {
+    logger.debug(chalk.dim(`${TEST_RESULT_INDENT}  URL: ${transformedRequest.url}`));
+  }
+  if (transformedRequest.method) {
+    logger.debug(chalk.dim(`${TEST_RESULT_INDENT}  Method: ${transformedRequest.method}`));
+  }
+}
+
+/**
+ * Display detailed test results with suggestions.
+ */
+function displayTestResult(result: TestResult, testName: string): void {
   const analysis = 'analysis' in result ? result.analysis : undefined;
   const sessionId = 'sessionId' in result ? result.sessionId : undefined;
   const reason = 'reason' in result ? result.reason : undefined;
-  const transformedRequest =
-    'transformedRequest' in result &&
-    result.transformedRequest !== null &&
-    typeof result.transformedRequest === 'object'
-      ? (result.transformedRequest as Record<string, unknown>)
-      : undefined;
 
   if (result.success) {
-    logger.info(chalk.green(`  ✓ ${testName}`));
-    if (result.message && result.message !== 'Test completed') {
-      logger.info(chalk.dim(`${indent}${result.message}`));
-    }
-    if (sessionId) {
-      logger.info(chalk.dim(`${indent}Session ID: ${sessionId}`));
-    }
+    displaySuccessfulTestResult(result, testName, sessionId);
   } else {
-    // Check if this is a "suggestions" failure (configuration issue) vs a hard error
-    const hasSuggestions = analysis?.changes_needed;
-    const isHardError = result.error && !hasSuggestions;
-
-    if (isHardError) {
-      logger.error(chalk.red(`  ✗ ${testName}`));
-      if (result.message) {
-        logger.error(chalk.red(`${indent}${result.message}`));
-      }
-      if (result.error && result.error !== result.message) {
-        logger.error(chalk.red(`${indent}${result.error}`));
-      }
-    } else if (hasSuggestions) {
-      logger.warn(chalk.yellow(`  ⚠ ${testName}`));
-      if (result.message) {
-        logger.info(`${indent}${result.message}`);
-      }
-    } else {
-      logger.warn(chalk.yellow(`  ✗ ${testName}`));
-      if (result.message) {
-        logger.info(`${indent}${result.message}`);
-      }
-    }
-
-    if (reason) {
-      logger.info(chalk.dim(`${indent}Reason: ${reason}`));
-    }
+    displayFailedTestResult(result, testName, analysis, reason);
   }
 
-  // Display API analysis feedback if available (from testAnalyzerResponse)
-  if (analysis?.changes_needed) {
-    logger.info('');
-    logger.info(chalk.cyan(`${indent}Suggestions:`));
-    if (analysis.changes_needed_reason) {
-      logger.info(`${indent}${analysis.changes_needed_reason}`);
-    }
-    if (analysis.changes_needed_suggestions && Array.isArray(analysis.changes_needed_suggestions)) {
-      logger.info('');
-      analysis.changes_needed_suggestions.forEach((suggestion: string, idx: number) => {
-        logger.info(`${indent}${chalk.cyan(`${idx + 1}.`)} ${suggestion}`);
-      });
-    }
-  }
-
-  // Show transformed request if available (only when verbose or debug)
-  if (transformedRequest) {
-    logger.debug('');
-    logger.debug(chalk.dim(`${indent}Request details:`));
-    if (transformedRequest.url) {
-      logger.debug(chalk.dim(`${indent}  URL: ${transformedRequest.url}`));
-    }
-    if (transformedRequest.method) {
-      logger.debug(chalk.dim(`${indent}  Method: ${transformedRequest.method}`));
-    }
-  }
+  displayAnalysisFeedback(analysis);
+  displayTransformedRequest(getTransformedRequest(result));
 }
 
 interface ProviderTestSummary {

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -18,6 +18,7 @@ import { setupEnv } from '../util/index';
 import { isUuid } from '../util/uuid';
 import type { Command } from 'commander';
 
+import type { ProviderTestResult, SessionTestResult } from '../node/testProvider';
 import type { UnifiedConfig } from '../types/index';
 import type { ApiProvider } from '../types/providers';
 
@@ -82,20 +83,29 @@ async function testBasicConnectivity(provider: ApiProvider): Promise<{
 /**
  * Display detailed test results with suggestions
  */
-function displayTestResult(result: any, testName: string): void {
+function displayTestResult(result: ProviderTestResult | SessionTestResult, testName: string): void {
   const indent = '    ';
+  const analysis = 'analysis' in result ? result.analysis : undefined;
+  const sessionId = 'sessionId' in result ? result.sessionId : undefined;
+  const reason = 'reason' in result ? result.reason : undefined;
+  const transformedRequest =
+    'transformedRequest' in result &&
+    result.transformedRequest !== null &&
+    typeof result.transformedRequest === 'object'
+      ? (result.transformedRequest as Record<string, unknown>)
+      : undefined;
 
   if (result.success) {
     logger.info(chalk.green(`  ✓ ${testName}`));
     if (result.message && result.message !== 'Test completed') {
       logger.info(chalk.dim(`${indent}${result.message}`));
     }
-    if (result.sessionId) {
-      logger.info(chalk.dim(`${indent}Session ID: ${result.sessionId}`));
+    if (sessionId) {
+      logger.info(chalk.dim(`${indent}Session ID: ${sessionId}`));
     }
   } else {
     // Check if this is a "suggestions" failure (configuration issue) vs a hard error
-    const hasSuggestions = result.analysis?.changes_needed;
+    const hasSuggestions = analysis?.changes_needed;
     const isHardError = result.error && !hasSuggestions;
 
     if (isHardError) {
@@ -118,15 +128,13 @@ function displayTestResult(result: any, testName: string): void {
       }
     }
 
-    if (result.reason) {
-      logger.info(chalk.dim(`${indent}Reason: ${result.reason}`));
+    if (reason) {
+      logger.info(chalk.dim(`${indent}Reason: ${reason}`));
     }
   }
 
   // Display API analysis feedback if available (from testAnalyzerResponse)
-  if (result.analysis?.changes_needed) {
-    const analysis = result.analysis;
-
+  if (analysis?.changes_needed) {
     logger.info('');
     logger.info(chalk.cyan(`${indent}Suggestions:`));
     if (analysis.changes_needed_reason) {
@@ -141,14 +149,14 @@ function displayTestResult(result: any, testName: string): void {
   }
 
   // Show transformed request if available (only when verbose or debug)
-  if (result.transformedRequest) {
+  if (transformedRequest) {
     logger.debug('');
     logger.debug(chalk.dim(`${indent}Request details:`));
-    if (result.transformedRequest.url) {
-      logger.debug(chalk.dim(`${indent}  URL: ${result.transformedRequest.url}`));
+    if (transformedRequest.url) {
+      logger.debug(chalk.dim(`${indent}  URL: ${transformedRequest.url}`));
     }
-    if (result.transformedRequest.method) {
-      logger.debug(chalk.dim(`${indent}  Method: ${result.transformedRequest.method}`));
+    if (transformedRequest.method) {
+      logger.debug(chalk.dim(`${indent}  Method: ${transformedRequest.method}`));
     }
   }
 }

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -284,7 +284,7 @@ export async function doTargetPurposeDiscovery(
           throw new Error(errorMessage);
         }
 
-        if (turn > MAX_TURN_COUNT) {
+        if (turn >= MAX_TURN_COUNT) {
           const errorMessage = `Too many retries, giving up.`;
           logger.error(`${LOG_PREFIX} ${errorMessage}`);
           throw new Error(errorMessage);

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -218,108 +218,107 @@ export async function doTargetPurposeDiscovery(
   });
   let turn = 0;
 
-  while (!done && turn < MAX_TURN_COUNT) {
-    try {
-      turn++;
+  try {
+    while (!done && turn < MAX_TURN_COUNT) {
+      try {
+        turn++;
 
-      logger.debug(`${LOG_PREFIX} Discovery loop turn: ${turn}`);
+        logger.debug(`${LOG_PREFIX} Discovery loop turn: ${turn}`);
 
-      const response = await fetchWithProxy(getRemoteGenerationUrl(), {
-        method: 'POST',
-        // Auth is injected centrally at the fetch layer for the configured cloud
-        // origin only, so the saved token is never sent to a custom
-        // PROMPTFOO_REMOTE_GENERATION_URL.
-        headers: getRemoteGenerationHeaders(),
-        body: JSON.stringify(
-          TargetPurposeDiscoveryRequestSchema.parse({
-            state: {
-              currentQuestionIndex: state.currentQuestionIndex,
-              answers: state.answers,
-            },
-            task: 'target-purpose-discovery',
-            version: VERSION,
-            email: getUserEmail(),
-          }),
-        ),
-      });
-
-      if (!response.ok) {
-        throw await buildRemoteErrorFromResponse(response);
-      }
-
-      const responseData = await response.json();
-      const data = TargetPurposeDiscoveryTaskResponseSchema.parse(responseData);
-
-      logger.debug(
-        `${LOG_PREFIX} Received response from remote server: ${JSON.stringify(data, null, 2)}`,
-      );
-
-      done = data.done;
-      question = data.question;
-      discoveryResult = data.purpose;
-      state = data.state;
-
-      if (data.error) {
-        const errorMessage = `Error from remote server: ${data.error}`;
-        logger.error(`${LOG_PREFIX} ${errorMessage}`);
-        throw new Error(errorMessage);
-      }
-      // Should another question be asked?
-      else if (!done) {
-        invariant(question, 'Question should always be defined if `done` is falsy.');
-
-        const renderedPrompt = prompt
-          ? await renderPrompt(prompt, { prompt: question }, {}, target)
-          : question;
-
-        const targetResponse = await target.callApi(renderedPrompt, {
-          prompt: { raw: question, label: 'Target Discovery Question' },
-          vars: { sessionId },
-          bustCache: true,
+        const response = await fetchWithProxy(getRemoteGenerationUrl(), {
+          method: 'POST',
+          // Auth is injected centrally at the fetch layer for the configured cloud
+          // origin only, so the saved token is never sent to a custom
+          // PROMPTFOO_REMOTE_GENERATION_URL.
+          headers: getRemoteGenerationHeaders(),
+          body: JSON.stringify(
+            TargetPurposeDiscoveryRequestSchema.parse({
+              state: {
+                currentQuestionIndex: state.currentQuestionIndex,
+                answers: state.answers,
+              },
+              task: 'target-purpose-discovery',
+              version: VERSION,
+              email: getUserEmail(),
+            }),
+          ),
         });
 
-        if (targetResponse.error) {
-          const errorMessage = `Error from target: ${targetResponse.error}`;
-          logger.error(`${LOG_PREFIX} ${errorMessage}`);
-          throw new Error(errorMessage);
+        if (!response.ok) {
+          throw await buildRemoteErrorFromResponse(response);
         }
 
-        if (turn >= MAX_TURN_COUNT) {
-          const errorMessage = `Too many retries, giving up.`;
-          logger.error(`${LOG_PREFIX} ${errorMessage}`);
-          throw new Error(errorMessage);
-        }
+        const responseData = await response.json();
+        const data = TargetPurposeDiscoveryTaskResponseSchema.parse(responseData);
 
         logger.debug(
-          `${LOG_PREFIX} Received response from target: ${JSON.stringify(targetResponse, null, 2)}`,
+          `${LOG_PREFIX} Received response from remote server: ${JSON.stringify(data, null, 2)}`,
         );
 
-        // If the target is an HTTP provider and has no transformResponse defined, and the response is an object,
-        // prompt the user to define a transformResponse.
-        if (
-          target instanceof HttpProvider &&
-          target.config.transformResponse === undefined &&
-          typeof targetResponse.output === 'object' &&
-          targetResponse.output !== null
-        ) {
-          logger.warn(
-            `${LOG_PREFIX} Target response is an object; should a \`transformResponse\` function be defined?`,
-          );
-        }
+        done = data.done;
+        question = data.question;
+        discoveryResult = data.purpose;
+        state = data.state;
 
-        state.answers.push(targetResponse.output);
-      }
-    } finally {
-      if (showProgress) {
+        if (data.error) {
+          const errorMessage = `Error from remote server: ${data.error}`;
+          logger.error(`${LOG_PREFIX} ${errorMessage}`);
+          throw new Error(errorMessage);
+        }
+        // Should another question be asked?
+        else if (!done) {
+          invariant(question, 'Question should always be defined if `done` is falsy.');
+
+          if (turn >= MAX_TURN_COUNT) {
+            const errorMessage = `Too many retries, giving up.`;
+            logger.error(`${LOG_PREFIX} ${errorMessage}`);
+            throw new Error(errorMessage);
+          }
+
+          const renderedPrompt = prompt
+            ? await renderPrompt(prompt, { prompt: question }, {}, target)
+            : question;
+
+          const targetResponse = await target.callApi(renderedPrompt, {
+            prompt: { raw: question, label: 'Target Discovery Question' },
+            vars: { sessionId },
+            bustCache: true,
+          });
+
+          if (targetResponse.error) {
+            const errorMessage = `Error from target: ${targetResponse.error}`;
+            logger.error(`${LOG_PREFIX} ${errorMessage}`);
+            throw new Error(errorMessage);
+          }
+
+          logger.debug(
+            `${LOG_PREFIX} Received response from target: ${JSON.stringify(targetResponse, null, 2)}`,
+          );
+
+          // If the target is an HTTP provider and has no transformResponse defined, and the response is an object,
+          // prompt the user to define a transformResponse.
+          if (
+            target instanceof HttpProvider &&
+            target.config.transformResponse === undefined &&
+            typeof targetResponse.output === 'object' &&
+            targetResponse.output !== null
+          ) {
+            logger.warn(
+              `${LOG_PREFIX} Target response is an object; should a \`transformResponse\` function be defined?`,
+            );
+          }
+
+          state.answers.push(targetResponse.output);
+        }
+      } finally {
         pbar?.increment(1);
       }
     }
-  }
-  if (showProgress) {
+
+    return discoveryResult ? normalizeTargetPurposeDiscoveryResult(discoveryResult) : undefined;
+  } finally {
     pbar?.stop();
   }
-
-  return discoveryResult ? normalizeTargetPurposeDiscoveryResult(discoveryResult) : undefined;
 }
 
 // ========================================================

--- a/test/commands/validate-provider-tests.test.ts
+++ b/test/commands/validate-provider-tests.test.ts
@@ -127,6 +127,79 @@ describe('Validate Command Provider Tests', () => {
       );
     });
 
+    it('should display connectivity suggestions and transformed request details', async () => {
+      const mockStatelessHttpProvider = createMockProvider({
+        id: 'http://example.com',
+        config: { stateful: false },
+      });
+      vi.mocked(loadApiProvider).mockResolvedValue(mockStatelessHttpProvider);
+      vi.mocked(testProviderConnectivity).mockResolvedValue({
+        success: false,
+        message: 'Configuration needs changes',
+        providerResponse: { output: 'test' },
+        transformedRequest: {
+          url: 'http://example.com/api',
+          method: 'POST',
+        },
+        analysis: {
+          changes_needed: true,
+          changes_needed_reason: 'Response format needs changes',
+          changes_needed_suggestions: ['Add transformResponse'],
+        },
+      });
+
+      await doValidateTarget({ target: 'http://example.com' }, defaultConfig);
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Connectivity test'));
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Response format needs changes'),
+      );
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Add transformResponse'));
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('URL: http://example.com/api'),
+      );
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Method: POST'));
+    });
+
+    it('should ignore malformed connectivity suggestions', async () => {
+      const mockStatelessHttpProvider = createMockProvider({
+        id: 'http://example.com',
+        config: { stateful: false },
+      });
+      vi.mocked(loadApiProvider).mockResolvedValue(mockStatelessHttpProvider);
+      vi.mocked(testProviderConnectivity).mockResolvedValue({
+        success: false,
+        message: 'Configuration needs changes',
+        analysis: {
+          changes_needed: true,
+          changes_needed_suggestions: 'Add transformResponse' as unknown as string[],
+        },
+      });
+
+      await expect(
+        doValidateTarget({ target: 'http://example.com' }, defaultConfig),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should display the reason for a failed session test', async () => {
+      vi.mocked(loadApiProvider).mockResolvedValue(mockHttpProvider);
+      vi.mocked(testProviderConnectivity).mockResolvedValue({
+        success: true,
+        message: 'Connectivity test passed',
+      });
+      vi.mocked(testProviderSession).mockResolvedValue({
+        success: false,
+        message: 'Session test failed',
+        reason: 'The target did not preserve context',
+      });
+
+      await doValidateTarget({ target: 'http://example.com' }, defaultConfig);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Reason: The target did not preserve context'),
+      );
+    });
+
     it('should skip session test when target is not stateful (stateful=false)', async () => {
       const mockNonStatefulHttpProvider = createMockProvider({
         id: 'http://example.com',

--- a/test/node/testProvider.test.ts
+++ b/test/node/testProvider.test.ts
@@ -134,7 +134,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.restoreAllMocks();
+  vi.clearAllMocks();
 });
 
 function createMockProvider(overrides?: Record<string, unknown>): ApiProvider {

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -7,17 +7,18 @@ import {
 import { fetchWithProxy } from '../../../src/util/fetch/index';
 import { createMockProvider } from '../../factories/provider';
 
-const mockProgressBar = vi.hoisted(() => ({
-  increment: vi.fn(),
-  start: vi.fn(),
-  stop: vi.fn(),
+const { mockProgressBar, mockSingleBar } = vi.hoisted(() => ({
+  mockProgressBar: {
+    increment: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  },
+  mockSingleBar: vi.fn(),
 }));
 
 vi.mock('cli-progress', () => ({
   default: {
-    SingleBar: vi.fn(function () {
-      return mockProgressBar;
-    }),
+    SingleBar: mockSingleBar,
   },
 }));
 vi.mock('../../../src/util/fetch/index');
@@ -115,7 +116,10 @@ describe('normalizeTargetPurposeDiscoveryResult', () => {
 
 describe('doTargetPurposeDiscovery', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    mockSingleBar.mockImplementation(function () {
+      return mockProgressBar;
+    });
   });
 
   it('should handle empty prompt', async () => {

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -7,6 +7,19 @@ import {
 import { fetchWithProxy } from '../../../src/util/fetch/index';
 import { createMockProvider } from '../../factories/provider';
 
+const mockProgressBar = vi.hoisted(() => ({
+  increment: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+}));
+
+vi.mock('cli-progress', () => ({
+  default: {
+    SingleBar: vi.fn(function () {
+      return mockProgressBar;
+    }),
+  },
+}));
 vi.mock('../../../src/util/fetch/index');
 
 const mockedFetchWithProxy = vi.mocked(fetchWithProxy);
@@ -199,11 +212,14 @@ describe('doTargetPurposeDiscovery', () => {
       response: { output: 'Another answer' },
     });
 
-    await expect(doTargetPurposeDiscovery(target, undefined, false)).rejects.toThrow(
-      'Too many retries, giving up.',
-    );
+    await expect(doTargetPurposeDiscovery(target)).rejects.toThrow('Too many retries, giving up.');
     expect(mockedFetchWithProxy).toHaveBeenCalledTimes(10);
-    expect(target.callApi).toHaveBeenCalledTimes(10);
+    expect(target.callApi).toHaveBeenCalledTimes(9);
+    expect(mockProgressBar.increment).toHaveBeenCalledTimes(10);
+    expect(mockProgressBar.stop).toHaveBeenCalledOnce();
+    expect(mockProgressBar.increment.mock.invocationCallOrder.at(-1)!).toBeLessThan(
+      mockProgressBar.stop.mock.invocationCallOrder[0]!,
+    );
   });
 
   it('delegates auth to the fetch layer and never sends an Authorization header itself', async () => {

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -174,6 +174,38 @@ describe('doTargetPurposeDiscovery', () => {
     });
   });
 
+  it('should stop when the maximum turn count is reached', async () => {
+    mockedFetchWithProxy.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            done: false,
+            question: 'What else should I know?',
+            state: {
+              currentQuestionIndex: 0,
+              answers: [],
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        ),
+      ),
+    );
+
+    const target = createMockProvider({
+      id: 'test',
+      response: { output: 'Another answer' },
+    });
+
+    await expect(doTargetPurposeDiscovery(target, undefined, false)).rejects.toThrow(
+      'Too many retries, giving up.',
+    );
+    expect(mockedFetchWithProxy).toHaveBeenCalledTimes(10);
+    expect(target.callApi).toHaveBeenCalledTimes(10);
+  });
+
   it('delegates auth to the fetch layer and never sends an Authorization header itself', async () => {
     // Single done=true turn so exactly one remote-generation request is made.
     mockedFetchWithProxy.mockResolvedValue(

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ArgsSchema,
   doTargetPurposeDiscovery,
@@ -116,10 +116,13 @@ describe('normalizeTargetPurposeDiscoveryResult', () => {
 
 describe('doTargetPurposeDiscovery', () => {
   beforeEach(() => {
-    vi.resetAllMocks();
     mockSingleBar.mockImplementation(function () {
       return mockProgressBar;
     });
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
   });
 
   it('should handle empty prompt', async () => {
@@ -176,6 +179,9 @@ describe('doTargetPurposeDiscovery', () => {
     });
 
     expect(mockedFetchWithProxy).toHaveBeenCalledTimes(2);
+    expect(mockProgressBar.start).toHaveBeenCalledWith(5, 0);
+    expect(mockProgressBar.increment).toHaveBeenCalledTimes(2);
+    expect(mockProgressBar.stop).toHaveBeenCalledOnce();
 
     expect(discoveredPurpose).toEqual({
       purpose: 'Test purpose',
@@ -219,6 +225,7 @@ describe('doTargetPurposeDiscovery', () => {
     await expect(doTargetPurposeDiscovery(target)).rejects.toThrow('Too many retries, giving up.');
     expect(mockedFetchWithProxy).toHaveBeenCalledTimes(10);
     expect(target.callApi).toHaveBeenCalledTimes(9);
+    expect(mockProgressBar.start).toHaveBeenCalledWith(5, 0);
     expect(mockProgressBar.increment).toHaveBeenCalledTimes(10);
     expect(mockProgressBar.stop).toHaveBeenCalledOnce();
     expect(mockProgressBar.increment.mock.invocationCallOrder.at(-1)!).toBeLessThan(
@@ -397,7 +404,7 @@ describe('doTargetPurposeDiscovery', () => {
       callApi: vi.fn(),
     };
 
-    const error = await doTargetPurposeDiscovery(target, undefined, false).catch((e) => e);
+    const error = await doTargetPurposeDiscovery(target).catch((e) => e);
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toContain(
       'Remote server returned HTTP 400: Unknown task: target-purpose-discovery',
@@ -406,6 +413,8 @@ describe('doTargetPurposeDiscovery', () => {
     // Should not retry — fetch should only be called once
     expect(mockedFetchWithProxy).toHaveBeenCalledTimes(1);
     expect(target.callApi).not.toHaveBeenCalled();
+    expect(mockProgressBar.increment).toHaveBeenCalledOnce();
+    expect(mockProgressBar.stop).toHaveBeenCalledOnce();
   });
 
   it('should surface an auth hint on 401 responses', async () => {

--- a/test/util/eval/filterTests.test.ts
+++ b/test/util/eval/filterTests.test.ts
@@ -428,7 +428,9 @@ describe('filterTests', () => {
       });
       // Should include all 3 tests: test1 (ASSERT), test2 (ERROR), test3 (ASSERT)
       expect(result).toHaveLength(3);
-      expect(result.map((t: TestCase) => t.vars?.var1)).toEqual(['test1', 'test3', 'test2']);
+      expect(result.map((t: TestCase) => t.vars?.var1)).toEqual(
+        expect.arrayContaining(['test1', 'test2', 'test3']),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- replace untyped provider test output with concrete connectivity/session result types and split result rendering into focused, runtime-safe helpers
- make the target-discovery maximum-turn failure reachable without issuing a discarded target request, and always stop the progress bar on success or failure
- clean up hoisted mocks after each test and make the combined result-filter assertion order-independent
- add regression coverage for provider suggestions, transformed request details, session failure reasons, malformed remote analysis data, and discovery progress cleanup

## Validation

- `npx vitest run test/node/testProvider.test.ts test/redteam/commands/discover.test.ts test/util/eval/filterTests.test.ts test/commands/validate-provider-tests.test.ts test/commands/validate-exit-codes.test.ts --sequence.seed=19614` (120 tests)
- `npx vitest run test/redteam/commands/discover.test.ts --sequence.seed=<9614|19614|29614>`
- `npm run tsc`
- `npm run l`
- `npm run architecture:check`
- `npm run format:check`
- `npm run build`
- `node dist/src/main.js validate target -t echo`
- end-to-end `redteam discover` QA against a local remote-generation stub and `echo` target, verifying the two-turn result, progress cleanup, and no `Authorization` header on the custom endpoint
- `git diff --check`
