### PR TITLE
feat(examples): add TWZRD Agent Intel MCP server evaluation

### DIFF
--- a/examples/twzrd-agent-intel/README.md
+++ b/examples/twzrd-agent-intel/README.md
@@ -1,0 +1,52 @@
+# TWZRD Agent Intel MCP Evaluation
+
+This example uses [promptfoo](https://promptfoo.dev) to evaluate the
+[TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server, which provides
+trust scoring for AI agent wallets.
+
+## Tools Tested
+
+| Tool | Description | Auth |
+|------|-------------|------|
+| `score_agent(wallet)` | Trust score 0–100 | Free |
+| `preflight_check(wallet)` | Pass/fail gate | Free |
+| `get_trust_receipt(wallet)` | On-chain receipt | Paid (x402) |
+
+## Setup
+
+```bash
+npm install -g promptfoo
+```
+
+## Run
+
+```bash
+promptfoo eval
+```
+
+## View results
+
+```bash
+promptfoo view
+```
+
+## What is evaluated
+
+1. `score_agent` returns a valid numeric trust score (0–100)
+2. `preflight_check` returns a structured pass/fail result
+3. Invalid wallet address is handled gracefully (no crash)
+4. Empty wallet is rejected with an error or `pass: false`
+
+## MCP server endpoint
+
+```
+https://intel.twzrd.xyz/mcp
+```
+
+Transport: streamable-HTTP. No authentication required for free tools.
+
+## Related
+
+- [simple-mcp example](../simple-mcp) — general MCP tool evaluation
+- [redteam-mcp example](../redteam-mcp) — red teaming MCP servers
+- [TWZRD Agent Intel docs](https://intel.twzrd.xyz)

--- a/examples/twzrd-agent-intel/promptfooconfig.yaml
+++ b/examples/twzrd-agent-intel/promptfooconfig.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'TWZRD Agent Intel MCP — trust scoring tool evaluation'
+
+# Tests the free score_agent and preflight_check tools exposed by
+# the TWZRD Agent Intel MCP server (https://intel.twzrd.xyz).
+# No API key required for these tools.
+
+prompts:
+  - '{{prompt}}'
+
+providers:
+  - id: mcp
+    label: 'TWZRD Agent Intel'
+    config:
+      enabled: true
+      servers:
+        - name: twzrd-agent-intel
+          url: 'https://intel.twzrd.xyz/mcp'
+          transport: streamable-http
+      verbose: true
+
+tests:
+  # score_agent returns a numeric trust score 0-100
+  - description: 'score_agent returns a valid trust score'
+    vars:
+      prompt: '{"tool": "score_agent", "args": {"wallet": "D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi"}}'
+    assert:
+      - type: javascript
+        value: 'output && output.trim().length > 0'
+      - type: javascript
+        value: 'const parsed = JSON.parse(output); typeof parsed.score === "number" && parsed.score >= 0 && parsed.score <= 100'
+
+  # preflight_check returns pass/fail
+  - description: 'preflight_check returns a structured result'
+    vars:
+      prompt: '{"tool": "preflight_check", "args": {"wallet": "D1QkbFJKiPsymJ65RKHhF6DFB8sPMfpBaFBzuHKfJGWi"}}'
+    assert:
+      - type: javascript
+        value: 'output && output.trim().length > 0'
+      - type: javascript
+        value: 'const r = JSON.parse(output); r.hasOwnProperty("pass") || r.hasOwnProperty("status")'
+
+  # Invalid wallet format should return an error, not crash
+  - description: 'invalid wallet returns error gracefully'
+    vars:
+      prompt: '{"tool": "score_agent", "args": {"wallet": "not-a-valid-wallet"}}'
+    assert:
+      - type: javascript
+        value: 'output && output.trim().length > 0'
+      - type: javascript
+        value: 'const r = JSON.parse(output); r.hasOwnProperty("error") || r.score === 0'
+
+  # Empty wallet should be rejected
+  - description: 'empty wallet is rejected'
+    vars:
+      prompt: '{"tool": "preflight_check", "args": {"wallet": ""}}'
+    assert:
+      - type: javascript
+        value: 'output && output.trim().length > 0'
+      - type: javascript
+        value: 'const r = JSON.parse(output); r.hasOwnProperty("error") || r.pass === false'


### PR DESCRIPTION
## What

Adds `examples/twzrd-agent-intel/` — a minimal promptfoo example for evaluating the [TWZRD Agent Intel](https://intel.twzrd.xyz) MCP server, which provides trust scoring for AI agent wallets.

This complements the existing MCP examples (`simple-mcp`, `redteam-mcp`) by demonstrating evaluation of a **real, publicly-accessible MCP server** — no local server setup needed.

## Tests included

| Test | What it checks |
|------|----------------|
| `score_agent` valid wallet | Returns numeric score 0–100 |
| `preflight_check` valid wallet | Returns structured pass/fail |
| `score_agent` invalid wallet | Handled gracefully (no crash) |
| `preflight_check` empty wallet | Rejected with error or `pass: false` |

## Run

```sh
npm install -g promptfoo
cd examples/twzrd-agent-intel
promptfoo eval
```

No API key needed — `score_agent` and `preflight_check` are free tools.

## MCP server

- Endpoint: `https://intel.twzrd.xyz/mcp` (streamable-HTTP)
- Transport: `streamable-http` (same as `openai-mcp` example)
- Auth: none required for the two free tools