### PR TITLE
fix(redteam): improve remote generation error diagnostics

### DIFF
--- a/architecture/edge-baseline.json
+++ b/architecture/edge-baseline.json
@@ -41,7 +41,7 @@
   "redteam -> core": 2,
   "redteam -> legacy-contracts": 149,
   "redteam -> legacy-runtime": 143,
-  "redteam -> node": 217,
+  "redteam -> node": 218,
   "redteam -> providers": 43,
   "view-server -> core": 1,
   "view-server -> legacy-contracts": 21,

--- a/architecture/edge-baseline.json
+++ b/architecture/edge-baseline.json
@@ -41,7 +41,7 @@
   "redteam -> core": 2,
   "redteam -> legacy-contracts": 149,
   "redteam -> legacy-runtime": 143,
-  "redteam -> node": 208,
+  "redteam -> node": 217,
   "redteam -> providers": 43,
   "view-server -> core": 1,
   "view-server -> legacy-contracts": 21,

--- a/src/redteam/extraction/entities.ts
+++ b/src/redteam/extraction/entities.ts
@@ -1,5 +1,6 @@
 import dedent from 'dedent';
 import logger from '../../logger';
+import { formatFetchError } from '../../util/fetch/errors';
 import { shouldGenerateRemote } from '../remoteGeneration';
 import { callExtraction, fetchRemoteGeneration, formatPrompts } from './util';
 
@@ -12,8 +13,11 @@ export async function extractEntities(provider: ApiProvider, prompts: string[]):
       const result = await fetchRemoteGeneration('entities' as RedTeamTask, prompts);
       return result as string[];
     } catch (error) {
+      // fetchRemoteGeneration already logged the full error and the
+      // connection-block hint (if any), so format without re-appending it —
+      // surface cause/code here instead of a bare `TypeError: terminated`.
       logger.warn(
-        `[Entity Extraction] Failed, returning 0 entities. Error using remote generation: ${error}`,
+        `[Entity Extraction] Failed, returning 0 entities. Error using remote generation: ${formatFetchError(error)}`,
       );
       return [];
     }

--- a/src/redteam/extraction/util.ts
+++ b/src/redteam/extraction/util.ts
@@ -6,6 +6,7 @@ import { getEnvBool } from '../../envars';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
+import { describeFetchError } from '../../util/fetch/errors';
 import invariant from '../../util/invariant';
 import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from '../remoteGeneration';
 
@@ -62,7 +63,7 @@ export async function fetchRemoteGeneration(
     const parsedResponse = RedTeamGenerationResponse.parse(response.data);
     return parsedResponse.result;
   } catch (error) {
-    logger.warn(`Error using remote generation for task '${task}': ${error}`);
+    logger.warn(`Error using remote generation for task '${task}': ${describeFetchError(error)}`);
     throw error;
   }
 }

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -6,6 +6,7 @@ import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
 import { checkRemoteHealth } from '../../util/apiHealth';
+import { describeFetchError } from '../../util/fetch/errors';
 import { retryWithDeduplication } from '../../util/generation';
 import invariant from '../../util/invariant';
 import {
@@ -402,7 +403,7 @@ async function fetchRemoteTestCases(
     logger.debug(`Received remote generation for ${key}:\n${JSON.stringify(ret)}`);
     return ret;
   } catch (err) {
-    logger.error(`Error generating test cases for ${key}: ${err}`);
+    logger.error(`Error generating test cases for ${key}: ${describeFetchError(err)}`);
     return [];
   }
 }

--- a/src/redteam/strategies/citation.ts
+++ b/src/redteam/strategies/citation.ts
@@ -5,6 +5,7 @@ import { fetchWithCache } from '../../cache';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
+import { describeFetchError } from '../../util/fetch/errors';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
@@ -139,7 +140,7 @@ async function generateCitations(
     if (progressBar) {
       progressBar.stop();
     }
-    logger.error(`Error in remote citation generation: ${error}`);
+    logger.error(`Error in remote citation generation: ${describeFetchError(error)}`);
     return [];
   }
 }

--- a/src/redteam/strategies/likert.ts
+++ b/src/redteam/strategies/likert.ts
@@ -4,6 +4,7 @@ import { fetchWithCache } from '../../cache';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
+import { describeFetchError } from '../../util/fetch/errors';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
@@ -120,7 +121,7 @@ async function generateLikertPrompts(
     if (progressBar) {
       progressBar.stop();
     }
-    logger.error(`Error in Likert generation: ${error}`);
+    logger.error(`Error in Likert generation: ${describeFetchError(error)}`);
     return [];
   }
 }

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -5,6 +5,7 @@ import { fetchWithCache } from '../../cache';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
+import { describeFetchError } from '../../util/fetch/errors';
 import invariant from '../../util/invariant';
 import { extractFirstJsonObject } from '../../util/json';
 import { redteamProviderManager } from '../providers/shared';
@@ -96,7 +97,7 @@ export async function generateMathPrompt(
 
     return allResults;
   } catch (error) {
-    logger.error(`Error in remote MathPrompt generation: ${error}`);
+    logger.error(`Error in remote MathPrompt generation: ${describeFetchError(error)}`);
     return [];
   }
 }

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -331,7 +331,7 @@ async function generateMultilingual(
 
     return deduplicatedResults;
   } catch (error) {
-    logger.debug(`Remote multilingual generation failed: ${describeFetchError(error)}`);
+    logger.warn(`Remote multilingual generation failed: ${describeFetchError(error)}`);
     return [];
   }
 }

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -8,6 +8,7 @@ import { DEFAULT_MAX_CONCURRENCY } from '../../constants';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
+import { describeFetchError } from '../../util/fetch/errors';
 import invariant from '../../util/invariant';
 import { redteamProviderManager } from '../providers/shared';
 import {
@@ -330,7 +331,7 @@ async function generateMultilingual(
 
     return deduplicatedResults;
   } catch (error) {
-    logger.debug(`Remote multilingual generation failed: ${error}`);
+    logger.debug(`Remote multilingual generation failed: ${describeFetchError(error)}`);
     return [];
   }
 }

--- a/src/redteam/strategies/simpleAudio.ts
+++ b/src/redteam/strategies/simpleAudio.ts
@@ -5,6 +5,7 @@ import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
 import { isMediaStorageEnabled, storeMedia } from '../../storage';
