### PR TITLE
fix(redteam): preserve team context in cloud tasks

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -13,7 +13,11 @@ import { getConfigDirectoryPath } from './util/config/manage';
 import { sha256 } from './util/createHash';
 import { isTransientConnectionError } from './util/fetch/errors';
 import { fetchWithRetries, getFetchWithProxyHeaders } from './util/fetch/index';
-import { getCloudBearerToken } from './util/fetch/monkeyPatchFetch';
+import {
+  getCloudBearerToken,
+  getCloudTaskTeamId,
+  PROMPTFOO_TEAM_ID_HEADER,
+} from './util/fetch/monkeyPatchFetch';
 import { isSecretField, looksLikeSecret } from './util/sanitizer';
 import { sleep } from './util/time';
 import type { Cache } from 'cache-manager';
@@ -410,6 +414,11 @@ function getHeadersForCacheKey(url: RequestInfo, options: RequestInit) {
   const cloudAuth = getCloudBearerToken(url);
   if (cloudAuth && !headers.has('Authorization')) {
     headers.set('Authorization', cloudAuth);
+  }
+
+  const cloudTaskTeamId = getCloudTaskTeamId(url);
+  if (cloudTaskTeamId && !headers.has(PROMPTFOO_TEAM_ID_HEADER)) {
+    headers.set(PROMPTFOO_TEAM_ID_HEADER, cloudTaskTeamId);
   }
 
   return Array.from(headers.entries())

--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -10,6 +10,8 @@ import {
 } from '../prompts/index';
 import { getDefaultProviders } from '../providers/defaults';
 import { shouldGenerateRemote } from '../redteam/remoteGeneration';
+import { remoteGenerationContextPayload } from '../redteam/remoteGenerationContext';
+import { getCloudTargetIdFromProviders } from '../redteam/remoteGenerationContextFromProviders';
 import { doRemoteGrading } from '../remoteGrading';
 import { doRemoteScoringWithPi } from '../remoteScoring';
 import invariant from '../util/invariant';
@@ -203,6 +205,9 @@ export async function matchesLlmRubric(
           output: gradingOutput,
           vars: vars || {},
           ...(imageOutputs.length ? { images: imageOutputs } : {}),
+          ...remoteGenerationContextPayload(
+            getCloudTargetIdFromProviders(cliState.config?.providers),
+          ),
         })),
         assertion,
       };

--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -9,9 +9,11 @@ import {
   TRAJECTORY_GOAL_SUCCESS_PROMPT,
 } from '../prompts/index';
 import { getDefaultProviders } from '../providers/defaults';
-import { shouldGenerateRemote } from '../redteam/remoteGeneration';
-import { remoteGenerationContextPayload } from '../redteam/remoteGenerationContext';
-import { getCloudTargetIdFromProviders } from '../redteam/remoteGenerationContextFromProviders';
+import {
+  getCloudTargetIdFromProviders,
+  remoteGenerationContextPayload,
+  shouldGenerateRemote,
+} from '../redteam/remoteGeneration';
 import { doRemoteGrading } from '../remoteGrading';
 import { doRemoteScoringWithPi } from '../remoteScoring';
 import invariant from '../util/invariant';

--- a/src/matchers/similarity.ts
+++ b/src/matchers/similarity.ts
@@ -1,8 +1,10 @@
 import cliState from '../cliState';
 import { getDefaultProviders } from '../providers/defaults';
-import { shouldGenerateRemote } from '../redteam/remoteGeneration';
-import { remoteGenerationContextPayload } from '../redteam/remoteGenerationContext';
-import { getCloudTargetIdFromProviders } from '../redteam/remoteGenerationContextFromProviders';
+import {
+  getCloudTargetIdFromProviders,
+  remoteGenerationContextPayload,
+  shouldGenerateRemote,
+} from '../redteam/remoteGeneration';
 import { doRemoteGrading } from '../remoteGrading';
 import { accumulateTokenUsage } from '../util/tokenUsageUtils';
 import { getAndCheckProvider } from './providers';

--- a/src/matchers/similarity.ts
+++ b/src/matchers/similarity.ts
@@ -1,6 +1,8 @@
 import cliState from '../cliState';
 import { getDefaultProviders } from '../providers/defaults';
 import { shouldGenerateRemote } from '../redteam/remoteGeneration';
+import { remoteGenerationContextPayload } from '../redteam/remoteGenerationContext';
+import { getCloudTargetIdFromProviders } from '../redteam/remoteGenerationContextFromProviders';
 import { doRemoteGrading } from '../remoteGrading';
 import { accumulateTokenUsage } from '../util/tokenUsageUtils';
 import { getAndCheckProvider } from './providers';
