### PR TITLE
fix: address AI quality findings

### DIFF
--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -66,10 +66,10 @@ async function testBasicConnectivity(provider: ApiProvider): Promise<{
       return { success: false, error: result.error };
     } else if (result.output) {
       logger.info(chalk.green(`  ✓ Connectivity test`));
-      const responsePreview = JSON.stringify(result.output).substring(0, 100);
-      logger.info(
-        chalk.dim(`    Response: ${responsePreview}${responsePreview.length >= 100 ? '...' : ''}`),
-      );
+      const fullResponse = JSON.stringify(result.output);
+      const isTruncated = fullResponse.length > 100;
+      const responsePreview = fullResponse.substring(0, 100);
+      logger.info(chalk.dim(`    Response: ${responsePreview}${isTruncated ? '...' : ''}`));
       return { success: true };
     } else {
       logger.warn(chalk.yellow(`  ✗ Connectivity test`));

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -199,7 +199,7 @@ export async function doTargetPurposeDiscovery(
   let pbar: cliProgress.SingleBar | undefined;
   if (showProgress) {
     pbar = new cliProgress.SingleBar({
-      format: `Mapping the target {bar} {percentage}% | {value}${DEFAULT_TURN_COUNT ? '/{total}' : ''} turns`,
+      format: 'Mapping the target {bar} {percentage}% | {value}/{total} turns',
       barCompleteChar: '\u2588',
       barIncompleteChar: '\u2591',
       hideCursor: true,
@@ -414,10 +414,6 @@ export function discoverCommand(
       }
       // Check the current working directory for a promptfooconfig.yaml file:
       else if (defaultConfig) {
-        if (!defaultConfig) {
-          throw new Error(`Config is invalid at ${defaultConfigPath}`);
-        }
-
         if (!defaultConfig.providers) {
           throw new Error('Config must contain a target or provider');
         }

--- a/test/assertions/equals.test.ts
+++ b/test/assertions/equals.test.ts
@@ -40,7 +40,7 @@ describe('handleEquals', () => {
     expect(result.pass).toBe(true);
   });
 
-  it('fails equals when an object value cannot equal non-JSON output', async () => {
+  it('fails equals when an object value does not match non-JSON output', async () => {
     const params: AssertionParams = {
       ...defaultParams,
       assertion: { type: 'equals', value: { foo: 'bar' } },
@@ -51,5 +51,77 @@ describe('handleEquals', () => {
 
     const result = await handleEquals(params);
     expect(result.pass).toBe(false);
+  });
+
+  it('passes equals when an object value matches valid JSON output', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'equals', value: { foo: 'bar' } },
+      renderedValue: { foo: 'bar' } as AssertionValue,
+      outputString: '{"foo":"bar"}',
+      inverse: false,
+    };
+
+    const result = await handleEquals(params);
+    expect(result.pass).toBe(true);
+  });
+
+  it('fails equals when an object value does not match valid JSON output', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'equals', value: { foo: 'bar' } },
+      renderedValue: { foo: 'bar' } as AssertionValue,
+      outputString: '{"foo":"baz"}',
+      inverse: false,
+    };
+
+    const result = await handleEquals(params);
+    expect(result.pass).toBe(false);
+  });
+
+  it.each([
+    {
+      name: 'passes equals for matching primitive values',
+      assertionType: 'equals' as const,
+      expectedValue: 'hello world',
+      outputString: 'hello world',
+      inverse: false,
+      expectedPass: true,
+    },
+    {
+      name: 'fails equals for different primitive values',
+      assertionType: 'equals' as const,
+      expectedValue: 'goodbye world',
+      outputString: 'hello world',
+      inverse: false,
+      expectedPass: false,
+    },
+    {
+      name: 'fails not-equals for matching primitive values',
+      assertionType: 'not-equals' as const,
+      expectedValue: 'hello world',
+      outputString: 'hello world',
+      inverse: true,
+      expectedPass: false,
+    },
+    {
+      name: 'passes not-equals for different primitive values',
+      assertionType: 'not-equals' as const,
+      expectedValue: 'goodbye world',
+      outputString: 'hello world',
+      inverse: true,
+      expectedPass: true,
+    },
+  ])('$name', async ({ assertionType, expectedValue, outputString, inverse, expectedPass }) => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: assertionType, value: expectedValue },
+      renderedValue: expectedValue as AssertionValue,
+      outputString,
+      inverse,
+    };
+
+    const result = await handleEquals(params);
+    expect(result.pass).toBe(expectedPass);
   });
 });