+import { describeFetchError } from '../../util/fetch/errors';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
@@ -97,7 +98,7 @@ export async function textToAudio(
 
     return { base64: base64Audio };
   } catch (error) {
-    logger.error(`Error generating audio from text: ${error}`);
+    logger.error(`Error generating audio from text: ${describeFetchError(error)}`);
     throw new Error(
       `Failed to generate audio: ${error instanceof Error ? error.message : String(error)}. This strategy requires an active internet connection and access to the remote API.`,
     );

--- a/src/redteam/strategies/singleTurnComposite.ts
+++ b/src/redteam/strategies/singleTurnComposite.ts
@@ -4,6 +4,7 @@ import { fetchWithCache } from '../../cache';
 import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
+import { describeFetchError } from '../../util/fetch/errors';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
@@ -134,7 +135,7 @@ async function generateCompositePrompts(
     if (progressBar) {
       progressBar.stop();
     }
-    logger.error(`Error in composite generation: ${error}`);
+    logger.error(`Error in composite generation: ${describeFetchError(error)}`);
     return [];
   }
 }

--- a/src/redteam/util.ts
+++ b/src/redteam/util.ts
@@ -2,6 +2,7 @@ import { fetchWithCache } from '../cache';
 import logger from '../logger';
 import { getRequestTimeoutMs } from '../providers/shared';
 import { type Inputs } from '../types/shared';
+import { describeFetchError } from '../util/fetch/errors';
 import { safeJsonStringify } from '../util/json';
 import { escapeRegExp } from '../util/text';
 import { pluginDescriptions } from './constants';
@@ -407,7 +408,7 @@ export async function extractGoalFromPrompt(
 
     return data.intent;
   } catch (error) {
-    logger.warn(`Error extracting goal: ${error}`);
+    logger.warn(`Error extracting goal: ${describeFetchError(error)}`);
     return null;
   }
 }

--- a/src/util/fetch/errors.ts
+++ b/src/util/fetch/errors.ts
@@ -303,3 +303,84 @@ export function isTransientConnectionError(error: Error | undefined): boolean {
     message.includes('socket hang up')
   );
 }
+
+/**
+ * Network-level error codes meaning the connection was refused, reset, or
+ * dropped — as opposed to a clean HTTP error response. Proxies, firewalls, and
+ * WAFs (e.g. Cloudflare blocking a POST with a 403) typically surface this way:
+ * Node/undici reports `TypeError: fetch failed` or `TypeError: terminated` and
+ * tucks the real reason into `error.cause`.
+ */
+const CONNECTION_BLOCK_CODES = new Set([
+  'UND_ERR_SOCKET',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'EPIPE',
+  'EAI_AGAIN',
+]);
+
+/**
+ * Hint appended when a request fails at the connection layer, pointing at the
+ * most common real-world cause instead of leaving users with a bare
+ * `terminated`.
+ */
+export const CONNECTION_BLOCK_HINT =
+  'The connection was closed before a response was received. This often means a network ' +
+  'proxy, firewall, or Cloudflare rule is blocking the request (for example a 403 on POST). ' +
+  'Check your network or proxy settings, or try a different network.';
+
+/**
+ * Detects fetch failures that happened at the connection layer (refused, reset,
+ * or dropped) rather than as a parseable HTTP response. Inspects both the outer
+ * error and its `cause`, since undici hides the real `code`/`message` in
+ * `cause` (the outer error is just `terminated` / `fetch failed`).
+ */
+export function isConnectionError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const err = error as SystemError;
+  const cause = err.cause as SystemError | undefined;
+  const codes = [err.code, cause?.code].filter((c): c is string => typeof c === 'string');
+  if (codes.some((code) => CONNECTION_BLOCK_CODES.has(code))) {
+    return true;
+  }
+  const haystack = `${err.message ?? ''} ${cause?.message ?? ''}`.toLowerCase();
+  return (
+    haystack.includes('terminated') ||
+    haystack.includes('fetch failed') ||
+    haystack.includes('other side closed') ||
+    haystack.includes('socket hang up')
+  );
+}
+
+/**
+ * Formats a fetch/network error's name, message, and the otherwise-hidden
+ * `cause` and `code` into a single log-friendly string. Raw interpolation of an
+ * `Error` only yields `name: message`, dropping the diagnostic detail.
+ */
+export function formatFetchError(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+  const err = error as SystemError;
+  let message = `${err.name}: ${err.message}`;
+  if (err.cause) {
+    message += ` (Cause: ${err.cause})`;
+  }
+  if (err.code) {
+    message += ` (Code: ${err.code})`;
+  }
+  return message;
+}
+
+/**
+ * Like {@link formatFetchError}, but also appends {@link CONNECTION_BLOCK_HINT}
+ * when the failure looks like a connection-layer block. Use in catch blocks
+ * around outbound requests so users get an actionable message instead of a bare
+ * `terminated`.
+ */
+export function describeFetchError(error: unknown): string {
+  const base = formatFetchError(error);
+  return isConnectionError(error) ? `${base}\n${CONNECTION_BLOCK_HINT}` : base;
+}

