### PR TITLE
docs(agents): watch main CI after landing a PR and fix flakes at the source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,15 @@ When asked to fix, improve, or land a PR, own the full loop: check out the branc
 
 **Standing commit/push authorization on feature branches.** When the user has asked you to fix, improve, or land work on a non-`main` branch, you have durable authorization to `git commit` and `git push` to that branch's tracking remote without per-step confirmation. Do not pause to ask "want me to commit?" — committing and pushing is part of the requested work. The safety constraints in _Git Workflow (CRITICAL)_ below (no commits to `main`, no `--force` without approval, no `--no-verify`, etc.) still apply.
 
+**After landing a PR, watch `main` until its CI is green.** Merging is not the end of the loop. The squash commit kicks off a fresh CI run on `main` that can fail for reasons the PR's own checks never surfaced — a base that advanced, a flaky job, or a real regression from the merge. After you merge, follow that `main` run to completion and do not leave `main` red:
+
+- **Classify before reacting.** Read the failing job's logs and decide whether it is a flake or a real failure. A failure is a _flake_ when the tests themselves pass and the job dies on infrastructure noise — e.g. a vitest `Worker exited unexpectedly` / `Timeout terminating forks worker` printed _after_ `Test Files N passed`, a cache-cleanup step (`Post Use Node …`), or a transient `Install Dependencies` error. The signature of a flake is non-determinism: different jobs/files fail across consecutive commits. A _real_ failure is deterministic and attributable to the change — the same test, build, or type error fails on re-run.
+- **Flake → re-run.** Re-run only the failed jobs (`gh run rerun <run-id> --failed`) and confirm the run goes green. Do not blame the just-merged change for a flake it cannot have caused (e.g. a config-only diff breaking a test worker).
+- **Real regression → fix it.** Open a follow-up PR (never commit to `main` directly). If the regression is yours and `main` is broken for everyone, prefer reverting the merge to get `main` green quickly, then re-land with the fix.
+- **Recurring class of flake → fix the flake itself.** If the same failure mode keeps reddening `main` across unrelated PRs, treat the flake as the bug: open a separate PR that fixes it at the source (a leaked handle keeping a test worker alive, an over-tight timeout, a fragile setup step) instead of re-running indefinitely.
+
+Confirm the final `main` state is green, or that the only remaining failure is a pre-existing, clearly-unrelated issue you have explicitly flagged.
+
 For behavior changes, do not stop at unit tests. Run the actual CLI or example with the local build. For eval and redteam work, prefer:
 
 ```bash


### PR DESCRIPTION
## What

Adds a post-merge expectation to `AGENTS.md` (under **End-to-End Work Expectations**): after landing a PR, follow the resulting `main` CI run to green and don't leave `main` red.

## Why

Merging isn't the end of the loop — the squash commit triggers a fresh CI run on `main` that can fail for reasons a PR's own checks never surfaced (an advanced base, a flaky job, or a real regression). Agents have been treating merge as "done" and missing red `main`. This codifies the loop:

- **Classify before reacting** — flake (tests pass, job dies on infra noise like vitest `Worker exited unexpectedly` / `Timeout terminating forks worker` after `Test Files N passed`, a `Post Use Node …` cache-cleanup step, or a transient `Install Dependencies` error; non-deterministic across commits) vs a real, deterministic regression.
- **Flake → re-run** the failed jobs (`gh run rerun <run-id> --failed`) and confirm green. Don't blame a config-only diff for a worker crash it can't have caused.
- **Real regression → fix it** in a follow-up PR (never commit to `main`); revert the merge if `main` is broken for everyone.
- **Recurring class of flake → fix the flake itself** in a separate PR rather than re-running indefinitely.

## Scope

Docs-only change to `AGENTS.md` (which `CLAUDE.md` imports). No code or behavior change.

A companion PR will address the specific recurring flake that motivated this (vitest forks-pool worker-teardown timeout).