### PR TITLE
fix(init): use GITHUB_TOKEN for example download API requests

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,6 +6,7 @@ import select from '@inquirer/select';
 import chalk from 'chalk';
 import dedent from 'dedent';
 import { VERSION } from '../constants';
+import { getEnvString } from '../envars';
 import logger from '../logger';
 import { initializeProject } from '../onboarding';
 import telemetry from '../telemetry';
@@ -36,11 +37,16 @@ interface GitHubContentItem {
   download_url: string | null;
 }
 
-function getGitHubHeaders() {
-  return {
+function getGitHubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
     Accept: 'application/vnd.github.v3+json',
     'User-Agent': 'promptfoo-cli',
   };
+  const token = getEnvString('GITHUB_TOKEN');
+  if (token) {
+    headers['Authorization'] = `token ${token}`;
+  }
+  return headers;
 }
 
 async function fetchExamplesTree(ref: string): Promise<GitHubTreeItem[]> {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -160,6 +160,44 @@ describe('init command', () => {
         'Network error',
       );
     });
+
+    it('should include Authorization header when GITHUB_TOKEN is set', async () => {
+      process.env.GITHUB_TOKEN = 'test-token-123';
+      try {
+        const mockResponse = createMockResponse({
+          ok: true,
+          json: () => Promise.resolve([]),
+        });
+        mockFetchWithProxy.mockResolvedValueOnce(mockResponse);
+
+        await init.downloadDirectory('example', '/path/to/target');
+
+        expect(mockFetchWithProxy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: 'token test-token-123',
+            }),
+          }),
+        );
+      } finally {
+        delete process.env.GITHUB_TOKEN;
+      }
+    });
+
+    it('should not include Authorization header when GITHUB_TOKEN is not set', async () => {
+      delete process.env.GITHUB_TOKEN;
+      const mockResponse = createMockResponse({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+      mockFetchWithProxy.mockResolvedValueOnce(mockResponse);
+
+      await init.downloadDirectory('example', '/path/to/target');
+
+      const headers = mockFetchWithProxy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers).not.toHaveProperty('Authorization');
+    });
   });
 
   describe('downloadExample', () => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as init from '../../src/commands/init';
 import logger from '../../src/logger';
 import { fetchWithProxy } from '../../src/util/fetch/index';
-import { createMockResponse } from '../util/utils';
+import { createMockResponse, mockProcessEnv } from '../util/utils';
 
 vi.mock('../../src/redteam/commands/init', async (importOriginal) => {
   return {
@@ -162,7 +162,7 @@ describe('init command', () => {
     });
 
     it('should include Authorization header when GITHUB_TOKEN is set', async () => {
-      process.env.GITHUB_TOKEN = 'test-token-123';
+      const restoreEnv = mockProcessEnv({ GITHUB_TOKEN: 'test-token-123' });
       try {
         const mockResponse = createMockResponse({
           ok: true,
@@ -181,22 +181,26 @@ describe('init command', () => {
           }),
         );
       } finally {
-        delete process.env.GITHUB_TOKEN;
+        restoreEnv();
       }
     });
 
     it('should not include Authorization header when GITHUB_TOKEN is not set', async () => {
-      delete process.env.GITHUB_TOKEN;
-      const mockResponse = createMockResponse({
-        ok: true,
-        json: () => Promise.resolve([]),
-      });
-      mockFetchWithProxy.mockResolvedValueOnce(mockResponse);
+      const restoreEnv = mockProcessEnv({ GITHUB_TOKEN: undefined });
+      try {
+        const mockResponse = createMockResponse({
+          ok: true,
+          json: () => Promise.resolve([]),
+        });
+        mockFetchWithProxy.mockResolvedValueOnce(mockResponse);
 
-      await init.downloadDirectory('example', '/path/to/target');
+        await init.downloadDirectory('example', '/path/to/target');
 
-      const headers = mockFetchWithProxy.mock.calls[0][1]?.headers as Record<string, string>;
-      expect(headers).not.toHaveProperty('Authorization');
+        const headers = mockFetchWithProxy.mock.calls[0][1]?.headers as Record<string, string>;
+        expect(headers).not.toHaveProperty('Authorization');
+      } finally {
+        restoreEnv();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- `getGitHubHeaders()` in `src/commands/init.ts` never included an `Authorization` header, so all GitHub API requests from `promptfoo init --example` are unauthenticated and subject to the 60 requests/hour anonymous rate limit
- When the limit is exhausted (shared across all GitHub API usage from the same IP), users get a `403 rate limit exceeded` error with no workaround
- This reads `GITHUB_TOKEN` from the environment (already a recognized env var in `envars.ts`) and attaches it to API requests when present, raising the limit to 5,000 req/hour

## Test plan

- [x] Added test: Authorization header is included when `GITHUB_TOKEN` is set
- [x] Added test: Authorization header is absent when `GITHUB_TOKEN` is not set  
- [x] All existing tests in `test/commands/init.test.ts` continue to pass (28/28)
- [x] Manual verification: `promptfoo init --example eval-self-grading` succeeds with token set after previously failing with 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)