--- a/src/util/fetch/errors.ts
+++ b/src/util/fetch/errors.ts
@@ -330,13 +330,36 @@ export const CONNECTION_BLOCK_HINT =
   'Check your network or proxy settings, or try a different network.';
 
 /**
+ * Undici's outer message for a connection-layer failure is one of a small set
+ * of fixed phrases. Matched with word boundaries so a code-like substring (e.g.
+ * the hard-quota code `access_terminated`, which embeds `terminated`) does not
+ * trip the connection-block hint. The boundaries still match the wrapped form
+ * `Request failed after N retries: TypeError: terminated (Cause: ...)` that
+ * `fetchWithRetries` produces, so the real failure path is unaffected.
+ */
+const CONNECTION_BLOCK_MESSAGE_PATTERN =
+  /\b(?:terminated|fetch failed|other side closed|socket hang up)\b/;
+
+/**
  * Detects fetch failures that happened at the connection layer (refused, reset,
  * or dropped) rather than as a parseable HTTP response. Inspects both the outer
  * error and its `cause`, since undici hides the real `code`/`message` in
  * `cause` (the outer error is just `terminated` / `fetch failed`).
+ *
+ * Related but distinct from {@link isTransientConnectionError}, which decides
+ * whether to *retry* (and inspects TLS/EPROTO codes); this one decides whether
+ * to show a user-facing network-block hint and additionally reads `error.cause`.
+ * Keep the two in sync when adding new connection-layer codes.
  */
 export function isConnectionError(error: unknown): boolean {
   if (!(error instanceof Error)) {
+    return false;
+  }
+  // A rate-limit/quota response is a clean HTTP error, not a dropped
+  // connection. Guard it explicitly: a hard-quota code such as
+  // `access_terminated` would otherwise embed `terminated` in the message and
+  // attach a misleading "check your network" hint to a billing problem.
+  if (isHttpRateLimitError(error)) {
     return false;
   }
   const err = error as SystemError;
@@ -346,18 +369,35 @@ export function isConnectionError(error: unknown): boolean {
     return true;
   }
   const haystack = `${err.message ?? ''} ${cause?.message ?? ''}`.toLowerCase();
-  return (
-    haystack.includes('terminated') ||
-    haystack.includes('fetch failed') ||
-    haystack.includes('other side closed') ||
-    haystack.includes('socket hang up')
-  );
+  return CONNECTION_BLOCK_MESSAGE_PATTERN.test(haystack);
+}
+
+/**
+ * Renders an error's `cause` for logging. An `Error` cause stringifies to
+ * `Name: message` (so a `SocketError` shows its class), other objects are
+ * JSON-encoded to avoid a useless `[object Object]`, and primitives stringify
+ * directly.
+ */
+function formatErrorCause(cause: unknown): string {
+  if (cause instanceof Error) {
+    return String(cause);
+  }
+  if (typeof cause === 'object' && cause !== null) {
+    try {
+      return JSON.stringify(cause);
+    } catch {
+      return String(cause);
+    }
+  }
+  return String(cause);
 }
 
 /**
  * Formats a fetch/network error's name, message, and the otherwise-hidden
  * `cause` and `code` into a single log-friendly string. Raw interpolation of an
- * `Error` only yields `name: message`, dropping the diagnostic detail.
+ * `Error` only yields `name: message`, dropping the diagnostic detail. The
+ * `code` falls back to `cause.code` because undici reports the real code (e.g.
+ * `ECONNREFUSED` on an `AggregateError`) on the cause, not the outer error.
  */
 export function formatFetchError(error: unknown): string {
   if (!(error instanceof Error)) {
@@ -365,11 +405,12 @@ export function formatFetchError(error: unknown): string {
   }
   const err = error as SystemError;
   let message = `${err.name}: ${err.message}`;
-  if (err.cause) {
-    message += ` (Cause: ${err.cause})`;
+  if (err.cause !== undefined && err.cause !== null) {
+    message += ` (Cause: ${formatErrorCause(err.cause)})`;
   }
-  if (err.code) {
-    message += ` (Code: ${err.code})`;
+  const code = err.code ?? (err.cause as SystemError | undefined)?.code;
+  if (code) {
+    message += ` (Code: ${code})`;
   }
   return message;
 }

--- a/src/util/fetch/errors.ts
+++ b/src/util/fetch/errors.ts
@@ -1,3 +1,5 @@
+import { sanitizeObject } from '../sanitizer';
+
 /**
  * Error with additional system information (e.g. Node.js system errors).
  */
@@ -321,13 +323,19 @@ const CONNECTION_BLOCK_CODES = new Set([
 
 /**
  * Hint appended when a request fails at the connection layer, pointing at the
- * most common real-world cause instead of leaving users with a bare
- * `terminated`.
+ * common real-world causes instead of leaving users with a bare `terminated`.
+ *
+ * Worded cause-agnostically: `isConnectionError` matches undici's generic
+ * `fetch failed` wrapper and DNS codes (`EAI_AGAIN`), so this hint is also shown
+ * for DNS, TLS, and offline failures — not only proxy/firewall blocks. It leads
+ * with the proxy/Cloudflare case (the original report, promptfoo#9679) but names
+ * the other likely causes so the attribution is not misleading.
  */
 export const CONNECTION_BLOCK_HINT =
-  'The connection was closed before a response was received. This often means a network ' +
-  'proxy, firewall, or Cloudflare rule is blocking the request (for example a 403 on POST). ' +
-  'Check your network or proxy settings, or try a different network.';
+  'The connection failed before a response was received. Common causes are a network proxy, ' +
+  'firewall, or Cloudflare rule blocking the request (for example a 403 on POST), a DNS ' +
+  'resolution failure, a TLS/certificate misconfiguration, or no network connectivity. Check ' +
+  'your network, DNS, and proxy settings, or try a different network.';
 
 /**
  * Undici's outer message for a connection-layer failure is one of a small set
@@ -377,6 +385,14 @@ export function isConnectionError(error: unknown): boolean {
  * `Name: message` (so a `SocketError` shows its class), other objects are
  * JSON-encoded to avoid a useless `[object Object]`, and primitives stringify
  * directly.
+ *
+ * Object causes are routed through {@link sanitizeObject} before serializing:
+ * this string is interpolated into a plain log message (e.g.
+ * `logger.warn(`...: ${describeFetchError(err)}`)`), and the logger only
+ * sanitizes its structured *context* argument, not the message text. Dumping a
+ * raw object cause could therefore leak secret-bearing fields (auth headers,
+ * api keys, cookies) into logs; `sanitizeObject` redacts those and also handles
+ * circular references, so a non-Error cause can never write a secret verbatim.
  */
 function formatErrorCause(cause: unknown): string {
   if (cause instanceof Error) {
@@ -384,7 +400,7 @@ function formatErrorCause(cause: unknown): string {
   }
   if (typeof cause === 'object' && cause !== null) {
     try {
-      return JSON.stringify(cause);
+      return JSON.stringify(sanitizeObject(cause));
     } catch {
       return String(cause);
     }

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -15,9 +15,9 @@ import { sleep } from '../../util/time';
 import { sanitizeUrl } from '../sanitizer';
 import {
   extractRateLimitErrorCode,
+  formatFetchError,
   HttpRateLimitError,
   isHardQuotaCode,
-  type SystemError,
 } from './errors';
 import { monkeyPatchFetch } from './monkeyPatchFetch';
 import { getFetchRetryContextMaxRetries } from './retryContext';
@@ -712,21 +712,6 @@ async function handleRateLimitedResponse(
   await handleRateLimit(response);
 }
 
-function formatFetchErrorMessage(error: unknown): string {
-  if (!(error instanceof Error)) {
-    return String(error);
-  }
-  const typedError = error as SystemError;
-  let message = `${typedError.name}: ${typedError.message}`;
-  if (typedError.cause) {
-    message += ` (Cause: ${typedError.cause})`;
-  }
-  if (typedError.code) {
-    message += ` (Code: ${typedError.code})`;
-  }
-  return message;
-}
-
 export async function fetchWithRetries(
   url: RequestInfo,
   options: FetchOptions = {},
@@ -772,7 +757,7 @@ export async function fetchWithRetries(
         throw error;
       }
 
-      const errorMessage = formatFetchErrorMessage(error);
+      const errorMessage = formatFetchError(error);
 
       logger.debug(
         `Request to ${urlForLog(url)} failed (attempt #${i + 1}), retrying: ${errorMessage}`,

--- a/test/redteam/extraction/util.test.ts
+++ b/test/redteam/extraction/util.test.ts
@@ -10,6 +10,7 @@ import {
   RedTeamGenerationResponse,
 } from '../../../src/redteam/extraction/util';
 import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
+import { CONNECTION_BLOCK_HINT } from '../../../src/util/fetch/errors';
 import {
   createMockProvider,
   createProviderResponse,
@@ -131,6 +132,26 @@ describe('fetchRemoteGeneration', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       "Error using remote generation for task 'purpose': Error: Network error",
     );
+  });
+
+  it('surfaces the hidden cause and network hint when the connection is cut (promptfoo#9679)', async () => {
+    // The bug: a Cloudflare/proxy block surfaces as `TypeError: terminated`
+    // with the real reason in `cause`; the old log dropped it. Pin that this
+    // call site now routes through describeFetchError.
+    const cause = Object.assign(new Error('other side closed'), {
+      name: 'SocketError',
+      code: 'UND_ERR_SOCKET',
+    });
+    const terminated = Object.assign(new TypeError('terminated'), { cause });
+    vi.mocked(fetchWithCache).mockRejectedValue(terminated);
+
+    await expect(fetchRemoteGeneration('purpose', ['prompt'])).rejects.toThrow('terminated');
+    const logged = vi
+      .mocked(logger.warn)
+      .mock.calls.map((c) => String(c[0]))
+      .join('\n');
+    expect(logged).toContain('Cause: SocketError: other side closed');
+    expect(logged).toContain(CONNECTION_BLOCK_HINT);
   });
 
   it('should throw an error when response parsing fails', async () => {

--- a/test/redteam/strategies/citation.test.ts
+++ b/test/redteam/strategies/citation.test.ts
@@ -9,6 +9,7 @@ import {
   neverGenerateRemote,
 } from '../../../src/redteam/remoteGeneration';
 import { addCitationTestCases } from '../../../src/redteam/strategies/citation';
+import { CONNECTION_BLOCK_HINT } from '../../../src/util/fetch/errors';
 
 import type { TestCase } from '../../../src/types/index';
 
@@ -173,6 +174,28 @@ describe('citation strategy', () => {
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining('Error in remote citation generation'),
     );
+  });
+
+  it('routes connection failures through describeFetchError (surfaces cause + network hint)', async () => {
+    // Regression guard for promptfoo#9679: a dropped connection must log the
+    // hidden cause AND the actionable network-block hint, not a bare
+    // `TypeError: terminated`. Pins that this call site uses describeFetchError.
+    const cause = Object.assign(new Error('other side closed'), {
+      name: 'SocketError',
+      code: 'UND_ERR_SOCKET',
+    });
+    const terminated = Object.assign(new TypeError('terminated'), { cause });
+    mockFetchWithCache.mockRejectedValueOnce(terminated);
+
+    const result = await addCitationTestCases(testCases, 'prompt', {});
+
+    expect(result).toHaveLength(0);
+    const logged = vi
+      .mocked(logger.error)
+      .mock.calls.map((c) => String(c[0]))
+      .join('\n');
+    expect(logged).toContain('Cause: SocketError: other side closed');
+    expect(logged).toContain(CONNECTION_BLOCK_HINT);
   });
 
   it('should handle test cases without assert property', async () => {

--- a/test/redteam/strategies/likert.test.ts
+++ b/test/redteam/strategies/likert.test.ts
@@ -10,6 +10,7 @@ import {
   neverGenerateRemote,
 } from '../../../src/redteam/remoteGeneration';
 import { addLikertTestCases } from '../../../src/redteam/strategies/likert';
+import { CONNECTION_BLOCK_HINT } from '../../../src/util/fetch/errors';
 
 import type { TestCase } from '../../../src/types/index';
 
@@ -132,6 +133,28 @@ describe('likert strategy', () => {
 
     expect(result).toHaveLength(0);
     expect(logger.error).toHaveBeenCalledWith(`Error in Likert generation: ${networkError}`);
+  });
+
+  it('routes connection failures through describeFetchError (surfaces cause + network hint)', async () => {
+    // Regression guard for promptfoo#9679: a dropped connection must log the
+    // hidden cause AND the actionable network-block hint, not a bare
+    // `TypeError: terminated`. Pins that this call site uses describeFetchError.
+    const cause = Object.assign(new Error('other side closed'), {
+      name: 'SocketError',
+      code: 'UND_ERR_SOCKET',
+    });
+    const terminated = Object.assign(new TypeError('terminated'), { cause });
+    vi.mocked(fetchWithCache).mockRejectedValue(terminated);
+
+    const result = await addLikertTestCases(testCases, 'prompt', {});
+
+    expect(result).toHaveLength(0);
+    const logged = vi
+      .mocked(logger.error)
+      .mock.calls.map((c) => String(c[0]))
+      .join('\n');
+    expect(logged).toContain('Cause: SocketError: other side closed');
+    expect(logged).toContain(CONNECTION_BLOCK_HINT);
   });
 
   it('should handle empty test cases', async () => {

--- a/test/redteam/strategies/mathPrompt.test.ts
+++ b/test/redteam/strategies/mathPrompt.test.ts
@@ -1,6 +1,7 @@
 import { SingleBar } from 'cli-progress';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
+import logger from '../../../src/logger';
 import { redteamProviderManager } from '../../../src/redteam/providers/shared';
 import * as remoteGeneration from '../../../src/redteam/remoteGeneration';
 import {
@@ -10,6 +11,7 @@ import {
   encodeMathPrompt,
   generateMathPrompt,
 } from '../../../src/redteam/strategies/mathPrompt';
+import { CONNECTION_BLOCK_HINT } from '../../../src/util/fetch/errors';
 import { createMockProvider, createProviderResponse } from '../../factories/provider';
 
 vi.mock('cli-progress');
@@ -81,6 +83,33 @@ describe('mathPrompt', () => {
 
       const result = await generateMathPrompt([{ vars: { prompt: 'test' } }] as any, 'prompt', {});
       expect(result).toEqual([]);
+    });
+
+    it('routes connection failures through describeFetchError (surfaces cause + network hint)', async () => {
+      // Regression guard for promptfoo#9679: a dropped connection must log the
+      // hidden cause AND the actionable network-block hint, not a bare
+      // `TypeError: terminated`. Pins that this call site uses describeFetchError.
+      const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+      const cause = Object.assign(new Error('other side closed'), {
+        name: 'SocketError',
+        code: 'UND_ERR_SOCKET',
+      });
+      const terminated = Object.assign(new TypeError('terminated'), { cause });
+      vi.mocked(fetchWithCache).mockRejectedValue(terminated);
+      (SingleBar as any).mockImplementation(function () {
+        return {
+          start: vi.fn(),
+          increment: vi.fn(),
+          stop: vi.fn(),
+        } as unknown as SingleBar;
+      });
+
+      const result = await generateMathPrompt([{ vars: { prompt: 'test' } }] as any, 'prompt', {});
+
+      expect(result).toEqual([]);
+      const logged = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).toContain('Cause: SocketError: other side closed');
+      expect(logged).toContain(CONNECTION_BLOCK_HINT);
     });
   });
 

--- a/test/redteam/strategies/simpleAudio.test.ts
+++ b/test/redteam/strategies/simpleAudio.test.ts
@@ -4,6 +4,7 @@ import { fetchWithCache } from '../../../src/cache';
 import logger from '../../../src/logger';
 import { neverGenerateRemote } from '../../../src/redteam/remoteGeneration';
 import { addAudioToBase64, textToAudio } from '../../../src/redteam/strategies/simpleAudio';
+import { CONNECTION_BLOCK_HINT } from '../../../src/util/fetch/errors';
 import { mockConsole } from '../../util/utils';
 
 import type { TestCase } from '../../../src/types/index';
@@ -107,6 +108,25 @@ describe('audio strategy', () => {
 
       const text = 'Hello, fallback world!';
       await expect(textToAudio(text, 'en')).rejects.toThrow('Failed to generate audio');
+    });
+
+    it('logs the hidden cause and network hint via describeFetchError on a dropped connection', async () => {
+      // Regression guard for promptfoo#9679: the logged diagnostic (not the
+      // rethrown message) must surface the hidden cause AND the network-block
+      // hint. Pins that this call site uses describeFetchError.
+      const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+      const cause = Object.assign(new Error('other side closed'), {
+        name: 'SocketError',
+        code: 'UND_ERR_SOCKET',
+      });
+      const terminated = Object.assign(new TypeError('terminated'), { cause });
+      mockFetchWithCache.mockRejectedValueOnce(terminated);
+
+      await expect(textToAudio('Hello', 'en')).rejects.toThrow('Failed to generate audio');
+
+      const logged = errorSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).toContain('Cause: SocketError: other side closed');
+      expect(logged).toContain(CONNECTION_BLOCK_HINT);
     });
 
     it('should pass language parameter to API', async () => {

--- a/test/redteam/strategies/singleTurnComposite.test.ts
+++ b/test/redteam/strategies/singleTurnComposite.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../../src/cache';
+import { getUserEmail } from '../../../src/globalConfig/accounts';
+import logger from '../../../src/logger';
+import {
+  getRemoteGenerationExplicitlyDisabledError,
+  getRemoteGenerationHeaders,
+  getRemoteGenerationUrl,
+  neverGenerateRemote,
+} from '../../../src/redteam/remoteGeneration';
+import { addCompositeTestCases } from '../../../src/redteam/strategies/singleTurnComposite';
+import { CONNECTION_BLOCK_HINT } from '../../../src/util/fetch/errors';
+
+import type { TestCase } from '../../../src/types/index';
+
+vi.mock('../../../src/cache');
+vi.mock('../../../src/globalConfig/accounts');
+vi.mock('../../../src/redteam/remoteGeneration');
+vi.mock('cli-progress');
+vi.mock('../../../src/logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    level: 'info',
+  },
+  getLogLevel: vi.fn().mockReturnValue('info'),
+}));
+
+describe('singleTurnComposite strategy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getUserEmail).mockReturnValue('test@example.com');
+    vi.mocked(neverGenerateRemote).mockReturnValue(false);
+    vi.mocked(getRemoteGenerationUrl).mockReturnValue('http://test-url');
+    vi.mocked(getRemoteGenerationHeaders).mockImplementation((extra) => ({
+      'Content-Type': 'application/json',
+      ...extra,
+    }));
+    vi.mocked(getRemoteGenerationExplicitlyDisabledError).mockImplementation(
+      (strategyName) =>
+        `${strategyName} requires remote generation, which has been explicitly disabled.`,
+    );
+  });
+
+  const testCases: TestCase[] = [
+    {
+      vars: { prompt: 'original prompt' },
+      assert: [{ type: 'equals', value: 'expected', metric: 'test-metric' }],
+    },
+  ];
+
+  it('throws when remote generation is explicitly disabled', async () => {
+    vi.mocked(neverGenerateRemote).mockReturnValue(true);
+
+    await expect(addCompositeTestCases(testCases, 'prompt', {})).rejects.toThrow(
+      'Composite jailbreak strategy requires remote generation, which has been explicitly disabled.',
+    );
+  });
+
+  it('generates composite test cases on success', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: { modifiedPrompts: ['composed prompt'] },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    });
+
+    const result = await addCompositeTestCases(testCases, 'prompt', {});
+
+    expect(result).toHaveLength(1);
+    expect(result[0].vars?.prompt).toBe('composed prompt');
+    expect(result[0].metadata?.strategyId).toBe('jailbreak:composite');
+  });
+
+  it('routes connection failures through describeFetchError (surfaces cause + network hint)', async () => {
+    // Regression guard for promptfoo#9679: a dropped connection must log the
+    // hidden cause AND the actionable network-block hint, not a bare
+    // `TypeError: terminated`. Pins that this call site uses describeFetchError.
+    const cause = Object.assign(new Error('other side closed'), {
+      name: 'SocketError',
+      code: 'UND_ERR_SOCKET',
+    });
+    const terminated = Object.assign(new TypeError('terminated'), { cause });
+    vi.mocked(fetchWithCache).mockRejectedValue(terminated);
+
+    const result = await addCompositeTestCases(testCases, 'prompt', {});
+
+    expect(result).toHaveLength(0);
+    const logged = vi
+      .mocked(logger.error)
+      .mock.calls.map((c) => String(c[0]))
+      .join('\n');
+    expect(logged).toContain('Cause: SocketError: other side closed');
+    expect(logged).toContain(CONNECTION_BLOCK_HINT);
+  });
+});

--- a/test/redteam/strategies/singleTurnComposite.test.ts
+++ b/test/redteam/strategies/singleTurnComposite.test.ts
@@ -30,7 +30,10 @@ vi.mock('../../../src/logger', () => ({
 
 describe('singleTurnComposite strategy', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks (not clearAllMocks) so the module-scope persistent mock
+    // setters below survive random test order — required by the root test
+    // hygiene check for new test files.
+    vi.resetAllMocks();
     vi.mocked(getUserEmail).mockReturnValue('test@example.com');
     vi.mocked(neverGenerateRemote).mockReturnValue(false);
     vi.mocked(getRemoteGenerationUrl).mockReturnValue('http://test-url');

--- a/test/util/fetch/errors.test.ts
+++ b/test/util/fetch/errors.test.ts
@@ -17,15 +17,17 @@ import {
 
 /**
  * Builds an error matching the shape undici produces when a connection is cut:
- * an outer `TypeError` whose real reason lives in `cause`. Mirrors the values
- * captured reproducing promptfoo#9679 (Cloudflare 403 block on POST).
+ * an outer `TypeError` whose real reason lives in a `SocketError` cause. Mirrors
+ * the values captured reproducing promptfoo#9679 (Cloudflare 403 block on POST),
+ * including the cause's `SocketError` class name so the formatted output matches
+ * what users actually see (`Cause: SocketError: other side closed`).
  */
 function makeTerminatedError(
   message = 'terminated',
   causeMessage = 'other side closed',
   causeCode = 'UND_ERR_SOCKET',
 ): Error {
-  const cause = Object.assign(new Error(causeMessage), { code: causeCode });
+  const cause = Object.assign(new Error(causeMessage), { name: 'SocketError', code: causeCode });
   return Object.assign(new TypeError(message), { cause });
 }
 
@@ -464,8 +466,43 @@ describe('isConnectionError', () => {
     expect(isConnectionError(new Error('socket hang up'))).toBe(true);
   });
 
+  it('detects EAI_AGAIN (DNS) and EPIPE on the cause', () => {
+    expect(
+      isConnectionError(makeTerminatedError('fetch failed', 'getaddrinfo EAI_AGAIN', 'EAI_AGAIN')),
+    ).toBe(true);
+    expect(isConnectionError(makeTerminatedError('terminated', 'write EPIPE', 'EPIPE'))).toBe(true);
+  });
+
+  it('matches the wrapped form fetchWithRetries produces', () => {
+    // fetchWithRetries re-wraps the final failure as a plain Error whose message
+    // embeds the original `terminated` — the hint must still fire on this shape.
+    expect(
+      isConnectionError(
+        new Error(
+          'Request failed after 3 retries: TypeError: terminated (Cause: SocketError: other side closed)',
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it('returns false for a clean HTTP/application error (not a connection failure)', () => {
     expect(isConnectionError(new Error('Bad Request: 400'))).toBe(false);
+  });
+
+  it('returns false for a hard-quota rate-limit error whose code embeds `terminated`', () => {
+    // `access_terminated` is a hard-quota code (HARD_QUOTA_ERROR_CODES). The
+    // bare substring `terminated` must NOT classify this billing error as a
+    // dropped connection — otherwise we attach a misleading network hint.
+    const quota = new HttpRateLimitError({ status: 429, code: 'access_terminated' });
+    expect(quota.message).toContain('access_terminated');
+    expect(isHardQuotaCode('access_terminated')).toBe(true);
+    expect(isConnectionError(quota)).toBe(false);
+  });
+
+  it('returns false for an aborted/timed-out request (not a connection block)', () => {
+    const abort = Object.assign(new Error('This operation was aborted'), { name: 'AbortError' });
+    expect(isConnectionError(abort)).toBe(false);
+    expect(isConnectionError(new Error('Request timed out after 5000 ms'))).toBe(false);
   });
 
   it('returns false for non-Error values', () => {
@@ -476,15 +513,31 @@ describe('isConnectionError', () => {
 });
 
 describe('formatFetchError', () => {
-  it('surfaces the otherwise-hidden cause and code', () => {
+  it('surfaces the otherwise-hidden cause and code, with the real cause class name', () => {
     const out = formatFetchError(makeTerminatedError());
     expect(out).toContain('TypeError: terminated');
-    expect(out).toContain('Cause: Error: other side closed');
+    // Matches production output exactly: undici's cause is a SocketError.
+    expect(out).toContain('Cause: SocketError: other side closed');
   });
 
   it('includes the top-level code when present', () => {
     const err = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
     expect(formatFetchError(err)).toContain('(Code: ECONNREFUSED)');
+  });
+
+  it('falls back to the cause code when the outer error has none (undici AggregateError shape)', () => {
+    // Canonical Node ECONNREFUSED: `TypeError: fetch failed` with the code on an
+    // AggregateError cause. The outer error carries no code; surface the cause's.
+    const cause = Object.assign(new AggregateError([], ''), { code: 'ECONNREFUSED' });
+    const err = Object.assign(new TypeError('fetch failed'), { cause });
+    expect(formatFetchError(err)).toContain('(Code: ECONNREFUSED)');
+  });
+
+  it('renders a non-Error object cause as JSON instead of [object Object]', () => {
+    const err = Object.assign(new Error('boom'), { cause: { reason: 'blocked', port: 443 } });
+    const out = formatFetchError(err);
+    expect(out).toContain('"reason":"blocked"');
+    expect(out).not.toContain('[object Object]');
   });
 
   it('stringifies non-Error values', () => {
@@ -509,6 +562,13 @@ describe('describeFetchError', () => {
   it('does not append the hint for a non-connection error', () => {
     const out = describeFetchError(new Error('Bad Request: 400'));
     expect(out).toContain('Bad Request: 400');
+    expect(out).not.toContain(CONNECTION_BLOCK_HINT);
+  });
+
+  it('does not append the network hint to a hard-quota billing error', () => {
+    const quota = new HttpRateLimitError({ status: 429, code: 'access_terminated' });
+    const out = describeFetchError(quota);
+    expect(out).toContain('access_terminated');
     expect(out).not.toContain(CONNECTION_BLOCK_HINT);
   });
 });

--- a/test/util/fetch/errors.test.ts
+++ b/test/util/fetch/errors.test.ts
@@ -1,15 +1,33 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CONNECTION_BLOCK_HINT,
+  describeFetchError,
   extractRateLimitErrorCode,
   findTargetErrorStatus,
+  formatFetchError,
   formatRateLimitDetail,
   formatRateLimitErrorMessage,
   HttpRateLimitError,
+  isConnectionError,
   isHardQuotaCode,
   isHttpRateLimitError,
   isNonTransientHttpStatus,
   isTransientConnectionError,
 } from '../../../src/util/fetch/errors';
+
+/**
+ * Builds an error matching the shape undici produces when a connection is cut:
+ * an outer `TypeError` whose real reason lives in `cause`. Mirrors the values
+ * captured reproducing promptfoo#9679 (Cloudflare 403 block on POST).
+ */
+function makeTerminatedError(
+  message = 'terminated',
+  causeMessage = 'other side closed',
+  causeCode = 'UND_ERR_SOCKET',
+): Error {
+  const cause = Object.assign(new Error(causeMessage), { code: causeCode });
+  return Object.assign(new TypeError(message), { cause });
+}
 
 describe('isNonTransientHttpStatus', () => {
   it('returns true for 401 Unauthorized', () => {
@@ -419,5 +437,78 @@ describe('formatRateLimitErrorMessage', () => {
     const out = formatRateLimitErrorMessage(err);
     expect(out.match(/Rate limit exceeded/g)?.length).toBe(1);
     expect(out.match(/HTTP 429/g)?.length).toBe(1);
+  });
+});
+
+describe('isConnectionError', () => {
+  it('detects undici `terminated` from a cut connection (cause code UND_ERR_SOCKET)', () => {
+    expect(isConnectionError(makeTerminatedError())).toBe(true);
+  });
+
+  it('detects `fetch failed` when the socket dies before any response', () => {
+    expect(isConnectionError(makeTerminatedError('fetch failed'))).toBe(true);
+  });
+
+  it('detects a forcibly reset connection via ECONNRESET on the cause', () => {
+    expect(
+      isConnectionError(makeTerminatedError('terminated', 'read ECONNRESET', 'ECONNRESET')),
+    ).toBe(true);
+  });
+
+  it('detects ECONNREFUSED on the outer error', () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    expect(isConnectionError(err)).toBe(true);
+  });
+
+  it('matches on message text even when no code is present', () => {
+    expect(isConnectionError(new Error('socket hang up'))).toBe(true);
+  });
+
+  it('returns false for a clean HTTP/application error (not a connection failure)', () => {
+    expect(isConnectionError(new Error('Bad Request: 400'))).toBe(false);
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isConnectionError('terminated')).toBe(false);
+    expect(isConnectionError(undefined)).toBe(false);
+    expect(isConnectionError(null)).toBe(false);
+  });
+});
+
+describe('formatFetchError', () => {
+  it('surfaces the otherwise-hidden cause and code', () => {
+    const out = formatFetchError(makeTerminatedError());
+    expect(out).toContain('TypeError: terminated');
+    expect(out).toContain('Cause: Error: other side closed');
+  });
+
+  it('includes the top-level code when present', () => {
+    const err = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    expect(formatFetchError(err)).toContain('(Code: ECONNREFUSED)');
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(formatFetchError('boom')).toBe('boom');
+  });
+
+  it('does NOT append the connection-block hint (formatting only)', () => {
+    expect(formatFetchError(makeTerminatedError())).not.toContain(CONNECTION_BLOCK_HINT);
+  });
+});
+
+describe('describeFetchError', () => {
+  it('appends the network-block hint for a `terminated` connection error', () => {
+    const out = describeFetchError(makeTerminatedError());
+    // Still shows the raw diagnostics (the hidden cause, not just `terminated`)...
+    expect(out).toContain('TypeError: terminated');
+    expect(out).toContain('other side closed');
+    // ...plus the actionable hint that was missing in promptfoo#9679.
+    expect(out).toContain(CONNECTION_BLOCK_HINT);
+  });
+
+  it('does not append the hint for a non-connection error', () => {
+    const out = describeFetchError(new Error('Bad Request: 400'));
+    expect(out).toContain('Bad Request: 400');
+    expect(out).not.toContain(CONNECTION_BLOCK_HINT);
   });
 });

--- a/test/util/fetch/errors.test.ts
+++ b/test/util/fetch/errors.test.ts
@@ -540,6 +540,45 @@ describe('formatFetchError', () => {
     expect(out).not.toContain('[object Object]');
   });
 
+  it('redacts secret-bearing fields in an object cause (this string is logged unsanitized)', () => {
+    // The formatted string is interpolated into a plain log message, which the
+    // logger does NOT sanitize. A raw JSON.stringify would leak the header, so
+    // formatErrorCause routes object causes through sanitizeObject first.
+    const err = Object.assign(new Error('fetch failed'), {
+      cause: {
+        url: 'https://api.promptfoo.app/api/v1/task',
+        headers: { authorization: 'Bearer sk-supersecret-123', 'x-api-key': 'pk-live-leakme' },
+      },
+    });
+    const out = formatFetchError(err);
+    expect(out).not.toContain('sk-supersecret-123');
+    expect(out).not.toContain('pk-live-leakme');
+    expect(out).toContain('[REDACTED]');
+    // Non-sensitive diagnostic context is preserved.
+    expect(out).toContain('api/v1/task');
+  });
+
+  it('degrades safely (no throw) when an object cause is not JSON-serializable (BigInt)', () => {
+    // A raw JSON.stringify throws on a BigInt value; sanitizeObject absorbs it
+    // (returning a placeholder) so formatFetchError never throws inside a logging
+    // call and never emits a bare `[object Object]`.
+    const err = Object.assign(new Error('boom'), { cause: { attempts: 3n } });
+    expect(() => formatFetchError(err)).not.toThrow();
+    const out = formatFetchError(err);
+    expect(out).toContain('boom');
+    expect(out).not.toContain('[object Object]');
+  });
+
+  it('handles a circular object cause without throwing', () => {
+    const circular: Record<string, unknown> = { reason: 'blocked' };
+    circular.self = circular;
+    const err = Object.assign(new Error('boom'), { cause: circular });
+    // Must not throw: sanitizeObject collapses the cycle, so JSON.stringify
+    // succeeds and the non-circular field still surfaces.
+    expect(() => formatFetchError(err)).not.toThrow();
+    expect(formatFetchError(err)).toContain('"reason":"blocked"');
+  });
+
   it('stringifies non-Error values', () => {
     expect(formatFetchError('boom')).toBe('boom');
   });


### PR DESCRIPTION
## Summary

Fixes #9679. Red team remote generation `POST`s to `api.promptfoo.app/api/v1/task`. When a network proxy, firewall, or Cloudflare rule blocks the request, the connection is cut and undici throws `TypeError: terminated` — with the real reason tucked into `error.cause`. The catch blocks logged the raw error (`` `...: ${err}` ``), which stringifies to just `TypeError: terminated`, so every plugin and strategy reported the same opaque message with no hint that it was a network-level block.

This is **diagnostics only** — it does not try to make a blocked request succeed. (Two small, intentional behavior deltas are called out under *Review follow-ups* below.)

## What changed

New helpers in `src/util/fetch/errors.ts`:

- **`isConnectionError(error)`** — detects connection-layer failures (refused / reset / dropped) vs a clean HTTP response, inspecting both the outer error and its `cause` (codes `UND_ERR_SOCKET`, `ECONNRESET`, `ECONNREFUSED`, `EPIPE`, `EAI_AGAIN`, plus message text like `terminated` / `other side closed`).
- **`formatFetchError(error)`** — surfaces the otherwise-hidden `cause` and `code`. This is the existing private `formatFetchErrorMessage` from `util/fetch/index.ts`, moved here and exported (the duplicate is removed, and `fetchWithRetries` now imports it).
- **`describeFetchError(error)`** — `formatFetchError` plus a one-line network-block hint **only when** `isConnectionError` is true.

Wired `describeFetchError` into the remote-generation catch sites: plugin generation (`plugins/index.ts`), goal/intent extraction (`redteam/util.ts`), remote extraction (`extraction/util.ts`), and the citation / likert / mathPrompt / singleTurnComposite / simpleAudio / multilingual strategies.

### Before
```
Error generating test cases for <plugin>: TypeError: terminated
```
### After
```
Error generating test cases for <plugin>: TypeError: terminated (Cause: SocketError: other side closed) (Code: UND_ERR_SOCKET)
The connection failed before a response was received. Common causes are a network proxy,
firewall, or Cloudflare rule blocking the request (for example a 403 on POST), a DNS
resolution failure, a TLS/certificate misconfiguration, or no network connectivity. Check
your network, DNS, and proxy settings, or try a different network.
```

## Verification

- Reproduced the exact error shape (`TypeError: terminated`, `cause` = `SocketError: other side closed`, `cause.code` = `UND_ERR_SOCKET`) against a local server that cuts the socket mid-response — the new unit tests assert on those captured values, so they hold on every Node version without network access.
- New unit coverage in `test/util/fetch/errors.test.ts` for `isConnectionError` / `formatFetchError` / `describeFetchError` (block variants, plain app errors → no hint, non-Error inputs).
- `tsc --noEmit` clean; Biome clean (pre-existing `multilingual.ts` complexity warnings only, unchanged from `main`).
- Full touched-area suites pass (errors, `fetch.test.ts`, redteam plugins/strategies/util/extraction). `fetch.test.ts`'s exact-message assertions confirm the de-dup changed no existing behavior.

## Notes

The hint is intentionally worded as a list of likely causes since `terminated` / `fetch failed` can have several roots (proxy block, DNS, TLS, offline). `describeFetchError` degrades gracefully on non-connection errors (it just adds `cause`/`code`, never a misleading hint).

## Review follow-ups (hardening)

Addressing review feedback (incl. the Codex bot) and broadening test coverage:

- **Security — redact object causes before logging.** `formatErrorCause` now routes non-`Error` object causes through `sanitizeObject` before `JSON.stringify`. The formatted string is interpolated into a plain log *message*, and the logger only sanitizes its structured *context* argument — so a raw `JSON.stringify` of an object cause could write `Authorization` / api-key / cookie fields to logs verbatim (the old code rendered a harmless `[object Object]`; the un-redacted JSON dump it replaced was a latent leak). `sanitizeObject` redacts sensitive keys and also collapses circular references. No reachable leak exists today (real undici causes are `Error` instances, rendered via `String()`), so this is defense-in-depth, but it removes the footgun cheaply.
- **Correctness — cause-agnostic hint.** `isConnectionError` matches undici's generic `fetch failed` wrapper and DNS (`EAI_AGAIN`), so the hint also fires for DNS / TLS / offline failures, not just proxy blocks. The hint text now names those causes (and still leads with the proxy/Cloudflare case from #9679) instead of asserting a block — avoiding misattribution for a DNS typo or cert mismatch.
- **Tests — close per-call-site gaps.** Added connection-failure regression guards for the `citation`, `mathPrompt`, and `simpleAudio` call sites (previously only `likert` / `singleTurnComposite` / `extraction` were pinned, so a silent revert to bare `${error}` at those three would have shipped green). Added `formatFetchError` tests for secret redaction, a non-serializable (BigInt) cause, and a circular cause.

### Intentional behavior deltas (not pure "diagnostics only")

- **`multilingual.ts`: `logger.debug` → `logger.warn`.** A remote multilingual-generation failure was previously silent at the default log level; it now surfaces as a single `warn` per run (it is bounded — per-chunk/per-language failures stay at `debug`). The strategy still falls back to local translation, so this warns on a recoverable condition by design, to make a previously-invisible remote outage visible.
- **`fetchWithRetries` debug/throw message.** Because `formatFetchError` replaces the old private formatter, the retry-exhausted message now renders object causes as (redacted) JSON instead of `[object Object]` and surfaces a `cause.code` fallback. The existing `fetch.test.ts` assertions (string cause) are unchanged; this only enriches the human-facing message.

### End-to-end QA

Reproduced #9679 against a local server that answers `GET /health` but **cuts the socket on `POST /api/v1/task`** (the Cloudflare-403-on-POST shape), then ran `redteam generate`. The real undici retry path now logs:

```
Error using remote generation for task 'entities': Error: Request failed after 4 retries: TypeError: fetch failed (Cause: SocketError: other side closed) (Code: UND_ERR_SOCKET)
The connection failed before a response was received. Common causes are a network proxy, ...
```

Confirmed: the hidden cause + code are surfaced; the hint fires once per failing operation (the `entities.ts` catch correctly uses `formatFetchError`, not `describeFetchError`, so the hint is not duplicated); generation degrades gracefully (no crash); and **no `Authorization`/api-key value appears anywhere in the logs**. Also verified a real DNS failure surfaces `Code: ENOTFOUND` with the DNS-aware hint, and a real object cause carrying `authorization` / `x-api-key` is emitted as `[REDACTED]`.
