### PR TITLE
ci(codecov): fix CLI signature verification (bump action to v7.0.0)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,9 @@ jobs:
           files: ./coverage/coverage-final.json
           flags: backend
           name: backend-coverage
-          fail_ci_if_error: true
+          # Coverage upload is informational and runs after tests/ratchets; don't
+          # fail CI on Codecov-side infra issues (e.g. CLI signature verification).
+          fail_ci_if_error: false
           use_oidc: true
           version: v11.2.7
 
@@ -450,7 +452,9 @@ jobs:
           files: ./site/coverage/coverage-final.json
           flags: site
           name: site-coverage
-          fail_ci_if_error: true
+          # Coverage upload is informational and runs after tests/ratchets; don't
+          # fail CI on Codecov-side infra issues (e.g. CLI signature verification).
+          fail_ci_if_error: false
           use_oidc: true
           version: v11.2.7
 
@@ -496,7 +500,9 @@ jobs:
           files: ./src/app/coverage/coverage-final.json
           flags: frontend
           name: frontend-coverage
-          fail_ci_if_error: true
+          # Coverage upload is informational and runs after tests/ratchets; don't
+          # fail CI on Codecov-side infra issues (e.g. CLI signature verification).
+          fail_ci_if_error: false
           use_oidc: true
           version: v11.2.7
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,6 +145,9 @@ jobs:
           # Codecov); keep it non-blocking so Codecov infra outages can't fail main.
           fail_ci_if_error: false
           use_oidc: true
+          # Pin the CLI version too: the action SHA pins the wrapper, but the CLI
+          # binary it downloads is otherwise unpinned (action default is latest).
+          version: v11.2.8
 
   build:
     needs: ci-config
@@ -445,6 +448,12 @@ jobs:
         working-directory: site
         run: npm run test:coverage
 
+      # Site has no coverage ratchet, so the Codecov upload is the only consumer of
+      # this report. Since that upload is now non-blocking, verify the artifact was
+      # produced here — otherwise a missing/misnamed report would fail silently.
+      - name: Verify site coverage report exists
+        run: test -s ./site/coverage/coverage-final.json
+
       - name: Upload Site Coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -455,6 +464,9 @@ jobs:
           # Codecov); keep it non-blocking so Codecov infra outages can't fail main.
           fail_ci_if_error: false
           use_oidc: true
+          # Pin the CLI version too: the action SHA pins the wrapper, but the CLI
+          # binary it downloads is otherwise unpinned (action default is latest).
+          version: v11.2.8
 
   webui:
     name: webui tests
@@ -502,6 +514,9 @@ jobs:
           # Codecov); keep it non-blocking so Codecov infra outages can't fail main.
           fail_ci_if_error: false
           use_oidc: true
+          # Pin the CLI version too: the action SHA pins the wrapper, but the CLI
+          # binary it downloads is otherwise unpinned (action default is latest).
+          version: v11.2.8
 
   integration-tests:
     name: Run Integration Tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,16 +136,15 @@ jobs:
 
       - name: Upload Backend Coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.node == '20.20' && !matrix.shard
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverage/coverage-final.json
           flags: backend
           name: backend-coverage
-          # Coverage upload is informational and runs after tests/ratchets; don't
-          # fail CI on Codecov-side infra issues (e.g. CLI signature verification).
+          # Codecov upload is informational (coverage is gated in-repo, not by
+          # Codecov); keep it non-blocking so Codecov infra outages can't fail main.
           fail_ci_if_error: false
           use_oidc: true
-          version: v11.2.7
 
   build:
     needs: ci-config
@@ -447,16 +446,15 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload Site Coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./site/coverage/coverage-final.json
           flags: site
           name: site-coverage
-          # Coverage upload is informational and runs after tests/ratchets; don't
-          # fail CI on Codecov-side infra issues (e.g. CLI signature verification).
+          # Codecov upload is informational (coverage is gated in-repo, not by
+          # Codecov); keep it non-blocking so Codecov infra outages can't fail main.
           fail_ci_if_error: false
           use_oidc: true
-          version: v11.2.7
 
   webui:
     name: webui tests
@@ -495,16 +493,15 @@ jobs:
         run: npm run test:coverage:ratchet -- --report frontend
 
       - name: Upload Frontend Coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./src/app/coverage/coverage-final.json
           flags: frontend
           name: frontend-coverage
-          # Coverage upload is informational and runs after tests/ratchets; don't
-          # fail CI on Codecov-side infra issues (e.g. CLI signature verification).
+          # Codecov upload is informational (coverage is gated in-repo, not by
+          # Codecov); keep it non-blocking so Codecov infra outages can't fail main.
           fail_ci_if_error: false
           use_oidc: true
-          version: v11.2.7
 
   integration-tests:
     name: Run Integration Tests


### PR DESCRIPTION
## Problem

CI fails on every push to `main`. The failing jobs (Site tests, webui tests, Test on Node 20.20) all **pass their tests** — they die at the Codecov upload step:

```
-> Downloading https://cli.codecov.io/v11.2.7/linux/codecov.SHA256SUM.sig
gpg: Signature made Tue Apr 21 19:26:23 2026 UTC
gpg: Can't check signature: No public key
==> Could not verify signature. Exiting...
```

## Root cause

This is **deterministic**, not transient flakiness (it failed on two consecutive `main` commits ~13h apart).

- Our action was pinned to `e79a6962…` = **codecov-action v6.0.1**, whose wrapper imports the CLI signing key from `keybase.io/codecovsecurity/pgp_keys.asc`.
- **Codecov deleted the `codecovsecurity` Keybase account** and moved CLI signing to `codecovsecops` (documented verbatim in the codecov-action v7.0.0 release notes).
- The CLI artifacts were re-signed on **2026-04-21** (matches the `Signature made Tue Apr 21` in the error) with the key now published only under `codecovsecops`.
- v6.0.1's keyring lacks that key → `Can't check signature: No public key` → upload fails.

Verified directly: v6.0.1's `dist/codecov.sh` fetches from `…/codecovsecurity/…`, while **v6.0.2 and v7.0.0 (the same commit `fb8b3582…`)** fetch from `…/codecovsecops/…`.

## Fix

- Bump the action on all three upload steps from `e79a6962…` (v6.0.1) → `fb8b3582c8e4def4969c97caa2f19720cb33a72f` (**v7.0.0**), which uses the live `codecovsecops` signing key. This **fixes CI and restores coverage uploads**.
- Drop the stale, undocumented `version: v11.2.7` CLI pin (it was added by accident inside an unrelated Vitest bump in #8869) so uploads float on the action default.
- Keep `fail_ci_if_error: false` as defense-in-depth: coverage is gated by the in-repo ratchet (`Check Backend/Frontend Coverage Ratchets`), **not** Codecov, so a Codecov-side outage should never be able to fail `main`.

> Note: simply silencing the step (`fail_ci_if_error: false` alone) would turn CI green but leave coverage uploads **silently broken**. Bumping the action is the actual fix; the non-blocking flag is just a safety net.

`use_oidc: true` is unchanged — OIDC already satisfies Codecov's "token required" setting, so no `CODECOV_TOKEN` secret is needed.