### PR TITLE
fix(redteam): allow token plugins with multi-input

### DIFF
--- a/src/redteam/constants/plugins.ts
+++ b/src/redteam/constants/plugins.ts
@@ -479,13 +479,7 @@ export const DATASET_EXEMPT_PLUGINS = [
 ] as const;
 
 // Plugins excluded from multi-input mode (in addition to dataset plugins)
-export const MULTI_INPUT_EXCLUDED_PLUGINS = [
-  'cca',
-  'cross-session-leak',
-  'special-token-injection',
-  'system-prompt-override',
-  'ascii-smuggling',
-] as const;
+export const MULTI_INPUT_EXCLUDED_PLUGINS = ['cca', 'cross-session-leak'] as const;
 export type MultiInputExcludedPlugin = (typeof MULTI_INPUT_EXCLUDED_PLUGINS)[number];
 
 // Plugins that don't use strategies (standalone plugins) - combination of agentic and dataset

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -4161,7 +4161,7 @@ describe('Language configuration', () => {
       expect(multiInputMessage).toContain('context');
     });
 
-    it('should exclude all MULTI_INPUT_EXCLUDED_PLUGINS in multi-input mode', async () => {
+    it('should exclude only plugins that still do not support multi-input mode', async () => {
       await synthesize({
         language: 'en',
         numTests: 1,
@@ -4170,6 +4170,7 @@ describe('Language configuration', () => {
           { id: 'cross-session-leak', numTests: 1 },
           { id: 'special-token-injection', numTests: 1 },
           { id: 'system-prompt-override', numTests: 1 },
+          { id: 'ascii-smuggling', numTests: 1 },
           { id: 'contracts', numTests: 1 }, // Regular plugin - should NOT be excluded
         ],
         prompts: ['Test {{query}}'],
@@ -4178,17 +4179,18 @@ describe('Language configuration', () => {
         inputs: { query: 'user query', context: 'additional context' },
       });
 
-      // Check that all 4 MULTI_INPUT_EXCLUDED_PLUGINS are in skip message
+      // Check that only the explicit non-dataset exclusions are in the skip message.
       const skipMessage = vi
         .mocked(logger.info)
         .mock.calls.map(([arg]) => arg)
-        .find((arg): arg is string => typeof arg === 'string' && arg.includes('Skipping 4 plugin'));
+        .find((arg): arg is string => typeof arg === 'string' && arg.includes('Skipping 2 plugin'));
 
       expect(skipMessage).toBeDefined();
       expect(skipMessage).toContain('cca');
       expect(skipMessage).toContain('cross-session-leak');
-      expect(skipMessage).toContain('special-token-injection');
-      expect(skipMessage).toContain('system-prompt-override');
+      expect(skipMessage).not.toContain('special-token-injection');
+      expect(skipMessage).not.toContain('system-prompt-override');
+      expect(skipMessage).not.toContain('ascii-smuggling');
     });
   });
 });

--- a/test/server/routes/redteam.test.ts
+++ b/test/server/routes/redteam.test.ts
@@ -233,8 +233,13 @@ describe('Redteam Routes', () => {
         expect(mockPluginFactory.action).toHaveBeenCalled();
       });
 
-      it('should exclude system-prompt-override with multi-input config', async () => {
-        // 'system-prompt-override' is a MULTI_INPUT_EXCLUDED_PLUGIN
+      it('should not exclude system-prompt-override with multi-input config', async () => {
+        const mockPluginFactory = {
+          key: 'system-prompt-override',
+          action: vi.fn().mockResolvedValue([{ vars: { __prompt: 'test' } }]),
+        };
+        mockedPlugins.find = vi.fn().mockReturnValue(mockPluginFactory);
+
         const response = await request(app)
           .post('/api/redteam/generate-test')
           .send({
@@ -256,11 +261,11 @@ describe('Redteam Routes', () => {
           });
 
         expect(response.status).toBe(200);
-        expect(response.body).toEqual({ testCases: [], count: 0 });
+        expect(mockPluginFactory.action).toHaveBeenCalled();
+        expect(response.body.prompt).toBe('generated test prompt');
       });
 
       it('should NOT exclude special-token-injection without multi-input config', async () => {
-        // 'special-token-injection' is a MULTI_INPUT_EXCLUDED_PLUGIN
         const mockPluginFactory = {
           key: 'special-token-injection',
           action: vi.fn().mockResolvedValue([{ vars: { query: 'test' } }]),


### PR DESCRIPTION
## Summary

- Removes `ascii-smuggling`, `special-token-injection`, and `system-prompt-override` from the explicit multi-input exclusion list.
- Keeps `cca` and `cross-session-leak` excluded while those flows need separate multi-input designs.
- Updates route and synthesis tests so multi-input mode no longer skips the newly-supported token/override plugins.

## Test plan

- `pnpm vitest run test/server/routes/redteam.test.ts test/redteam/index.test.ts`
- Previously also ran `pnpm lint` and `pnpm build` in the submodule while validating this patch.