### PR TITLE
fix(redteam): make skill commands and script paths work for marketplace users

### DIFF
--- a/plugins/promptfoo/skills/promptfoo-provider-setup/SKILL.md
+++ b/plugins/promptfoo/skills/promptfoo-provider-setup/SKILL.md
@@ -16,9 +16,12 @@ or target configuration. Prefer a working smoke test over a clever abstraction.
 
 Read `references/provider-patterns.md` when you need concrete YAML or provider
 wrapper examples.
-For OpenAPI specs, you can run
+For OpenAPI specs, you can run the bundled
 `scripts/openapi-operation-to-config.mjs` to draft a one-operation HTTP smoke
-config, then inspect and edit the result before probing. With `--token-env`, it
+config, then inspect and edit the result before probing. The script ships in this
+skill's `scripts/` directory; when the skill is installed as a plugin it lives in
+the plugin cache, not your project, so run it by its absolute path (or copy it in)
+rather than a bare `scripts/...` path. With `--token-env`, it
 infers Bearer/OAuth2/OpenID and header/query/cookie API-key auth; use
 `--auth-header`/`--auth-prefix` to override.
 

--- a/plugins/promptfoo/skills/promptfoo-redteam-run/SKILL.md
+++ b/plugins/promptfoo/skills/promptfoo-redteam-run/SKILL.md
@@ -53,12 +53,19 @@ If a target or generated tests are missing, use `promptfoo-provider-setup` or
 
 ### 2. Preflight
 
-From the promptfoo repo, align Node first:
+Use the CLI form that matches your environment for every command below: from the
+promptfoo repo, `npm run local -- redteam …` (align Node first with
+`source ~/.nvm/nvm.sh && nvm use`); outside the repo (an installed plugin or your
+own app project), `npx promptfoo@latest redteam …`, or a globally installed
+`promptfoo redteam …`.
+
+Validate first:
 
 ```bash
-source ~/.nvm/nvm.sh && nvm use
 npm run local -- validate config -c path/to/redteam.yaml
 npm run local -- validate target -c path/to/redteam.yaml
+# Outside the repo:
+npx promptfoo@latest validate config -c path/to/redteam.yaml
 ```
 
 Check that generated tests include `assert`, `metadata.pluginId`,
@@ -80,6 +87,8 @@ Evaluate generated tests:
 
 ```bash
 npm run local -- redteam eval -c path/to/redteam.yaml -o /tmp/redteam-results.json --no-cache --no-share --no-progress-bar
+# Outside the repo:
+npx promptfoo@latest redteam eval -c path/to/redteam.yaml -o /tmp/redteam-results.json --no-cache --no-share --no-progress-bar
 ```
 
 Generate and evaluate in one command only when needed. `redteam run` has no

--- a/plugins/promptfoo/skills/promptfoo-redteam-setup/SKILL.md
+++ b/plugins/promptfoo/skills/promptfoo-redteam-setup/SKILL.md
@@ -17,9 +17,12 @@ Start with a narrow scan that can be generated and inspected, then expand.
 
 Read `references/redteam-setup-patterns.md` when you need concrete YAML
 patterns.
-For OpenAPI specs, you can run
+For OpenAPI specs, you can run the bundled
 `scripts/openapi-operation-to-redteam-config.mjs` to draft a one-operation
-redteam setup config, then inspect the inferred inputs, policy, and plugins.
+redteam setup config, then inspect the inferred inputs, policy, and plugins. The
+script ships in this skill's `scripts/` directory; when the skill is installed as
+a plugin it lives in the plugin cache, not your project, so run it by its absolute
+path (or copy it in) rather than a bare `scripts/...` path.
 With `--token-env`, it infers Bearer/OAuth2/OpenID and header/query/cookie API-key auth; use
 `--auth-header`/`--auth-prefix` to override.
 For live connectivity QA, add `--smoke-test true` to include one deterministic
@@ -126,6 +129,13 @@ From the promptfoo repo:
 npm run local -- validate config -c path/to/promptfooconfig.yaml
 npm run local -- validate target -c path/to/promptfooconfig.yaml
 npm run local -- redteam generate -c path/to/promptfooconfig.yaml -o /tmp/redteam.yaml --no-cache --force --no-progress-bar --strict
+```
+
+Outside the repo (installed plugin or your own project), use the published CLI:
+
+```bash
+npx promptfoo@latest validate config -c path/to/promptfooconfig.yaml
+npx promptfoo@latest redteam generate -c path/to/promptfooconfig.yaml -o /tmp/redteam.yaml --no-cache --force --no-progress-bar --strict
 ```
 
 Use a non-precreated output path or keep `--force`; `redteam generate` reads an


### PR DESCRIPTION
## Summary

Follow-up to #9665 (which published all four promptfoo skills to the Claude Code marketplace). End-to-end QA of the published bundle in a clean external project — driving each skill through a real Claude Code session — surfaced two real gaps for **marketplace users** (people who install the plugin in their own app repo, not the promptfoo source checkout):

1. **Red-team skills only documented repo-local commands.** `promptfoo-redteam-setup` and `promptfoo-redteam-run` told users to run `npm run local -- redteam …`, which requires the promptfoo source checkout. A marketplace user has no such script. In QA the scan only succeeded because the agent *improvised* `promptfoo` — it explicitly reported: *"The skill documentation references `npm run local --` … That command does not exist here … substitutes `promptfoo`."* The eval and provider skills already document `npx promptfoo@latest …`; the red-team skills didn't.
2. **Bundled helper scripts referenced by a cwd-relative path.** `promptfoo-provider-setup` and `promptfoo-redteam-setup` said to run `scripts/openapi-operation-*.mjs`. When installed as a plugin those scripts live in the plugin cache, not the user's project, so `node scripts/…` resolves against the wrong dir (verified: the script is only in `~/.claude/plugins/cache/…`, absent from the user's cwd).

## Changes (shared bundle → benefits both Codex and Claude Code)

- `promptfoo-redteam-run/SKILL.md`: add an explicit external CLI path (`npx promptfoo@latest redteam …` / global `promptfoo`) beside the repo form, with a one-time convention note covering the remaining command blocks.
- `promptfoo-redteam-setup/SKILL.md`: add `npx promptfoo@latest validate` + `redteam generate` external commands beside the repo form.
- `promptfoo-provider-setup` + `promptfoo-redteam-setup`: note the bundled `scripts/openapi-operation-*.mjs` helper ships in the skill dir (plugin cache when installed) — resolve its absolute path / copy it, not a bare `scripts/...` path.

Cross-skill handoffs are intentionally left as bare names (`promptfoo-provider-setup`): hardcoding Claude's `promptfoo:` namespace would be wrong for Codex, and each platform resolves bare skill names.

## Verification

- Re-installed the **fixed** bundle into Claude Code from this branch and re-ran the red-team-run skill end-to-end in a clean external project. The agent now follows the skill's own external command — it quoted `npx promptfoo@latest redteam eval …` from the skill and ran the scan (8 pii tests, 0 errors, `shareableUrl: null`). No improvising around a missing `npm run local`.
- `npx vitest run test/agentSkills/promptfooPlugin.test.ts` → 124 passed.
- `quick_validate.py` on all three edited skills → valid.
- SKILL.md line counts stay under the 200-line contract limit (redteam-setup 193, redteam-run 175, provider-setup 169).

(Two further QA observations — `validate config` rejecting a redteam *setup* config that lacks `prompts:`, and an agent using `redteam.target` instead of top-level `targets:` — were traced to agent quirks; the redteam-setup skill already shows the correct `targets:` key, so no skill change was needed.)