@@ -180,6 +182,9 @@ export async function matchesSimilarity(
         output,
         threshold,
         inverse,
+        ...remoteGenerationContextPayload(
+          getCloudTargetIdFromProviders(cliState.config?.providers),
+        ),
       });
     } catch (error) {
       return fail(`Could not perform remote grading: ${error}`);

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -9,6 +9,10 @@ import {
   neverGenerateRemote,
   neverGenerateRemoteForRegularEvals,
 } from '../redteam/remoteGeneration';
+import {
+  type RedteamGenerationContext,
+  remoteGenerationContextPayload,
+} from '../redteam/remoteGenerationContext';
 import { getRemoteMaterializationContextFromVars } from '../redteam/remoteMaterialization';
 import { fetchWithRetries } from '../util/fetch/index';
 import { getRequestTimeoutMs } from './shared';
@@ -30,6 +34,7 @@ interface PromptfooHarmfulCompletionOptions {
   purpose: string;
   config?: PluginConfig;
   targetId?: string;
+  redteamGenerationContext?: RedteamGenerationContext;
 }
 
 /**
@@ -42,6 +47,7 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
   purpose: string;
   config?: PluginConfig;
   targetId?: string;
+  redteamGenerationContext?: RedteamGenerationContext;
 
   constructor(options: PromptfooHarmfulCompletionOptions) {
     this.harmCategory = options.harmCategory;
@@ -49,6 +55,9 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
     this.purpose = options.purpose;
     this.config = options.config;
     this.targetId = options.targetId;
+    this.redteamGenerationContext =
+      options.redteamGenerationContext ??
+      (options.targetId ? { providerTargetIds: [], cloudTargetId: options.targetId } : undefined);
   }
 
   id(): string {
@@ -86,7 +95,7 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
       purpose: this.purpose,
       version: VERSION,
       config: this.config,
-      ...(this.targetId ? { targetId: this.targetId } : {}),
+      ...remoteGenerationContextPayload(this.redteamGenerationContext ?? this.targetId),
     };
 
     try {
@@ -142,6 +151,7 @@ interface PromptfooChatCompletionOptions {
   preferSmallModel: boolean;
   /** Cloud target database ID used to resolve the owning team for remote tasks. */
   targetId?: string;
+  redteamGenerationContext?: RedteamGenerationContext;
   task:
     | 'crescendo'
     | 'goat'
@@ -207,7 +217,9 @@ export class PromptfooChatCompletionProvider implements ApiProvider {
       step: context?.prompt.label,
       task: this.options.task,
       email: getUserEmail(),
-      ...(this.options.targetId ? { targetId: this.options.targetId } : {}),
+      ...remoteGenerationContextPayload(
+        this.options.redteamGenerationContext ?? this.options.targetId,
+      ),
       // Pass inputs schema for multi-input mode
       ...(this.options.inputs && { inputs: this.options.inputs }),
       ...(materializationContext ? { materializationContext } : {}),
@@ -259,6 +271,9 @@ interface PromptfooAgentOptions {
   env?: EnvOverrides;
   id?: string;
   instructions?: string;
+  /** Cloud target database ID used to resolve the owning team for remote tasks. */
+  targetId?: string;
+  redteamGenerationContext?: RedteamGenerationContext;
 }
 
 // Task ID constants for simulated user provider
@@ -327,6 +342,9 @@ export class PromptfooSimulatedUserProvider implements ApiProvider {
       history: messages,
       email: getUserEmail(),
       version: VERSION,
+      ...remoteGenerationContextPayload(
+        this.options.redteamGenerationContext ?? this.options.targetId,
+      ),
     };
 
     try {

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -29,6 +29,7 @@ interface PromptfooHarmfulCompletionOptions {
   n: number;
   purpose: string;
   config?: PluginConfig;
+  targetId?: string;
 }
 
 /**
@@ -40,12 +41,14 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
   n: number;
   purpose: string;
   config?: PluginConfig;
+  targetId?: string;
 
   constructor(options: PromptfooHarmfulCompletionOptions) {
     this.harmCategory = options.harmCategory;
     this.n = options.n;
     this.purpose = options.purpose;
     this.config = options.config;
+    this.targetId = options.targetId;
   }
 
   id(): string {
@@ -83,6 +86,7 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
       purpose: this.purpose,
       version: VERSION,
       config: this.config,
+      ...(this.targetId ? { targetId: this.targetId } : {}),
     };
 
     try {

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -8,11 +8,8 @@ import {
   getRemoteGenerationUrlForUnaligned,
   neverGenerateRemote,
   neverGenerateRemoteForRegularEvals,
+  providerRemoteGenerationContextPayload,
 } from '../redteam/remoteGeneration';
-import {
-  type RedteamGenerationContext,
-  remoteGenerationContextPayload,
-} from '../redteam/remoteGenerationContext';
 import { getRemoteMaterializationContextFromVars } from '../redteam/remoteMaterialization';
 import { fetchWithRetries } from '../util/fetch/index';
 import { getRequestTimeoutMs } from './shared';
@@ -25,6 +22,7 @@ import type {
   Inputs,
   PluginConfig,
   ProviderResponse,
+  RemoteGenerationContext,
   TokenUsage,
 } from '../types/index';
 
@@ -34,7 +32,7 @@ interface PromptfooHarmfulCompletionOptions {
   purpose: string;
   config?: PluginConfig;
   targetId?: string;
-  redteamGenerationContext?: RedteamGenerationContext;
+  redteamGenerationContext?: RemoteGenerationContext;
 }
 
 /**
@@ -47,7 +45,7 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
   purpose: string;
   config?: PluginConfig;
   targetId?: string;
-  redteamGenerationContext?: RedteamGenerationContext;
+  redteamGenerationContext?: RemoteGenerationContext;
 
   constructor(options: PromptfooHarmfulCompletionOptions) {
     this.harmCategory = options.harmCategory;
@@ -95,7 +93,7 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
       purpose: this.purpose,
       version: VERSION,
       config: this.config,
-      ...remoteGenerationContextPayload(this.redteamGenerationContext ?? this.targetId),
+      ...providerRemoteGenerationContextPayload(this.redteamGenerationContext ?? this.targetId),
     };
 
     try {
@@ -151,7 +149,7 @@ interface PromptfooChatCompletionOptions {
   preferSmallModel: boolean;
   /** Cloud target database ID used to resolve the owning team for remote tasks. */
   targetId?: string;
-  redteamGenerationContext?: RedteamGenerationContext;
+  redteamGenerationContext?: RemoteGenerationContext;
   task:
     | 'crescendo'
     | 'goat'
@@ -217,7 +215,7 @@ export class PromptfooChatCompletionProvider implements ApiProvider {
       step: context?.prompt.label,
       task: this.options.task,
       email: getUserEmail(),
-      ...remoteGenerationContextPayload(
+      ...providerRemoteGenerationContextPayload(
         this.options.redteamGenerationContext ?? this.options.targetId,
       ),
       // Pass inputs schema for multi-input mode
@@ -273,7 +271,7 @@ interface PromptfooAgentOptions {
   instructions?: string;
   /** Cloud target database ID used to resolve the owning team for remote tasks. */
   targetId?: string;
-  redteamGenerationContext?: RedteamGenerationContext;
+  redteamGenerationContext?: RemoteGenerationContext;
 }
 
 // Task ID constants for simulated user provider
@@ -342,7 +340,7 @@ export class PromptfooSimulatedUserProvider implements ApiProvider {
       history: messages,
       email: getUserEmail(),
       version: VERSION,
-      ...remoteGenerationContextPayload(
+      ...providerRemoteGenerationContextPayload(
         this.options.redteamGenerationContext ?? this.options.targetId,
       ),
     };

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -140,6 +140,8 @@ interface PromptfooChatCompletionOptions {
   id?: string;
   jsonOnly: boolean;
   preferSmallModel: boolean;
+  /** Cloud target database ID used to resolve the owning team for remote tasks. */
+  targetId?: string;
   task:
     | 'crescendo'
     | 'goat'
@@ -205,6 +207,7 @@ export class PromptfooChatCompletionProvider implements ApiProvider {
       step: context?.prompt.label,
       task: this.options.task,
       email: getUserEmail(),
+      ...(this.options.targetId ? { targetId: this.options.targetId } : {}),
       // Pass inputs schema for multi-input mode
       ...(this.options.inputs && { inputs: this.options.inputs }),
       ...(materializationContext ? { materializationContext } : {}),

--- a/src/providers/simulatedUser.ts
+++ b/src/providers/simulatedUser.ts
@@ -7,13 +7,13 @@ import { sleep } from '../util/time';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageUtils';
 import { PromptfooSimulatedUserProvider } from './promptfoo';
 
-import type { RedteamGenerationContext } from '../redteam/remoteGenerationContext';
 import type {
   ApiProvider,
   CallApiContextParams,
   CallApiOptionsParams,
   ProviderOptions,
   ProviderResponse,
+  RemoteGenerationContext,
   TokenUsage,
 } from '../types/index';
 
@@ -36,7 +36,7 @@ type AgentProviderOptions = ProviderOptions & {
     initialMessages?: Message[] | string;
     /** Cloud target database ID used to resolve target-owned redteam task context. */
     targetId?: string;
-    redteamGenerationContext?: RedteamGenerationContext;
+    redteamGenerationContext?: RemoteGenerationContext;
   };
 };
 
@@ -48,7 +48,7 @@ export class SimulatedUser implements ApiProvider {
   private readonly identifier: string;
   private readonly maxTurns: number;
   private readonly rawInstructions: string;
-  private readonly redteamGenerationContext?: RedteamGenerationContext;
+  private readonly redteamGenerationContext?: RemoteGenerationContext;
   private readonly stateful: boolean;
   private readonly configInitialMessages?: Message[] | string;
 

--- a/src/providers/simulatedUser.ts
+++ b/src/providers/simulatedUser.ts
@@ -7,6 +7,7 @@ import { sleep } from '../util/time';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageUtils';
 import { PromptfooSimulatedUserProvider } from './promptfoo';
 
+import type { RedteamGenerationContext } from '../redteam/remoteGenerationContext';
 import type {
   ApiProvider,
   CallApiContextParams,
@@ -33,6 +34,9 @@ type AgentProviderOptions = ProviderOptions & {
      * Useful for testing specific conversation states or reproducing bugs.
      */
     initialMessages?: Message[] | string;
+    /** Cloud target database ID used to resolve target-owned redteam task context. */
+    targetId?: string;
+    redteamGenerationContext?: RedteamGenerationContext;
   };
 };
 
@@ -44,6 +48,7 @@ export class SimulatedUser implements ApiProvider {
   private readonly identifier: string;
   private readonly maxTurns: number;
   private readonly rawInstructions: string;
+  private readonly redteamGenerationContext?: RedteamGenerationContext;
   private readonly stateful: boolean;
   private readonly configInitialMessages?: Message[] | string;
 
@@ -57,6 +62,9 @@ export class SimulatedUser implements ApiProvider {
     this.identifier = id ?? label ?? 'agent-provider';
     this.maxTurns = config.maxTurns ?? 10;
     this.rawInstructions = config.instructions || '{{instructions}}';
+    this.redteamGenerationContext =
+      config.redteamGenerationContext ??
+      (config.targetId ? { providerTargetIds: [], cloudTargetId: config.targetId } : undefined);
     this.stateful = config.stateful ?? false;
     this.configInitialMessages = config.initialMessages;
   }
@@ -260,7 +268,10 @@ export class SimulatedUser implements ApiProvider {
 
     const instructions = getNunjucksEngine().renderString(this.rawInstructions, context?.vars);
 
-    const userProvider = new PromptfooSimulatedUserProvider({ instructions }, this.taskId);
+    const userProvider = new PromptfooSimulatedUserProvider(
+      { instructions, redteamGenerationContext: this.redteamGenerationContext },
+      this.taskId,
+    );
 
     logger.debug(`[SimulatedUser] Formatted user instructions: ${instructions}`);
 

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -22,6 +22,8 @@ import {
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
+import { getCloudTargetIdFromProviders } from '../remoteGenerationContextFromProviders';
 
 import type { ApiProvider, Prompt, UnifiedConfig } from '../../types/index';
 
@@ -37,6 +39,7 @@ const TargetPurposeDiscoveryStateSchema = z.object({
 export const TargetPurposeDiscoveryRequestSchema = z.object({
   state: TargetPurposeDiscoveryStateSchema,
   task: z.literal('target-purpose-discovery'),
+  targetId: z.string().optional(),
   version: z.string(),
   email: z.string().optional().nullable(),
 });
@@ -186,12 +189,14 @@ async function buildRemoteErrorFromResponse(response: Response): Promise<Error> 
  * @param target - The target API provider.
  * @param prompt - The prompt to use for the discovery.
  * @param showProgress - Whether to show the progress bar.
+ * @param targetId - Cloud target database ID used to resolve target-owned task context.
  * @returns The discovery result.
  */
 export async function doTargetPurposeDiscovery(
   target: ApiProvider,
   prompt?: Prompt,
   showProgress: boolean = true,
+  targetId?: string,
 ): Promise<TargetPurposeDiscoveryResult | undefined> {
   // Generate a unique session id to pass to the target across all turns.
   const sessionId = randomUUID();
@@ -238,6 +243,7 @@ export async function doTargetPurposeDiscovery(
                 answers: state.answers,
               },
               task: 'target-purpose-discovery',
+              ...remoteGenerationContextPayload(targetId),
               version: VERSION,
               email: getUserEmail(),
             }),
@@ -376,6 +382,7 @@ export function discoverCommand(
       // Although the providers/targets property supports multiple values, Redteaming only supports
       // a single target at a time.
       let target: ApiProvider | undefined = undefined;
+      let cloudTargetId: string | undefined;
       // Fallback to the default config path:
 
       // If user provides a config, read the target from it:
@@ -405,12 +412,14 @@ export function discoverCommand(
         const providers = await loadApiProviders(config.providers);
 
         target = providers[0];
+        cloudTargetId = getCloudTargetIdFromProviders(config.providers);
       }
       // If the target flag is provided, load it from Cloud:
       else if (args.target) {
         // Let the internal error handling bubble up:
         const providerOptions = await getProviderFromCloud(args.target);
         target = await loadApiProvider(providerOptions.id, { options: providerOptions });
+        cloudTargetId = args.target;
       }
       // Check the current working directory for a promptfooconfig.yaml file:
       else if (defaultConfig) {
@@ -420,6 +429,7 @@ export function discoverCommand(
 
         const providers = await loadApiProviders(defaultConfig.providers);
         target = providers[0];
+        cloudTargetId = getCloudTargetIdFromProviders(defaultConfig.providers);
 
         // Alert the user that we're using a config from the current working directory:
         logger.info(`Using config from ${chalk.italic(defaultConfigPath)}`);
@@ -432,7 +442,12 @@ export function discoverCommand(
       }
 
       try {
-        const discoveryResult = await doTargetPurposeDiscovery(target);
+        const discoveryResult = await doTargetPurposeDiscovery(
+          target,
+          undefined,
+          true,
+          cloudTargetId,
+        );
 
         if (discoveryResult) {
           if (discoveryResult.purpose) {

--- a/src/redteam/commands/discover.ts
+++ b/src/redteam/commands/discover.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'crypto';
+import path from 'path';
 
 import chalk from 'chalk';
 import cliProgress from 'cli-progress';
@@ -10,7 +11,7 @@ import { renderPrompt } from '../../evaluatorHelpers';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { HttpProvider } from '../../providers/http';
-import { loadApiProvider, loadApiProviders } from '../../providers/index';
+import { loadApiProvider, loadApiProviders, resolveProviderConfigs } from '../../providers/index';
 import telemetry from '../../telemetry';
 import { getProviderFromCloud } from '../../util/cloud';
 import { readConfig } from '../../util/config/load';
@@ -92,6 +93,8 @@ export type TargetPurposeDiscoveryResult = z.infer<typeof TargetPurposeDiscovery
 
 type Args = z.infer<typeof ArgsSchema>;
 
+type DiscoveryProviderConfig = NonNullable<UnifiedConfig['providers']>;
+
 // ========================================================
 // Constants
 // ========================================================
@@ -104,6 +107,27 @@ const COMMAND = 'discover';
 // ========================================================
 // Utils
 // ========================================================
+
+/**
+ * Expands provider file references and derives context from the first provider that discovery uses.
+ */
+export function resolveDiscoveryProviderContext(
+  providers: DiscoveryProviderConfig,
+  basePath?: string,
+): {
+  providers: DiscoveryProviderConfig;
+  cloudTargetId?: string;
+} {
+  const resolvedProviders = resolveProviderConfigs(providers, { basePath });
+  const selectedProvider = Array.isArray(resolvedProviders)
+    ? resolvedProviders[0]
+    : resolvedProviders;
+
+  return {
+    providers: resolvedProviders,
+    cloudTargetId: getCloudTargetIdFromProviders(selectedProvider),
+  };
+}
 
 // Helper function to check if a string value should be considered null
 const isNullLike = (value: string | null | undefined): boolean => {
@@ -409,10 +433,12 @@ export function discoverCommand(
           throw new Error('Config must contain a target');
         }
 
-        const providers = await loadApiProviders(config.providers);
+        const basePath = path.dirname(path.resolve(args.config));
+        const resolved = resolveDiscoveryProviderContext(config.providers, basePath);
+        const providers = await loadApiProviders(resolved.providers, { basePath });
 
         target = providers[0];
-        cloudTargetId = getCloudTargetIdFromProviders(config.providers);
+        cloudTargetId = resolved.cloudTargetId;
       }
       // If the target flag is provided, load it from Cloud:
       else if (args.target) {
@@ -427,9 +453,13 @@ export function discoverCommand(
           throw new Error('Config must contain a target or provider');
         }
 
-        const providers = await loadApiProviders(defaultConfig.providers);
+        const basePath = defaultConfigPath
+          ? path.dirname(path.resolve(defaultConfigPath))
+          : undefined;
+        const resolved = resolveDiscoveryProviderContext(defaultConfig.providers, basePath);
+        const providers = await loadApiProviders(resolved.providers, { basePath });
         target = providers[0];
-        cloudTargetId = getCloudTargetIdFromProviders(defaultConfig.providers);
+        cloudTargetId = resolved.cloudTargetId;
 
         // Alert the user that we're using a config from the current working directory:
         logger.info(`Using config from ${chalk.italic(defaultConfigPath)}`);

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -41,6 +41,7 @@ import { getCustomPolicies } from '../../util/generation';
 import { printBorder, renderVarsInObject, setupEnv } from '../../util/index';
 import invariant from '../../util/invariant';
 import { promptfooCommand } from '../../util/promptfooCommand';
+import { normalizeProviderRef } from '../../util/providerRef';
 import { checkRedteamProbeLimit, MONTHLY_PROBE_LIMIT } from '../../util/redteamProbeLimit';
 import { isUuid } from '../../util/uuid';
 import { RedteamConfigSchema, RedteamGenerateOptionsSchema } from '../../validators/redteam';
@@ -144,6 +145,12 @@ function getCloudTargetDatabaseIdFromProviders(
     if (typeof providerConfig.id === 'string' && isCloudProvider(providerConfig.id)) {
       return getCloudDatabaseId(providerConfig.id);
     }
+
+    for (const providerId of Object.keys(provider)) {
+      if (isCloudProvider(providerId)) {
+        return getCloudDatabaseId(providerId);
+      }
+    }
   }
 
   return undefined;
@@ -157,10 +164,10 @@ function getTargetIdsFromProviders(providers: Partial<UnifiedConfig>['providers'
     return [];
   }
 
-  return providers
-    .filter((provider) => typeof provider !== 'function')
-    .map((provider) => (typeof provider === 'string' ? provider : provider.id))
-    .filter((id): id is string => typeof id === 'string');
+  return providers.flatMap((provider, index) => {
+    const descriptor = normalizeProviderRef(provider, { index });
+    return descriptor.kind === 'unknown' || descriptor.kind === 'function' ? [] : [descriptor.id];
+  });
 }
 
 function getDefaultPurposeVars(testSuite: TestSuite): Record<string, unknown> {

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -113,6 +113,41 @@ function handleFailedPlugins(failedPlugins: FailedPluginInfo[], strict: boolean)
   );
 }
 
+function getCloudTargetDatabaseIdFromProviders(
+  providers: Partial<UnifiedConfig>['providers'],
+): string | undefined {
+  if (!Array.isArray(providers)) {
+    return undefined;
+  }
+
+  for (const provider of providers) {
+    if (typeof provider === 'string') {
+      if (isCloudProvider(provider)) {
+        return getCloudDatabaseId(provider);
+      }
+      continue;
+    }
+
+    if (typeof provider !== 'object' || provider === null || Array.isArray(provider)) {
+      continue;
+    }
+
+    const providerConfig = provider as {
+      id?: unknown;
+      config?: { linkedTargetId?: unknown };
+    };
+    const linkedTargetId = providerConfig.config?.linkedTargetId;
+    if (typeof linkedTargetId === 'string' && isCloudProvider(linkedTargetId)) {
+      return getCloudDatabaseId(linkedTargetId);
+    }
+    if (typeof providerConfig.id === 'string' && isCloudProvider(providerConfig.id)) {
+      return getCloudDatabaseId(providerConfig.id);
+    }
+  }
+
+  return undefined;
+}
+
 function getDefaultPurposeVars(testSuite: TestSuite): Record<string, unknown> {
   return typeof testSuite.defaultTest === 'object' && testSuite.defaultTest?.vars
     ? testSuite.defaultTest.vars
@@ -596,6 +631,7 @@ async function doGenerateRedteamInternal(
           })
           .filter((id): id is string => typeof id === 'string')
       : []) ?? [];
+  const cloudTargetDatabaseId = getCloudTargetDatabaseIdFromProviders(resolvedConfig?.providers);
 
   logger.debug(
     `Extracted ${targetIds.length} target IDs from config providers: ${JSON.stringify(targetIds)}`,
@@ -671,6 +707,7 @@ async function doGenerateRedteamInternal(
             maxConcurrency: config.maxConcurrency,
             delay: config.delay,
             abortSignal: options.abortSignal,
+            cloudTargetDatabaseId,
             targetIds,
             showProgressBar: options.progressBar !== false,
             testGenerationInstructions: augmentedTestGenerationInstructions,
@@ -735,6 +772,7 @@ async function doGenerateRedteamInternal(
         maxConcurrency: config.maxConcurrency,
         delay: config.delay,
         abortSignal: options.abortSignal,
+        cloudTargetDatabaseId,
         targetIds,
         showProgressBar: options.progressBar !== false,
         testGenerationInstructions: augmentedTestGenerationInstructions,

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -58,7 +58,7 @@ import { extractMcpToolsInfo } from '../extraction/mcpTools';
 import { MAX_MAX_CONCURRENCY, synthesize } from '../index';
 import { determinePolicyTypeFromId, isValidPolicyObject } from '../plugins/policy/utils';
 import { neverGenerateRemote, shouldGenerateRemote } from '../remoteGeneration';
-import { getRedteamGenerationContextFromProviders } from '../remoteGenerationContext';
+import { getRedteamGenerationContextFromProviders } from '../remoteGenerationContextFromProviders';
 import { PartialGenerationError, ProbeLimitExceededError } from '../types';
 import type { Command } from 'commander';
 

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -58,6 +58,7 @@ import { extractMcpToolsInfo } from '../extraction/mcpTools';
 import { MAX_MAX_CONCURRENCY, synthesize } from '../index';
 import { determinePolicyTypeFromId, isValidPolicyObject } from '../plugins/policy/utils';
 import { neverGenerateRemote, shouldGenerateRemote } from '../remoteGeneration';
+import { getRedteamGenerationContextFromProviders } from '../remoteGenerationContext';
 import { PartialGenerationError, ProbeLimitExceededError } from '../types';
 import type { Command } from 'commander';
 
@@ -111,75 +112,6 @@ function handleFailedPlugins(failedPlugins: FailedPluginInfo[], strict: boolean)
       `Continuing with partial results. Use ${chalk.bold('--strict')} flag to fail on plugin generation errors.`,
     ),
   );
-}
-
-function getCloudTargetDatabaseIdFromProviders(
-  providers: Partial<UnifiedConfig>['providers'],
-): string | undefined {
-  if (!providers) {
-    return undefined;
-  }
-
-  const providerList = Array.isArray(providers) ? providers : [providers];
-  for (const provider of providerList) {
-    if (typeof provider === 'string') {
-      if (isCloudProvider(provider)) {
-        return getCloudDatabaseId(provider);
-      }
-      continue;
-    }
-
-    if (typeof provider !== 'object' || provider === null || Array.isArray(provider)) {
-      continue;
-    }
-
-    const providerConfig = provider as {
-      id?: unknown;
-      config?: { linkedTargetId?: unknown };
-    };
-    const linkedTargetId = providerConfig.config?.linkedTargetId;
-    if (typeof linkedTargetId === 'string' && isCloudProvider(linkedTargetId)) {
-      return getCloudDatabaseId(linkedTargetId);
-    }
-    if (typeof providerConfig.id === 'string' && isCloudProvider(providerConfig.id)) {
-      return getCloudDatabaseId(providerConfig.id);
-    }
-
-    for (const providerId of Object.keys(provider)) {
-      if (isCloudProvider(providerId)) {
-        return getCloudDatabaseId(providerId);
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function getTargetIdsFromProviders(providers: Partial<UnifiedConfig>['providers']): string[] {
-  if (typeof providers === 'string') {
-    return [providers];
-  }
-  if (!Array.isArray(providers)) {
-    return [];
-  }
-
-  return providers.flatMap((provider) => {
-    if (typeof provider === 'string') {
-      return [provider];
-    }
-    if (typeof provider !== 'object' || provider === null || Array.isArray(provider)) {
-      return [];
-    }
-    if (typeof provider.id === 'string') {
-      return [provider.id];
-    }
-
-    try {
-      return getProviderIds([provider]);
-    } catch {
-      return [];
-    }
-  });
 }
 
 function getDefaultPurposeVars(testSuite: TestSuite): Record<string, unknown> {
@@ -670,8 +602,10 @@ async function doGenerateRedteamInternal(
 
   // Extract target IDs from the config providers (targets get rewritten to providers)
   // IDs are used for retry strategy to match failed tests by target ID
-  const targetIds = getTargetIdsFromProviders(selectedProviderConfigs);
-  const cloudTargetDatabaseId = getCloudTargetDatabaseIdFromProviders(selectedProviderConfigs);
+  const redteamGenerationContext =
+    getRedteamGenerationContextFromProviders(selectedProviderConfigs);
+  const targetIds = redteamGenerationContext.providerTargetIds;
+  const cloudTargetDatabaseId = redteamGenerationContext.cloudTargetId;
 
   logger.debug(
     `Extracted ${targetIds.length} target IDs from config providers: ${JSON.stringify(targetIds)}`,
@@ -747,6 +681,7 @@ async function doGenerateRedteamInternal(
             maxConcurrency: config.maxConcurrency,
             delay: config.delay,
             abortSignal: options.abortSignal,
+            redteamGenerationContext,
             cloudTargetDatabaseId,
             targetIds,
             showProgressBar: options.progressBar !== false,
@@ -812,6 +747,7 @@ async function doGenerateRedteamInternal(
         maxConcurrency: config.maxConcurrency,
         delay: config.delay,
         abortSignal: options.abortSignal,
+        redteamGenerationContext,
         cloudTargetDatabaseId,
         targetIds,
         showProgressBar: options.progressBar !== false,

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -254,9 +254,20 @@ function getNoTestCasesGeneratedMessage(strategies: RedteamStrategyObject[]): st
   `;
 }
 
-async function getConfigHash(configPath: string): Promise<string> {
+async function getConfigHash(
+  configPath: string,
+  options: Pick<RedteamCliGenerateOptions, 'filterProviders' | 'filterTargets'>,
+): Promise<string> {
   const content = await fs.readFile(configPath, 'utf8');
-  return createHash('md5').update(`${VERSION}:${content}`).digest('hex');
+  const filters = {
+    ...(options.filterProviders ? { filterProviders: options.filterProviders } : {}),
+    ...(options.filterTargets ? { filterTargets: options.filterTargets } : {}),
+  };
+  const hashInput =
+    Object.keys(filters).length > 0
+      ? JSON.stringify({ version: VERSION, content, filters })
+      : `${VERSION}:${content}`;
+  return createHash('md5').update(hashInput).digest('hex');
 }
 
 function createHeaderComments({
@@ -373,7 +384,7 @@ async function doGenerateRedteamInternal(
       await fs.readFile(outputPath, 'utf8'),
     ) as Partial<UnifiedConfig>;
     const storedHash = redteamContent.metadata?.configHash;
-    const currentHash = await getConfigHash(configPath);
+    const currentHash = await getConfigHash(configPath, options);
 
     if (storedHash === currentHash) {
       logger.warn(
@@ -903,7 +914,7 @@ async function doGenerateRedteamInternal(
         metadata: {
           ...(existingYaml.metadata || {}),
           ...(configPath && redteamTests.length > 0
-            ? { configHash: await getConfigHash(configPath) }
+            ? { configHash: await getConfigHash(configPath, options) }
             : { configHash: 'force-regenerate' }),
           ...(pluginSeverityOverridesId ? { pluginSeverityOverridesId } : {}),
         },
@@ -968,7 +979,7 @@ async function doGenerateRedteamInternal(
       // Add the config hash to metadata
       existingConfig.metadata = {
         ...(existingConfig.metadata || {}),
-        configHash: await getConfigHash(configPath),
+        configHash: await getConfigHash(configPath, options),
       };
       const author = getAuthor();
       const userEmail = getUserEmail();

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -114,6 +114,21 @@ function handleFailedPlugins(failedPlugins: FailedPluginInfo[], strict: boolean)
   );
 }
 
+function getProviderTargetIds(providers: Partial<UnifiedConfig>['providers']): string[] {
+  if (!providers) {
+    return [];
+  }
+
+  const providerList = Array.isArray(providers) ? providers : [providers];
+  return providerList.flatMap((provider) => {
+    try {
+      return getProviderIds([provider]);
+    } catch {
+      return [];
+    }
+  });
+}
+
 function getDefaultPurposeVars(testSuite: TestSuite): Record<string, unknown> {
   return typeof testSuite.defaultTest === 'object' && testSuite.defaultTest?.vars
     ? testSuite.defaultTest.vars
@@ -600,10 +615,13 @@ async function doGenerateRedteamInternal(
     throw new Error(`Invalid redteam configuration:\n${errorMessage}`);
   }
 
-  // Extract target IDs from the config providers (targets get rewritten to providers)
-  // IDs are used for retry strategy to match failed tests by target ID
-  const redteamGenerationContext =
-    getRedteamGenerationContextFromProviders(selectedProviderConfigs);
+  // Resolve IDs at this orchestration boundary so the context helper stays independent of the
+  // provider registry. IDs are used for retry strategy to match failed tests by target ID.
+  const providerTargetIds = getProviderTargetIds(selectedProviderConfigs);
+  const redteamGenerationContext = getRedteamGenerationContextFromProviders(
+    selectedProviderConfigs,
+    providerTargetIds,
+  );
   const targetIds = redteamGenerationContext.providerTargetIds;
   const cloudTargetDatabaseId = redteamGenerationContext.cloudTargetId;
 

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -116,11 +116,12 @@ function handleFailedPlugins(failedPlugins: FailedPluginInfo[], strict: boolean)
 function getCloudTargetDatabaseIdFromProviders(
   providers: Partial<UnifiedConfig>['providers'],
 ): string | undefined {
-  if (!Array.isArray(providers)) {
+  if (!providers) {
     return undefined;
   }
 
-  for (const provider of providers) {
+  const providerList = Array.isArray(providers) ? providers : [providers];
+  for (const provider of providerList) {
     if (typeof provider === 'string') {
       if (isCloudProvider(provider)) {
         return getCloudDatabaseId(provider);
@@ -146,6 +147,20 @@ function getCloudTargetDatabaseIdFromProviders(
   }
 
   return undefined;
+}
+
+function getTargetIdsFromProviders(providers: Partial<UnifiedConfig>['providers']): string[] {
+  if (typeof providers === 'string') {
+    return [providers];
+  }
+  if (!Array.isArray(providers)) {
+    return [];
+  }
+
+  return providers
+    .filter((provider) => typeof provider !== 'function')
+    .map((provider) => (typeof provider === 'string' ? provider : provider.id))
+    .filter((id): id is string => typeof id === 'string');
 }
 
 function getDefaultPurposeVars(testSuite: TestSuite): Record<string, unknown> {
@@ -618,19 +633,7 @@ async function doGenerateRedteamInternal(
 
   // Extract target IDs from the config providers (targets get rewritten to providers)
   // IDs are used for retry strategy to match failed tests by target ID
-  const targetIds: string[] =
-    (Array.isArray(resolvedConfig?.providers)
-      ? resolvedConfig.providers
-          .filter((target) => typeof target !== 'function')
-          .map((target) => {
-            if (typeof target === 'string') {
-              return target; // Use the provider string as ID
-            }
-            const providerObj = target as { id?: string };
-            return providerObj.id;
-          })
-          .filter((id): id is string => typeof id === 'string')
-      : []) ?? [];
+  const targetIds = getTargetIdsFromProviders(resolvedConfig?.providers);
   const cloudTargetDatabaseId = getCloudTargetDatabaseIdFromProviders(resolvedConfig?.providers);
 
   logger.debug(

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -328,6 +328,7 @@ async function doGenerateRedteamInternal(
   const outputPath = options.output || 'redteam.yaml';
   let commandLineOptions: Record<string, any> | undefined;
   let resolvedConfig: Partial<UnifiedConfig> | undefined;
+  let selectedProviderConfigs: Partial<UnifiedConfig>['providers'];
 
   // Write a remote config to a temporary file
   if (options.configFromCloud) {
@@ -370,6 +371,8 @@ async function doGenerateRedteamInternal(
     const resolved = await resolveConfigs(
       {
         config: [configPath],
+        filterProviders: options.filterProviders,
+        filterTargets: options.filterTargets,
       },
       options.defaultConfig || {},
     );
@@ -377,8 +380,12 @@ async function doGenerateRedteamInternal(
     redteamConfig = resolved.config.redteam;
     commandLineOptions = resolved.commandLineOptions;
     resolvedConfig = resolved.config;
+    selectedProviderConfigs = resolved.selectedProviderConfigs ?? resolved.config.providers;
 
-    await checkCloudPermissions(resolved.config);
+    await checkCloudPermissions({
+      ...resolved.config,
+      providers: selectedProviderConfigs,
+    });
 
     // Warn if both tests section and redteam config are present
     if (redteamConfig && resolved.testSuite.tests && resolved.testSuite.tests.length > 0) {
@@ -402,7 +409,7 @@ async function doGenerateRedteamInternal(
 
     try {
       // If the provider is a cloud provider, check for plugin severity overrides:
-      const providerId = getProviderIds(resolved.config.providers!)[0];
+      const providerId = getProviderIds(selectedProviderConfigs!)[0];
       if (isCloudProvider(providerId)) {
         const cloudId = getCloudDatabaseId(providerId);
         const overrides = await getPluginSeverityOverridesFromCloud(cloudId);
@@ -633,8 +640,8 @@ async function doGenerateRedteamInternal(
 
   // Extract target IDs from the config providers (targets get rewritten to providers)
   // IDs are used for retry strategy to match failed tests by target ID
-  const targetIds = getTargetIdsFromProviders(resolvedConfig?.providers);
-  const cloudTargetDatabaseId = getCloudTargetDatabaseIdFromProviders(resolvedConfig?.providers);
+  const targetIds = getTargetIdsFromProviders(selectedProviderConfigs);
+  const cloudTargetDatabaseId = getCloudTargetDatabaseIdFromProviders(selectedProviderConfigs);
 
   logger.debug(
     `Extracted ${targetIds.length} target IDs from config providers: ${JSON.stringify(targetIds)}`,

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -41,7 +41,6 @@ import { getCustomPolicies } from '../../util/generation';
 import { printBorder, renderVarsInObject, setupEnv } from '../../util/index';
 import invariant from '../../util/invariant';
 import { promptfooCommand } from '../../util/promptfooCommand';
-import { normalizeProviderRef } from '../../util/providerRef';
 import { checkRedteamProbeLimit, MONTHLY_PROBE_LIMIT } from '../../util/redteamProbeLimit';
 import { isUuid } from '../../util/uuid';
 import { RedteamConfigSchema, RedteamGenerateOptionsSchema } from '../../validators/redteam';
@@ -164,9 +163,22 @@ function getTargetIdsFromProviders(providers: Partial<UnifiedConfig>['providers'
     return [];
   }
 
-  return providers.flatMap((provider, index) => {
-    const descriptor = normalizeProviderRef(provider, { index });
-    return descriptor.kind === 'unknown' || descriptor.kind === 'function' ? [] : [descriptor.id];
+  return providers.flatMap((provider) => {
+    if (typeof provider === 'string') {
+      return [provider];
+    }
+    if (typeof provider !== 'object' || provider === null || Array.isArray(provider)) {
+      return [];
+    }
+    if (typeof provider.id === 'string') {
+      return [provider.id];
+    }
+
+    try {
+      return getProviderIds([provider]);
+    } catch {
+      return [];
+    }
   });
 }
 

--- a/src/redteam/extraction/entities.ts
+++ b/src/redteam/extraction/entities.ts
@@ -3,13 +3,21 @@ import logger from '../../logger';
 import { shouldGenerateRemote } from '../remoteGeneration';
 import { callExtraction, fetchRemoteGeneration, formatPrompts } from './util';
 
-import type { ApiProvider } from '../../types/index';
+import type { ApiProvider, RemoteGenerationContext } from '../../types/index';
 import type { RedTeamTask } from './util';
 
-export async function extractEntities(provider: ApiProvider, prompts: string[]): Promise<string[]> {
+export async function extractEntities(
+  provider: ApiProvider,
+  prompts: string[],
+  generationContext?: RemoteGenerationContext,
+): Promise<string[]> {
   if (shouldGenerateRemote()) {
     try {
-      const result = await fetchRemoteGeneration('entities' as RedTeamTask, prompts);
+      const result = await fetchRemoteGeneration(
+        'entities' as RedTeamTask,
+        prompts,
+        generationContext,
+      );
       return result as string[];
     } catch (error) {
       logger.warn(

--- a/src/redteam/extraction/purpose.ts
+++ b/src/redteam/extraction/purpose.ts
@@ -3,7 +3,7 @@ import logger from '../../logger';
 import { neverGenerateRemote } from '../remoteGeneration';
 import { callExtraction, fetchRemoteGeneration, formatPrompts } from './util';
 
-import type { ApiProvider } from '../../types/index';
+import type { ApiProvider, RemoteGenerationContext } from '../../types/index';
 import type { RedTeamTask } from './util';
 
 export const DEFAULT_PURPOSE = 'An AI system';
@@ -11,6 +11,7 @@ export const DEFAULT_PURPOSE = 'An AI system';
 export async function extractSystemPurpose(
   provider: ApiProvider,
   prompts: string[],
+  generationContext?: RemoteGenerationContext,
 ): Promise<string> {
   const onlyTemplatePrompt =
     prompts.length === 1 && prompts[0] && prompts[0].trim().replace(/\s+/g, '') === '{{prompt}}';
@@ -22,7 +23,11 @@ export async function extractSystemPurpose(
 
   if (!neverGenerateRemote()) {
     try {
-      const result = await fetchRemoteGeneration('purpose' as RedTeamTask, prompts);
+      const result = await fetchRemoteGeneration(
+        'purpose' as RedTeamTask,
+        prompts,
+        generationContext,
+      );
       return result as string;
     } catch (error) {
       logger.warn(`[purpose] Error using remote generation, returning empty string: ${error}`);

--- a/src/redteam/extraction/util.ts
+++ b/src/redteam/extraction/util.ts
@@ -8,8 +8,9 @@ import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 
-import type { ApiProvider } from '../../types/index';
+import type { ApiProvider, RemoteGenerationContext } from '../../types/index';
 
 export const RedTeamGenerationResponse = z.object({
   task: z.string(),
@@ -23,6 +24,7 @@ export type RedTeamTask = 'purpose' | 'entities';
  *
  * @param task - The type of task to perform ('purpose' or 'entities').
  * @param prompts - An array of prompts to process.
+ * @param generationContext - Resolved target context for routing the remote task.
  * @returns A Promise that resolves to either a string or an array of strings, depending on the task.
  * @throws Will throw an error if the remote generation fails.
  *
@@ -35,6 +37,7 @@ export type RedTeamTask = 'purpose' | 'entities';
 export async function fetchRemoteGeneration(
   task: RedTeamTask,
   prompts: string[],
+  generationContext?: RemoteGenerationContext,
 ): Promise<string | string[]> {
   invariant(
     !getEnvBool('PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION'),
@@ -46,6 +49,7 @@ export async function fetchRemoteGeneration(
       prompts,
       version: VERSION,
       email: getUserEmail(),
+      ...remoteGenerationContextPayload(generationContext),
     };
 
     const response = await fetchWithCache(

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -956,6 +956,7 @@ function isStrategyCollection(id: string): id is keyof typeof STRATEGY_COLLECTIO
  */
 export async function synthesize({
   abortSignal,
+  cloudTargetDatabaseId: explicitCloudTargetDatabaseId,
   delay,
   entities: entitiesOverride,
   injectVar,
@@ -997,7 +998,8 @@ export async function synthesize({
     logger.warn('Delay is enabled, setting max concurrency to 1.');
   }
 
-  const cloudTargetDatabaseId = getCloudTargetDatabaseId(targetIds);
+  const cloudTargetDatabaseId =
+    explicitCloudTargetDatabaseId ?? getCloudTargetDatabaseId(targetIds);
 
   if (maxConcurrency > MAX_MAX_CONCURRENCY) {
     maxConcurrency = MAX_MAX_CONCURRENCY;
@@ -1369,6 +1371,7 @@ export async function synthesize({
           injectVar,
           n: plugin.numTests,
           delayMs: delay || 0,
+          targetId: cloudTargetDatabaseId,
           config: {
             ...resolvePluginConfigWithMaxChars(plugin.config, maxCharsPerMessage),
             ...(lang ? { language: lang } : {}),

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -601,6 +601,7 @@ async function applyStrategies(
   purpose: string,
   excludeTargetOutputFromAgenticAttackGeneration?: boolean,
   maxCharsPerMessage?: number,
+  targetId?: string,
 ): Promise<{
   testCases: TestCaseWithPlugin[];
   strategyResults: Record<string, { requested: number; generated: number }>;
@@ -680,6 +681,7 @@ async function applyStrategies(
         // Pass redteam provider from config so agentic strategies (iterative, crescendo, etc.) can use it
         redteamProvider: cliState.config?.redteam?.provider,
         excludeTargetOutputFromAgenticAttackGeneration,
+        ...(targetId ? { targetId } : {}),
       },
       strategy.id,
     );
@@ -1672,6 +1674,7 @@ export async function synthesize({
       purpose,
       undefined,
       maxCharsPerMessage,
+      cloudTargetDatabaseId,
     );
     pluginTestCases.push(...retryTestCases);
     Object.assign(strategyResults, retryResults);
@@ -1696,6 +1699,7 @@ export async function synthesize({
       purpose,
       excludeTargetOutputFromAgenticAttackGeneration,
       maxCharsPerMessage,
+      cloudTargetDatabaseId,
     );
 
   Object.assign(strategyResults, otherStrategyResults);

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -43,6 +43,10 @@ import { isValidPolicyObject, makeInlinePolicyIdSync } from './plugins/policy/ut
 import { redteamProviderManager } from './providers/shared';
 import { getRemoteHealthUrl, shouldGenerateRemote } from './remoteGeneration';
 import {
+  remoteGenerationContextPayload,
+  resolveRedteamGenerationContext,
+} from './remoteGenerationContext';
+import {
   getGeneratedPromptOverLimit,
   getMaxCharsPerMessageModifierValue,
   MAX_CHARS_PER_MESSAGE_MODIFIER_KEY,
@@ -61,13 +65,13 @@ import type { Inputs } from '../types/shared';
 import type {
   FailedPluginInfo,
   Policy,
+  RedteamGenerationContext,
   RedteamPluginObject,
   RedteamStrategyObject,
   SynthesizeOptions,
 } from './types';
 
 const MATERIALIZED_MULTI_INPUT_PROMPT_METADATA_KEY = '__promptfooMaterializedMultiInputPrompt';
-const CLOUD_TARGET_PROVIDER_PREFIX = 'promptfoo://provider/';
 
 function getMaterializedMultiInputPromptSnapshot(
   metadata: TestCase['metadata'] | undefined,
@@ -83,13 +87,6 @@ function getMaterializedMultiInputPromptMetadata(
   return typeof prompt === 'string'
     ? { [MATERIALIZED_MULTI_INPUT_PROMPT_METADATA_KEY]: prompt }
     : undefined;
-}
-
-function getCloudTargetDatabaseId(targetIds: string[]): string | undefined {
-  const cloudTargetId = targetIds.find((targetId) =>
-    targetId.startsWith(CLOUD_TARGET_PROVIDER_PREFIX),
-  );
-  return cloudTargetId?.slice(CLOUD_TARGET_PROVIDER_PREFIX.length);
 }
 
 function getPolicyText(metadata: TestCase['metadata'] | undefined): string | undefined {
@@ -601,7 +598,7 @@ async function applyStrategies(
   purpose: string,
   excludeTargetOutputFromAgenticAttackGeneration?: boolean,
   maxCharsPerMessage?: number,
-  targetId?: string,
+  redteamGenerationContext?: RedteamGenerationContext,
 ): Promise<{
   testCases: TestCaseWithPlugin[];
   strategyResults: Record<string, { requested: number; generated: number }>;
@@ -681,7 +678,7 @@ async function applyStrategies(
         // Pass redteam provider from config so agentic strategies (iterative, crescendo, etc.) can use it
         redteamProvider: cliState.config?.redteam?.provider,
         excludeTargetOutputFromAgenticAttackGeneration,
-        ...(targetId ? { targetId } : {}),
+        ...remoteGenerationContextPayload(redteamGenerationContext),
       },
       strategy.id,
     );
@@ -970,6 +967,7 @@ export async function synthesize({
   prompts,
   provider,
   purpose: purposeOverride,
+  redteamGenerationContext: inputRedteamGenerationContext,
   strategies,
   targetIds,
   showProgressBar: showProgressBarOverride,
@@ -1000,8 +998,12 @@ export async function synthesize({
     logger.warn('Delay is enabled, setting max concurrency to 1.');
   }
 
-  const cloudTargetDatabaseId =
-    explicitCloudTargetDatabaseId ?? getCloudTargetDatabaseId(targetIds);
+  const redteamGenerationContext = resolveRedteamGenerationContext({
+    cloudTargetDatabaseId: explicitCloudTargetDatabaseId,
+    redteamGenerationContext: inputRedteamGenerationContext,
+    targetIds,
+  });
+  const cloudTargetId = redteamGenerationContext.cloudTargetId;
 
   if (maxConcurrency > MAX_MAX_CONCURRENCY) {
     maxConcurrency = MAX_MAX_CONCURRENCY;
@@ -1373,7 +1375,8 @@ export async function synthesize({
           injectVar,
           n: plugin.numTests,
           delayMs: delay || 0,
-          targetId: cloudTargetDatabaseId,
+          targetId: cloudTargetId,
+          redteamGenerationContext,
           config: {
             ...resolvePluginConfigWithMaxChars(plugin.config, maxCharsPerMessage),
             ...(lang ? { language: lang } : {}),
@@ -1471,7 +1474,7 @@ export async function synthesize({
               purpose,
               plugin.id,
               policy,
-              cloudTargetDatabaseId,
+              cloudTargetId,
             );
 
             (testCase.metadata as any).goal = extractedGoal;
@@ -1609,7 +1612,7 @@ export async function synthesize({
               purpose,
               plugin.id,
               policy,
-              cloudTargetDatabaseId,
+              cloudTargetId,
             );
 
             (testCase.metadata as any).goal = extractedGoal;
@@ -1663,7 +1666,7 @@ export async function synthesize({
     }
     logger.debug('Applying retry strategy first');
     retryStrategy.config = {
-      targetIds,
+      targetIds: redteamGenerationContext.providerTargetIds,
       ...retryStrategy.config,
     };
     const { testCases: retryTestCases, strategyResults: retryResults } = await applyStrategies(
@@ -1674,7 +1677,7 @@ export async function synthesize({
       purpose,
       undefined,
       maxCharsPerMessage,
-      cloudTargetDatabaseId,
+      redteamGenerationContext,
     );
     pluginTestCases.push(...retryTestCases);
     Object.assign(strategyResults, retryResults);
@@ -1699,7 +1702,7 @@ export async function synthesize({
       purpose,
       excludeTargetOutputFromAgenticAttackGeneration,
       maxCharsPerMessage,
-      cloudTargetDatabaseId,
+      redteamGenerationContext,
     );
 
   Object.assign(strategyResults, otherStrategyResults);

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -1323,7 +1323,9 @@ export async function synthesize({
   } else {
     logger.info('Extracting system purpose...');
   }
-  const purpose = purposeOverride || (await extractSystemPurpose(redteamProvider, prompts));
+  const purpose =
+    purposeOverride ||
+    (await extractSystemPurpose(redteamProvider, prompts, redteamGenerationContext));
 
   if (showProgressBar) {
     progressBar?.update({ task: 'Extracting entities' });
@@ -1332,7 +1334,7 @@ export async function synthesize({
   }
   const entities: string[] = Array.isArray(entitiesOverride)
     ? entitiesOverride
-    : await extractEntities(redteamProvider, prompts);
+    : await extractEntities(redteamProvider, prompts, redteamGenerationContext);
 
   logger.debug(`System purpose: ${purpose}`);
 

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -67,6 +67,7 @@ import type {
 } from './types';
 
 const MATERIALIZED_MULTI_INPUT_PROMPT_METADATA_KEY = '__promptfooMaterializedMultiInputPrompt';
+const CLOUD_TARGET_PROVIDER_PREFIX = 'promptfoo://provider/';
 
 function getMaterializedMultiInputPromptSnapshot(
   metadata: TestCase['metadata'] | undefined,
@@ -82,6 +83,13 @@ function getMaterializedMultiInputPromptMetadata(
   return typeof prompt === 'string'
     ? { [MATERIALIZED_MULTI_INPUT_PROMPT_METADATA_KEY]: prompt }
     : undefined;
+}
+
+function getCloudTargetDatabaseId(targetIds: string[]): string | undefined {
+  const cloudTargetId = targetIds.find((targetId) =>
+    targetId.startsWith(CLOUD_TARGET_PROVIDER_PREFIX),
+  );
+  return cloudTargetId?.slice(CLOUD_TARGET_PROVIDER_PREFIX.length);
 }
 
 function getPolicyText(metadata: TestCase['metadata'] | undefined): string | undefined {
@@ -989,6 +997,8 @@ export async function synthesize({
     logger.warn('Delay is enabled, setting max concurrency to 1.');
   }
 
+  const cloudTargetDatabaseId = getCloudTargetDatabaseId(targetIds);
+
   if (maxConcurrency > MAX_MAX_CONCURRENCY) {
     maxConcurrency = MAX_MAX_CONCURRENCY;
     logger.info(`Max concurrency for test generation is capped at ${MAX_MAX_CONCURRENCY}.`);
@@ -1451,7 +1461,13 @@ export async function synthesize({
             const prompt = Array.isArray(promptVar) ? promptVar[0] : String(promptVar);
 
             const policy = getPolicyText(testCase.metadata);
-            const extractedGoal = await extractGoalFromPrompt(prompt, purpose, plugin.id, policy);
+            const extractedGoal = await extractGoalFromPrompt(
+              prompt,
+              purpose,
+              plugin.id,
+              policy,
+              cloudTargetDatabaseId,
+            );
 
             (testCase.metadata as any).goal = extractedGoal;
           }
@@ -1583,7 +1599,13 @@ export async function synthesize({
             const prompt = Array.isArray(promptVar) ? promptVar[0] : String(promptVar);
 
             const policy = getPolicyText(testCase.metadata);
-            const extractedGoal = await extractGoalFromPrompt(prompt, purpose, plugin.id, policy);
+            const extractedGoal = await extractGoalFromPrompt(
+              prompt,
+              purpose,
+              plugin.id,
+              policy,
+              cloudTargetDatabaseId,
+            );
 
             (testCase.metadata as any).goal = extractedGoal;
           }

--- a/src/redteam/plugins/harmful/unaligned.ts
+++ b/src/redteam/plugins/harmful/unaligned.ts
@@ -74,7 +74,7 @@ async function processPromptForInputs(
 }
 
 export async function getHarmfulTests(
-  { purpose, injectVar, n, delayMs = 0, config }: PluginActionParams,
+  { purpose, injectVar, n, delayMs = 0, config, targetId }: PluginActionParams,
   plugin: keyof typeof UNALIGNED_PROVIDER_HARM_PLUGINS,
 ): Promise<TestCase[]> {
   const maxHarmfulTests = getEnvInt('PROMPTFOO_MAX_HARMFUL_TESTS_PER_REQUEST', 5);
@@ -83,6 +83,7 @@ export async function getHarmfulTests(
     n: Math.min(n, maxHarmfulTests),
     harmCategory: plugin,
     config,
+    targetId,
   });
 
   const generatePrompts = async (): Promise<string[]> => {

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -90,6 +90,7 @@ type PluginClass<T extends PluginConfig> = new (
   purpose: string,
   injectVar: string,
   config: T,
+  targetId?: string,
 ) => RedteamPluginBase;
 
 const MAX_CHARS_RETRY_MODIFIER_KEY = '__maxCharsPerMessageRetry';
@@ -339,6 +340,7 @@ async function fetchRemoteTestCases(
   injectVar: string,
   n: number,
   config: PluginConfig,
+  targetId?: string,
 ): Promise<TestCase[]> {
   invariant(
     !getEnvBool('PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION'),
@@ -373,6 +375,7 @@ async function fetchRemoteTestCases(
     n,
     purpose,
     task: key,
+    ...(targetId ? { targetId } : {}),
     version: VERSION,
     email: getUserEmail(),
   });
@@ -415,15 +418,26 @@ function createPluginFactory<T extends PluginConfig>(
   return {
     key,
     validate: validate as ((config: PluginConfig) => void) | undefined,
-    action: async ({ provider, purpose, injectVar, n, delayMs, config }: PluginActionParams) => {
+    action: async ({
+      provider,
+      purpose,
+      injectVar,
+      n,
+      delayMs,
+      config,
+      targetId,
+    }: PluginActionParams) => {
       const configWithDefaults = applyDefaultGraderExamples(key, config as T);
 
       if ((PluginClass as any).canGenerateRemote === false || !shouldGenerateRemote()) {
         logger.debug(`Using local redteam generation for ${key}`);
-        return new PluginClass(provider, purpose, injectVar, configWithDefaults as T).generateTests(
-          n,
-          delayMs,
-        );
+        return new PluginClass(
+          provider,
+          purpose,
+          injectVar,
+          configWithDefaults as T,
+          targetId,
+        ).generateTests(n, delayMs);
       }
       const pluginId = getShortPluginId(key);
       const testCases = await fetchRemoteTestCases(
@@ -432,6 +446,7 @@ function createPluginFactory<T extends PluginConfig>(
         injectVar,
         n,
         configWithDefaults ?? {},
+        targetId,
       );
       const computedModifiers = computeModifiersFromConfig(configWithDefaults);
 
@@ -557,6 +572,7 @@ const piiPlugins: PluginFactory[] = PII_PLUGINS.map((category: string) => ({
         params.injectVar,
         params.n,
         params.config ?? {},
+        params.targetId,
       );
       const computedModifiers = computeModifiersFromConfig(params.config);
       return testCases.map((testCase) => ({
@@ -598,6 +614,7 @@ const biasPlugins: PluginFactory[] = BIAS_PLUGINS.map((category: string) => ({
       params.injectVar,
       params.n,
       params.config ?? {},
+      params.targetId,
     );
     const computedModifiers = computeModifiersFromConfig(params.config);
     return testCases.map((testCase) => ({
@@ -621,7 +638,7 @@ function createRemotePlugin<T extends PluginConfig>(
   return {
     key,
     validate: validate as ((config: PluginConfig) => void) | undefined,
-    action: async ({ purpose, injectVar, n, config }: PluginActionParams) => {
+    action: async ({ purpose, injectVar, n, config, targetId }: PluginActionParams) => {
       const configWithDefaults = applyDefaultRemotePluginConfig(key, config);
 
       if (neverGenerateRemote()) {
@@ -635,6 +652,7 @@ function createRemotePlugin<T extends PluginConfig>(
         injectVar,
         n,
         configWithDefaults ?? {},
+        targetId,
       );
       const computedModifiers = computeModifiersFromConfig(configWithDefaults);
       const testsWithMetadata = testCases.map((testCase) => ({

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -26,6 +26,10 @@ import {
   shouldGenerateRemote,
 } from '../remoteGeneration';
 import {
+  type RedteamGenerationContext,
+  remoteGenerationContextPayload,
+} from '../remoteGenerationContext';
+import {
   assertRemoteMaterializationHandled,
   type RemoteMaterializationResponse,
   requiresRemoteMaterialization,
@@ -340,7 +344,7 @@ async function fetchRemoteTestCases(
   injectVar: string,
   n: number,
   config: PluginConfig,
-  targetId?: string,
+  redteamGenerationContext?: RedteamGenerationContext | string,
 ): Promise<TestCase[]> {
   invariant(
     !getEnvBool('PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION'),
@@ -375,7 +379,7 @@ async function fetchRemoteTestCases(
     n,
     purpose,
     task: key,
-    ...(targetId ? { targetId } : {}),
+    ...remoteGenerationContextPayload(redteamGenerationContext),
     version: VERSION,
     email: getUserEmail(),
   });
@@ -426,6 +430,7 @@ function createPluginFactory<T extends PluginConfig>(
       delayMs,
       config,
       targetId,
+      redteamGenerationContext,
     }: PluginActionParams) => {
       const configWithDefaults = applyDefaultGraderExamples(key, config as T);
 
@@ -446,7 +451,7 @@ function createPluginFactory<T extends PluginConfig>(
         injectVar,
         n,
         configWithDefaults ?? {},
-        targetId,
+        redteamGenerationContext ?? targetId,
       );
       const computedModifiers = computeModifiersFromConfig(configWithDefaults);
 
@@ -638,7 +643,14 @@ function createRemotePlugin<T extends PluginConfig>(
   return {
     key,
     validate: validate as ((config: PluginConfig) => void) | undefined,
-    action: async ({ purpose, injectVar, n, config, targetId }: PluginActionParams) => {
+    action: async ({
+      purpose,
+      injectVar,
+      n,
+      config,
+      targetId,
+      redteamGenerationContext,
+    }: PluginActionParams) => {
       const configWithDefaults = applyDefaultRemotePluginConfig(key, config);
 
       if (neverGenerateRemote()) {
@@ -652,7 +664,7 @@ function createRemotePlugin<T extends PluginConfig>(
         injectVar,
         n,
         configWithDefaults ?? {},
-        targetId,
+        redteamGenerationContext ?? targetId,
       );
       const computedModifiers = computeModifiersFromConfig(configWithDefaults);
       const testsWithMetadata = testCases.map((testCase) => ({

--- a/src/redteam/plugins/intent.ts
+++ b/src/redteam/plugins/intent.ts
@@ -23,7 +23,13 @@ export class IntentPlugin extends RedteamPluginBase {
   static readonly canGenerateRemote = false;
   private intents: (string | string[])[];
 
-  constructor(provider: ApiProvider, purpose: string, injectVar: string, config: PluginConfig) {
+  constructor(
+    provider: ApiProvider,
+    purpose: string,
+    injectVar: string,
+    config: PluginConfig,
+    private readonly targetId?: string,
+  ) {
     super(provider, purpose, injectVar, config);
     invariant(config.intent, 'An "intent" property is required for the intent plugin.');
     // Handle both string and array configs
@@ -52,7 +58,13 @@ export class IntentPlugin extends RedteamPluginBase {
 
     for (const intent of this.intents) {
       if (typeof intent === 'string') {
-        const extractedIntent = await extractGoalFromPrompt(intent, this.purpose, this.id);
+        const extractedIntent = await extractGoalFromPrompt(
+          intent,
+          this.purpose,
+          this.id,
+          undefined,
+          this.targetId,
+        );
 
         testCases.push({
           vars: {
@@ -67,7 +79,13 @@ export class IntentPlugin extends RedteamPluginBase {
         });
       } else {
         const firstPrompt = Array.isArray(intent) ? intent[0] : intent;
-        const extractedIntent = await extractGoalFromPrompt(firstPrompt, this.purpose, this.id);
+        const extractedIntent = await extractGoalFromPrompt(
+          firstPrompt,
+          this.purpose,
+          this.id,
+          undefined,
+          this.targetId,
+        );
 
         testCases.push({
           vars: {

--- a/src/redteam/providers/agentic/memoryPoisoning.ts
+++ b/src/redteam/providers/agentic/memoryPoisoning.ts
@@ -6,6 +6,7 @@ import invariant from '../../../util/invariant';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../../util/tokenUsageUtils';
 import { REDTEAM_MEMORY_POISONING_PLUGIN_ID } from '../../plugins/agentic/constants';
 import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../../remoteGeneration';
+import { remoteGenerationContextPayload } from '../../remoteGenerationContext';
 import { throwIfTargetPromptExceedsMaxChars } from '../../shared/promptLength';
 import { messagesToRedteamHistory } from '../shared';
 
@@ -68,7 +69,7 @@ export class MemoryPoisoningProvider implements ApiProvider {
         {
           body: JSON.stringify({
             task: 'agentic:memory-poisoning-scenario',
-            ...(this.targetId ? { targetId: this.targetId } : {}),
+            ...remoteGenerationContextPayload(this.targetId),
             purpose,
             version: VERSION,
             email: getUserEmail(),

--- a/src/redteam/providers/agentic/memoryPoisoning.ts
+++ b/src/redteam/providers/agentic/memoryPoisoning.ts
@@ -17,8 +17,21 @@ import type {
   ProviderResponse,
 } from '../../../types/providers';
 
+interface MemoryPoisoningConfig extends ProviderOptions {
+  targetId?: string;
+}
+
 export class MemoryPoisoningProvider implements ApiProvider {
-  constructor(readonly config: ProviderOptions) {}
+  constructor(readonly config: MemoryPoisoningConfig) {}
+
+  private get targetId(): string | undefined {
+    if (typeof this.config.targetId === 'string') {
+      return this.config.targetId;
+    }
+    return typeof this.config.config?.targetId === 'string'
+      ? this.config.config.targetId
+      : undefined;
+  }
 
   id() {
     return REDTEAM_MEMORY_POISONING_PLUGIN_ID;
@@ -55,6 +68,7 @@ export class MemoryPoisoningProvider implements ApiProvider {
         {
           body: JSON.stringify({
             task: 'agentic:memory-poisoning-scenario',
+            ...(this.targetId ? { targetId: this.targetId } : {}),
             purpose,
             version: VERSION,
             email: getUserEmail(),

--- a/src/redteam/providers/authoritativeMarkupInjection.ts
+++ b/src/redteam/providers/authoritativeMarkupInjection.ts
@@ -11,6 +11,7 @@ import {
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
 
 import type {
@@ -73,7 +74,7 @@ export default class AuthoritativeMarkupInjectionProvider implements ApiProvider
       i: 0,
       prompt: context?.prompt?.raw,
       task: 'authoritative-markup-injection',
-      ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
+      ...remoteGenerationContextPayload(this.config.targetId),
       version: VERSION,
       email: getUserEmail(),
       purpose: context?.test?.metadata?.purpose,

--- a/src/redteam/providers/authoritativeMarkupInjection.ts
+++ b/src/redteam/providers/authoritativeMarkupInjection.ts
@@ -23,6 +23,7 @@ import type {
 
 interface AuthoritativeMarkupInjectionConfig {
   injectVar: string;
+  targetId?: string;
 }
 
 export default class AuthoritativeMarkupInjectionProvider implements ApiProvider {
@@ -35,6 +36,7 @@ export default class AuthoritativeMarkupInjectionProvider implements ApiProvider
   constructor(
     options: ProviderOptions & {
       injectVar?: string;
+      targetId?: string;
     } = {},
   ) {
     if (neverGenerateRemote()) {
@@ -45,6 +47,7 @@ export default class AuthoritativeMarkupInjectionProvider implements ApiProvider
     invariant(typeof options.injectVar === 'string', 'Expected injectVar to be set');
     this.config = {
       injectVar: options.injectVar,
+      targetId: options.targetId,
     };
     logger.debug('[AuthoritativeMarkupInjection] Constructor options', {
       injectVar: options.injectVar,
@@ -70,6 +73,7 @@ export default class AuthoritativeMarkupInjectionProvider implements ApiProvider
       i: 0,
       prompt: context?.prompt?.raw,
       task: 'authoritative-markup-injection',
+      ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
       version: VERSION,
       email: getUserEmail(),
       purpose: context?.test?.metadata?.purpose,

--- a/src/redteam/providers/bestOfN.ts
+++ b/src/redteam/providers/bestOfN.ts
@@ -31,6 +31,7 @@ interface BestOfNResponse {
 
 interface BestOfNConfig {
   injectVar: string;
+  targetId?: string;
   maxConcurrency: number;
   nSteps?: number;
   maxCandidatesPerStep?: number;
@@ -49,6 +50,7 @@ export default class BestOfNProvider implements ApiProvider {
       maxConcurrency?: number;
       nSteps?: number;
       maxCandidatesPerStep?: number;
+      targetId?: string;
     } = {},
   ) {
     if (neverGenerateRemote()) {
@@ -61,6 +63,7 @@ export default class BestOfNProvider implements ApiProvider {
       maxConcurrency: options.maxConcurrency || 3,
       nSteps: options.nSteps,
       maxCandidatesPerStep: options.maxCandidatesPerStep,
+      targetId: options.targetId,
     };
   }
 
@@ -85,6 +88,7 @@ export default class BestOfNProvider implements ApiProvider {
           headers: getRemoteGenerationHeaders(),
           body: JSON.stringify({
             task: 'jailbreak:best-of-n',
+            ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
             prompt: context.vars[this.config.injectVar],
             nSteps: this.config.nSteps,
             maxCandidatesPerStep: this.config.maxCandidatesPerStep,

--- a/src/redteam/providers/bestOfN.ts
+++ b/src/redteam/providers/bestOfN.ts
@@ -14,6 +14,7 @@ import {
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
 import { getSessionId } from '../util';
 
@@ -88,7 +89,7 @@ export default class BestOfNProvider implements ApiProvider {
           headers: getRemoteGenerationHeaders(),
           body: JSON.stringify({
             task: 'jailbreak:best-of-n',
-            ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
+            ...remoteGenerationContextPayload(this.config.targetId),
             prompt: context.vars[this.config.injectVar],
             nSteps: this.config.nSteps,
             maxCandidatesPerStep: this.config.maxCandidatesPerStep,

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -222,6 +222,7 @@ export class CrescendoProvider implements ApiProvider {
           task: 'crescendo',
           jsonOnly: true,
           preferSmallModel: false,
+          ...(typeof this.config.targetId === 'string' ? { targetId: this.config.targetId } : {}),
           // Pass inputs schema for multi-input mode
           inputs: this.config.inputs,
         });
@@ -243,6 +244,7 @@ export class CrescendoProvider implements ApiProvider {
           task: 'crescendo',
           jsonOnly: false,
           preferSmallModel: false,
+          ...(typeof this.config.targetId === 'string' ? { targetId: this.config.targetId } : {}),
         });
       } else {
         // Don't pass explicit provider - let getGradingProvider check CLI --grader first
@@ -496,6 +498,7 @@ export class CrescendoProvider implements ApiProvider {
           lastResponse: lastResponse.output,
           goal: this.userGoal,
           purpose: context?.test?.metadata?.purpose,
+          targetId: typeof this.config.targetId === 'string' ? this.config.targetId : undefined,
         });
 
         if (unblockingResult.success && unblockingResult.unblockingPrompt) {
@@ -1097,6 +1100,7 @@ export class CrescendoProvider implements ApiProvider {
         this.perTurnLayers,
         Strategies,
         {
+          targetId: typeof this.config.targetId === 'string' ? this.config.targetId : undefined,
           evaluationId: context?.evaluationId,
           testCaseId: context?.test?.metadata?.testCaseId as string | undefined,
           purpose: context?.test?.metadata?.purpose as string | undefined,

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -19,6 +19,7 @@ import {
   materializeInputVariablesWithMetadata,
 } from '../../inputVariables';
 import { shouldGenerateRemote } from '../../remoteGeneration';
+import { remoteGenerationContextPayload } from '../../remoteGenerationContext';
 import {
   assertRemoteMaterializationHandled,
   buildRemoteMaterializationContextVars,
@@ -222,7 +223,7 @@ export class CrescendoProvider implements ApiProvider {
           task: 'crescendo',
           jsonOnly: true,
           preferSmallModel: false,
-          ...(typeof this.config.targetId === 'string' ? { targetId: this.config.targetId } : {}),
+          ...remoteGenerationContextPayload(this.config.targetId),
           // Pass inputs schema for multi-input mode
           inputs: this.config.inputs,
         });
@@ -244,7 +245,7 @@ export class CrescendoProvider implements ApiProvider {
           task: 'crescendo',
           jsonOnly: false,
           preferSmallModel: false,
-          ...(typeof this.config.targetId === 'string' ? { targetId: this.config.targetId } : {}),
+          ...remoteGenerationContextPayload(this.config.targetId),
         });
       } else {
         // Don't pass explicit provider - let getGradingProvider check CLI --grader first

--- a/src/redteam/providers/custom/index.ts
+++ b/src/redteam/providers/custom/index.ts
@@ -130,6 +130,7 @@ export interface CustomResponse extends ProviderResponse {
 interface CustomConfig {
   injectVar: string;
   strategyText: string;
+  targetId?: string;
   maxTurns?: number;
   maxBacktracks?: number;
   redteamProvider: RedteamFileConfig['provider'];
@@ -223,6 +224,7 @@ export class CustomProvider implements ApiProvider {
           task: 'crescendo',
           jsonOnly: true,
           preferSmallModel: false,
+          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
         });
       } else {
         this.redTeamProvider = await redteamProviderManager.getProvider({
@@ -242,6 +244,7 @@ export class CustomProvider implements ApiProvider {
           task: 'crescendo',
           jsonOnly: false,
           preferSmallModel: false,
+          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
         });
       } else {
         this.scoringProvider = await redteamProviderManager.getProvider({
@@ -452,6 +455,7 @@ export class CustomProvider implements ApiProvider {
           lastResponse: lastResponse.output,
           goal: this.userGoal,
           purpose: context?.test?.metadata?.purpose,
+          targetId: this.config.targetId,
         });
 
         if (unblockingResult.success && unblockingResult.unblockingPrompt) {
@@ -850,6 +854,7 @@ export class CustomProvider implements ApiProvider {
         this.config.injectVar,
         this.perTurnLayers,
         Strategies,
+        { targetId: this.config.targetId },
       );
 
       if (lastTransformResult.error) {

--- a/src/redteam/providers/custom/index.ts
+++ b/src/redteam/providers/custom/index.ts
@@ -10,6 +10,7 @@ import { sleep } from '../../../util/time';
 import { TokenUsageTracker } from '../../../util/tokenUsage';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../../util/tokenUsageUtils';
 import { shouldGenerateRemote } from '../../remoteGeneration';
+import { remoteGenerationContextPayload } from '../../remoteGenerationContext';
 import {
   applyRuntimeTransforms,
   type LayerConfig,
@@ -224,7 +225,7 @@ export class CustomProvider implements ApiProvider {
           task: 'crescendo',
           jsonOnly: true,
           preferSmallModel: false,
-          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
+          ...remoteGenerationContextPayload(this.config.targetId),
         });
       } else {
         this.redTeamProvider = await redteamProviderManager.getProvider({
@@ -244,7 +245,7 @@ export class CustomProvider implements ApiProvider {
           task: 'crescendo',
           jsonOnly: false,
           preferSmallModel: false,
-          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
+          ...remoteGenerationContextPayload(this.config.targetId),
         });
       } else {
         this.scoringProvider = await redteamProviderManager.getProvider({

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -100,6 +100,7 @@ export interface ExtractAttackFailureResponse {
 
 interface GoatConfig {
   injectVar: string;
+  targetId?: string;
   maxCharsPerMessage?: number;
   maxTurns: number;
   excludeTargetOutputFromAgenticAttackGeneration: boolean;
@@ -151,6 +152,7 @@ export default class GoatProvider implements ApiProvider {
       tracing?: RawTracingConfig;
       _perTurnLayers?: LayerConfig[];
       inputs?: Inputs;
+      targetId?: string;
     } = {},
   ) {
     if (neverGenerateRemote()) {
@@ -173,6 +175,7 @@ export default class GoatProvider implements ApiProvider {
       tracing: options.tracing,
       _perTurnLayers: options._perTurnLayers,
       inputs: options.inputs,
+      targetId: options.targetId,
     };
     this.perTurnLayers = options._perTurnLayers ?? [];
     this.nunjucks = getNunjucksEngine();
@@ -276,6 +279,7 @@ export default class GoatProvider implements ApiProvider {
             lastResponse: previousTargetOutput,
             goal: context?.test?.metadata?.goal || context?.vars[this.config.injectVar],
             purpose: context?.test?.metadata?.purpose,
+            targetId: this.config.targetId,
           });
 
           if (unblockingResult.success && unblockingResult.unblockingPrompt) {
@@ -298,6 +302,7 @@ export default class GoatProvider implements ApiProvider {
                 this.perTurnLayers,
                 Strategies,
                 {
+                  targetId: this.config.targetId,
                   evaluationId: context?.evaluationId,
                   testCaseId: context?.test?.metadata?.testCaseId as string | undefined,
                   purpose: context?.test?.metadata?.purpose as string | undefined,
@@ -352,6 +357,7 @@ export default class GoatProvider implements ApiProvider {
             targetOutput: previousTargetOutput,
             attackAttempt: previousAttackerMessage,
             task: 'extract-goat-failure',
+            ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
             modifiers: context?.test?.metadata?.modifiers,
             traceSummary: previousTraceSummary,
           });
@@ -383,6 +389,7 @@ export default class GoatProvider implements ApiProvider {
             : messages,
           prompt: context?.prompt?.raw,
           task: 'goat',
+          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
           version: VERSION,
           email: getUserEmail(),
           excludeTargetOutputFromAgenticAttackGeneration:
@@ -503,6 +510,7 @@ export default class GoatProvider implements ApiProvider {
             this.perTurnLayers,
             Strategies,
             {
+              targetId: this.config.targetId,
               evaluationId: context?.evaluationId,
               testCaseId: context?.test?.metadata?.testCaseId as string | undefined,
               purpose: context?.test?.metadata?.purpose as string | undefined,

--- a/src/redteam/providers/goat.ts
+++ b/src/redteam/providers/goat.ts
@@ -21,6 +21,7 @@ import {
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import {
   assertRemoteMaterializationHandled,
   buildRemoteMaterializedInputVariables,
@@ -357,7 +358,7 @@ export default class GoatProvider implements ApiProvider {
             targetOutput: previousTargetOutput,
             attackAttempt: previousAttackerMessage,
             task: 'extract-goat-failure',
-            ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
+            ...remoteGenerationContextPayload(this.config.targetId),
             modifiers: context?.test?.metadata?.modifiers,
             traceSummary: previousTraceSummary,
           });
@@ -389,7 +390,7 @@ export default class GoatProvider implements ApiProvider {
             : messages,
           prompt: context?.prompt?.raw,
           task: 'goat',
-          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
+          ...remoteGenerationContextPayload(this.config.targetId),
           version: VERSION,
           email: getUserEmail(),
           excludeTargetOutputFromAgenticAttackGeneration:

--- a/src/redteam/providers/hydra/index.ts
+++ b/src/redteam/providers/hydra/index.ts
@@ -106,6 +106,7 @@ interface HydraResponse extends ProviderResponse {
 interface HydraConfig {
   injectVar: string;
   scanId?: string;
+  targetId?: string;
   maxTurns?: number;
   maxBacktracks?: number;
   stateful?: boolean;
@@ -187,6 +188,7 @@ export class HydraProvider implements ApiProvider {
       task: 'hydra-decision',
       jsonOnly: true,
       preferSmallModel: false,
+      ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
       // Pass inputs schema for multi-input mode
       inputs: this.config.inputs,
     });
@@ -550,6 +552,7 @@ export class HydraProvider implements ApiProvider {
           this.perTurnLayers,
           Strategies,
           {
+            targetId: this.config.targetId,
             evaluationId: context?.evaluationId,
             testCaseId: test?.metadata?.testCaseId as string | undefined,
             purpose: test?.metadata?.purpose as string | undefined,

--- a/src/redteam/providers/hydra/index.ts
+++ b/src/redteam/providers/hydra/index.ts
@@ -20,6 +20,7 @@ import {
   neverGenerateRemote,
   shouldGenerateRemote,
 } from '../../remoteGeneration';
+import { remoteGenerationContextPayload } from '../../remoteGenerationContext';
 import {
   assertRemoteMaterializationHandled,
   buildRemoteMaterializedInputVariables,
@@ -188,7 +189,7 @@ export class HydraProvider implements ApiProvider {
       task: 'hydra-decision',
       jsonOnly: true,
       preferSmallModel: false,
-      ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
+      ...remoteGenerationContextPayload(this.config.targetId),
       // Pass inputs schema for multi-input mode
       inputs: this.config.inputs,
     });

--- a/src/redteam/providers/indirectWebPwn.ts
+++ b/src/redteam/providers/indirectWebPwn.ts
@@ -6,6 +6,7 @@ import { fetchWithRetries } from '../../util/fetch/index';
 import invariant from '../../util/invariant';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import { getTargetResponse } from './shared';
 
 import type {
@@ -29,6 +30,7 @@ interface IndirectWebPwnConfig {
   maxFetchAttempts: number;
   stateful: boolean;
   scanId: string;
+  targetId?: string;
   useLlm: boolean;
   preferSmallModel: boolean;
   [key: string]: unknown;
@@ -83,6 +85,7 @@ export default class IndirectWebPwnProvider implements ApiProvider {
       maxFetchAttempts?: number;
       stateful?: boolean;
       scanId?: string;
+      targetId?: string;
       useLlm?: boolean;
       preferSmallModel?: boolean;
     } = {},
@@ -95,6 +98,7 @@ export default class IndirectWebPwnProvider implements ApiProvider {
       maxFetchAttempts: options.maxFetchAttempts ?? 3,
       stateful: options.stateful ?? false,
       scanId: options.scanId ?? randomUUID(),
+      targetId: options.targetId,
       useLlm: options.useLlm ?? true,
       preferSmallModel: options.preferSmallModel ?? true,
     };
@@ -105,6 +109,7 @@ export default class IndirectWebPwnProvider implements ApiProvider {
       maxFetchAttempts: this.config.maxFetchAttempts,
       stateful: this.config.stateful,
       scanId: this.config.scanId,
+      targetId: this.config.targetId,
       useLlm: this.config.useLlm,
       preferSmallModel: this.config.preferSmallModel,
     });
@@ -147,6 +152,7 @@ export default class IndirectWebPwnProvider implements ApiProvider {
           email: getUserEmail(),
           useLlm: this.config.useLlm,
           preferSmallModel: this.config.preferSmallModel,
+          ...remoteGenerationContextPayload(this.config.targetId),
         }),
       },
       60000, // 60s timeout for LLM generation
@@ -177,6 +183,7 @@ export default class IndirectWebPwnProvider implements ApiProvider {
           uuid,
           evalId,
           email: getUserEmail(),
+          ...remoteGenerationContextPayload(this.config.targetId),
         }),
       },
       10000,

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -20,6 +20,7 @@ import {
   materializeInputVariablesWithMetadata,
 } from '../inputVariables';
 import { shouldGenerateRemote } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import {
   assertRemoteMaterializationHandled,
   buildRemoteMaterializationContextVars,
@@ -858,13 +859,13 @@ class RedteamIterativeProvider implements ApiProvider {
         task: 'judge',
         jsonOnly: true,
         preferSmallModel: false,
-        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
+        ...remoteGenerationContextPayload(config.targetId),
       });
       this.redteamProvider = new PromptfooChatCompletionProvider({
         task: 'iterative',
         jsonOnly: true,
         preferSmallModel: false,
-        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
+        ...remoteGenerationContextPayload(config.targetId),
         // Pass inputs schema for multi-input mode
         inputs: this.inputs,
       });

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -128,6 +128,7 @@ export async function runRedteamConversation({
   excludeTargetOutputFromAgenticAttackGeneration,
   perTurnLayers = [],
   inputs,
+  targetId,
 }: {
   context?: CallApiContextParams;
   filters: NunjucksFilterMap | undefined;
@@ -143,6 +144,7 @@ export async function runRedteamConversation({
   excludeTargetOutputFromAgenticAttackGeneration: boolean;
   perTurnLayers?: LayerConfig[];
   inputs?: Inputs;
+  targetId?: string;
 }): Promise<{
   output: string;
   prompt?: string;
@@ -350,6 +352,7 @@ export async function runRedteamConversation({
         perTurnLayers,
         Strategies,
         {
+          targetId,
           evaluationId: context?.evaluationId,
           testCaseId: test?.metadata?.testCaseId as string | undefined,
           purpose: test?.metadata?.purpose as string | undefined,
@@ -855,11 +858,13 @@ class RedteamIterativeProvider implements ApiProvider {
         task: 'judge',
         jsonOnly: true,
         preferSmallModel: false,
+        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
       });
       this.redteamProvider = new PromptfooChatCompletionProvider({
         task: 'iterative',
         jsonOnly: true,
         preferSmallModel: false,
+        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
         // Pass inputs schema for multi-input mode
         inputs: this.inputs,
       });
@@ -915,6 +920,7 @@ class RedteamIterativeProvider implements ApiProvider {
       excludeTargetOutputFromAgenticAttackGeneration:
         this.excludeTargetOutputFromAgenticAttackGeneration,
       inputs: this.inputs,
+      targetId: typeof this.config.targetId === 'string' ? this.config.targetId : undefined,
     });
   }
 }

--- a/src/redteam/providers/iterativeMeta.ts
+++ b/src/redteam/providers/iterativeMeta.ts
@@ -117,6 +117,7 @@ export async function runMetaAgentRedteam({
   excludeTargetOutputFromAgenticAttackGeneration = false,
   perTurnLayers = [],
   inputs,
+  targetId,
 }: {
   context?: CallApiContextParams;
   filters: NunjucksFilterMap | undefined;
@@ -132,6 +133,7 @@ export async function runMetaAgentRedteam({
   excludeTargetOutputFromAgenticAttackGeneration?: boolean;
   inputs?: Inputs;
   perTurnLayers?: LayerConfig[];
+  targetId?: string;
 }): Promise<{
   output: string;
   prompt?: string;
@@ -305,6 +307,7 @@ export async function runMetaAgentRedteam({
 
       // Build context for runtime transforms (needed by indirect-web-pwn for server-side tracking)
       const transformContext: RuntimeTransformContext = {
+        targetId,
         evaluationId: context?.evaluationId,
         testCaseId: context?.testCaseId || (test?.metadata?.testCaseId as string | undefined),
         purpose: test?.metadata?.purpose as string | undefined,
@@ -718,11 +721,13 @@ class RedteamIterativeMetaProvider implements ApiProvider {
       task: 'judge',
       jsonOnly: true,
       preferSmallModel: false,
+      ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
     });
     this.agentProvider = new PromptfooChatCompletionProvider({
       task: 'meta-agent-decision',
       jsonOnly: true,
       preferSmallModel: false,
+      ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
       // Pass inputs schema for multi-input mode
       inputs: this.inputs,
     });
@@ -769,6 +774,7 @@ class RedteamIterativeMetaProvider implements ApiProvider {
       excludeTargetOutputFromAgenticAttackGeneration:
         this.excludeTargetOutputFromAgenticAttackGeneration,
       inputs: this.inputs,
+      targetId: typeof this.config.targetId === 'string' ? this.config.targetId : undefined,
     });
   }
 }

--- a/src/redteam/providers/iterativeMeta.ts
+++ b/src/redteam/providers/iterativeMeta.ts
@@ -18,6 +18,7 @@ import {
   neverGenerateRemote,
   shouldGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import {
   assertRemoteMaterializationHandled,
   buildRemoteMaterializationContextVars,
@@ -721,13 +722,13 @@ class RedteamIterativeMetaProvider implements ApiProvider {
       task: 'judge',
       jsonOnly: true,
       preferSmallModel: false,
-      ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
+      ...remoteGenerationContextPayload(config.targetId),
     });
     this.agentProvider = new PromptfooChatCompletionProvider({
       task: 'meta-agent-decision',
       jsonOnly: true,
       preferSmallModel: false,
-      ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
+      ...remoteGenerationContextPayload(config.targetId),
       // Pass inputs schema for multi-input mode
       inputs: this.inputs,
     });

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -25,6 +25,7 @@ import { sleep } from '../../util/time';
 import { TokenUsageTracker } from '../../util/tokenUsage';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import { shouldGenerateRemote } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import {
   assertRemoteMaterializationHandled,
   buildRemoteMaterializationContextVars,
@@ -1322,13 +1323,13 @@ class RedteamIterativeTreeProvider implements ApiProvider {
         task: 'judge',
         jsonOnly: true,
         preferSmallModel: false,
-        ...(typeof this.config.targetId === 'string' ? { targetId: this.config.targetId } : {}),
+        ...remoteGenerationContextPayload(this.config.targetId),
       });
       redteamProvider = new PromptfooChatCompletionProvider({
         task: 'iterative:tree',
         jsonOnly: true,
         preferSmallModel: false,
-        ...(typeof this.config.targetId === 'string' ? { targetId: this.config.targetId } : {}),
+        ...remoteGenerationContextPayload(this.config.targetId),
         // Pass inputs schema for multi-input mode
         inputs: this.inputs,
       });

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -518,6 +518,7 @@ async function runRedteamConversation({
   excludeTargetOutputFromAgenticAttackGeneration,
   perTurnLayers = [],
   inputs,
+  targetId,
   treeParams,
 }: {
   context: CallApiContextParams;
@@ -533,6 +534,7 @@ async function runRedteamConversation({
   excludeTargetOutputFromAgenticAttackGeneration: boolean;
   perTurnLayers?: LayerConfig[];
   inputs?: Inputs;
+  targetId?: string;
   treeParams?: {
     maxDepth?: number;
     maxAttempts?: number;
@@ -684,6 +686,7 @@ async function runRedteamConversation({
             perTurnLayers,
             Strategies,
             {
+              targetId,
               evaluationId: context?.evaluationId,
               testCaseId: test?.metadata?.testCaseId as string | undefined,
               purpose: test?.metadata?.purpose as string | undefined,
@@ -1319,11 +1322,13 @@ class RedteamIterativeTreeProvider implements ApiProvider {
         task: 'judge',
         jsonOnly: true,
         preferSmallModel: false,
+        ...(typeof this.config.targetId === 'string' ? { targetId: this.config.targetId } : {}),
       });
       redteamProvider = new PromptfooChatCompletionProvider({
         task: 'iterative:tree',
         jsonOnly: true,
         preferSmallModel: false,
+        ...(typeof this.config.targetId === 'string' ? { targetId: this.config.targetId } : {}),
         // Pass inputs schema for multi-input mode
         inputs: this.inputs,
       });
@@ -1359,6 +1364,7 @@ class RedteamIterativeTreeProvider implements ApiProvider {
       excludeTargetOutputFromAgenticAttackGeneration:
         this.excludeTargetOutputFromAgenticAttackGeneration,
       inputs: this.inputs,
+      targetId: typeof this.config.targetId === 'string' ? this.config.targetId : undefined,
       treeParams: this.treeParams,
     });
   }

--- a/src/redteam/providers/mischievousUser.ts
+++ b/src/redteam/providers/mischievousUser.ts
@@ -12,6 +12,7 @@ type Config = {
   injectVar: string;
   maxTurns?: number;
   stateful?: boolean;
+  targetId?: string;
 };
 
 export default class RedteamMischievousUserProvider extends SimulatedUser {
@@ -33,6 +34,7 @@ export default class RedteamMischievousUserProvider extends SimulatedUser {
         instructions: `{{${config.injectVar}}}`,
         maxTurns,
         stateful: config.stateful ?? false,
+        targetId: config.targetId,
       },
     });
   }

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -28,6 +28,7 @@ import { safeJsonStringify } from '../../util/json';
 import { sleep } from '../../util/time';
 import { TokenUsageTracker } from '../../util/tokenUsage';
 import { TransformInputType, transform } from '../../util/transform';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
 import { ATTACKER_MODEL, ATTACKER_MODEL_SMALL, TEMPERATURE } from './constants';
 
@@ -666,7 +667,7 @@ export async function tryUnblocking({
       task: 'blocking-question-analysis',
       jsonOnly: true,
       preferSmallModel: false,
-      ...(targetId ? { targetId } : {}),
+      ...remoteGenerationContextPayload(targetId),
     });
 
     const unblockingRequest = {

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -622,11 +622,13 @@ export async function tryUnblocking({
   lastResponse,
   goal,
   purpose,
+  targetId,
 }: {
   messages: Message[];
   lastResponse: string;
   goal: string | undefined;
   purpose?: string;
+  targetId?: string;
 }): Promise<{
   success: boolean;
   unblockingPrompt?: string;
@@ -664,6 +666,7 @@ export async function tryUnblocking({
       task: 'blocking-question-analysis',
       jsonOnly: true,
       preferSmallModel: false,
+      ...(targetId ? { targetId } : {}),
     });
 
     const unblockingRequest = {

--- a/src/redteam/providers/voiceCrescendo/index.ts
+++ b/src/redteam/providers/voiceCrescendo/index.ts
@@ -147,6 +147,7 @@ interface VoiceCrescendoResponse extends ProviderResponse {
  */
 export interface VoiceCrescendoConfig {
   injectVar: string;
+  targetId?: string;
   maxTurns?: number;
   maxBacktracks?: number;
   redteamProvider?: string;
@@ -266,6 +267,7 @@ export class VoiceCrescendoProvider implements ApiProvider {
           task: 'voice-crescendo',
           jsonOnly: true,
           preferSmallModel: false,
+          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
         });
       } else {
         this.redTeamProvider = await redteamProviderManager.getProvider({
@@ -285,6 +287,7 @@ export class VoiceCrescendoProvider implements ApiProvider {
           task: 'voice-crescendo-eval',
           jsonOnly: true,
           preferSmallModel: false,
+          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
         });
       } else {
         // Don't pass explicit provider - let getGradingProvider check CLI --grader first

--- a/src/redteam/providers/voiceCrescendo/index.ts
+++ b/src/redteam/providers/voiceCrescendo/index.ts
@@ -22,6 +22,7 @@ import { sleep } from '../../../util/time';
 import { TokenUsageTracker } from '../../../util/tokenUsage';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../../util/tokenUsageUtils';
 import { shouldGenerateRemote } from '../../remoteGeneration';
+import { remoteGenerationContextPayload } from '../../remoteGenerationContext';
 import { textToAudio } from '../../strategies/simpleAudio';
 import { isBasicRefusal } from '../../util';
 import {
@@ -267,7 +268,7 @@ export class VoiceCrescendoProvider implements ApiProvider {
           task: 'voice-crescendo',
           jsonOnly: true,
           preferSmallModel: false,
-          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
+          ...remoteGenerationContextPayload(this.config.targetId),
         });
       } else {
         this.redTeamProvider = await redteamProviderManager.getProvider({
@@ -287,7 +288,7 @@ export class VoiceCrescendoProvider implements ApiProvider {
           task: 'voice-crescendo-eval',
           jsonOnly: true,
           preferSmallModel: false,
-          ...(this.config.targetId ? { targetId: this.config.targetId } : {}),
+          ...remoteGenerationContextPayload(this.config.targetId),
         });
       } else {
         // Don't pass explicit provider - let getGradingProvider check CLI --grader first

--- a/src/redteam/remoteGeneration.ts
+++ b/src/redteam/remoteGeneration.ts
@@ -3,10 +3,19 @@ import { getEnvBool, getEnvString } from '../envars';
 import { isLoggedIntoCloud } from '../globalConfig/accounts';
 import { CloudConfig } from '../globalConfig/cloud';
 import { hasCodexDefaultCredentials } from '../providers/openai/codexDefaults';
+import { remoteGenerationContextPayload as buildRemoteGenerationContextPayload } from './remoteGenerationContext';
 
 interface ShouldGenerateRemoteOptions {
   canUseCodexDefaultProvider?: boolean;
   requireEmbeddingProvider?: boolean;
+}
+
+// Provider implementations already depend on this module. Re-exporting the leaf helper here
+// avoids introducing a providers -> redteam context dependency solely for payload construction.
+export function providerRemoteGenerationContextPayload(contextOrCloudTargetId?: unknown): {
+  targetId?: string;
+} {
+  return buildRemoteGenerationContextPayload(contextOrCloudTargetId);
 }
 
 /**

--- a/src/redteam/remoteGeneration.ts
+++ b/src/redteam/remoteGeneration.ts
@@ -5,6 +5,9 @@ import { CloudConfig } from '../globalConfig/cloud';
 import { hasCodexDefaultCredentials } from '../providers/openai/codexDefaults';
 import { remoteGenerationContextPayload as buildRemoteGenerationContextPayload } from './remoteGenerationContext';
 
+export { remoteGenerationContextPayload } from './remoteGenerationContext';
+export { getCloudTargetIdFromProviders } from './remoteGenerationContextFromProviders';
+
 interface ShouldGenerateRemoteOptions {
   canUseCodexDefaultProvider?: boolean;
   requireEmbeddingProvider?: boolean;

--- a/src/redteam/remoteGenerationContext.ts
+++ b/src/redteam/remoteGenerationContext.ts
@@ -1,12 +1,8 @@
-import { getProviderIds } from '../providers/index';
 import { getCloudDatabaseId, isCloudProvider } from '../util/cloud';
 
-import type { UnifiedConfig } from '../types/index';
 import type { RedteamGenerationContext } from './types';
 
 export type { RedteamGenerationContext } from './types';
-
-type ProviderConfigLike = Partial<UnifiedConfig>['providers'];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -16,16 +12,6 @@ function getCloudTargetIdFromProviderId(providerId: unknown): string | undefined
   return typeof providerId === 'string' && isCloudProvider(providerId)
     ? getCloudDatabaseId(providerId)
     : undefined;
-}
-
-function getLinkedCloudTargetId(value: unknown): string | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-
-  const config = isRecord(value.config) ? value.config : value;
-  const linkedTargetId = config.linkedTargetId;
-  return getCloudTargetIdFromProviderId(linkedTargetId);
 }
 
 export function remoteGenerationContextPayload(contextOrCloudTargetId?: unknown): {
@@ -49,83 +35,6 @@ export function getCloudTargetIdFromTargetIds(targetIds: string[]): string | und
     }
   }
   return undefined;
-}
-
-export function getProviderTargetIds(providers: ProviderConfigLike): string[] {
-  if (!providers) {
-    return [];
-  }
-
-  const providerList = Array.isArray(providers) ? providers : [providers];
-  return providerList.flatMap((provider) => {
-    if (typeof provider === 'string') {
-      return [provider];
-    }
-    if (!isRecord(provider)) {
-      return [];
-    }
-    if (typeof provider.id === 'string') {
-      return [provider.id];
-    }
-
-    try {
-      return getProviderIds([provider]);
-    } catch {
-      return [];
-    }
-  });
-}
-
-export function getCloudTargetIdFromProviders(providers: ProviderConfigLike): string | undefined {
-  if (!providers) {
-    return undefined;
-  }
-
-  const providerList = Array.isArray(providers) ? providers : [providers];
-  for (const provider of providerList) {
-    const directCloudTargetId = getCloudTargetIdFromProviderId(provider);
-    if (directCloudTargetId) {
-      return directCloudTargetId;
-    }
-    if (!isRecord(provider)) {
-      continue;
-    }
-
-    const linkedCloudTargetId = getLinkedCloudTargetId(provider);
-    if (linkedCloudTargetId) {
-      return linkedCloudTargetId;
-    }
-
-    const idCloudTargetId = getCloudTargetIdFromProviderId(provider.id);
-    if (idCloudTargetId) {
-      return idCloudTargetId;
-    }
-
-    for (const [providerId, providerConfig] of Object.entries(provider)) {
-      const keyCloudTargetId = getCloudTargetIdFromProviderId(providerId);
-      if (keyCloudTargetId) {
-        return keyCloudTargetId;
-      }
-
-      const mappedLinkedCloudTargetId = getLinkedCloudTargetId(providerConfig);
-      if (mappedLinkedCloudTargetId) {
-        return mappedLinkedCloudTargetId;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-export function getRedteamGenerationContextFromProviders(
-  providers: ProviderConfigLike,
-): RedteamGenerationContext {
-  const providerTargetIds = getProviderTargetIds(providers);
-  return {
-    providerTargetIds,
-    cloudTargetId:
-      getCloudTargetIdFromProviders(providers) ?? getCloudTargetIdFromTargetIds(providerTargetIds),
-  };
 }
 
 export function resolveRedteamGenerationContext({

--- a/src/redteam/remoteGenerationContext.ts
+++ b/src/redteam/remoteGenerationContext.ts
@@ -1,17 +1,9 @@
-import { getCloudDatabaseId, isCloudProvider } from '../util/cloud';
-
 import type { RedteamGenerationContext } from './types';
 
 export type { RedteamGenerationContext } from './types';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function getCloudTargetIdFromProviderId(providerId: unknown): string | undefined {
-  return typeof providerId === 'string' && isCloudProvider(providerId)
-    ? getCloudDatabaseId(providerId)
-    : undefined;
 }
 
 export function remoteGenerationContextPayload(contextOrCloudTargetId?: unknown): {
@@ -25,6 +17,13 @@ export function remoteGenerationContextPayload(contextOrCloudTargetId?: unknown)
         : undefined;
 
   return cloudTargetId ? { targetId: cloudTargetId } : {};
+}
+
+function getCloudTargetIdFromProviderId(providerId: unknown): string | undefined {
+  const prefix = 'promptfoo://provider/';
+  return typeof providerId === 'string' && providerId.startsWith(prefix)
+    ? providerId.slice(prefix.length)
+    : undefined;
 }
 
 export function getCloudTargetIdFromTargetIds(targetIds: string[]): string | undefined {

--- a/src/redteam/remoteGenerationContext.ts
+++ b/src/redteam/remoteGenerationContext.ts
@@ -1,0 +1,148 @@
+import { getProviderIds } from '../providers/index';
+import { getCloudDatabaseId, isCloudProvider } from '../util/cloud';
+
+import type { UnifiedConfig } from '../types/index';
+import type { RedteamGenerationContext } from './types';
+
+export type { RedteamGenerationContext } from './types';
+
+type ProviderConfigLike = Partial<UnifiedConfig>['providers'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getCloudTargetIdFromProviderId(providerId: unknown): string | undefined {
+  return typeof providerId === 'string' && isCloudProvider(providerId)
+    ? getCloudDatabaseId(providerId)
+    : undefined;
+}
+
+function getLinkedCloudTargetId(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const config = isRecord(value.config) ? value.config : value;
+  const linkedTargetId = config.linkedTargetId;
+  return getCloudTargetIdFromProviderId(linkedTargetId);
+}
+
+export function remoteGenerationContextPayload(contextOrCloudTargetId?: unknown): {
+  targetId?: string;
+} {
+  const cloudTargetId =
+    typeof contextOrCloudTargetId === 'string'
+      ? contextOrCloudTargetId
+      : isRecord(contextOrCloudTargetId) && typeof contextOrCloudTargetId.cloudTargetId === 'string'
+        ? contextOrCloudTargetId.cloudTargetId
+        : undefined;
+
+  return cloudTargetId ? { targetId: cloudTargetId } : {};
+}
+
+export function getCloudTargetIdFromTargetIds(targetIds: string[]): string | undefined {
+  for (const targetId of targetIds) {
+    const cloudTargetId = getCloudTargetIdFromProviderId(targetId);
+    if (cloudTargetId) {
+      return cloudTargetId;
+    }
+  }
+  return undefined;
+}
+
+export function getProviderTargetIds(providers: ProviderConfigLike): string[] {
+  if (!providers) {
+    return [];
+  }
+
+  const providerList = Array.isArray(providers) ? providers : [providers];
+  return providerList.flatMap((provider) => {
+    if (typeof provider === 'string') {
+      return [provider];
+    }
+    if (!isRecord(provider)) {
+      return [];
+    }
+    if (typeof provider.id === 'string') {
+      return [provider.id];
+    }
+
+    try {
+      return getProviderIds([provider]);
+    } catch {
+      return [];
+    }
+  });
+}
+
+export function getCloudTargetIdFromProviders(providers: ProviderConfigLike): string | undefined {
+  if (!providers) {
+    return undefined;
+  }
+
+  const providerList = Array.isArray(providers) ? providers : [providers];
+  for (const provider of providerList) {
+    const directCloudTargetId = getCloudTargetIdFromProviderId(provider);
+    if (directCloudTargetId) {
+      return directCloudTargetId;
+    }
+    if (!isRecord(provider)) {
+      continue;
+    }
+
+    const linkedCloudTargetId = getLinkedCloudTargetId(provider);
+    if (linkedCloudTargetId) {
+      return linkedCloudTargetId;
+    }
+
+    const idCloudTargetId = getCloudTargetIdFromProviderId(provider.id);
+    if (idCloudTargetId) {
+      return idCloudTargetId;
+    }
+
+    for (const [providerId, providerConfig] of Object.entries(provider)) {
+      const keyCloudTargetId = getCloudTargetIdFromProviderId(providerId);
+      if (keyCloudTargetId) {
+        return keyCloudTargetId;
+      }
+
+      const mappedLinkedCloudTargetId = getLinkedCloudTargetId(providerConfig);
+      if (mappedLinkedCloudTargetId) {
+        return mappedLinkedCloudTargetId;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function getRedteamGenerationContextFromProviders(
+  providers: ProviderConfigLike,
+): RedteamGenerationContext {
+  const providerTargetIds = getProviderTargetIds(providers);
+  return {
+    providerTargetIds,
+    cloudTargetId:
+      getCloudTargetIdFromProviders(providers) ?? getCloudTargetIdFromTargetIds(providerTargetIds),
+  };
+}
+
+export function resolveRedteamGenerationContext({
+  cloudTargetDatabaseId,
+  redteamGenerationContext,
+  targetIds,
+}: {
+  cloudTargetDatabaseId?: string;
+  redteamGenerationContext?: RedteamGenerationContext;
+  targetIds?: string[];
+}): RedteamGenerationContext {
+  const providerTargetIds = redteamGenerationContext?.providerTargetIds ?? targetIds ?? [];
+  return {
+    providerTargetIds,
+    cloudTargetId:
+      redteamGenerationContext?.cloudTargetId ??
+      cloudTargetDatabaseId ??
+      getCloudTargetIdFromTargetIds(providerTargetIds),
+  };
+}

--- a/src/redteam/remoteGenerationContextFromProviders.ts
+++ b/src/redteam/remoteGenerationContextFromProviders.ts
@@ -1,0 +1,107 @@
+import { getProviderIds } from '../providers/index';
+import { getCloudDatabaseId, isCloudProvider } from '../util/cloud';
+import { getCloudTargetIdFromTargetIds } from './remoteGenerationContext';
+
+import type { UnifiedConfig } from '../types/index';
+import type { RedteamGenerationContext } from './types';
+
+// Keep provider-registry-aware extraction separate from remoteGenerationContext.ts.
+// Provider implementations import that leaf module while this adapter is only used
+// during config resolution, preventing the provider registry from importing itself.
+type ProviderConfigLike = Partial<UnifiedConfig>['providers'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getCloudTargetIdFromProviderId(providerId: unknown): string | undefined {
+  return typeof providerId === 'string' && isCloudProvider(providerId)
+    ? getCloudDatabaseId(providerId)
+    : undefined;
+}
+
+function getLinkedCloudTargetId(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const config = isRecord(value.config) ? value.config : value;
+  return getCloudTargetIdFromProviderId(config.linkedTargetId);
+}
+
+export function getProviderTargetIds(providers: ProviderConfigLike): string[] {
+  if (!providers) {
+    return [];
+  }
+
+  const providerList = Array.isArray(providers) ? providers : [providers];
+  return providerList.flatMap((provider) => {
+    if (typeof provider === 'string') {
+      return [provider];
+    }
+    if (!isRecord(provider)) {
+      return [];
+    }
+    if (typeof provider.id === 'string') {
+      return [provider.id];
+    }
+
+    try {
+      return getProviderIds([provider]);
+    } catch {
+      return [];
+    }
+  });
+}
+
+export function getCloudTargetIdFromProviders(providers: ProviderConfigLike): string | undefined {
+  if (!providers) {
+    return undefined;
+  }
+
+  const providerList = Array.isArray(providers) ? providers : [providers];
+  for (const provider of providerList) {
+    const directCloudTargetId = getCloudTargetIdFromProviderId(provider);
+    if (directCloudTargetId) {
+      return directCloudTargetId;
+    }
+    if (!isRecord(provider)) {
+      continue;
+    }
+
+    const linkedCloudTargetId = getLinkedCloudTargetId(provider);
+    if (linkedCloudTargetId) {
+      return linkedCloudTargetId;
+    }
+
+    const idCloudTargetId = getCloudTargetIdFromProviderId(provider.id);
+    if (idCloudTargetId) {
+      return idCloudTargetId;
+    }
+
+    for (const [providerId, providerConfig] of Object.entries(provider)) {
+      const keyCloudTargetId = getCloudTargetIdFromProviderId(providerId);
+      if (keyCloudTargetId) {
+        return keyCloudTargetId;
+      }
+
+      const mappedLinkedCloudTargetId = getLinkedCloudTargetId(providerConfig);
+      if (mappedLinkedCloudTargetId) {
+        return mappedLinkedCloudTargetId;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function getRedteamGenerationContextFromProviders(
+  providers: ProviderConfigLike,
+): RedteamGenerationContext {
+  const providerTargetIds = getProviderTargetIds(providers);
+  return {
+    providerTargetIds,
+    cloudTargetId:
+      getCloudTargetIdFromProviders(providers) ?? getCloudTargetIdFromTargetIds(providerTargetIds),
+  };
+}

--- a/src/redteam/remoteGenerationContextFromProviders.ts
+++ b/src/redteam/remoteGenerationContextFromProviders.ts
@@ -1,23 +1,13 @@
-import { getProviderIds } from '../providers/index';
-import { getCloudDatabaseId, isCloudProvider } from '../util/cloud';
 import { getCloudTargetIdFromTargetIds } from './remoteGenerationContext';
 
-import type { UnifiedConfig } from '../types/index';
 import type { RedteamGenerationContext } from './types';
-
-// Keep provider-registry-aware extraction separate from remoteGenerationContext.ts.
-// Provider implementations import that leaf module while this adapter is only used
-// during config resolution, preventing the provider registry from importing itself.
-type ProviderConfigLike = Partial<UnifiedConfig>['providers'];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function getCloudTargetIdFromProviderId(providerId: unknown): string | undefined {
-  return typeof providerId === 'string' && isCloudProvider(providerId)
-    ? getCloudDatabaseId(providerId)
-    : undefined;
+  return typeof providerId === 'string' ? getCloudTargetIdFromTargetIds([providerId]) : undefined;
 }
 
 function getLinkedCloudTargetId(value: unknown): string | undefined {
@@ -29,32 +19,7 @@ function getLinkedCloudTargetId(value: unknown): string | undefined {
   return getCloudTargetIdFromProviderId(config.linkedTargetId);
 }
 
-export function getProviderTargetIds(providers: ProviderConfigLike): string[] {
-  if (!providers) {
-    return [];
-  }
-
-  const providerList = Array.isArray(providers) ? providers : [providers];
-  return providerList.flatMap((provider) => {
-    if (typeof provider === 'string') {
-      return [provider];
-    }
-    if (!isRecord(provider)) {
-      return [];
-    }
-    if (typeof provider.id === 'string') {
-      return [provider.id];
-    }
-
-    try {
-      return getProviderIds([provider]);
-    } catch {
-      return [];
-    }
-  });
-}
-
-export function getCloudTargetIdFromProviders(providers: ProviderConfigLike): string | undefined {
+export function getCloudTargetIdFromProviders(providers: unknown): string | undefined {
   if (!providers) {
     return undefined;
   }
@@ -96,9 +61,9 @@ export function getCloudTargetIdFromProviders(providers: ProviderConfigLike): st
 }
 
 export function getRedteamGenerationContextFromProviders(
-  providers: ProviderConfigLike,
+  providers: unknown,
+  providerTargetIds: string[],
 ): RedteamGenerationContext {
-  const providerTargetIds = getProviderTargetIds(providers);
   return {
     providerTargetIds,
     cloudTargetId:

--- a/src/redteam/shared/runtimeTransform.ts
+++ b/src/redteam/shared/runtimeTransform.ts
@@ -48,6 +48,8 @@ export interface TransformResult {
  * This allows multi-turn providers to pass evaluation context to layer strategies.
  */
 export interface RuntimeTransformContext {
+  /** Cloud target database ID used to resolve target-owned task context. */
+  targetId?: string;
   /** The evaluation ID (for server-side tracking) */
   evaluationId?: string;
   /** The test case ID */
@@ -144,7 +146,10 @@ export async function applyRuntimeTransforms(
     try {
       // Call existing strategy action - this REUSES all existing implementation
       // The strategy expects an array of test cases and returns transformed test cases
-      const result = await strategy.action([testCase], injectVar, layerConfig);
+      const result = await strategy.action([testCase], injectVar, {
+        ...layerConfig,
+        ...(context?.targetId ? { targetId: context.targetId } : {}),
+      });
       const transformed = result[0];
 
       if (transformed) {

--- a/src/redteam/shared/runtimeTransform.ts
+++ b/src/redteam/shared/runtimeTransform.ts
@@ -9,6 +9,7 @@
  */
 
 import logger from '../../logger';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 
 import type { MediaData } from '../../storage/types';
 import type { TestCaseWithPlugin } from '../../types';
@@ -148,7 +149,7 @@ export async function applyRuntimeTransforms(
       // The strategy expects an array of test cases and returns transformed test cases
       const result = await strategy.action([testCase], injectVar, {
         ...layerConfig,
-        ...(context?.targetId ? { targetId: context.targetId } : {}),
+        ...remoteGenerationContextPayload(context?.targetId),
       });
       const transformed = result[0];
 

--- a/src/redteam/strategies/citation.ts
+++ b/src/redteam/strategies/citation.ts
@@ -49,6 +49,7 @@ async function generateCitations(
         injectVar,
         topic: testCase.vars[injectVar],
         config,
+        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
         email: getUserEmail(),
       };
 

--- a/src/redteam/strategies/citation.ts
+++ b/src/redteam/strategies/citation.ts
@@ -12,6 +12,7 @@ import {
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 
 import type { TestCase } from '../../types/index';
 
@@ -49,7 +50,7 @@ async function generateCitations(
         injectVar,
         topic: testCase.vars[injectVar],
         config,
-        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
+        ...remoteGenerationContextPayload(config.targetId),
         email: getUserEmail(),
       };
 

--- a/src/redteam/strategies/gcg.ts
+++ b/src/redteam/strategies/gcg.ts
@@ -53,6 +53,7 @@ async function generateGcgPrompts(
         task: 'gcg',
         query: testCase.vars[injectVar],
         ...(config.n && { n: config.n }),
+        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
         email: getUserEmail(),
       };
 

--- a/src/redteam/strategies/gcg.ts
+++ b/src/redteam/strategies/gcg.ts
@@ -11,6 +11,7 @@ import {
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 
 import type { TestCase } from '../../types/index';
 
@@ -53,7 +54,7 @@ async function generateGcgPrompts(
         task: 'gcg',
         query: testCase.vars[injectVar],
         ...(config.n && { n: config.n }),
-        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
+        ...remoteGenerationContextPayload(config.targetId),
         email: getUserEmail(),
       };
 

--- a/src/redteam/strategies/indirectWebPwn.ts
+++ b/src/redteam/strategies/indirectWebPwn.ts
@@ -219,6 +219,7 @@ async function createWebPage(
   purpose?: string,
   useLlm?: boolean,
   preferSmallModel?: boolean,
+  targetId?: string,
 ): Promise<CreateWebPageResponse> {
   const url = getRemoteGenerationUrl();
   logger.debug('[IndirectWebPwn] Creating web page via task API', {
@@ -247,6 +248,7 @@ async function createWebPage(
         email: getUserEmail(),
         useLlm: useLlm ?? true,
         preferSmallModel: preferSmallModel ?? true,
+        ...(targetId ? { targetId } : {}),
       }),
     },
     60000, // 60s timeout for LLM generation
@@ -274,6 +276,7 @@ async function updateWebPage(
   evalId?: string,
   useLlm?: boolean,
   preferSmallModel?: boolean,
+  targetId?: string,
 ): Promise<UpdateWebPageResponse> {
   const url = getRemoteGenerationUrl();
   logger.debug('[IndirectWebPwn] Updating web page via task API', {
@@ -299,6 +302,7 @@ async function updateWebPage(
         email: getUserEmail(),
         useLlm: useLlm ?? true,
         preferSmallModel: preferSmallModel ?? true,
+        ...(targetId ? { targetId } : {}),
       }),
     },
     60000,
@@ -416,6 +420,7 @@ async function transformForPerTurnLayer(
   const useLlmCreate = (config.useLlm as boolean) ?? true;
   const useLlmUpdate = (config.useLlm as boolean) ?? true;
   const preferSmallModel = (config.preferSmallModel as boolean) ?? true;
+  const targetId = typeof config.targetId === 'string' ? config.targetId : undefined;
 
   const results: TestCase[] = [];
 
@@ -471,6 +476,7 @@ async function transformForPerTurnLayer(
           evalId,
           useLlmUpdate,
           preferSmallModel,
+          targetId,
         );
 
         // Update state with new embedding location and fetch prompt
@@ -519,6 +525,7 @@ async function transformForPerTurnLayer(
           purpose,
           useLlmCreate,
           preferSmallModel,
+          targetId,
         );
 
         // Clean up expired entries before adding new ones

--- a/src/redteam/strategies/indirectWebPwn.ts
+++ b/src/redteam/strategies/indirectWebPwn.ts
@@ -4,6 +4,7 @@ import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { fetchWithRetries } from '../../util/fetch/index';
 import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 
 import type { TestCase, TestCaseWithPlugin } from '../../types/index';
 import type {
@@ -248,7 +249,7 @@ async function createWebPage(
         email: getUserEmail(),
         useLlm: useLlm ?? true,
         preferSmallModel: preferSmallModel ?? true,
-        ...(targetId ? { targetId } : {}),
+        ...remoteGenerationContextPayload(targetId),
       }),
     },
     60000, // 60s timeout for LLM generation
@@ -302,7 +303,7 @@ async function updateWebPage(
         email: getUserEmail(),
         useLlm: useLlm ?? true,
         preferSmallModel: preferSmallModel ?? true,
-        ...(targetId ? { targetId } : {}),
+        ...remoteGenerationContextPayload(targetId),
       }),
     },
     60000,

--- a/src/redteam/strategies/layer.ts
+++ b/src/redteam/strategies/layer.ts
@@ -102,6 +102,7 @@ export async function addLayerTestCases(
               injectVar,
               scanId,
               ...stepObj.config,
+              ...(typeof config?.targetId === 'string' ? { targetId: config.targetId } : {}),
               // Pass per-turn layers for runtime application
               ...(perTurnLayers.length > 0 && { _perTurnLayers: perTurnLayers }),
             },

--- a/src/redteam/strategies/layer.ts
+++ b/src/redteam/strategies/layer.ts
@@ -1,4 +1,5 @@
 import logger from '../../logger';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import { getAttackProviderFullId, isAttackProvider } from '../shared/attackProviders';
 import { pluginMatchesStrategyTargets } from './util';
 
@@ -102,7 +103,9 @@ export async function addLayerTestCases(
               injectVar,
               scanId,
               ...stepObj.config,
-              ...(typeof config?.targetId === 'string' ? { targetId: config.targetId } : {}),
+              ...remoteGenerationContextPayload(
+                typeof config?.targetId === 'string' ? config.targetId : undefined,
+              ),
               // Pass per-turn layers for runtime application
               ...(perTurnLayers.length > 0 && { _perTurnLayers: perTurnLayers }),
             },

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -60,6 +60,7 @@ export async function generateMathPrompt(
         testCases: batch,
         injectVar,
         config,
+        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
         email: getUserEmail(),
       };
 

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -13,6 +13,7 @@ import {
   getRemoteGenerationUrl,
   shouldGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 
 import type { TestCase } from '../../types/index';
 
@@ -60,7 +61,7 @@ export async function generateMathPrompt(
         testCases: batch,
         injectVar,
         config,
-        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
+        ...remoteGenerationContextPayload(config.targetId),
         email: getUserEmail(),
       };
 

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -15,6 +15,7 @@ import {
   getRemoteGenerationUrl,
   shouldGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 
 import type { TestCase } from '../../types/index';
 
@@ -132,7 +133,7 @@ async function processRemoteChunk(
     testCases,
     injectVar,
     config,
-    ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
+    ...remoteGenerationContextPayload(config.targetId),
     email: getUserEmail(),
   };
 

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -132,6 +132,7 @@ async function processRemoteChunk(
     testCases,
     injectVar,
     config,
+    ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
     email: getUserEmail(),
   };
 

--- a/src/redteam/strategies/simpleAudio.ts
+++ b/src/redteam/strategies/simpleAudio.ts
@@ -32,7 +32,7 @@ export interface TextToAudioResult {
 export async function textToAudio(
   text: string,
   language: string = 'en',
-  options?: { evalId?: string; storeToStorage?: boolean },
+  options?: { evalId?: string; storeToStorage?: boolean; targetId?: string },
 ): Promise<TextToAudioResult> {
   // Check if remote generation is disabled
   if (neverGenerateRemote()) {
@@ -48,6 +48,7 @@ export async function textToAudio(
       language,
       version: VERSION,
       email: getUserEmail(),
+      ...(options?.targetId ? { targetId: options.targetId } : {}),
     };
 
     interface AudioGenerationResponse {
@@ -145,7 +146,10 @@ export async function addAudioToBase64(
       'en';
 
     // Convert text to audio using the remote API
-    const audioResult = await textToAudio(originalText, language, { evalId });
+    const audioResult = await textToAudio(originalText, language, {
+      evalId,
+      targetId: typeof config.targetId === 'string' ? config.targetId : undefined,
+    });
 
     audioTestCases.push({
       ...testCase,

--- a/src/redteam/strategies/simpleAudio.ts
+++ b/src/redteam/strategies/simpleAudio.ts
@@ -12,6 +12,7 @@ import {
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 
 import type { TestCase } from '../../types/index';
 
@@ -48,7 +49,7 @@ export async function textToAudio(
       language,
       version: VERSION,
       email: getUserEmail(),
-      ...(options?.targetId ? { targetId: options.targetId } : {}),
+      ...remoteGenerationContextPayload(options?.targetId),
     };
 
     interface AudioGenerationResponse {

--- a/src/redteam/strategies/singleTurnComposite.ts
+++ b/src/redteam/strategies/singleTurnComposite.ts
@@ -11,6 +11,7 @@ import {
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
+import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 
 import type { TestCase } from '../../types/index';
 import type { Inputs } from '../../types/shared';
@@ -58,7 +59,7 @@ async function generateCompositePrompts(
         // Composite pipeline configuration
         ...(config.techniques && { techniques: config.techniques }),
         ...(config.evasions && { evasions: config.evasions }),
-        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
+        ...remoteGenerationContextPayload(config.targetId),
         ...(config.alwaysIncludeTechniques && {
           alwaysIncludeTechniques: config.alwaysIncludeTechniques,
         }),

--- a/src/redteam/strategies/singleTurnComposite.ts
+++ b/src/redteam/strategies/singleTurnComposite.ts
@@ -58,6 +58,7 @@ async function generateCompositePrompts(
         // Composite pipeline configuration
         ...(config.techniques && { techniques: config.techniques }),
         ...(config.evasions && { evasions: config.evasions }),
+        ...(typeof config.targetId === 'string' ? { targetId: config.targetId } : {}),
         ...(config.alwaysIncludeTechniques && {
           alwaysIncludeTechniques: config.alwaysIncludeTechniques,
         }),

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -265,6 +265,8 @@ export interface RedteamCliGenerateOptions extends CommonOptions {
   defaultConfigPath?: string;
   description?: string;
   envFile?: string;
+  filterProviders?: string;
+  filterTargets?: string;
   maxConcurrency?: number;
   output?: string;
   force?: boolean;

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -226,6 +226,7 @@ export interface PluginActionParams {
   config?: PluginConfig;
   /** Cloud target database ID used by remote task handlers to resolve target context. */
   targetId?: string;
+  redteamGenerationContext?: RedteamGenerationContext;
 }
 
 // Context for testing multiple security contexts/states
@@ -290,6 +291,7 @@ export interface RedteamFileConfig extends CommonOptions {
 
 export interface SynthesizeOptions extends CommonOptions {
   abortSignal?: AbortSignal;
+  redteamGenerationContext?: RedteamGenerationContext;
   /** Cloud target database ID used to preserve target-owned task context during generation. */
   cloudTargetDatabaseId?: string;
   entities?: string[];
@@ -303,6 +305,13 @@ export interface SynthesizeOptions extends CommonOptions {
   strategies: RedteamStrategyObject[];
   targetIds: string[];
   showProgressBar?: boolean;
+}
+
+export interface RedteamGenerationContext {
+  /** Provider IDs used for filtering, retry, and target identity. */
+  providerTargetIds: string[];
+  /** Cloud target database ID sent to Promptfoo Cloud task handlers. */
+  cloudTargetId?: string;
 }
 
 export type RedteamAssertionTypes = `promptfoo:redteam:${string}`;

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -224,6 +224,8 @@ export interface PluginActionParams {
   n: number;
   delayMs: number;
   config?: PluginConfig;
+  /** Cloud target database ID used by remote task handlers to resolve target context. */
+  targetId?: string;
 }
 
 // Context for testing multiple security contexts/states
@@ -286,6 +288,8 @@ export interface RedteamFileConfig extends CommonOptions {
 
 export interface SynthesizeOptions extends CommonOptions {
   abortSignal?: AbortSignal;
+  /** Cloud target database ID used to preserve target-owned task context during generation. */
+  cloudTargetDatabaseId?: string;
   entities?: string[];
   // Multi-variable inputs for test case generation (from target)
   inputs?: Inputs;

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -4,7 +4,7 @@ import { type FrameworkComplianceId, type Plugin, Severity, SeveritySchema } fro
 import { isValidPolicyId } from './plugins/policy/validators';
 
 import type { EventSource } from '../types/eventSource';
-import type { ApiProvider, ProviderOptions } from '../types/providers';
+import type { ApiProvider, ProviderOptions, RemoteGenerationContext } from '../types/providers';
 
 // Re-export Inputs from shared to maintain backwards compatibility
 export { type Inputs, InputsSchema };
@@ -307,12 +307,7 @@ export interface SynthesizeOptions extends CommonOptions {
   showProgressBar?: boolean;
 }
 
-export interface RedteamGenerationContext {
-  /** Provider IDs used for filtering, retry, and target identity. */
-  providerTargetIds: string[];
-  /** Cloud target database ID sent to Promptfoo Cloud task handlers. */
-  cloudTargetId?: string;
-}
+export type RedteamGenerationContext = RemoteGenerationContext;
 
 export type RedteamAssertionTypes = `promptfoo:redteam:${string}`;
 

--- a/src/redteam/util.ts
+++ b/src/redteam/util.ts
@@ -17,6 +17,7 @@ import {
   getRemoteGenerationUrl,
   neverGenerateRemote,
 } from './remoteGeneration';
+import { remoteGenerationContextPayload } from './remoteGenerationContext';
 
 import type { CallApiContextParams, ProviderResponse } from '../types/index';
 
@@ -374,7 +375,7 @@ export async function extractGoalFromPrompt(
     purpose,
     ...(pluginDescription && { pluginContext: pluginDescription }),
     ...(policy && { policy }),
-    ...(targetId && { targetId }),
+    ...remoteGenerationContextPayload(targetId),
   };
 
   interface ExtractIntentResponse {

--- a/src/redteam/util.ts
+++ b/src/redteam/util.ts
@@ -338,6 +338,7 @@ export function getShortPluginId(pluginId: string): string {
  * @param purpose - The purpose of the system.
  * @param pluginId - Optional plugin ID to provide context about the attack type.
  * @param policy - Optional policy text for custom policy tests to improve intent extraction.
+ * @param targetId - Optional cloud target database ID used by remote task handlers to resolve target-owned provider context.
  * @returns The extracted goal, or null if extraction fails.
  */
 export async function extractGoalFromPrompt(
@@ -345,6 +346,7 @@ export async function extractGoalFromPrompt(
   purpose: string,
   pluginId?: string,
   policy?: string,
+  targetId?: string,
 ): Promise<string | null> {
   if (neverGenerateRemote()) {
     logger.debug('Remote generation disabled, skipping goal extraction');
@@ -372,6 +374,7 @@ export async function extractGoalFromPrompt(
     purpose,
     ...(pluginDescription && { pluginContext: pluginDescription }),
     ...(policy && { policy }),
+    ...(targetId && { targetId }),
   };
 
   interface ExtractIntentResponse {

--- a/src/share.ts
+++ b/src/share.ts
@@ -131,8 +131,8 @@ async function sendEvalRecord(
   const traces = await evalRecord.getTraces();
   const redactedConfig = redactAzureBlobSasTokens(evalRecord.config);
 
-  // Inject current team ID into config metadata if cloud is enabled
-  // This ensures the eval is created in the correct team (not the default team)
+  // Preserve the verified runtime team on server-issued unified configs. For
+  // other configs, use the current CLI team to avoid falling back to default.
   let evalData: Record<string, unknown> = {
     ...evalRecord,
     config: redactedConfig,
@@ -142,14 +142,18 @@ async function sendEvalRecord(
   if (cloudConfig.isEnabled()) {
     const currentOrgId = cloudConfig.getCurrentOrganizationId();
     const currentTeamId = cloudConfig.getCurrentTeamId(currentOrgId);
-    if (currentTeamId) {
+    const unifiedConfigTeamId = redactedConfig?.metadata?.configId
+      ? redactedConfig.metadata.teamId
+      : undefined;
+    const effectiveTeamId = unifiedConfigTeamId ?? currentTeamId;
+    if (effectiveTeamId) {
       evalData = {
         ...evalData,
         config: {
           ...(redactedConfig || {}),
           metadata: {
             ...(redactedConfig?.metadata || {}),
-            teamId: currentTeamId,
+            teamId: effectiveTeamId,
           },
         },
       };

--- a/src/share.ts
+++ b/src/share.ts
@@ -121,6 +121,18 @@ function findLargestResultSize(results: EvalResult[], sampleSize: number = 1000)
   return maxSize;
 }
 
+function getEffectiveShareTeamId(eval_: Eval): string | undefined {
+  const unifiedConfigTeamId = eval_.config?.metadata?.configId
+    ? eval_.config.metadata.teamId
+    : undefined;
+  if (unifiedConfigTeamId) {
+    return unifiedConfigTeamId;
+  }
+
+  const currentOrgId = cloudConfig.getCurrentOrganizationId();
+  return cloudConfig.getCurrentTeamId(currentOrgId);
+}
+
 // This sends the eval record to the remote server
 async function sendEvalRecord(
   evalRecord: Eval,
@@ -140,12 +152,7 @@ async function sendEvalRecord(
     traces,
   };
   if (cloudConfig.isEnabled()) {
-    const currentOrgId = cloudConfig.getCurrentOrganizationId();
-    const currentTeamId = cloudConfig.getCurrentTeamId(currentOrgId);
-    const unifiedConfigTeamId = redactedConfig?.metadata?.configId
-      ? redactedConfig.metadata.teamId
-      : undefined;
-    const effectiveTeamId = unifiedConfigTeamId ?? currentTeamId;
+    const effectiveTeamId = getEffectiveShareTeamId(evalRecord);
     if (effectiveTeamId) {
       evalData = {
         ...evalData,
@@ -719,27 +726,24 @@ export async function createShareableUrl(
 }
 
 /**
- * Checks whether an eval has been shared to the current team.
+ * Checks whether an eval has been shared to its effective runtime team.
  * @param eval_ The eval to check.
- * @returns True if the eval has been shared to the current team, false otherwise.
+ * @returns True if the eval has been shared to the effective team, false otherwise.
  */
 export async function hasEvalBeenShared(eval_: Eval): Promise<boolean> {
   try {
-    // Get current team ID to scope the check to current team only
-    // This prevents false positives when eval exists in a different team
-    const currentOrgId = cloudConfig.getCurrentOrganizationId();
-    const currentTeamId = cloudConfig.getCurrentTeamId(currentOrgId);
+    const effectiveTeamId = getEffectiveShareTeamId(eval_);
 
     // GET /api/results/:id with optional teamId scope
-    const url = currentTeamId
-      ? `results/${eval_.id}?teamId=${currentTeamId}`
+    const url = effectiveTeamId
+      ? `results/${eval_.id}?teamId=${encodeURIComponent(effectiveTeamId)}`
       : `results/${eval_.id}`;
     const res = await makeCloudRequest(url, 'GET');
     switch (res.status) {
-      // 200: Eval already exists in the current team.
+      // 200: Eval already exists in the effective team.
       case 200:
         return true;
-      // 404: Eval not found in the current team.
+      // 404: Eval not found in the effective team.
       case 404:
         return false;
       default:

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -37,6 +37,13 @@ export type ProviderConfig =
   | ProviderOptionsMap;
 export type ProvidersConfig = ProviderId | ProviderFunction | ApiProvider | ProviderConfig[];
 
+export interface RemoteGenerationContext {
+  /** Provider IDs used for filtering, retry, and target identity. */
+  providerTargetIds: string[];
+  /** Cloud target database ID sent to Promptfoo Cloud task handlers. */
+  cloudTargetId?: string;
+}
+
 export type ProviderType = 'embedding' | 'classification' | 'text' | 'moderation';
 
 export interface SkillCallEntry {

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -29,6 +29,7 @@ import {
   type Scenario,
   type TestCase,
   type TestSuite,
+  type TestSuiteConfig,
   TestSuiteConfigSchema,
   type UnifiedConfig,
   UnifiedConfigSchema,
@@ -740,6 +741,7 @@ export async function resolveConfigs(
   config: Partial<UnifiedConfig>;
   basePath: string;
   commandLineOptions?: Partial<CommandLineOptions>;
+  selectedProviderConfigs?: TestSuiteConfig['providers'];
 }> {
   let fileConfig: Partial<UnifiedConfig> = {};
   let defaultConfig = _defaultConfig;
@@ -1066,5 +1068,6 @@ export async function resolveConfigs(
     testSuite,
     basePath,
     commandLineOptions,
+    selectedProviderConfigs: filteredProviderConfigs,
   };
 }

--- a/src/util/fetch/monkeyPatchFetch.ts
+++ b/src/util/fetch/monkeyPatchFetch.ts
@@ -10,6 +10,8 @@ import type { FetchOptions } from './types';
 
 const gzipAsync = promisify(gzip);
 
+export const PROMPTFOO_TEAM_ID_HEADER = 'x-promptfoo-team-id';
+
 function isConnectionError(error: Error) {
   return (
     error instanceof TypeError &&
@@ -85,6 +87,30 @@ export function getCloudBearerToken(url: string | URL | Request): string | undef
   return token ? `Bearer ${token}` : undefined;
 }
 
+function isPromptfooCloudTaskUrl(url: string | URL | Request): boolean {
+  if (!isPromptfooCloudApiHost(url)) {
+    return false;
+  }
+
+  try {
+    const targetUrl = new URL(getRequestUrlString(url));
+    const pathname = targetUrl.pathname.replace(/\/+$/, '');
+    return pathname.endsWith('/api/v1/task') || pathname.endsWith('/api/v1/task/harmful');
+  } catch {
+    return false;
+  }
+}
+
+/** Returns the persisted CLI team for authenticated Cloud task requests. */
+export function getCloudTaskTeamId(url: string | URL | Request): string | undefined {
+  if (!isPromptfooCloudTaskUrl(url)) {
+    return undefined;
+  }
+
+  const organizationId = cloudConfig.getCurrentOrganizationId();
+  return cloudConfig.getCurrentTeamId(organizationId);
+}
+
 /**
  * Resolves the caller-supplied headers for a request: the explicit `options.headers` when
  * present, otherwise the headers carried by a `Request` URL.
@@ -103,6 +129,10 @@ function getEffectiveHeaders(
 /** Case-insensitive check for a caller-supplied `Authorization` header (any `HeadersInit` shape). */
 function hasAuthorizationHeader(headers: HeadersInit | undefined): boolean {
   return new Headers(headers).has('authorization');
+}
+
+function hasHeader(headers: HeadersInit | undefined, name: string): boolean {
+  return new Headers(headers).has(name);
 }
 
 /**
@@ -156,6 +186,12 @@ export async function monkeyPatchFetch(
   const effectiveHeaders = getEffectiveHeaders(url, opts.headers);
   if (cloudAuth && !hasAuthorizationHeader(effectiveHeaders)) {
     opts.headers = setHeader(effectiveHeaders, 'Authorization', cloudAuth);
+  }
+
+  const cloudTaskTeamId = getCloudTaskTeamId(url);
+  const headersWithAuth = getEffectiveHeaders(url, opts.headers);
+  if (cloudTaskTeamId && !hasHeader(headersWithAuth, PROMPTFOO_TEAM_ID_HEADER)) {
+    opts.headers = setHeader(headersWithAuth, PROMPTFOO_TEAM_ID_HEADER, cloudTaskTeamId);
   }
   try {
     // biome-ignore lint/style/noRestrictedGlobals: we need raw fetch here

--- a/src/validators/redteam.ts
+++ b/src/validators/redteam.ts
@@ -222,6 +222,8 @@ export const RedteamGenerateOptionsSchema = z.object({
     .optional()
     .describe('Delay in milliseconds between plugin API calls'),
   envFile: z.string().optional().describe('Path to the environment file'),
+  filterProviders: z.string().optional().describe('Regex used to select providers'),
+  filterTargets: z.string().optional().describe('Regex used to select targets'),
   force: z.boolean().describe('Whether to force generation').prefault(false),
   injectVar: z.string().optional().describe('Variable to inject'),
   language: z

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1022,6 +1022,38 @@ describe('fetchWithCache', () => {
       expect(teamTwoResult.data).toEqual({ data: 'team two data' });
     });
 
+    it('should prefer an explicit team header when computing the cache key', async () => {
+      mockFetchWithRetries.mockResolvedValue(
+        mockFetchWithRetriesResponse(true, { data: 'explicit team data' }),
+      );
+      vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('team-one');
+
+      const requestOptions = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-promptfoo-team-id': 'team-explicit',
+        },
+        body: JSON.stringify({ task: 'extract-intent' }),
+      };
+      const firstResult = await fetchWithCache(
+        'https://api.promptfoo.app/api/v1/task',
+        requestOptions,
+        1000,
+      );
+
+      vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('team-two');
+      const secondResult = await fetchWithCache(
+        'https://api.promptfoo.app/api/v1/task',
+        requestOptions,
+        1000,
+      );
+
+      expect(mockFetchWithRetries).toHaveBeenCalledTimes(1);
+      expect(firstResult.data).toEqual({ data: 'explicit team data' });
+      expect(secondResult.data).toEqual({ data: 'explicit team data' });
+    });
+
     it('should not let the cloud token override a caller-supplied Authorization in the cache key', async () => {
       const cache = getCache();
       const restoreEnv = mockProcessEnv({ PROMPTFOO_API_KEY: 'saved-cloud-token-one' });

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -21,6 +21,7 @@ import {
   withCacheEnabled,
   withCacheNamespace,
 } from '../src/cache';
+import { cloudConfig } from '../src/globalConfig/cloud';
 import { fetchWithRetries } from '../src/util/fetch/index';
 import { mockProcessEnv } from './util/utils';
 
@@ -32,6 +33,8 @@ vi.mock('../src/globalConfig/cloud', () => ({
   cloudConfig: {
     getApiHost: vi.fn().mockReturnValue('https://api.promptfoo.app'),
     getApiKey: vi.fn(() => process.env.PROMPTFOO_API_KEY),
+    getCurrentOrganizationId: vi.fn().mockReturnValue('org-1'),
+    getCurrentTeamId: vi.fn(),
   },
 }));
 
@@ -289,6 +292,8 @@ describe('fetchWithCache', () => {
   beforeEach(async () => {
     vi.resetModules();
     mockFetchWithRetries.mockReset();
+    vi.mocked(cloudConfig.getCurrentOrganizationId).mockReturnValue('org-1');
+    vi.mocked(cloudConfig.getCurrentTeamId).mockReset().mockReturnValue(undefined);
     await clearCache();
     enableCache();
   });
@@ -986,6 +991,35 @@ describe('fetchWithCache', () => {
       } finally {
         restoreEnv();
       }
+    });
+
+    it('should isolate Cloud task responses by the current CLI team', async () => {
+      mockFetchWithRetries
+        .mockResolvedValueOnce(mockFetchWithRetriesResponse(true, { data: 'team one data' }))
+        .mockResolvedValueOnce(mockFetchWithRetriesResponse(true, { data: 'team two data' }));
+      vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('team-one');
+
+      const requestOptions = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ task: 'extract-intent' }),
+      };
+      const teamOneResult = await fetchWithCache(
+        'https://api.promptfoo.app/api/v1/task',
+        requestOptions,
+        1000,
+      );
+
+      vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('team-two');
+      const teamTwoResult = await fetchWithCache(
+        'https://api.promptfoo.app/api/v1/task',
+        requestOptions,
+        1000,
+      );
+
+      expect(mockFetchWithRetries).toHaveBeenCalledTimes(2);
+      expect(teamOneResult.data).toEqual({ data: 'team one data' });
+      expect(teamTwoResult.data).toEqual({ data: 'team two data' });
     });
 
     it('should not let the cloud token override a caller-supplied Authorization in the cache key', async () => {

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -59,6 +59,8 @@ vi.mock('../src/globalConfig/cloud', () => ({
   cloudConfig: {
     getApiHost: vi.fn().mockReturnValue('https://api.promptfoo.dev'),
     getApiKey: vi.fn(),
+    getCurrentOrganizationId: vi.fn(),
+    getCurrentTeamId: vi.fn(),
   },
 }));
 

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -21,9 +21,13 @@ vi.mock('../../src/cliState');
 vi.mock('../../src/remoteGrading', () => ({
   doRemoteGrading: vi.fn(),
 }));
-vi.mock('../../src/redteam/remoteGeneration', () => ({
-  shouldGenerateRemote: vi.fn().mockReturnValue(false),
-}));
+vi.mock('../../src/redteam/remoteGeneration', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/redteam/remoteGeneration')>();
+  return {
+    ...actual,
+    shouldGenerateRemote: vi.fn().mockReturnValue(false),
+  };
+});
 // Create mock functions that can be configured in tests - use vi.hoisted for mock factory access
 const { mockExistsSync, mockReadFileSync } = vi.hoisted(() => ({
   mockExistsSync: vi.fn(),

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -2266,6 +2266,27 @@ Evaluate the response
     expect(result.reason).toBe('Remote grading passed');
   });
 
+  it('should include Cloud target context in remote grading requests', async () => {
+    const rubric = 'Test rubric';
+    const llmOutput = 'Test output';
+    const remoteGeneration = await import('../../src/redteam/remoteGeneration');
+    vi.mocked(remoteGeneration.shouldGenerateRemote).mockReturnValue(true);
+    (cliState as any).config = {
+      providers: ['promptfoo://provider/cloud-target-123'],
+      redteam: {},
+    };
+
+    await matchesLlmRubric(rubric, llmOutput, {});
+
+    expect(remoteGrading.doRemoteGrading).toHaveBeenCalledWith({
+      task: 'llm-rubric',
+      rubric,
+      output: llmOutput,
+      vars: {},
+      targetId: 'cloud-target-123',
+    });
+  });
+
   it('should call remote with image outputs when multimodal grading is remote-eligible', async () => {
     const rubric = 'Does the image match?';
     const llmOutput = 'Generated image';

--- a/test/matchers/similarity.test.ts
+++ b/test/matchers/similarity.test.ts
@@ -95,6 +95,30 @@ describe('matchesSimilarity', () => {
     });
   });
 
+  it('should include Cloud target context in remote similarity requests', async () => {
+    (cliState as any).config = {
+      providers: ['promptfoo://provider/cloud-target-123'],
+      redteam: {},
+    };
+    vi.spyOn(remoteGeneration, 'shouldGenerateRemote').mockReturnValue(true);
+    vi.spyOn(remoteGrading, 'doRemoteGrading').mockResolvedValue({
+      pass: true,
+      score: 1,
+      reason: 'remote',
+    });
+
+    await matchesSimilarity('Expected output', 'Sample output', 0.5);
+
+    expect(remoteGrading.doRemoteGrading).toHaveBeenCalledWith({
+      task: 'similar',
+      expected: 'Expected output',
+      output: 'Sample output',
+      threshold: 0.5,
+      inverse: false,
+      targetId: 'cloud-target-123',
+    });
+  });
+
   it('should fail when inverted similarity is above the threshold', async () => {
     const expected = 'Expected output';
     const output = 'Sample output';

--- a/test/monkeyPatchFetch.test.ts
+++ b/test/monkeyPatchFetch.test.ts
@@ -108,13 +108,15 @@ describe('monkeyPatchFetch', () => {
     });
   });
 
-  it('should add Authorization header for configured on-prem cloud API requests', async () => {
+  it('should add authorization and current team for configured on-prem cloud task requests', async () => {
     const mockResponse = createMockResponse({ ok: true, status: 200 });
     mockOriginalFetch.mockResolvedValue(mockResponse);
 
     const apiKey = 'test-api-key-123';
     vi.mocked(cloudConfig.getApiHost).mockReturnValue('https://onprem.example.com/api');
     vi.mocked(cloudConfig.getApiKey).mockReturnValue(apiKey);
+    vi.mocked(cloudConfig.getCurrentOrganizationId).mockReturnValue('org-1');
+    vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('team-current');
 
     const url = 'https://onprem.example.com/api/v1/task';
     await monkeyPatchFetch(url);
@@ -122,6 +124,7 @@ describe('monkeyPatchFetch', () => {
     expect(mockOriginalFetch).toHaveBeenCalledWith(url, {
       headers: {
         Authorization: `Bearer ${apiKey}`,
+        'x-promptfoo-team-id': 'team-current',
       },
     });
   });

--- a/test/monkeyPatchFetch.test.ts
+++ b/test/monkeyPatchFetch.test.ts
@@ -19,6 +19,8 @@ vi.mock('../src/globalConfig/cloud', () => ({
   cloudConfig: {
     getApiHost: vi.fn(),
     getApiKey: vi.fn(),
+    getCurrentOrganizationId: vi.fn(),
+    getCurrentTeamId: vi.fn(),
   },
 }));
 
@@ -42,6 +44,8 @@ describe('monkeyPatchFetch', () => {
   beforeEach(() => {
     vi.mocked(cloudConfig.getApiHost).mockReturnValue(CLOUD_API_HOST);
     vi.mocked(cloudConfig.getApiKey).mockReturnValue(undefined);
+    vi.mocked(cloudConfig.getCurrentOrganizationId).mockReturnValue(undefined);
+    vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue(undefined);
   });
 
   afterEach(() => {
@@ -123,16 +127,63 @@ describe('monkeyPatchFetch', () => {
   });
 
   it.each([
+    '/api/v1/task',
+    '/api/v1/task/harmful',
+  ])('should add the current CLI team to Cloud task requests at %s', async (pathname) => {
+    const mockResponse = createMockResponse({ ok: true, status: 200 });
+    mockOriginalFetch.mockResolvedValue(mockResponse);
+    vi.mocked(cloudConfig.getCurrentOrganizationId).mockReturnValue('org-1');
+    vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('team-current');
+
+    const url = CLOUD_API_HOST + pathname;
+    await monkeyPatchFetch(url);
+
+    const requestInit = mockOriginalFetch.mock.calls[0][1] as RequestInit;
+    expect(new Headers(requestInit.headers).get('x-promptfoo-team-id')).toBe('team-current');
+    expect(cloudConfig.getCurrentTeamId).toHaveBeenCalledWith('org-1');
+  });
+
+  it('should not add the current CLI team to non-task Cloud requests', async () => {
+    const mockResponse = createMockResponse({ ok: true, status: 200 });
+    mockOriginalFetch.mockResolvedValue(mockResponse);
+    vi.mocked(cloudConfig.getCurrentOrganizationId).mockReturnValue('org-1');
+    vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('team-current');
+
+    const url = CLOUD_API_HOST + '/api/v1/users/me';
+    await monkeyPatchFetch(url);
+
+    const requestInit = mockOriginalFetch.mock.calls[0][1] as RequestInit;
+    expect(new Headers(requestInit.headers).has('x-promptfoo-team-id')).toBe(false);
+  });
+
+  it.each([
     'https://custom.example.com/harmful',
     'https://api.promptfoo.dev.attacker.example.com/api/v1/task',
   ])('should not forward cloud credentials to %s', async (url) => {
     const mockResponse = createMockResponse({ ok: true, status: 200 });
     mockOriginalFetch.mockResolvedValue(mockResponse);
     vi.mocked(cloudConfig.getApiKey).mockReturnValue('test-api-key-123');
+    vi.mocked(cloudConfig.getCurrentOrganizationId).mockReturnValue('org-1');
+    vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('team-current');
 
     await monkeyPatchFetch(url);
 
     expect(mockOriginalFetch).toHaveBeenCalledWith(url, {});
+  });
+
+  it('should not override a caller-supplied team header', async () => {
+    const mockResponse = createMockResponse({ ok: true, status: 200 });
+    mockOriginalFetch.mockResolvedValue(mockResponse);
+    vi.mocked(cloudConfig.getCurrentOrganizationId).mockReturnValue('org-1');
+    vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('team-current');
+
+    const url = CLOUD_API_HOST + '/api/v1/task';
+    await monkeyPatchFetch(url, {
+      headers: { 'x-promptfoo-team-id': 'team-explicit' },
+    });
+
+    const requestInit = mockOriginalFetch.mock.calls[0][1] as RequestInit;
+    expect(new Headers(requestInit.headers).get('x-promptfoo-team-id')).toBe('team-explicit');
   });
 
   it('should attach the token for a port-bearing on-prem cloud host', async () => {

--- a/test/providers/promptfoo.test.ts
+++ b/test/providers/promptfoo.test.ts
@@ -490,6 +490,35 @@ describe('PromptfooSimulatedUserProvider', () => {
     });
   });
 
+  it('should include target context in task requests', async () => {
+    const providerWithTarget = new PromptfooSimulatedUserProvider(
+      {
+        instructions: 'test instructions',
+        targetId: 'cloud-target-123',
+      },
+      REDTEAM_SIMULATED_USER_TASK_ID,
+    );
+    const mockResponse = new Response(
+      JSON.stringify({
+        result: 'test result',
+        tokenUsage: { total: 100 },
+      }),
+      {
+        status: 200,
+        statusText: 'OK',
+      },
+    );
+    vi.mocked(fetchWithRetries).mockResolvedValue(mockResponse);
+
+    await providerWithTarget.callApi(JSON.stringify([{ role: 'user', content: 'hello' }]));
+
+    const requestBody = JSON.parse(String(vi.mocked(fetchWithRetries).mock.calls[0][1]?.body));
+    expect(requestBody).toMatchObject({
+      task: REDTEAM_SIMULATED_USER_TASK_ID,
+      targetId: 'cloud-target-123',
+    });
+  });
+
   it('should handle API error response', async () => {
     const mockResponse = new Response('API Error', {
       status: 400,

--- a/test/providers/promptfoo.test.ts
+++ b/test/providers/promptfoo.test.ts
@@ -243,6 +243,28 @@ describe('PromptfooChatCompletionProvider', () => {
     });
   });
 
+  it('should include target context in remote task requests', async () => {
+    provider = new PromptfooChatCompletionProvider({
+      ...options,
+      targetId: 'cloud-target-123',
+    });
+    vi.mocked(fetchWithRetries).mockResolvedValue(
+      new Response(JSON.stringify({ result: 'test result' }), { status: 200 }),
+    );
+
+    await provider.callApi('test prompt');
+
+    const request = vi.mocked(fetchWithRetries).mock.calls[0]?.[1];
+    expect(request).toBeDefined();
+    if (!request) {
+      throw new Error('Expected remote task request');
+    }
+    expect(JSON.parse(request.body as string)).toMatchObject({
+      targetId: 'cloud-target-123',
+      task: 'crescendo',
+    });
+  });
+
   it('should pass remote materialization context through to the remote task server', async () => {
     const mockResponse = new Response(
       JSON.stringify({

--- a/test/providers/promptfoo.test.ts
+++ b/test/providers/promptfoo.test.ts
@@ -79,6 +79,27 @@ describe('PromptfooHarmfulCompletionProvider', () => {
     expect(result).toEqual({ output: ['test output'] });
   });
 
+  it('should include target context in harmful generation requests', async () => {
+    provider = new PromptfooHarmfulCompletionProvider({
+      ...options,
+      targetId: 'cloud-target-123',
+    });
+    vi.mocked(fetchWithRetries).mockResolvedValue(
+      new Response(JSON.stringify({ output: 'test output' }), { status: 200 }),
+    );
+
+    await provider.callApi('test prompt');
+
+    expect(fetchWithRetries).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"targetId":"cloud-target-123"'),
+      }),
+      expect.any(Number),
+      expect.any(Number),
+    );
+  });
+
   it('should filter out null and undefined values from output array', async () => {
     const mockResponse = new Response(
       JSON.stringify({ output: ['value1', null, 'value2', undefined] }),

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -202,6 +202,37 @@ describe('doTargetPurposeDiscovery', () => {
     });
   });
 
+  it('should include Cloud target context in discovery requests', async () => {
+    mockedFetchWithProxy.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          done: true,
+          purpose: {
+            purpose: 'Test purpose',
+            limitations: null,
+            tools: [],
+            user: null,
+          },
+          state: {
+            currentQuestionIndex: 0,
+            answers: [],
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    const target = createMockProvider({ id: 'test', response: { output: 'unused' } });
+
+    await doTargetPurposeDiscovery(target, undefined, false, 'cloud-target-123');
+
+    const request = mockedFetchWithProxy.mock.calls[0]?.[1];
+    expect(request).toBeDefined();
+    expect(JSON.parse(request!.body as string)).toMatchObject({
+      task: 'target-purpose-discovery',
+      targetId: 'cloud-target-123',
+    });
+  });
+
   it('should stop when the maximum turn count is reached', async () => {
     mockedFetchWithProxy.mockImplementation(() =>
       Promise.resolve(

--- a/test/redteam/commands/discover.test.ts
+++ b/test/redteam/commands/discover.test.ts
@@ -1,8 +1,13 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ArgsSchema,
   doTargetPurposeDiscovery,
   normalizeTargetPurposeDiscoveryResult,
+  resolveDiscoveryProviderContext,
 } from '../../../src/redteam/commands/discover';
 import { fetchWithProxy } from '../../../src/util/fetch/index';
 import { createMockProvider } from '../../factories/provider';
@@ -37,6 +42,53 @@ describe('ArgsSchema', () => {
     const { success, error } = ArgsSchema.safeParse(args);
     expect(success).toBe(false);
     expect(error?.issues[0].message).toBe('Cannot specify both config and target!');
+  });
+});
+
+describe('resolveDiscoveryProviderContext', () => {
+  it('derives target context from a Cloud provider in a file reference', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'promptfoo-discover-'));
+    const providerPath = path.join(tempDir, 'targets.yaml');
+
+    try {
+      await fs.writeFile(providerPath, 'id: promptfoo://provider/cloud-target-123\n');
+
+      const result = resolveDiscoveryProviderContext(`file://${providerPath}`);
+
+      expect(result.cloudTargetId).toBe('cloud-target-123');
+      expect(result.providers).toEqual([{ id: 'promptfoo://provider/cloud-target-123' }]);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('derives linked target context from a local provider in a file reference', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'promptfoo-discover-'));
+    const providerPath = path.join(tempDir, 'targets.yaml');
+
+    try {
+      await fs.writeFile(
+        providerPath,
+        [
+          'id: openai:gpt-4.1-mini',
+          'config:',
+          '  linkedTargetId: promptfoo://provider/linked-target-123',
+          '',
+        ].join('\n'),
+      );
+
+      const result = resolveDiscoveryProviderContext(`file://${providerPath}`);
+
+      expect(result.cloudTargetId).toBe('linked-target-123');
+      expect(result.providers).toEqual([
+        {
+          id: 'openai:gpt-4.1-mini',
+          config: { linkedTargetId: 'promptfoo://provider/linked-target-123' },
+        },
+      ]);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -305,6 +305,7 @@ describe('doGenerateRedteam', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getProviderIds).mockReturnValue(['test-provider']);
     // Reset mock implementations that persist across tests (clearAllMocks only clears call history)
     resetCommonMocks();
     mockProvider = createMockProvider({
@@ -3975,6 +3976,7 @@ describe('target ID extraction for retry strategy', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getProviderIds).mockReturnValue(['test-provider']);
 
     mockProvider = createMockProvider({
       response: { output: 'test output' },
@@ -4140,6 +4142,7 @@ describe('target ID extraction for retry strategy', () => {
   });
 
   it('should preserve target context for a map-form Cloud provider', async () => {
+    vi.mocked(getProviderIds).mockReturnValue(['promptfoo://provider/cloud-target-123']);
     vi.mocked(isCloudProvider).mockImplementation((providerId) =>
       providerId.startsWith('promptfoo://provider/'),
     );
@@ -4303,6 +4306,11 @@ describe('target ID extraction for retry strategy', () => {
   });
 
   it('should filter out providers without id', async () => {
+    vi.mocked(getProviderIds)
+      .mockReturnValueOnce(['test-provider'])
+      .mockImplementationOnce(() => {
+        throw new Error('Invalid provider');
+      });
     vi.mocked(configModule.resolveConfigs).mockResolvedValue({
       basePath: '/mock/path',
       testSuite: {

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../../../src/globalConfig/accounts';
 import { cloudConfig } from '../../../src/globalConfig/cloud';
 import logger from '../../../src/logger';
-import { getProviderIds } from '../../../src/providers';
 import { doTargetPurposeDiscovery } from '../../../src/redteam/commands/discover';
 import { doGenerateRedteam, redteamGenerateCommand } from '../../../src/redteam/commands/generate';
 import { Severity } from '../../../src/redteam/constants';
@@ -295,8 +294,6 @@ vi.mock('../../../src/providers', async (importOriginal) => {
         cleanup: vi.fn(),
       },
     ]),
-
-    getProviderIds: vi.fn().mockReturnValue(['test-provider']),
   };
 });
 
@@ -305,7 +302,6 @@ describe('doGenerateRedteam', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getProviderIds).mockReturnValue(['test-provider']);
     // Reset mock implementations that persist across tests (clearAllMocks only clears call history)
     resetCommonMocks();
     mockProvider = createMockProvider({
@@ -4040,7 +4036,6 @@ describe('target ID extraction for retry strategy', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getProviderIds).mockReturnValue(['test-provider']);
 
     mockProvider = createMockProvider({
       response: { output: 'test output' },
@@ -4206,7 +4201,6 @@ describe('target ID extraction for retry strategy', () => {
   });
 
   it('should preserve target context for a map-form Cloud provider', async () => {
-    vi.mocked(getProviderIds).mockReturnValue(['promptfoo://provider/cloud-target-123']);
     vi.mocked(isCloudProvider).mockImplementation((providerId) =>
       providerId.startsWith('promptfoo://provider/'),
     );
@@ -4247,7 +4241,6 @@ describe('target ID extraction for retry strategy', () => {
   });
 
   it('should derive target context from the provider selected by a filter', async () => {
-    vi.mocked(getProviderIds).mockReturnValueOnce(['promptfoo://provider/selected-target']);
     vi.mocked(isCloudProvider).mockImplementation((providerId) =>
       providerId.startsWith('promptfoo://provider/'),
     );
@@ -4370,11 +4363,6 @@ describe('target ID extraction for retry strategy', () => {
   });
 
   it('should filter out providers without id', async () => {
-    vi.mocked(getProviderIds)
-      .mockReturnValueOnce(['test-provider'])
-      .mockImplementationOnce(() => {
-        throw new Error('Invalid provider');
-      });
     vi.mocked(configModule.resolveConfigs).mockResolvedValue({
       basePath: '/mock/path',
       testSuite: {

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -26,7 +26,9 @@ import { PartialGenerationError, ProbeLimitExceededError } from '../../../src/re
 import {
   ConfigPermissionError,
   checkCloudPermissions,
+  getCloudDatabaseId,
   getConfigFromCloud,
+  isCloudProvider,
   resolveTeamId,
 } from '../../../src/util/cloud';
 import * as configModule from '../../../src/util/config/load';
@@ -4054,6 +4056,46 @@ describe('target ID extraction for retry strategy', () => {
     expect(synthesize).toHaveBeenCalledWith(
       expect.objectContaining({
         targetIds: ['openai:gpt-4o-mini', 'openai:gpt-4o'],
+      }),
+    );
+  });
+
+  it('should preserve a linked Cloud target separately from the local provider ID', async () => {
+    vi.mocked(isCloudProvider).mockReturnValueOnce(false).mockReturnValueOnce(true);
+    vi.mocked(getCloudDatabaseId).mockReturnValueOnce('cloud-target-123');
+    vi.mocked(configModule.resolveConfigs).mockResolvedValue({
+      basePath: '/mock/path',
+      testSuite: {
+        providers: [mockProvider],
+        prompts: [{ raw: 'Test prompt', label: 'Test label' }],
+        tests: [],
+      },
+      config: {
+        providers: [
+          {
+            id: 'file://local-provider.ts',
+            config: { linkedTargetId: 'promptfoo://provider/cloud-target-123' },
+          },
+        ],
+        redteam: {
+          plugins: ['harmful:hate' as unknown as RedteamPluginObject],
+          strategies: [],
+        },
+      },
+    });
+
+    await doGenerateRedteam({
+      output: 'output.yaml',
+      config: 'config.yaml',
+      cache: true,
+      defaultConfig: {},
+      write: false,
+    });
+
+    expect(synthesize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloudTargetDatabaseId: 'cloud-target-123',
+        targetIds: ['file://local-provider.ts'],
       }),
     );
   });

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -60,6 +60,8 @@ const { TEST_PROBE_LIMIT } = vi.hoisted(() => ({ TEST_PROBE_LIMIT: 100_000 }));
 function resetCommonMocks() {
   vi.mocked(extractA2AAgentCardInfo).mockReset().mockResolvedValue('');
   vi.mocked(extractMcpToolsInfo).mockReset().mockResolvedValue('');
+  vi.mocked(getCloudDatabaseId).mockReset();
+  vi.mocked(isCloudProvider).mockReset().mockReturnValue(false);
   vi.mocked(checkEmailStatusAndMaybeExit).mockReset().mockResolvedValue('ok');
   vi.mocked(promptForEmailUnverified).mockReset().mockResolvedValue({
     emailNeedsValidation: false,
@@ -4124,8 +4126,7 @@ describe('target ID extraction for retry strategy', () => {
   });
 
   it('should preserve a linked Cloud target separately from the local provider ID', async () => {
-    vi.mocked(isCloudProvider).mockReturnValueOnce(false).mockReturnValueOnce(true);
-    vi.mocked(getCloudDatabaseId).mockReturnValueOnce('cloud-target-123');
+    vi.mocked(isCloudProvider).mockReturnValue(false);
     vi.mocked(configModule.resolveConfigs).mockResolvedValue({
       basePath: '/mock/path',
       testSuite: {

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../src/globalConfig/accounts';
 import { cloudConfig } from '../../../src/globalConfig/cloud';
 import logger from '../../../src/logger';
+import { getProviderIds } from '../../../src/providers';
 import { doTargetPurposeDiscovery } from '../../../src/redteam/commands/discover';
 import { doGenerateRedteam, redteamGenerateCommand } from '../../../src/redteam/commands/generate';
 import { Severity } from '../../../src/redteam/constants';
@@ -28,6 +29,7 @@ import {
   checkCloudPermissions,
   getCloudDatabaseId,
   getConfigFromCloud,
+  getPluginSeverityOverridesFromCloud,
   isCloudProvider,
   resolveTeamId,
 } from '../../../src/util/cloud';
@@ -4133,6 +4135,58 @@ describe('target ID extraction for retry strategy', () => {
       expect.objectContaining({
         cloudTargetDatabaseId: 'cloud-target-123',
         targetIds: ['promptfoo://provider/cloud-target-123'],
+      }),
+    );
+  });
+
+  it('should derive target context from the provider selected by a filter', async () => {
+    vi.mocked(getProviderIds).mockReturnValueOnce(['promptfoo://provider/selected-target']);
+    vi.mocked(isCloudProvider).mockImplementation((providerId) =>
+      providerId.startsWith('promptfoo://provider/'),
+    );
+    vi.mocked(getCloudDatabaseId).mockImplementation((providerId) =>
+      providerId.replace('promptfoo://provider/', ''),
+    );
+    vi.mocked(configModule.resolveConfigs).mockResolvedValue({
+      basePath: '/mock/path',
+      testSuite: {
+        providers: [mockProvider],
+        prompts: [{ raw: 'Test prompt', label: 'Test label' }],
+        tests: [],
+      },
+      config: {
+        providers: ['promptfoo://provider/excluded-target', 'promptfoo://provider/selected-target'],
+        redteam: {
+          plugins: ['harmful:hate' as unknown as RedteamPluginObject],
+          strategies: [],
+        },
+      },
+      selectedProviderConfigs: ['promptfoo://provider/selected-target'],
+    });
+
+    await doGenerateRedteam({
+      output: 'output.yaml',
+      config: 'config.yaml',
+      cache: true,
+      defaultConfig: {},
+      filterTargets: 'selected-target',
+      write: false,
+    });
+
+    expect(configModule.resolveConfigs).toHaveBeenCalledWith(
+      expect.objectContaining({ filterTargets: 'selected-target' }),
+      {},
+    );
+    expect(checkCloudPermissions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: ['promptfoo://provider/selected-target'],
+      }),
+    );
+    expect(getPluginSeverityOverridesFromCloud).toHaveBeenCalledWith('selected-target');
+    expect(synthesize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloudTargetDatabaseId: 'selected-target',
+        targetIds: ['promptfoo://provider/selected-target'],
       }),
     );
   });

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -45,7 +45,7 @@ import type {
   RedteamCliGenerateOptions,
   RedteamPluginObject,
 } from '../../../src/redteam/types';
-import type { ApiProvider, TestCaseWithPlugin } from '../../../src/types/index';
+import type { ApiProvider, TestCaseWithPlugin, UnifiedConfig } from '../../../src/types/index';
 
 // Type for synthesize mock return value to avoid type inference issues in CI
 type SynthesizeMockResult = {
@@ -396,6 +396,70 @@ describe('doGenerateRedteam', () => {
       'output.yaml',
       expect.any(Array),
     );
+  });
+
+  it.each([
+    ['filterProviders value', { filterProviders: 'team-a' }, { filterProviders: 'team-b' }],
+    ['filterTargets value', { filterTargets: 'team-a' }, { filterTargets: 'team-b' }],
+    ['filter option', { filterProviders: 'team-a' }, { filterTargets: 'team-a' }],
+  ] as const)('should regenerate when the %s changes for an existing output', async (_, initialFilters, changedFilters) => {
+    const configPath = 'config.yaml';
+    const outputPath = 'output.yaml';
+    const configContent = yaml.dump({
+      providers: ['promptfoo://provider/team-a', 'promptfoo://provider/team-b'],
+      redteam: { plugins: ['harmful:hate'] },
+    });
+    let generatedOutput: Partial<UnifiedConfig> | undefined;
+
+    vi.mocked(fs.existsSync).mockImplementation((filePath) => {
+      const path = String(filePath);
+      return path === configPath || (path === outputPath && generatedOutput !== undefined);
+    });
+    vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+      return String(filePath) === outputPath ? yaml.dump(generatedOutput) : configContent;
+    });
+    vi.mocked(synthesize).mockResolvedValue({
+      testCases: [
+        {
+          vars: { input: 'Test input' },
+          assert: [{ type: 'equals', value: 'Test output' }],
+          metadata: { pluginId: 'redteam' },
+        },
+      ],
+      purpose: 'Test purpose',
+      entities: [],
+      injectVar: 'input',
+      failedPlugins: [],
+    });
+
+    const options: RedteamCliGenerateOptions = {
+      output: outputPath,
+      config: configPath,
+      cache: true,
+      defaultConfig: {},
+      write: false,
+      ...initialFilters,
+    };
+
+    await doGenerateRedteam(options);
+    generatedOutput = vi.mocked(writePromptfooConfig).mock.calls[0][0];
+    const firstHash = generatedOutput.metadata?.configHash;
+    expect(firstHash).toEqual(expect.any(String));
+
+    vi.clearAllMocks();
+    await doGenerateRedteam(options);
+
+    expect(synthesize).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'No changes detected in redteam configuration. Skipping generation (use --force to generate anyway)',
+    );
+
+    vi.clearAllMocks();
+    await doGenerateRedteam({ ...options, ...changedFilters });
+
+    expect(synthesize).toHaveBeenCalledTimes(1);
+    const changedOutput = vi.mocked(writePromptfooConfig).mock.calls[0][0];
+    expect(changedOutput.metadata?.configHash).not.toBe(firstHash);
   });
 
   it('should write to config file when write option is true', async () => {

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -4100,6 +4100,43 @@ describe('target ID extraction for retry strategy', () => {
     );
   });
 
+  it('should preserve target context for a scalar Cloud provider', async () => {
+    vi.mocked(isCloudProvider).mockImplementation((providerId) =>
+      providerId.startsWith('promptfoo://provider/'),
+    );
+    vi.mocked(getCloudDatabaseId).mockReturnValue('cloud-target-123');
+    vi.mocked(configModule.resolveConfigs).mockResolvedValue({
+      basePath: '/mock/path',
+      testSuite: {
+        providers: [mockProvider],
+        prompts: [{ raw: 'Test prompt', label: 'Test label' }],
+        tests: [],
+      },
+      config: {
+        providers: 'promptfoo://provider/cloud-target-123',
+        redteam: {
+          plugins: ['harmful:hate' as unknown as RedteamPluginObject],
+          strategies: [],
+        },
+      },
+    });
+
+    await doGenerateRedteam({
+      output: 'output.yaml',
+      config: 'config.yaml',
+      cache: true,
+      defaultConfig: {},
+      write: false,
+    });
+
+    expect(synthesize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloudTargetDatabaseId: 'cloud-target-123',
+        targetIds: ['promptfoo://provider/cloud-target-123'],
+      }),
+    );
+  });
+
   it('should handle mixed string and object providers', async () => {
     vi.mocked(configModule.resolveConfigs).mockResolvedValue({
       basePath: '/mock/path',

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -4139,6 +4139,46 @@ describe('target ID extraction for retry strategy', () => {
     );
   });
 
+  it('should preserve target context for a map-form Cloud provider', async () => {
+    vi.mocked(isCloudProvider).mockImplementation((providerId) =>
+      providerId.startsWith('promptfoo://provider/'),
+    );
+    vi.mocked(getCloudDatabaseId).mockImplementation((providerId) =>
+      providerId.replace('promptfoo://provider/', ''),
+    );
+    vi.mocked(configModule.resolveConfigs).mockResolvedValue({
+      basePath: '/mock/path',
+      testSuite: {
+        providers: [mockProvider],
+        prompts: [{ raw: 'Test prompt', label: 'Test label' }],
+        tests: [],
+      },
+      config: {
+        providers: [{ 'promptfoo://provider/cloud-target-123': {} }],
+        redteam: {
+          plugins: ['harmful:hate' as unknown as RedteamPluginObject],
+          strategies: [],
+        },
+      },
+      selectedProviderConfigs: [{ 'promptfoo://provider/cloud-target-123': {} }],
+    });
+
+    await doGenerateRedteam({
+      output: 'output.yaml',
+      config: 'config.yaml',
+      cache: true,
+      defaultConfig: {},
+      write: false,
+    });
+
+    expect(synthesize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloudTargetDatabaseId: 'cloud-target-123',
+        targetIds: ['promptfoo://provider/cloud-target-123'],
+      }),
+    );
+  });
+
   it('should derive target context from the provider selected by a filter', async () => {
     vi.mocked(getProviderIds).mockReturnValueOnce(['promptfoo://provider/selected-target']);
     vi.mocked(isCloudProvider).mockImplementation((providerId) =>

--- a/test/redteam/extraction/entities.test.ts
+++ b/test/redteam/extraction/entities.test.ts
@@ -76,7 +76,10 @@ describe('Entities Extractor', () => {
       cached: false,
     });
 
-    const result = await extractEntities(provider, ['prompt1', 'prompt2']);
+    const result = await extractEntities(provider, ['prompt1', 'prompt2'], {
+      providerTargetIds: ['file://local-provider.ts'],
+      cloudTargetId: 'cloud-target-123',
+    });
 
     expect(result).toEqual(['Apple', 'Google']);
     expect(fetchWithCache).toHaveBeenCalledWith(
@@ -88,6 +91,7 @@ describe('Entities Extractor', () => {
           prompts: ['prompt1', 'prompt2'],
           version: VERSION,
           email: null,
+          targetId: 'cloud-target-123',
         }),
       }),
       expect.any(Number),

--- a/test/redteam/extraction/purpose.test.ts
+++ b/test/redteam/extraction/purpose.test.ts
@@ -65,7 +65,10 @@ describe('System Purpose Extractor', () => {
       cached: false,
     });
 
-    const result = await extractSystemPurpose(provider, ['prompt1', 'prompt2']);
+    const result = await extractSystemPurpose(provider, ['prompt1', 'prompt2'], {
+      providerTargetIds: ['file://local-provider.ts'],
+      cloudTargetId: 'cloud-target-123',
+    });
 
     expect(result).toBe('Remote extracted purpose');
     expect(fetchWithCache).toHaveBeenCalledWith(
@@ -77,6 +80,7 @@ describe('System Purpose Extractor', () => {
           prompts: ['prompt1', 'prompt2'],
           version: VERSION,
           email: null,
+          targetId: 'cloud-target-123',
         }),
       }),
       expect.any(Number),

--- a/test/redteam/extraction/util.test.ts
+++ b/test/redteam/extraction/util.test.ts
@@ -123,6 +123,35 @@ describe('fetchRemoteGeneration', () => {
     );
   });
 
+  it('should include the resolved cloud target in the remote generation payload', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: { task: 'purpose', result: 'This is a purpose' },
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    });
+
+    await fetchRemoteGeneration('purpose', ['prompt'], {
+      providerTargetIds: ['file://local-provider.ts'],
+      cloudTargetId: 'cloud-target-123',
+    });
+
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      'https://api.promptfoo.app/api/v1/task',
+      expect.objectContaining({
+        body: JSON.stringify({
+          task: 'purpose',
+          prompts: ['prompt'],
+          version: VERSION,
+          email: null,
+          targetId: 'cloud-target-123',
+        }),
+      }),
+      getRequestTimeoutMs(),
+      'json',
+    );
+  });
+
   it('should throw an error when fetchWithCache fails', async () => {
     const mockError = new Error('Network error');
     vi.mocked(fetchWithCache).mockRejectedValue(mockError);

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -3913,6 +3913,7 @@ describe('Language configuration', () => {
 
         try {
           await synthesize({
+            cloudTargetDatabaseId: 'cloud-target-123',
             numTests: 1,
             plugins: [{ id: 'test-plugin', numTests: 1 }],
             prompts: ['Test prompt'],
@@ -3924,6 +3925,7 @@ describe('Language configuration', () => {
           expect(mockStrategyAction).toHaveBeenCalled();
           expect(capturedConfig).toBeDefined();
           expect(capturedConfig?.redteamProvider).toBe('vertex:gemini-2.5-flash');
+          expect(capturedConfig?.targetId).toBe('cloud-target-123');
         } finally {
           getProviderSpy.mockRestore();
           getGradingProviderSpy.mockRestore();

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -150,18 +150,31 @@ describe('synthesize', () => {
       expect(extractSystemPurpose).not.toHaveBeenCalled();
     });
 
-    it('should extract purpose and entities if not provided', async () => {
+    it('should pass resolved target context when extracting purpose and entities', async () => {
+      const generationContext = {
+        providerTargetIds: ['file://local-provider.ts'],
+        cloudTargetId: 'cloud-target-123',
+      };
       await synthesize({
+        cloudTargetDatabaseId: 'cloud-target-123',
         language: 'english',
         numTests: 1,
         plugins: [{ id: 'test-plugin', numTests: 1 }],
         prompts: ['Test prompt'],
         strategies: [],
-        targetIds: ['test-provider'],
+        targetIds: ['file://local-provider.ts'],
       });
 
-      expect(extractEntities).toHaveBeenCalledWith(expect.any(Object), ['Test prompt']);
-      expect(extractSystemPurpose).toHaveBeenCalledWith(expect.any(Object), ['Test prompt']);
+      expect(extractEntities).toHaveBeenCalledWith(
+        expect.any(Object),
+        ['Test prompt'],
+        generationContext,
+      );
+      expect(extractSystemPurpose).toHaveBeenCalledWith(
+        expect.any(Object),
+        ['Test prompt'],
+        generationContext,
+      );
     });
 
     it('should handle empty prompts array', async () => {
@@ -187,14 +200,15 @@ describe('synthesize', () => {
         targetIds: ['test-provider'],
       });
 
-      expect(extractSystemPurpose).toHaveBeenCalledWith(expect.any(Object), [
-        'Prompt 1',
-        'Prompt 2',
-        'Prompt 3',
-      ]);
+      expect(extractSystemPurpose).toHaveBeenCalledWith(
+        expect.any(Object),
+        ['Prompt 1', 'Prompt 2', 'Prompt 3'],
+        expect.any(Object),
+      );
       expect(extractEntities).toHaveBeenCalledWith(
         expect.objectContaining({ id: expect.any(Function) }),
         ['Prompt 1', 'Prompt 2', 'Prompt 3'],
+        expect.any(Object),
       );
     });
   });

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -3069,7 +3069,7 @@ describe('Language configuration', () => {
         plugins: [{ id: 'policy', numTests: 1 }],
         prompts: ['Test prompt'],
         strategies: [{ id: 'goat' }],
-        targetIds: ['test-provider'],
+        targetIds: ['promptfoo://provider/target-123'],
       });
 
       // Verify extractGoalFromPrompt was called with the policy
@@ -3079,6 +3079,7 @@ describe('Language configuration', () => {
       expect(call[1]).toBe('Test purpose'); // purpose
       expect(call[2]).toBe('policy'); // pluginId
       expect(call[3]).toBe(policyText); // policy
+      expect(call[4]).toBe('target-123'); // targetId
     });
 
     it('should not pass policy when metadata does not contain policy', async () => {

--- a/test/redteam/index.test.ts
+++ b/test/redteam/index.test.ts
@@ -3082,6 +3082,38 @@ describe('Language configuration', () => {
       expect(call[4]).toBe('target-123'); // targetId
     });
 
+    it('should pass an explicit linked Cloud target to extractGoalFromPrompt', async () => {
+      const mockExtractGoal = vi.mocked(
+        (await import('../../src/redteam/util')).extractGoalFromPrompt,
+      );
+      mockExtractGoal.mockClear();
+
+      const mockPluginAction = vi.fn().mockResolvedValue([
+        {
+          vars: { query: 'Test prompt' },
+          metadata: { pluginId: 'promptfoo:redteam:policy' },
+        },
+      ]);
+      vi.spyOn(Plugins, 'find').mockReturnValue({
+        key: 'policy',
+        action: mockPluginAction,
+      } as any);
+
+      await synthesize({
+        cloudTargetDatabaseId: 'linked-target-123',
+        numTests: 1,
+        plugins: [{ id: 'policy', numTests: 1 }],
+        prompts: ['Test prompt'],
+        strategies: [{ id: 'goat' }],
+        targetIds: ['file://local-provider.ts'],
+      });
+
+      expect(mockPluginAction).toHaveBeenCalledWith(
+        expect.objectContaining({ targetId: 'linked-target-123' }),
+      );
+      expect(mockExtractGoal.mock.calls[0][4]).toBe('linked-target-123');
+    });
+
     it('should not pass policy when metadata does not contain policy', async () => {
       const mockExtractGoal = vi.mocked(
         (await import('../../src/redteam/util')).extractGoalFromPrompt,

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -302,6 +302,7 @@ describe('Plugins', () => {
         n: 1,
         config: {},
         delayMs: 0,
+        targetId: 'cloud-target-123',
       });
 
       expect(fetchWithCache).toHaveBeenCalledWith(
@@ -315,6 +316,7 @@ describe('Plugins', () => {
             n: 1,
             purpose: 'test',
             task: 'ssrf',
+            targetId: 'cloud-target-123',
             version: VERSION,
             email: null,
           }),

--- a/test/redteam/plugins/intent.test.ts
+++ b/test/redteam/plugins/intent.test.ts
@@ -70,9 +70,15 @@ describe('IntentPlugin', () => {
   });
 
   it('should initialize with a single string intent and extract intent goal', async () => {
-    const plugin = new IntentPlugin(mockProvider, 'test-purpose', 'prompt', {
-      intent: 'View order details belonging to Jane Smith while authenticated as John Doe',
-    });
+    const plugin = new IntentPlugin(
+      mockProvider,
+      'test-purpose',
+      'prompt',
+      {
+        intent: 'View order details belonging to Jane Smith while authenticated as John Doe',
+      },
+      'cloud-target-123',
+    );
 
     const tests = await plugin.generateTests(1, 0);
     expect(tests).toHaveLength(1);
@@ -82,6 +88,10 @@ describe('IntentPlugin', () => {
     );
     expect(tests[0].metadata).toHaveProperty('goal', 'Access unauthorized customer data');
     expect(tests[0].metadata).toHaveProperty('pluginId', 'promptfoo:redteam:intent');
+    const requestBody = JSON.parse(
+      (vi.mocked(fetchWithCache).mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(requestBody.targetId).toBe('cloud-target-123');
   });
 
   it('should initialize with an array of string intents', async () => {

--- a/test/redteam/providers/agentic/memoryPoisoning.test.ts
+++ b/test/redteam/providers/agentic/memoryPoisoning.test.ts
@@ -129,6 +129,29 @@ describe('MemoryPoisoningProvider', () => {
     expect(mockTargetProvider.callApi).toHaveBeenCalledWith('follow up text', context, undefined);
   });
 
+  it('should include target context in scenario generation requests', async () => {
+    provider = new MemoryPoisoningProvider({ config: { targetId: 'cloud-target-123' } });
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ memory: 'memory text', followUp: 'follow up text' }), {
+        status: 200,
+      }),
+    );
+    const context: CallApiContextParams = {
+      prompt: { raw: 'test', display: 'test', label: 'test' },
+      vars: {},
+      originalProvider: mockTargetProvider,
+      test: { metadata: { purpose: 'test purpose' } },
+    };
+
+    await provider.callApi('test prompt', context);
+
+    const request = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      targetId: 'cloud-target-123',
+      task: 'agentic:memory-poisoning-scenario',
+    });
+  });
+
   it('should accumulate token usage from all target provider calls', async () => {
     const scenario = {
       memory: 'memory text',

--- a/test/redteam/providers/authoritativeMarkupInjection.test.ts
+++ b/test/redteam/providers/authoritativeMarkupInjection.test.ts
@@ -80,6 +80,21 @@ describe('AuthoritativeMarkupInjectionProvider', () => {
     );
   });
 
+  it('should include target context in remote generation requests', async () => {
+    const provider = new AuthoritativeMarkupInjectionProvider({
+      injectVar: 'input',
+      targetId: 'cloud-target-123',
+    });
+
+    await provider.callApi('test prompt', createMockContext(mockTargetProvider));
+
+    const request = mockFetchWithProxy.mock.calls[0]?.[1] as { body?: string } | undefined;
+    expect(JSON.parse(request?.body ?? '{}')).toMatchObject({
+      targetId: 'cloud-target-123',
+      task: 'authoritative-markup-injection',
+    });
+  });
+
   it('should pass options to target provider callApi', async () => {
     const provider = new AuthoritativeMarkupInjectionProvider({
       injectVar: 'input',

--- a/test/redteam/providers/bestOfN.test.ts
+++ b/test/redteam/providers/bestOfN.test.ts
@@ -97,6 +97,22 @@ describe('BestOfNProvider - Runtime Behavior', () => {
     );
   });
 
+  it('should include target context in remote generation requests', async () => {
+    const provider = new BestOfNProvider({
+      injectVar: 'input',
+      targetId: 'cloud-target-123',
+    });
+
+    await provider.callApi('test prompt', createMockContext(mockTargetProvider));
+
+    const request = mockFetchWithProxy.mock.calls[0]?.[1] as { body?: string } | undefined;
+    expect(request?.body).toBeDefined();
+    expect(JSON.parse(request?.body ?? '{}')).toMatchObject({
+      targetId: 'cloud-target-123',
+      task: 'jailbreak:best-of-n',
+    });
+  });
+
   it('should pass options to target provider callApi', async () => {
     const provider = new BestOfNProvider({
       injectVar: 'input',

--- a/test/redteam/providers/goat.test.ts
+++ b/test/redteam/providers/goat.test.ts
@@ -218,6 +218,22 @@ describe('RedteamGoatProvider', () => {
     expect(lastCallBody.messages).toBeDefined();
   });
 
+  it('should include target context in remote agentic task requests', async () => {
+    const provider = new RedteamGoatProvider({
+      injectVar: 'goal',
+      maxTurns: 1,
+      targetId: 'cloud-target-123',
+    });
+
+    await provider.callApi('test prompt', createMockContext(createMockTargetProvider()));
+
+    const requestBody = JSON.parse((mockFetch.mock.calls[0][1] as { body: string }).body);
+    expect(requestBody).toMatchObject({
+      targetId: 'cloud-target-123',
+      task: 'goat',
+    });
+  });
+
   it('should not dereference file:// paths in remote attacker messages', async () => {
     const provider = new RedteamGoatProvider({
       injectVar: 'goal',

--- a/test/redteam/providers/hydra/index.test.ts
+++ b/test/redteam/providers/hydra/index.test.ts
@@ -245,12 +245,13 @@ describe('HydraProvider', () => {
     });
 
     it('should create agent provider with correct config', () => {
-      new HydraProvider({ injectVar: 'input' });
+      new HydraProvider({ injectVar: 'input', targetId: 'cloud-target-123' });
 
       expect(PromptfooChatCompletionProvider).toHaveBeenCalledWith({
         task: 'hydra-decision',
         jsonOnly: true,
         preferSmallModel: false,
+        targetId: 'cloud-target-123',
       });
     });
   });

--- a/test/redteam/remoteGenerationContext.test.ts
+++ b/test/redteam/remoteGenerationContext.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getRedteamGenerationContextFromProviders,
+  remoteGenerationContextPayload,
+  resolveRedteamGenerationContext,
+} from '../../src/redteam/remoteGenerationContext';
+
+describe('remoteGenerationContext', () => {
+  it('builds a task payload from a cloud target id', () => {
+    expect(remoteGenerationContextPayload('target-123')).toEqual({ targetId: 'target-123' });
+    expect(remoteGenerationContextPayload({ cloudTargetId: 'target-123' })).toEqual({
+      targetId: 'target-123',
+    });
+    expect(remoteGenerationContextPayload()).toEqual({});
+  });
+
+  it('extracts provider target ids and cloud target id from direct cloud providers', () => {
+    const context = getRedteamGenerationContextFromProviders([
+      'openai:gpt-4o-mini',
+      'promptfoo://provider/cloud-target-123',
+    ]);
+
+    expect(context).toEqual({
+      providerTargetIds: ['openai:gpt-4o-mini', 'promptfoo://provider/cloud-target-123'],
+      cloudTargetId: 'cloud-target-123',
+    });
+  });
+
+  it('extracts cloud target id from linked target provider config', () => {
+    const context = getRedteamGenerationContextFromProviders([
+      {
+        id: 'file://local-provider.ts',
+        config: {
+          linkedTargetId: 'promptfoo://provider/linked-target-123',
+        },
+      },
+    ]);
+
+    expect(context).toEqual({
+      providerTargetIds: ['file://local-provider.ts'],
+      cloudTargetId: 'linked-target-123',
+    });
+  });
+
+  it('extracts cloud target id from mapped provider config values', () => {
+    const context = getRedteamGenerationContextFromProviders([
+      {
+        'openai:gpt-4o-mini': {
+          config: {
+            linkedTargetId: 'promptfoo://provider/mapped-linked-target',
+          },
+        },
+      },
+    ]);
+
+    expect(context).toEqual({
+      providerTargetIds: ['openai:gpt-4o-mini'],
+      cloudTargetId: 'mapped-linked-target',
+    });
+  });
+
+  it('preserves explicit context over legacy fields', () => {
+    const context = resolveRedteamGenerationContext({
+      cloudTargetDatabaseId: 'legacy-target',
+      redteamGenerationContext: {
+        providerTargetIds: ['promptfoo://provider/context-target'],
+        cloudTargetId: 'context-target',
+      },
+      targetIds: ['promptfoo://provider/target-id'],
+    });
+
+    expect(context).toEqual({
+      providerTargetIds: ['promptfoo://provider/context-target'],
+      cloudTargetId: 'context-target',
+    });
+  });
+});

--- a/test/redteam/remoteGenerationContext.test.ts
+++ b/test/redteam/remoteGenerationContext.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
-  getRedteamGenerationContextFromProviders,
   remoteGenerationContextPayload,
   resolveRedteamGenerationContext,
 } from '../../src/redteam/remoteGenerationContext';
+import { getRedteamGenerationContextFromProviders } from '../../src/redteam/remoteGenerationContextFromProviders';
 
 describe('remoteGenerationContext', () => {
   it('builds a task payload from a cloud target id', () => {

--- a/test/redteam/remoteGenerationContext.test.ts
+++ b/test/redteam/remoteGenerationContext.test.ts
@@ -15,10 +15,8 @@ describe('remoteGenerationContext', () => {
   });
 
   it('extracts provider target ids and cloud target id from direct cloud providers', () => {
-    const context = getRedteamGenerationContextFromProviders([
-      'openai:gpt-4o-mini',
-      'promptfoo://provider/cloud-target-123',
-    ]);
+    const providerTargetIds = ['openai:gpt-4o-mini', 'promptfoo://provider/cloud-target-123'];
+    const context = getRedteamGenerationContextFromProviders(providerTargetIds, providerTargetIds);
 
     expect(context).toEqual({
       providerTargetIds: ['openai:gpt-4o-mini', 'promptfoo://provider/cloud-target-123'],
@@ -27,14 +25,17 @@ describe('remoteGenerationContext', () => {
   });
 
   it('extracts cloud target id from linked target provider config', () => {
-    const context = getRedteamGenerationContextFromProviders([
-      {
-        id: 'file://local-provider.ts',
-        config: {
-          linkedTargetId: 'promptfoo://provider/linked-target-123',
+    const context = getRedteamGenerationContextFromProviders(
+      [
+        {
+          id: 'file://local-provider.ts',
+          config: {
+            linkedTargetId: 'promptfoo://provider/linked-target-123',
+          },
         },
-      },
-    ]);
+      ],
+      ['file://local-provider.ts'],
+    );
 
     expect(context).toEqual({
       providerTargetIds: ['file://local-provider.ts'],
@@ -43,15 +44,18 @@ describe('remoteGenerationContext', () => {
   });
 
   it('extracts cloud target id from mapped provider config values', () => {
-    const context = getRedteamGenerationContextFromProviders([
-      {
-        'openai:gpt-4o-mini': {
-          config: {
-            linkedTargetId: 'promptfoo://provider/mapped-linked-target',
+    const context = getRedteamGenerationContextFromProviders(
+      [
+        {
+          'openai:gpt-4o-mini': {
+            config: {
+              linkedTargetId: 'promptfoo://provider/mapped-linked-target',
+            },
           },
         },
-      },
-    ]);
+      ],
+      ['openai:gpt-4o-mini'],
+    );
 
     expect(context).toEqual({
       providerTargetIds: ['openai:gpt-4o-mini'],

--- a/test/redteam/shared/runtimeTransform.test.ts
+++ b/test/redteam/shared/runtimeTransform.test.ts
@@ -171,6 +171,18 @@ describe('runtimeTransform', () => {
       );
     });
 
+    it('should pass target context to per-turn layer strategies', async () => {
+      await applyRuntimeTransforms('hello', 'input', ['base64'], mockStrategies, {
+        targetId: 'cloud-target-123',
+      });
+
+      expect(mockBase64Strategy.action).toHaveBeenCalledWith(
+        expect.any(Array),
+        'input',
+        expect.objectContaining({ targetId: 'cloud-target-123' }),
+      );
+    });
+
     it('should skip unknown strategies with warning', async () => {
       const result = await applyRuntimeTransforms(
         'hello',

--- a/test/redteam/strategies/layer.test.ts
+++ b/test/redteam/strategies/layer.test.ts
@@ -614,7 +614,14 @@ describe('addLayerTestCases', () => {
         testCases,
         'input',
         {
-          steps: [{ id: 'jailbreak:hydra', config: { maxTurns: 5, stateful: true } }, 'audio'],
+          targetId: 'cloud-target-123',
+          steps: [
+            {
+              id: 'jailbreak:hydra',
+              config: { maxTurns: 5, stateful: true, targetId: 'stale-target' },
+            },
+            'audio',
+          ],
         },
         mockStrategies,
         mockLoadStrategy,
@@ -628,6 +635,7 @@ describe('addLayerTestCases', () => {
           expect.objectContaining({
             maxTurns: 5,
             stateful: true,
+            targetId: 'cloud-target-123',
             _perTurnLayers: ['audio'],
           }),
         );

--- a/test/redteam/strategies/mathPrompt.test.ts
+++ b/test/redteam/strategies/mathPrompt.test.ts
@@ -54,12 +54,19 @@ describe('mathPrompt', () => {
       };
 
       vi.mocked(fetchWithCache).mockResolvedValue(mockResponse as any);
-      const result = await generateMathPrompt(mockTestCases as any, 'prompt', {});
+      const result = await generateMathPrompt(mockTestCases as any, 'prompt', {
+        targetId: 'cloud-target-123',
+      });
 
       expect(result).toEqual(mockResult);
       expect(mockProgressBar.start).toHaveBeenCalledWith(1, 0);
       expect(mockProgressBar.increment).toHaveBeenCalledWith(1);
       expect(mockProgressBar.stop).toHaveBeenCalledWith();
+      const requestBody = vi.mocked(fetchWithCache).mock.calls[0]?.[1]?.body;
+      expect(requestBody).toBeTypeOf('string');
+      expect(JSON.parse(requestBody as string)).toMatchObject({
+        targetId: 'cloud-target-123',
+      });
     });
 
     it('should handle errors gracefully', async () => {

--- a/test/redteam/util.test.ts
+++ b/test/redteam/util.test.ts
@@ -242,6 +242,34 @@ describe('extractGoalFromPrompt', () => {
     );
   });
 
+  it('should include targetId when provided', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data: { intent: 'target-scoped goal' },
+      deleteFromCache: async () => {},
+    });
+
+    const result = await extractGoalFromPrompt(
+      'test prompt',
+      'test purpose',
+      undefined,
+      undefined,
+      'target-123',
+    );
+    expect(result).toBe('target-scoped goal');
+
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"targetId":"target-123"'),
+      }),
+      expect.any(Number),
+    );
+  });
+
   it('should skip remote call when remote generation is disabled', async () => {
     const restoreEnv = mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'true' });
     try {

--- a/test/redteam/validators.test.ts
+++ b/test/redteam/validators.test.ts
@@ -127,10 +127,16 @@ describe('redteamGenerateOptionsSchema', () => {
       maxConcurrency: 5,
       maxCharsPerMessage: 125,
       delay: 1000,
+      filterProviders: 'openai',
+      filterTargets: 'target-team-b',
     };
 
     const result = RedteamGenerateOptionsSchema.safeParse(options);
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.filterProviders).toBe('openai');
+      expect(result.data.filterTargets).toBe('target-team-b');
+    }
   });
 
   it('should reject invalid plugin names', () => {

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -440,6 +440,67 @@ describe('createShareableUrl', () => {
     expect(mockEval.useOldResults).toHaveBeenCalled();
   });
 
+  it('preserves the runtime team from a server-issued unified config', async () => {
+    vi.mocked(cloudConfig.isEnabled).mockReturnValue(true);
+    vi.mocked(cloudConfig.getAppUrl).mockReturnValue('https://app.example.com');
+    vi.mocked(cloudConfig.getApiHost).mockReturnValue('https://api.example.com');
+    vi.mocked(cloudConfig.getApiKey).mockReturnValue('mock-api-key');
+    vi.mocked(cloudConfig.getCurrentOrganizationId).mockReturnValue('org-123');
+    vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('current-team');
+
+    const mockEval = buildMockEval();
+    mockEval.config = {
+      ...(mockEval.config ?? {}),
+      metadata: {
+        configId: 'org-scoped-template',
+        teamId: 'provider-team',
+      },
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 'mock-eval-id' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+    await createShareableUrl(mockEval as Eval);
+
+    const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(requestBody.config.metadata).toMatchObject({
+      configId: 'org-scoped-template',
+      teamId: 'provider-team',
+    });
+  });
+
+  it('uses the current CLI team when runtime metadata is absent', async () => {
+    vi.mocked(cloudConfig.isEnabled).mockReturnValue(true);
+    vi.mocked(cloudConfig.getAppUrl).mockReturnValue('https://app.example.com');
+    vi.mocked(cloudConfig.getApiHost).mockReturnValue('https://api.example.com');
+    vi.mocked(cloudConfig.getApiKey).mockReturnValue('mock-api-key');
+    vi.mocked(cloudConfig.getCurrentOrganizationId).mockReturnValue('org-123');
+    vi.mocked(cloudConfig.getCurrentTeamId).mockReturnValue('current-team');
+
+    const mockEval = buildMockEval();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 'mock-eval-id' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+    await createShareableUrl(mockEval as Eval);
+
+    const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(requestBody.config.metadata.teamId).toBe('current-team');
+  });
+
   it('Cloud: creates correct URL (uses server-assigned ID for idempotency)', async () => {
     vi.mocked(cloudConfig.isEnabled).mockReturnValue(true);
     vi.mocked(cloudConfig.getAppUrl).mockReturnValue('https://app.example.com');

--- a/test/share.test.ts
+++ b/test/share.test.ts
@@ -1271,6 +1271,48 @@ describe('hasEvalBeenShared', () => {
     expect(makeRequest).toHaveBeenCalledWith(expect.stringContaining('teamId=team-456'), 'GET');
   });
 
+  it('checks the runtime team for a server-issued unified config', async () => {
+    const mockEval: Partial<Eval> = {
+      config: {
+        metadata: {
+          configId: 'org-scoped-template',
+          teamId: 'runtime-team',
+        },
+      },
+      id: randomUUID(),
+    };
+
+    vi.mocked(makeRequest).mockResolvedValue({ status: 200 } as Response);
+
+    const result = await hasEvalBeenShared(mockEval as Eval);
+
+    expect(result).toBe(true);
+    expect(makeRequest).toHaveBeenCalledWith(expect.stringContaining('teamId=runtime-team'), 'GET');
+    expect(makeRequest).not.toHaveBeenCalledWith(expect.stringContaining('teamId=team-456'), 'GET');
+  });
+
+  it('ignores unverified metadata team context', async () => {
+    const mockEval: Partial<Eval> = {
+      config: {
+        metadata: {
+          teamId: 'unverified-team',
+        },
+      },
+      id: randomUUID(),
+    };
+
+    vi.mocked(makeRequest).mockResolvedValue({ status: 200 } as Response);
+
+    const result = await hasEvalBeenShared(mockEval as Eval);
+
+    expect(result).toBe(true);
+    expect(makeRequest).toHaveBeenCalledWith(expect.stringContaining('teamId=team-456'), 'GET');
+    expect(makeRequest).not.toHaveBeenCalledWith(
+      expect.stringContaining('teamId=unverified-team'),
+      'GET',
+    );
+  });
+
   it('returns false if the server returns 404', async () => {
     const mockEval: Partial<Eval> = {
       config: {},

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -1560,6 +1560,24 @@ describe('resolveConfigs', () => {
     expect(cliState.basePath).toBe(path.dirname('config.json'));
   });
 
+  it('should return the provider configs selected by a target filter', async () => {
+    const providers = [
+      { id: 'promptfoo://provider/excluded-target', config: { label: 'excluded' } },
+      { id: 'promptfoo://provider/selected-target', config: { label: 'selected' } },
+    ];
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ prompts: ['prompt1'], providers }));
+    vi.mocked(globSync).mockReturnValueOnce(['config.json']);
+
+    const result = await resolveConfigs(
+      { config: ['config.json'], filterTargets: 'selected-target' },
+      {},
+    );
+
+    expect(result.selectedProviderConfigs).toEqual([providers[1]]);
+    expect(loadApiProviders).toHaveBeenCalledWith([providers[1]], expect.any(Object));
+  });
+
   it('should load scenarios and tests from external files', async () => {
     const cmdObj = { config: ['config.json'] };
     const defaultConfig = {};


### PR DESCRIPTION
## Summary

- Preserve saved target context in extract-intent task payloads so Promptfoo Cloud can resolve the target-owning team.
- Send the CLI's current team as `x-promptfoo-team-id` on Promptfoo Cloud task requests when the caller has not supplied the header explicitly.
- Restrict the team header to the configured Promptfoo Cloud origin and include it in task cache keys to prevent cross-team cache reuse.
- Preserve the verified runtime team on server-issued unified configs when sharing results, using the current CLI team only as a fallback for other configs.
- Add regression coverage for task transport, cache isolation, explicit-header precedence, result-sharing precedence, and current-team fallback.

## Related

- promptfoo-cloud PR: https://github.com/promptfoo/promptfoo-cloud/pull/4373

## Test plan

- `pnpm vitest run test/share.test.ts test/monkeyPatchFetch.test.ts test/cache.test.ts test/fetch.test.ts` (247 tests passed)
- `pnpm lint` (passes with existing repository warnings)
- `pnpm exec tsc --noEmit --pretty false` remains blocked by unrelated Anthropic SDK `output_tokens_details` errors already present on the branch.
