### PR TITLE
docs(readme): add hvtracker badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
   <a href="https://github.com/promptfoo/promptfoo/actions/workflows/main.yml"><img src="https://img.shields.io/github/actions/workflow/status/promptfoo/promptfoo/main.yml" alt="GitHub Workflow Status"></a>
   <a href="https://github.com/promptfoo/promptfoo/blob/main/LICENSE"><img src="https://img.shields.io/github/license/promptfoo/promptfoo" alt="MIT license"></a>
   <a href="https://discord.gg/promptfoo"><img src="https://img.shields.io/discord/1146610656779440188?logo=discord&label=promptfoo" alt="Discord"></a>
+  <a href="https://hvtracker.net/agents/promptfoo/"><img src="https://hvtracker.net/badge/promptfoo.svg" alt="HVTrust"></a>
+  <a href="https://hvtracker.net/agents/promptfoo/"><img src="https://hvtracker.net/badge/promptfoo-grade.svg" alt="Evidence Grade"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
This PR adds the live HVTracker trust and evidence-grade badges to the README as optional independent trust signals for users who want a quick external view of Promptfoo's current profile.

Validation included `npx prettier --write README.md` and `git diff --check`.

Fixes #9563.