### PR TITLE
fix(ci): update architecture edge baseline for evalTableUtils CSV imports

### DIFF
--- a/architecture/edge-baseline.json
+++ b/architecture/edge-baseline.json
@@ -30,7 +30,7 @@
   "legacy-runtime -> redteam": 6,
   "node -> core": 8,
   "node -> legacy-contracts": 102,
-  "node -> legacy-runtime": 150,
+  "node -> legacy-runtime": 152,
   "node -> providers": 7,
   "node -> redteam": 10,
   "providers -> core": 1,


### PR DESCRIPTION
## Summary

`main`'s CI is **deterministically red**: the `Check architecture boundaries` step inside the **Style Check** job fails on every push.

### Root cause

PR #9609 (CSV formula-injection escaping, commit c039bffb23) added two imports to the node-layer file `src/util/eval/evalTableUtils.ts`:

```ts
import { escapeCsvFormula } from '../../csv';   // src/csv.ts      -> legacy-runtime layer
import { getEnvBool } from '../../envars';        // src/envars.ts   -> legacy-runtime layer
```

Both targets live in the `legacy-runtime` layer, so the `node -> legacy-runtime` cross-layer edge grew from **150 → 152**, but `architecture/edge-baseline.json` was not refreshed. The ratchet check then fails:

```
Cross-layer dependency baseline regressions found:
- node -> legacy-runtime: 152 imports (was 150)
```

### Fix

These imports follow the established, accepted pattern (`getEnvBool` and the CSV helpers are already imported widely across the `node` layer — that's why the baseline was already 150). So the correct, documented remedy is to regenerate the baseline:

```
npm run architecture:baseline
```

The result is a one-line bump of the `node -> legacy-runtime` count. No production code changes.

## Test plan

```
$ npm run architecture:check
...
Architecture boundaries passed.
```

The full Style Check job will now pass on this branch and, once merged, on `main`.