--- a/test/commands/validate-provider-tests.test.ts
+++ b/test/commands/validate-provider-tests.test.ts
@@ -239,8 +239,9 @@ describe('Validate Command Provider Tests', () => {
       expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Connectivity test'));
     });
 
-    it('should not mark an exact 100-character response as truncated', async () => {
+    it('should not mark an exact 100-character serialized response as truncated', async () => {
       const output = 'x'.repeat(98);
+      expect(JSON.stringify(output)).toHaveLength(100);
       mockEchoProvider.callApi.mockResolvedValue({ output });
       vi.mocked(loadApiProvider).mockResolvedValue(mockEchoProvider);
 

--- a/test/commands/validate-provider-tests.test.ts
+++ b/test/commands/validate-provider-tests.test.ts
@@ -239,6 +239,20 @@ describe('Validate Command Provider Tests', () => {
       expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Connectivity test'));
     });
 
+    it('should not mark an exact 100-character response as truncated', async () => {
+      const output = 'x'.repeat(98);
+      mockEchoProvider.callApi.mockResolvedValue({ output });
+      vi.mocked(loadApiProvider).mockResolvedValue(mockEchoProvider);
+
+      await doValidateTarget({ target: 'echo' }, defaultConfig);
+
+      const responseLog = vi
+        .mocked(logger.info)
+        .mock.calls.find(([message]) => String(message).includes('Response:'));
+      expect(responseLog?.[0]).toContain(JSON.stringify(output));
+      expect(responseLog?.[0]).not.toContain('...');
+    });
+
     it('should load cloud provider when -t flag is UUID', async () => {
       const cloudUUID = '12345678-1234-1234-1234-123456789abc';
       const mockProviderOptions = {

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -178,6 +178,11 @@ describe('doTargetPurposeDiscovery', () => {
       bustCache: true,
     });
 
+    expect(mockSingleBar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        format: 'Mapping the target {bar} {percentage}% | {value}/{total} turns',
+      }),
+    );
     expect(mockedFetchWithProxy).toHaveBeenCalledTimes(2);
     expect(mockProgressBar.start).toHaveBeenCalledWith(5, 0);
     expect(mockProgressBar.increment).toHaveBeenCalledTimes(2);

--- a/test/remoteGrading.test.ts
+++ b/test/remoteGrading.test.ts
@@ -10,6 +10,19 @@ import { doRemoteGrading } from '../src/remoteGrading';
 
 const mockLoggerDebug = vi.hoisted(() => vi.fn());
 
+function containsString(value: unknown, needle: string): boolean {
+  if (typeof value === 'string') {
+    return value.includes(needle);
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => containsString(item, needle));
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).some((item) => containsString(item, needle));
+  }
+  return false;
+}
+
 vi.mock('../src/cache', () => ({
   fetchWithCache: vi.fn(),
 }));
@@ -148,7 +161,7 @@ describe('doRemoteGrading', () => {
       body: { images: Array<{ data: string; mimeType: string }> };
     };
     expect(firstDebugPayload.body.images[0].data).toBe('[REDACTED_IMAGE_DATA]');
-    expect(firstDebugPayload.body.images[0].data).not.toContain('abc123');
+    expect(containsString(mockLoggerDebug.mock.calls, 'abc123')).toBe(false);
     expect(fetchWithCache).toHaveBeenCalledWith(
       'https://api.promptfoo.test/task',
       expect.objectContaining({

--- a/test/remoteGrading.test.ts
+++ b/test/remoteGrading.test.ts
@@ -80,6 +80,39 @@ describe('doRemoteGrading', () => {
     );
   });
 
+  it('does not add grader error metadata when remote grading succeeds without metadata', async () => {
+    vi.mocked(getUserEmail).mockReturnValue('user@example.com');
+    vi.mocked(getRemoteGenerationUrl).mockReturnValue('https://api.promptfoo.test/task');
+    vi.mocked(getRemoteGenerationHeaders).mockReturnValue({ authorization: 'Bearer test' });
+    vi.mocked(getRequestTimeoutMs).mockReturnValue(1234);
+    vi.mocked(fetchWithCache).mockResolvedValueOnce({
+      data: {
+        result: {
+          pass: true,
+          score: 1,
+          reason: 'ok',
+        },
+      },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    } as any);
+
+    const result = await doRemoteGrading({
+      task: 'llm-rubric',
+      rubric: 'Only pass if the response is correct.',
+      output: 'Example output',
+      vars: {},
+    });
+
+    expect(result).toMatchObject({
+      pass: true,
+      score: 1,
+      reason: 'ok',
+    });
+    expect(result.metadata?.graderError).toBeUndefined();
+  });
+
   it('redacts inline image data from remote grading debug logs', async () => {
     vi.mocked(getUserEmail).mockReturnValue('user@example.com');
     vi.mocked(getRemoteGenerationUrl).mockReturnValue('https://api.promptfoo.test/task');
@@ -111,7 +144,11 @@ describe('doRemoteGrading', () => {
         images: [{ data: '[REDACTED_IMAGE_DATA]', mimeType: 'image/png' }],
       }),
     });
-    expect(JSON.stringify(mockLoggerDebug.mock.calls)).not.toContain('abc123');
+    const firstDebugPayload = mockLoggerDebug.mock.calls[0][1] as {
+      body: { images: Array<{ data: string; mimeType: string }> };
+    };
+    expect(firstDebugPayload.body.images[0].data).toBe('[REDACTED_IMAGE_DATA]');
+    expect(firstDebugPayload.body.images[0].data).not.toContain('abc123');
     expect(fetchWithCache).toHaveBeenCalledWith(
       'https://api.promptfoo.test/task',
       expect.objectContaining({

--- a/test/util/eval/evalTableUtils.test.ts
+++ b/test/util/eval/evalTableUtils.test.ts
@@ -19,6 +19,10 @@ import type {
   Prompt,
 } from '../../../src/types/index';
 
+type LegacyCompletedPrompt = Omit<CompletedPrompt, 'metrics'> & {
+  metrics: Omit<NonNullable<CompletedPrompt['metrics']>, 'namedScoresCount'>;
+};
+
 describe('evalTableUtils', () => {
   let mockTable: {
     head: { prompts: CompletedPrompt[]; vars: string[] };
@@ -1182,15 +1186,20 @@ describe('evalTableUtils', () => {
   // Build a CompletedPrompt that mimics legacy/imported persistence: the
   // `metrics` object exists but lacks `namedScoresCount`. The streaming CSV
   // path must fall back to a row-scan discovery pass for these prompts.
+  // `overrides.namedScores` contains aggregate prompt-level metrics; per-row
+  // named scores remain on the individual result rows.
   function createLegacyCompletedPrompt(
     raw: string,
     overrides: { namedScores: Record<string, number> } & Partial<Omit<CompletedPrompt, 'metrics'>>,
-  ): CompletedPrompt {
+  ): LegacyCompletedPrompt {
     const { namedScores, ...rest } = overrides;
     const prompt = createCompletedPrompt(raw, rest);
+    const { namedScoresCount: _namedScoresCount, ...legacyMetrics } = createPromptMetrics({
+      namedScores,
+    });
     return {
       ...prompt,
-      metrics: { ...createPromptMetrics({ namedScores }), namedScoresCount: undefined as never },
+      metrics: legacyMetrics,
     };
   }
 
@@ -1285,7 +1294,7 @@ describe('evalTableUtils', () => {
       isRedteam = false,
     }: {
       vars: string[];
-      prompts: CompletedPrompt[];
+      prompts: Array<CompletedPrompt | LegacyCompletedPrompt>;
       results: unknown[];
       isRedteam?: boolean;
     }): Promise<string> {


### PR DESCRIPTION
## Summary

- fix exact-length provider response previews and simplify target discovery dead code
- add complete equals and remote-grading edge-case coverage with direct redaction assertions
- model legacy eval prompt metrics without bypassing TypeScript

Addresses all 10 AI findings visible on June 6, 2026 across 5 files.

## Test Plan

- `npm ci`
- `npx vitest test/commands/validate-provider-tests.test.ts test/redteam/commands/discover.test.ts test/remoteGrading.test.ts test/assertions/equals.test.ts test/util/eval/evalTableUtils.test.ts --run`
- `npx vitest test/assertions test/commands/validate-provider-tests.test.ts test/redteam/commands/discover.test.ts test/remoteGrading.test.ts test/util/eval --run`
- `npm run tsc`
- `npm run f`
- `npm run l` (existing `discover.ts` complexity warning only)
- `npm run architecture:check`
- `npm run build`
- `PROMPTFOO_DISABLE_UPDATE=true PROMPTFOO_DISABLE_TELEMETRY=true npm run local -- validate target -t echo`