### PR TITLE
fix(providers): preserve Anthropic thinking token usage

### DIFF
--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -441,14 +441,21 @@ export function getTokenUsage(data: any, cached: boolean): Partial<TokenUsage> {
         completion: data.usage.output_tokens ?? 0,
       };
 
-      // Track Anthropic prompt caching details (stored in completionDetails since there is no dedicated inputDetails field)
-      if (
+      const thinkingTokens = data.usage.output_tokens_details?.thinking_tokens;
+      const hasCacheDetails =
         data.usage.cache_read_input_tokens != null ||
-        data.usage.cache_creation_input_tokens != null
-      ) {
+        data.usage.cache_creation_input_tokens != null;
+
+      if (thinkingTokens != null || hasCacheDetails) {
         usage.completionDetails = {
-          cacheReadInputTokens: cacheRead,
-          cacheCreationInputTokens: cacheCreation,
+          ...(thinkingTokens == null ? {} : { reasoning: thinkingTokens }),
+          // Anthropic has no dedicated input-details field in Promptfoo's usage contract.
+          ...(hasCacheDetails
+            ? {
+                cacheReadInputTokens: cacheRead,
+                cacheCreationInputTokens: cacheCreation,
+              }
+            : {}),
         };
       }
 

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -1528,6 +1528,23 @@ describe('Anthropic utilities', () => {
       expect(result).toEqual({ total: 150, prompt: 100, completion: 50 });
     });
 
+    it('should preserve Anthropic thinking token usage', () => {
+      const data = {
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          output_tokens_details: { thinking_tokens: 20 },
+        },
+      };
+      const result = getTokenUsage(data, false);
+      expect(result).toEqual({
+        total: 150,
+        prompt: 100,
+        completion: 50,
+        completionDetails: { reasoning: 20 },
+      });
+    });
+
     it('should return cached token usage', () => {
       const data = { usage: { input_tokens: 100, output_tokens: 50 } };
       const result = getTokenUsage(data, true);


### PR DESCRIPTION
## Summary

- map Anthropic `usage.output_tokens_details.thinking_tokens` to Promptfoo's `completionDetails.reasoning`
- preserve existing total, prompt, completion, cache-token, and cached-response accounting
- add a focused regression for the SDK's new thinking-token breakdown

## Why

`@anthropic-ai/sdk` 0.100.x added `usage.output_tokens_details`, but the Anthropic provider dropped its `thinking_tokens` field during response normalization. Extended-thinking evaluations therefore reported correct billed output totals while losing the reasoning-token breakdown in result JSON, summaries, and tracing.

## Validation

- regression failed before the fix and passed after it
- `npx vitest run test/providers/anthropic --sequence.shuffle=false` (`277` tests)
- `npm run tsc -- --pretty false`
- `npm run l`
- `npm run f`
- `npm run architecture:check`
- `npm run build`
- local mock Anthropic eval via `npm run local -- eval ... --no-cache`; exported JSON retained `5` prompt, `11` completion, `16` total, and `7` reasoning tokens