### PR TITLE
fix(providers): type anthropic thinking usage

### DIFF
--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -214,7 +214,13 @@ function coerceMcpToolInput(input: unknown): Record<string, unknown> {
 function mergeAnthropicUsage(
   messages: Anthropic.Messages.Message[],
 ): Anthropic.Messages.Message['usage'] | undefined {
-  const usageEntries = messages.map((message) => message.usage).filter((usage) => usage != null);
+  type AnthropicUsageWithThinkingDetails = NonNullable<Anthropic.Messages.Message['usage']> & {
+    output_tokens_details?: { thinking_tokens?: number | null } | null;
+  };
+
+  const usageEntries = messages
+    .map((message) => message.usage)
+    .filter((usage): usage is AnthropicUsageWithThinkingDetails => usage != null);
 
   if (usageEntries.length === 0) {
     return undefined;
@@ -223,23 +229,27 @@ function mergeAnthropicUsage(
   const [firstUsage, ...remainingUsageEntries] = usageEntries;
 
   return remainingUsageEntries.reduce<NonNullable<Anthropic.Messages.Message['usage']>>(
-    (acc, usage) => ({
-      ...usage,
-      input_tokens: acc.input_tokens + (usage.input_tokens ?? 0),
-      output_tokens: acc.output_tokens + (usage.output_tokens ?? 0),
-      cache_creation_input_tokens:
-        (acc.cache_creation_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0),
-      cache_read_input_tokens:
-        (acc.cache_read_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0),
-      output_tokens_details:
-        acc.output_tokens_details || usage.output_tokens_details
-          ? {
-              thinking_tokens:
-                (acc.output_tokens_details?.thinking_tokens ?? 0) +
-                (usage.output_tokens_details?.thinking_tokens ?? 0),
-            }
-          : null,
-    }),
+    (acc, usage) => {
+      const accWithDetails = acc as AnthropicUsageWithThinkingDetails;
+      const thinkingTokens =
+        accWithDetails.output_tokens_details || usage.output_tokens_details
+          ? (accWithDetails.output_tokens_details?.thinking_tokens ?? 0) +
+            (usage.output_tokens_details?.thinking_tokens ?? 0)
+          : undefined;
+
+      return {
+        ...usage,
+        input_tokens: acc.input_tokens + (usage.input_tokens ?? 0),
+        output_tokens: acc.output_tokens + (usage.output_tokens ?? 0),
+        cache_creation_input_tokens:
+          (acc.cache_creation_input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0),
+        cache_read_input_tokens:
+          (acc.cache_read_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0),
+        ...(thinkingTokens === undefined
+          ? {}
+          : { output_tokens_details: { thinking_tokens: thinkingTokens } }),
+      } as AnthropicUsageWithThinkingDetails;
+    },
     firstUsage,
   );
 }

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -1486,7 +1486,7 @@ describe('AnthropicMessagesProvider', () => {
             output_tokens_details: { thinking_tokens: 3 },
             server_tool_use: null,
           },
-        } as Anthropic.Messages.Message)
+        } as unknown as Anthropic.Messages.Message)
         .mockResolvedValueOnce({
           content: [{ type: 'text', text: 'Acme Solar and Gridwise match your query.' }],
           stop_reason: 'end_turn',
@@ -1496,7 +1496,7 @@ describe('AnthropicMessagesProvider', () => {
             output_tokens_details: { thinking_tokens: 2 },
             server_tool_use: null,
           },
-        } as Anthropic.Messages.Message);
+        } as unknown as Anthropic.Messages.Message);
 
       const result = await provider.callApi('Find clean energy companies');
 


### PR DESCRIPTION
## Summary

Promptfoo recently started preserving Anthropic `output_tokens_details.thinking_tokens` so MCP continuation rounds can report reasoning-token usage instead of dropping it. The runtime behavior was correct, but the installed Anthropic SDK type does not yet expose `usage.output_tokens_details`, so current `origin/main` failed `npm run tsc` after PR #9680 merged.

This change keeps the runtime aggregation behavior and adds a narrow local structural type for the newer usage field. It also updates the Anthropic test fixtures to cast mocked partial SDK messages through `unknown`, matching TypeScript's guidance for intentionally incomplete API fixtures.

## Verification

- `node_modules/.bin/vitest run test/providers/anthropic/messages.test.ts test/providers/anthropic/util.test.ts`
- `node_modules/.bin/vitest run test/evaluatorHelpers.test.ts test/commands/validate-falsy-output.test.ts test/fetch.compression.test.ts test/util/fetch/stripDecompressionHeaders.test.ts test/blobs/index.test.ts test/blobs/shareUpload.test.ts test/share.test.ts test/util/inlineBlobsForShare.test.ts test/providers/anthropic/messages.test.ts test/providers/anthropic/util.test.ts test/providers/bedrock/anthropicMessages.test.ts test/providers/bedrock/converse.test.ts test/providers/bedrock/index.test.ts test/providers/families/aws.test.ts test/providers/google/vertex.test.ts test/redteam/index.test.ts test/server/routes/redteam.test.ts test/agentSkills/promptfooPlugin.test.ts test/util/eval/evalTableUtils.test.ts test/csv.test.ts test/assertions/equals.test.ts test/commands/validate-provider-tests.test.ts test/redteam/commands/discover.test.ts test/remoteGrading.test.ts`
- `npm run tsc`
- `npm run architecture:check`
- `npm run f`
- `npm run l`
- `git diff --check`