### PR TITLE
fix(code-scan): keep SARIF skip errors off stdout

### DIFF
--- a/src/codeScan/scanner/index.ts
+++ b/src/codeScan/scanner/index.ts
@@ -337,7 +337,7 @@ export async function executeScan(repoPath: string, options: ScanOptions): Promi
           githubPr: options.githubPr,
         });
       } else if (outputFormat === CodeScanOutputFormat.SARIF) {
-        logger.error(
+        console.error(
           `Scan skipped: ${msg} SARIF output was not generated because the scan did not complete.`,
         );
         cliState.postActionCallback = async () => {

--- a/test/codeScans/scanner/fork-pr-auth.test.ts
+++ b/test/codeScans/scanner/fork-pr-auth.test.ts
@@ -137,9 +137,11 @@ describe('Scanner fork PR auth rejection', () => {
     vi.doUnmock('../../../src/codeScan/scanner/output');
 
     const stdoutSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { executeScan } = await import('../../../src/codeScan/scanner/index');
     const cliState = (await import('../../../src/cliState')).default;
+    const logger = (await import('../../../src/logger')).default;
 
     await executeScan('/test/repo', {
       format: 'sarif',
@@ -150,6 +152,10 @@ describe('Scanner fork PR auth rejection', () => {
     await cliState.postActionCallback?.();
 
     expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledWith(
+      `Scan skipped: ${SKIP_MESSAGE} SARIF output was not generated because the scan did not complete.`,
+    );
+    expect(logger.error).not.toHaveBeenCalled();
     expect(process.exitCode).toBe(1);
   });
 


### PR DESCRIPTION
## Summary
- write fork-authorization SARIF skip diagnostics directly to stderr
- keep structured stdout empty for library and CLI consumers
- add regression coverage for the stderr path

## Validation
- `npx vitest run test/codeScans --sequence.shuffle=false`
- `npm run tsc`
- `npm run architecture:check`
- `npm run l`
- `npm run f`
- `npm run build`
- built CLI invalid structured-mode smoke check (exit 1, 0 stdout bytes)