### PR TITLE
fix(assertions): respect inverse when an object value can't parse output as JSON

### DIFF
--- a/src/assertions/equals.ts
+++ b/src/assertions/equals.ts
@@ -16,7 +16,10 @@ export const handleEquals = async ({
     try {
       pass = util.isDeepStrictEqual(renderedValue, JSON.parse(outputString)) !== inverse;
     } catch {
-      pass = false;
+      // The output is not valid JSON, so it cannot deep-equal the object value (the "equal"
+      // result is false). Respect `inverse` (false !== inverse) so `not-equals` passes here
+      // instead of falsely failing.
+      pass = inverse;
     }
     renderedValue = JSON.stringify(renderedValue);
   } else {

--- a/test/assertions/equals.test.ts
+++ b/test/assertions/equals.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { handleEquals } from '../../src/assertions/equals';
+import { createMockProvider, createProviderResponse } from '../factories/provider';
+
+import type { AssertionParams, AssertionValue, AtomicTestCase } from '../../src/types/index';
+
+const mockProvider = createMockProvider({
+  id: 'mock',
+  response: createProviderResponse({ output: 'mock' }),
+});
+
+const defaultParams = {
+  baseType: 'equals' as const,
+  assertionValueContext: {
+    vars: {},
+    test: {} as AtomicTestCase,
+    prompt: 'test prompt',
+    logProbs: undefined,
+    provider: mockProvider,
+    providerResponse: { output: 'hello world' },
+  },
+  output: 'hello world',
+  providerResponse: { output: 'hello world' },
+  test: {} as AtomicTestCase,
+};
+
+describe('handleEquals', () => {
+  it('passes not-equals when an object value cannot equal non-JSON output', async () => {
+    // The output is plain text (not JSON), so it plainly does NOT equal the object value;
+    // a `not-equals` assertion should therefore pass. The catch path used to ignore `inverse`.
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'not-equals', value: { foo: 'bar' } },
+      renderedValue: { foo: 'bar' } as AssertionValue,
+      outputString: 'hello world',
+      inverse: true,
+    };
+
+    const result = await handleEquals(params);
+    expect(result.pass).toBe(true);
+  });
+
+  it('fails equals when an object value cannot equal non-JSON output', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'equals', value: { foo: 'bar' } },
+      renderedValue: { foo: 'bar' } as AssertionValue,
+      outputString: 'hello world',
+      inverse: false,
+    };
+
+    const result = await handleEquals(params);
+    expect(result.pass).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

In `handleEquals` (`src/assertions/equals.ts`), when the expected `value` is an object and the model output is **not valid JSON**, `JSON.parse(outputString)` throws and the catch block sets `pass = false` unconditionally:

```ts
if (typeof renderedValue === 'object') {
  try {
    pass = util.isDeepStrictEqual(renderedValue, JSON.parse(outputString)) !== inverse;
  } catch {
    pass = false;   // ignores `inverse`
  }
```

For a normal `equals`, `false` is correct. But `not-equals` routes here with `inverse = true`, and the output plainly does **not** equal the object — so the assertion should **pass**. Instead it falsely fails.

So `assert: [{ type: not-equals, value: { foo: "bar" } }]` against a plain-text output like `"hello world"` reports a false failure, dragging down pass rates / failing CI for a condition that is actually true. (`not-equals` is documented as a supported negation for every assertion type.)

Every other branch folds `inverse` into the result via `... !== inverse` — including the non-object branch on the very next line and the `try` branch directly above. Only this catch path dropped it.

## Fix

Set `pass = inverse` in the catch (equivalent to `false !== inverse`, since an unparseable output cannot deep-equal the object).

## Verification

Added `test/assertions/equals.test.ts`: with an object value and non-JSON output, `not-equals` (`inverse: true`) now passes and `equals` (`inverse: false`) still fails. Verified the not-equals case fails before the fix and passes after. `test/assertions/runAssertion.test.ts` and `test/assertions/index.test.ts` remain green (168 passed); `biome` clean.