### PR TITLE
test: resolve ai findings in harnesses

### DIFF
--- a/test/redteam/shared/runtimeTransform.test.ts
+++ b/test/redteam/shared/runtimeTransform.test.ts
@@ -172,7 +172,7 @@ describe('runtimeTransform', () => {
     });
 
     it('should pass target context to per-turn layer strategies', async () => {
-      await applyRuntimeTransforms('hello', 'input', ['base64'], mockStrategies, {
+      const result = await applyRuntimeTransforms('hello', 'input', ['base64'], mockStrategies, {
         targetId: 'cloud-target-123',
       });
 
@@ -180,6 +180,14 @@ describe('runtimeTransform', () => {
         expect.any(Array),
         'input',
         expect.objectContaining({ targetId: 'cloud-target-123' }),
+      );
+
+      const parsedPrompt = JSON.parse(result.prompt);
+      expect(parsedPrompt).toEqual(
+        expect.objectContaining({
+          prompt: 'aGVsbG8=',
+          targetId: 'cloud-target-123',
+        }),
       );
     });
 

--- a/test/redteam/shared/runtimeTransform.test.ts
+++ b/test/redteam/shared/runtimeTransform.test.ts
@@ -182,13 +182,8 @@ describe('runtimeTransform', () => {
         expect.objectContaining({ targetId: 'cloud-target-123' }),
       );
 
-      const parsedPrompt = JSON.parse(result.prompt);
-      expect(parsedPrompt).toEqual(
-        expect.objectContaining({
-          prompt: 'aGVsbG8=',
-          targetId: 'cloud-target-123',
-        }),
-      );
+      expect(result.prompt).toBe('aGVsbG8=');
+      expect(result.originalPrompt).toBe('hello');
     });
 
     it('should skip unknown strategies with warning', async () => {

--- a/test/smoke/cli.test.ts
+++ b/test/smoke/cli.test.ts
@@ -372,7 +372,7 @@ describe('CLI Smoke Tests', () => {
           });
         },
       ],
-    ])('1.8.%# - keeps %s stdout machine-readable under --verbose and LOG_LEVEL=debug', async (_label, outputArgs, assertPayload) => {
+    ])('1.8 - keeps %s stdout machine-readable under --verbose and LOG_LEVEL=debug', async (_label, outputArgs, assertPayload) => {
       const { stdout, stderr, exitCode } = await runEntrypointAsync(
         [
           'code-scans',

--- a/test/smoke/cli.test.ts
+++ b/test/smoke/cli.test.ts
@@ -372,7 +372,7 @@ describe('CLI Smoke Tests', () => {
           });
         },
       ],
-    ])('1.8 - keeps %s stdout machine-readable under --verbose and LOG_LEVEL=debug', async (_label, outputArgs, assertPayload) => {
+    ])('1.8.%# - keeps %s stdout machine-readable under --verbose and LOG_LEVEL=debug', async (_label, outputArgs, assertPayload) => {
       const { stdout, stderr, exitCode } = await runEntrypointAsync(
         [
           'code-scans',

--- a/test/util/fetch/stripDecompressionHeaders.test.ts
+++ b/test/util/fetch/stripDecompressionHeaders.test.ts
@@ -4,10 +4,12 @@ import type { Dispatcher } from 'undici';
 
 type RawHeaderPairs = [string, string][];
 type ResponseCallbackMode = 'started' | 'start' | 'both';
+type OnResponseStartArgs = Parameters<NonNullable<Dispatcher.DispatchHandler['onResponseStart']>>;
+type ParsedHeaders = OnResponseStartArgs[2];
 type TrackedEvent =
   | {
       method: 'onResponseStart';
-      args: [Dispatcher.DispatchController, number, Record<string, string | string[]>, string];
+      args: OnResponseStartArgs;
     }
   | {
       method: 'onResponseStarted';
@@ -16,7 +18,7 @@ type TrackedEvent =
 
 interface DispatchResponseStartOptions {
   rawHeaders?: Buffer[] | null;
-  parsedHeaders: Record<string, string | string[]>;
+  parsedHeaders: ParsedHeaders;
   statusCode?: number;
   dispatchResult?: boolean;
   callbackMode?: ResponseCallbackMode;

--- a/test/util/fetch/stripDecompressionHeaders.test.ts
+++ b/test/util/fetch/stripDecompressionHeaders.test.ts
@@ -4,6 +4,29 @@ import type { Dispatcher } from 'undici';
 
 type RawHeaderPairs = [string, string][];
 type ResponseCallbackMode = 'started' | 'start' | 'both';
+type TrackedEvent =
+  | {
+      method: 'onResponseStart';
+      args: [Dispatcher.DispatchController, number, Record<string, string | string[]>, string];
+    }
+  | {
+      method: 'onResponseStarted';
+      args: [];
+    };
+
+interface DispatchResponseStartOptions {
+  rawHeaders?: Buffer[] | null;
+  parsedHeaders: Record<string, string | string[]>;
+  statusCode?: number;
+  dispatchResult?: boolean;
+  callbackMode?: ResponseCallbackMode;
+}
+
+interface DispatchResponseStartResult {
+  controller: Dispatcher.DispatchController & { rawHeaders?: Buffer[] | null };
+  events: TrackedEvent[];
+  dispatched: boolean;
+}
 
 function makeRawHeaders(pairs: RawHeaderPairs): Buffer[] {
   return pairs.flatMap(([name, value]) => [Buffer.from(name), Buffer.from(value)]);
@@ -30,14 +53,8 @@ function dispatchResponseStart({
   statusCode = 200,
   dispatchResult = true,
   callbackMode = 'both',
-}: {
-  rawHeaders?: Buffer[] | null;
-  parsedHeaders: Record<string, string | string[]>;
-  statusCode?: number;
-  dispatchResult?: boolean;
-  callbackMode?: ResponseCallbackMode;
-}) {
-  const events: { method: string; args: unknown[] }[] = [];
+}: DispatchResponseStartOptions): DispatchResponseStartResult {
+  const events: TrackedEvent[] = [];
   const innerHandler: Dispatcher.DispatchHandler = {
     onResponseStart(controller, status, headers, statusMessage) {
       events.push({


### PR DESCRIPTION
## Summary
- strengthen the runtime-transform target-context test while preserving the real base64 output contract
- retain Vitest's supported `%#` case indexing so the structured-output smoke cases remain numbered `1.8.0` and `1.8.1`
- tighten the `stripDecompressionHeaders` harness with undici-derived option, result, callback, and event types
- sync the branch with current `main`

## Testing
- [exact-head CI](https://github.com/promptfoo/promptfoo/actions/runs/27390175779): all 30 jobs passed, including Node 20/22/24/26, Windows, macOS, smoke, integration, style, docs, web UI, and redteam checks
- [Code Quality / CodeQL](https://github.com/promptfoo/promptfoo/actions/runs/27390174264): passed
- `npm run f`
- `npm run l`
- `git diff --check`
- Node syntax checks for all changed TypeScript test files

Local `npm ci` is blocked by the repository's Socket policy for `undici@7.27.2`; the exact-head GitHub run installed dependencies and passed the full test matrix.
