### PR TITLE
test: retry temp-dir cleanup to fix Windows ENOTEMPTY flake

### DIFF
--- a/test/node/evaluatorRuntime.test.ts
+++ b/test/node/evaluatorRuntime.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import Eval from '../../src/models/eval';
 import { nodeEvaluatorRuntime } from '../../src/node/evaluatorRuntime';
+import { removeTempDir } from '../util/utils';
 
 import type { EvaluateResult } from '../../src/types/index';
 
@@ -14,7 +15,7 @@ describe('nodeEvaluatorRuntime', () => {
   afterEach(() => {
     vi.clearAllMocks();
     for (const tempDir of tempDirs.splice(0)) {
-      fs.rmSync(tempDir, { recursive: true, force: true });
+      removeTempDir(tempDir);
     }
   });
 

--- a/test/node/evaluatorRuntime.test.ts
+++ b/test/node/evaluatorRuntime.test.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import Eval from '../../src/models/eval';
 import { nodeEvaluatorRuntime } from '../../src/node/evaluatorRuntime';
-import { removeTempDir } from '../util/utils';
 
 import type { EvaluateResult } from '../../src/types/index';
 
@@ -15,7 +14,10 @@ describe('nodeEvaluatorRuntime', () => {
   afterEach(() => {
     vi.clearAllMocks();
     for (const tempDir of tempDirs.splice(0)) {
-      removeTempDir(tempDir);
+      // On Windows, file handles can linger briefly after a stream is closed, so an
+      // immediate recursive delete may throw ENOTEMPTY/EBUSY/EPERM. Retry with a short
+      // backoff (a no-op on POSIX, where these errors don't occur).
+      fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     }
   });
 

--- a/test/util/utils.test.ts
+++ b/test/util/utils.test.ts
@@ -102,6 +102,10 @@ describe('mockGlobal', () => {
 
 describe('removeTempDir', () => {
   it('retries transient recursive cleanup failures', async () => {
+    // Reset the module registry first so the dynamic import below re-evaluates
+    // ./utils against the mocked node:fs, even when this test runs in isolation
+    // (the top-level static import has already cached ./utils with the real fs).
+    vi.resetModules();
     const rmSync = vi.fn();
     vi.doMock('node:fs', async (importOriginal) => {
       const actual = await importOriginal<typeof import('node:fs')>();
@@ -120,6 +124,7 @@ describe('removeTempDir', () => {
   });
 
   it('does not attempt cleanup without a directory', async () => {
+    vi.resetModules();
     const rmSync = vi.fn();
     vi.doMock('node:fs', async (importOriginal) => {
       const actual = await importOriginal<typeof import('node:fs')>();

--- a/test/util/utils.test.ts
+++ b/test/util/utils.test.ts
@@ -24,6 +24,8 @@ function restoreTestEnv(): void {
 afterEach(() => {
   restoreTestEnv();
   Reflect.deleteProperty(globalThis, testGlobalName);
+  vi.doUnmock('node:fs');
+  vi.resetModules();
   vi.clearAllMocks();
 });
 
@@ -95,5 +97,38 @@ describe('mockGlobal', () => {
     restoreGlobal();
 
     expect((globalThis as Record<string, unknown>)[testGlobalName]).toBe('original');
+  });
+});
+
+describe('removeTempDir', () => {
+  it('retries transient recursive cleanup failures', async () => {
+    const rmSync = vi.fn();
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+      return { ...actual, rmSync };
+    });
+    const { removeTempDir } = await import('./utils');
+
+    removeTempDir('/tmp/promptfoo-test-dir');
+
+    expect(rmSync).toHaveBeenCalledWith('/tmp/promptfoo-test-dir', {
+      force: true,
+      maxRetries: 3,
+      recursive: true,
+      retryDelay: 100,
+    });
+  });
+
+  it('does not attempt cleanup without a directory', async () => {
+    const rmSync = vi.fn();
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+      return { ...actual, rmSync };
+    });
+    const { removeTempDir } = await import('./utils');
+
+    removeTempDir(undefined);
+
+    expect(rmSync).not.toHaveBeenCalled();
   });
 });

--- a/test/util/utils.ts
+++ b/test/util/utils.ts
@@ -164,5 +164,8 @@ export function removeTempDir(tempDir: string | undefined): void {
   if (!tempDir) {
     return;
   }
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  // On Windows, file handles can linger briefly after a stream is closed, so an
+  // immediate recursive delete may throw ENOTEMPTY/EBUSY/EPERM. Retry with a short
+  // backoff (a no-op on POSIX, where these errors don't occur).
+  fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 }


### PR DESCRIPTION
## Summary

CI on `main` has been intermittently red, driven almost entirely by **Windows-only** flakes on the `Test on Node X and windows-2025-vs2026` shards. One of them is a concrete, root-caused test bug that this PR fixes.

### The failure

`test/node/evaluatorRuntime.test.ts` fails in its `afterEach` cleanup:

```
##[error]Error: ENOTEMPTY: directory not empty, rmdir 'C:\Users\RUNNER~1\AppData\Local\Temp\promptfoo-evaluator-runtime-ICn6y2'
 ❯ test/node/evaluatorRuntime.test.ts:17:10
```

All tests in the file actually pass — only the recursive temp-dir delete throws. On Windows, file handles can linger briefly after a stream is `close()`d, so an immediate `fs.rmSync(dir, { recursive: true, force: true })` can hit `ENOTEMPTY`/`EBUSY`/`EPERM`. `force: true` only swallows `ENOENT`, not these transient errors.

### The fix

Use Node's documented remedy — `maxRetries`/`retryDelay`, which retries the delete with a linear backoff on exactly these error codes (and is a no-op on POSIX, where they don't occur):

- Inline the retry options in the failing test's `afterEach`.
- Apply the same hardening to the shared `removeTempDir` helper in `test/util/utils.ts`, since every caller has the identical latent bug.

> Note: the test deliberately keeps its own inline `fs.rmSync` rather than importing the shared helper — `test/util/utils.ts` is in the `legacy-runtime` architecture layer, and importing it from `test/node` would add a forbidden `node -> legacy-runtime` cross-layer edge (caught by `Check architecture boundaries`).

### Scope

This addresses the `ENOTEMPTY` rmdir flake specifically. The other Windows-shard failures seen on `main` (vitest "Worker exited unexpectedly" worker crashes, and `setup-node`/`Cache node_modules` action flakes) are separate infrastructure issues and are intentionally out of scope here.

## Test plan

- `npx vitest run test/node/evaluatorRuntime.test.ts test/util/utils` — 7 passed
- `npx tsx scripts/checkArchitectureBoundaries.ts` — passes, no baseline regression
- Biome check clean on both changed files

Cleanup logic is exercised on every test run; the change is behavior-preserving on POSIX and only adds retry backoff on Windows.