### PR TITLE
fix: correct validation and grading edge cases

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -66,10 +66,10 @@ async function testBasicConnectivity(provider: ApiProvider): Promise<{
       return { success: false, error: result.error };
     } else if (result.output) {
       logger.info(chalk.green(`  ✓ Connectivity test`));
-      const responsePreview = JSON.stringify(result.output).substring(0, 100);
-      logger.info(
-        chalk.dim(`    Response: ${responsePreview}${responsePreview.length >= 100 ? '...' : ''}`),
-      );
+      const fullResponse = JSON.stringify(result.output);
+      const isTruncated = fullResponse.length > 100;
+      const responsePreview = fullResponse.substring(0, 100);
+      logger.info(chalk.dim(`    Response: ${responsePreview}${isTruncated ? '...' : ''}`));
       return { success: true };
     } else {
       logger.warn(chalk.yellow(`  ✗ Connectivity test`));

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -199,7 +199,7 @@ export async function doTargetPurposeDiscovery(
   let pbar: cliProgress.SingleBar | undefined;
   if (showProgress) {
     pbar = new cliProgress.SingleBar({
-      format: `Mapping the target {bar} {percentage}% | {value}${DEFAULT_TURN_COUNT ? '/{total}' : ''} turns`,
+      format: 'Mapping the target {bar} {percentage}% | {value}/{total} turns',
       barCompleteChar: '\u2588',
       barIncompleteChar: '\u2591',
       hideCursor: true,
@@ -414,10 +414,6 @@ export function discoverCommand(
       }
       // Check the current working directory for a promptfooconfig.yaml file:
       else if (defaultConfig) {
-        if (!defaultConfig) {
-          throw new Error(`Config is invalid at ${defaultConfigPath}`);
-        }
-
         if (!defaultConfig.providers) {
           throw new Error('Config must contain a target or provider');
         }

--- a/test/commands/validate-provider-tests.test.ts
+++ b/test/commands/validate-provider-tests.test.ts
@@ -239,6 +239,20 @@ describe('Validate Command Provider Tests', () => {
       expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Connectivity test'));
     });
 
+    it('should not mark an exact 100-character response as truncated', async () => {
+      const output = 'x'.repeat(98);
+      mockEchoProvider.callApi.mockResolvedValue({ output });
+      vi.mocked(loadApiProvider).mockResolvedValue(mockEchoProvider);
+
+      await doValidateTarget({ target: 'echo' }, defaultConfig);
+
+      const responseLog = vi
+        .mocked(logger.info)
+        .mock.calls.find(([message]) => String(message).includes('Response:'));
+      expect(responseLog?.[0]).toContain(JSON.stringify(output));
+      expect(responseLog?.[0]).not.toContain('...');
+    });
+
     it('should load cloud provider when -t flag is UUID', async () => {
       const cloudUUID = '12345678-1234-1234-1234-123456789abc';
       const mockProviderOptions = {

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -178,6 +178,11 @@ describe('doTargetPurposeDiscovery', () => {
       bustCache: true,
     });
 
+    expect(mockSingleBar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: 'Mapping the target {bar} {percentage}% | {value}/{total} turns',
+      }),
+    );
     expect(mockedFetchWithProxy).toHaveBeenCalledTimes(2);
     expect(mockProgressBar.start).toHaveBeenCalledWith(5, 0);
     expect(mockProgressBar.increment).toHaveBeenCalledTimes(2);

--- a/test/remoteGrading.test.ts
+++ b/test/remoteGrading.test.ts
@@ -80,6 +80,39 @@ describe('doRemoteGrading', () => {
     );
   });
 
+  it('does not add grader error metadata when remote grading succeeds without metadata', async () => {
+    vi.mocked(getUserEmail).mockReturnValue('user@example.com');
+    vi.mocked(getRemoteGenerationUrl).mockReturnValue('https://api.promptfoo.test/task');
+    vi.mocked(getRemoteGenerationHeaders).mockReturnValue({ authorization: 'Bearer test' });
+    vi.mocked(getRequestTimeoutMs).mockReturnValue(1234);
+    vi.mocked(fetchWithCache).mockResolvedValueOnce({
+      data: {
+        result: {
+          pass: true,
+          score: 1,
+          reason: 'ok',
+        },
+      },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    } as any);
+
+    const result = await doRemoteGrading({
+      task: 'llm-rubric',
+      rubric: 'Only pass if the response is correct.',
+      output: 'Example output',
+      vars: {},
+    });
+
+    expect(result).toMatchObject({
+      pass: true,
+      score: 1,
+      reason: 'ok',
+    });
+    expect(result.metadata?.graderError).toBeUndefined();
+  });
+
   it('redacts inline image data from remote grading debug logs', async () => {
     vi.mocked(getUserEmail).mockReturnValue('user@example.com');
     vi.mocked(getRemoteGenerationUrl).mockReturnValue('https://api.promptfoo.test/task');
@@ -111,7 +144,11 @@ describe('doRemoteGrading', () => {
         images: [{ data: '[REDACTED_IMAGE_DATA]', mimeType: 'image/png' }],
       }),
     });
-    expect(JSON.stringify(mockLoggerDebug.mock.calls)).not.toContain('abc123');
+    const firstDebugPayload = mockLoggerDebug.mock.calls[0][1] as {
+      body: { images: Array<{ data: string; mimeType: string }> };
+    };
+    expect(firstDebugPayload.body.images[0].data).toBe('[REDACTED_IMAGE_DATA]');
+    expect(firstDebugPayload.body.images[0].data).not.toContain('abc123');
     expect(fetchWithCache).toHaveBeenCalledWith(
       'https://api.promptfoo.test/task',
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- fix validation response previews so exactly 100 serialized characters are not marked as truncated
- remove dead branches from target discovery and simplify its progress format
- strengthen remote grading coverage for successful metadata and direct image-redaction checks

Addresses all 5 AI findings visible across 3 files on June 5, 2026.

## Test plan

- `npx vitest run test/commands/validate-exit-codes.test.ts test/commands/validate-provider-tests.test.ts test/redteam/commands/discover.test.ts test/remoteGrading.test.ts`
- `npm run tsc`
- `npm run l`
- `npm run architecture:check`
- `npm run build`
- `PROMPTFOO_DISABLE_TELEMETRY=true npm run local -- validate target -t echo`
- `git diff --check`
