### PR TITLE
fix(matchers): respect filtered remote target context

### DIFF
--- a/src/cliState.ts
+++ b/src/cliState.ts
@@ -7,6 +7,7 @@ import type { UnifiedConfig } from './types/index';
 interface CliState {
   basePath?: string;
   config?: Partial<UnifiedConfig>;
+  selectedProviderConfigs?: Partial<UnifiedConfig>['providers'];
 
   // Forces remote inference wherever possible
   remote?: boolean;

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -11,6 +11,7 @@ import {
 import {
   type AtomicTestCase,
   type CompletedPrompt,
+  type EvalRuntimeOptions,
   type EvaluateSummaryV2,
   type GradingResult,
   type Prompt,
@@ -65,9 +66,7 @@ export const evalsTable = sqliteTable(
     config: text('config', { mode: 'json' }).$type<Partial<UnifiedConfig>>().notNull(),
     prompts: text('prompts', { mode: 'json' }).$type<CompletedPrompt[]>(),
     vars: text('vars', { mode: 'json' }).$type<string[]>(),
-    runtimeOptions: text('runtime_options', { mode: 'json' }).$type<
-      Partial<import('../types').EvaluateOptions>
-    >(),
+    runtimeOptions: text('runtime_options', { mode: 'json' }).$type<EvalRuntimeOptions>(),
     isRedteam: integer('is_redteam', { mode: 'boolean' }).notNull().default(false),
   },
   (table) => ({

--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -9,17 +9,13 @@ import {
   TRAJECTORY_GOAL_SUCCESS_PROMPT,
 } from '../prompts/index';
 import { getDefaultProviders } from '../providers/defaults';
-import {
-  getCloudTargetIdFromProviders,
-  remoteGenerationContextPayload,
-  shouldGenerateRemote,
-} from '../redteam/remoteGeneration';
+import { shouldGenerateRemote } from '../redteam/remoteGeneration';
 import { doRemoteGrading } from '../remoteGrading';
 import { doRemoteScoringWithPi } from '../remoteScoring';
 import invariant from '../util/invariant';
 import { extractFirstJsonObject } from '../util/json';
 import { accumulateTokenUsage } from '../util/tokenUsageUtils';
-import { callProviderWithContext, getAndCheckProvider } from './providers';
+import { callProviderWithContext, getAndCheckProvider, getRemoteGradingContext } from './providers';
 import {
   LlmRubricProviderError,
   loadRubricPrompt,
@@ -207,11 +203,7 @@ export async function matchesLlmRubric(
           output: gradingOutput,
           vars: vars || {},
           ...(imageOutputs.length ? { images: imageOutputs } : {}),
-          ...remoteGenerationContextPayload(
-            getCloudTargetIdFromProviders(
-              cliState.selectedProviderConfigs ?? cliState.config?.providers,
-            ),
-          ),
+          ...getRemoteGradingContext(),
         })),
         assertion,
       };

--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -208,7 +208,9 @@ export async function matchesLlmRubric(
           vars: vars || {},
           ...(imageOutputs.length ? { images: imageOutputs } : {}),
           ...remoteGenerationContextPayload(
-            getCloudTargetIdFromProviders(cliState.config?.providers),
+            getCloudTargetIdFromProviders(
+              cliState.selectedProviderConfigs ?? cliState.config?.providers,
+            ),
           ),
         })),
         assertion,

--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -9,13 +9,17 @@ import {
   TRAJECTORY_GOAL_SUCCESS_PROMPT,
 } from '../prompts/index';
 import { getDefaultProviders } from '../providers/defaults';
-import { shouldGenerateRemote } from '../redteam/remoteGeneration';
 import { doRemoteGrading } from '../remoteGrading';
 import { doRemoteScoringWithPi } from '../remoteScoring';
 import invariant from '../util/invariant';
 import { extractFirstJsonObject } from '../util/json';
 import { accumulateTokenUsage } from '../util/tokenUsageUtils';
-import { callProviderWithContext, getAndCheckProvider, getRemoteGradingContext } from './providers';
+import {
+  callProviderWithContext,
+  getAndCheckProvider,
+  getRemoteGradingContext,
+  shouldUseRemoteGrading,
+} from './providers';
 import {
   LlmRubricProviderError,
   loadRubricPrompt,
@@ -193,7 +197,7 @@ export async function matchesLlmRubric(
     shouldPreferRemote &&
     !cliState.config?.redteam?.provider &&
     cliState.config?.redteam &&
-    shouldGenerateRemote({ canUseCodexDefaultProvider: true })
+    shouldUseRemoteGrading({ canUseCodexDefaultProvider: true })
   ) {
     try {
       return {

--- a/src/matchers/providers.ts
+++ b/src/matchers/providers.ts
@@ -1,7 +1,7 @@
 import cliState from '../cliState';
 import logger from '../logger';
 import { loadApiProvider } from '../providers/index';
-import { remoteGenerationContextPayload } from '../redteam/remoteGenerationContext';
+import { shouldGenerateRemote } from '../redteam/remoteGeneration';
 import { getCloudTargetIdFromProviders } from '../redteam/remoteGenerationContextFromProviders';
 import { getProviderCallExecutionContext } from '../scheduler/providerCallExecutionContext';
 import { createProviderRateLimitOptions, isRateLimitWrapped } from '../scheduler/providerWrapper';
@@ -20,9 +20,16 @@ import type {
 } from '../types/index';
 
 export function getRemoteGradingContext(): { targetId?: string } {
-  return remoteGenerationContextPayload(
-    getCloudTargetIdFromProviders(cliState.selectedProviderConfigs ?? cliState.config?.providers),
+  const targetId = getCloudTargetIdFromProviders(
+    cliState.selectedProviderConfigs ?? cliState.config?.providers,
   );
+  return targetId ? { targetId } : {};
+}
+
+export function shouldUseRemoteGrading(
+  options?: Parameters<typeof shouldGenerateRemote>[0],
+): boolean {
+  return shouldGenerateRemote(options);
 }
 
 /**

--- a/src/matchers/providers.ts
+++ b/src/matchers/providers.ts
@@ -19,6 +19,10 @@ import type {
   VarValue,
 } from '../types/index';
 
+// These wrappers keep src/matchers' imports of the redteam layer confined to this file.
+// Inlining shouldGenerateRemote (or a context-payload helper) into similarity.ts and
+// llmGrading.ts adds core->redteam import statements beyond the ratchet in
+// architecture/edge-baseline.json and fails `npm run architecture:check`.
 export function getRemoteGradingContext(): { targetId?: string } {
   const targetId = getCloudTargetIdFromProviders(
     cliState.selectedProviderConfigs ?? cliState.config?.providers,

--- a/src/matchers/providers.ts
+++ b/src/matchers/providers.ts
@@ -1,6 +1,8 @@
 import cliState from '../cliState';
 import logger from '../logger';
 import { loadApiProvider } from '../providers/index';
+import { remoteGenerationContextPayload } from '../redteam/remoteGenerationContext';
+import { getCloudTargetIdFromProviders } from '../redteam/remoteGenerationContextFromProviders';
 import { getProviderCallExecutionContext } from '../scheduler/providerCallExecutionContext';
 import { createProviderRateLimitOptions, isRateLimitWrapped } from '../scheduler/providerWrapper';
 import invariant from '../util/invariant';
@@ -16,6 +18,12 @@ import type {
   TestCase,
   VarValue,
 } from '../types/index';
+
+export function getRemoteGradingContext(): { targetId?: string } {
+  return remoteGenerationContextPayload(
+    getCloudTargetIdFromProviders(cliState.selectedProviderConfigs ?? cliState.config?.providers),
+  );
+}
 
 /**
  * Helper to call provider with consistent context propagation pattern.

--- a/src/matchers/similarity.ts
+++ b/src/matchers/similarity.ts
@@ -1,9 +1,8 @@
 import cliState from '../cliState';
 import { getDefaultProviders } from '../providers/defaults';
-import { shouldGenerateRemote } from '../redteam/remoteGeneration';
 import { doRemoteGrading } from '../remoteGrading';
 import { accumulateTokenUsage } from '../util/tokenUsageUtils';
-import { getAndCheckProvider, getRemoteGradingContext } from './providers';
+import { getAndCheckProvider, getRemoteGradingContext, shouldUseRemoteGrading } from './providers';
 import {
   cosineSimilarity,
   dotProduct,
@@ -171,7 +170,7 @@ export async function matchesSimilarity(
   if (
     metric === 'cosine' &&
     cliState.config?.redteam &&
-    shouldGenerateRemote({ requireEmbeddingProvider: true })
+    shouldUseRemoteGrading({ requireEmbeddingProvider: true })
   ) {
     try {
       return await doRemoteGrading({

--- a/src/matchers/similarity.ts
+++ b/src/matchers/similarity.ts
@@ -185,7 +185,9 @@ export async function matchesSimilarity(
         threshold,
         inverse,
         ...remoteGenerationContextPayload(
-          getCloudTargetIdFromProviders(cliState.config?.providers),
+          getCloudTargetIdFromProviders(
+            cliState.selectedProviderConfigs ?? cliState.config?.providers,
+          ),
         ),
       });
     } catch (error) {

--- a/src/matchers/similarity.ts
+++ b/src/matchers/similarity.ts
@@ -1,13 +1,9 @@
 import cliState from '../cliState';
 import { getDefaultProviders } from '../providers/defaults';
-import {
-  getCloudTargetIdFromProviders,
-  remoteGenerationContextPayload,
-  shouldGenerateRemote,
-} from '../redteam/remoteGeneration';
+import { shouldGenerateRemote } from '../redteam/remoteGeneration';
 import { doRemoteGrading } from '../remoteGrading';
 import { accumulateTokenUsage } from '../util/tokenUsageUtils';
-import { getAndCheckProvider } from './providers';
+import { getAndCheckProvider, getRemoteGradingContext } from './providers';
 import {
   cosineSimilarity,
   dotProduct,
@@ -184,11 +180,7 @@ export async function matchesSimilarity(
         output,
         threshold,
         inverse,
-        ...remoteGenerationContextPayload(
-          getCloudTargetIdFromProviders(
-            cliState.selectedProviderConfigs ?? cliState.config?.providers,
-          ),
-        ),
+        ...getRemoteGradingContext(),
       });
     } catch (error) {
       return fail(`Could not perform remote grading: ${error}`);

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -22,6 +22,7 @@ import { getRiskCategorySeverityMap } from '../redteam/sharedFrontend';
 import { getTraceStore } from '../tracing/store';
 import {
   type CompletedPrompt,
+  type EvalRuntimeOptions,
   type EvalSummary,
   type EvaluateResult,
   type EvaluateStats,
@@ -314,7 +315,7 @@ export default class Eval {
   persisted: boolean;
   vars: string[];
   _resultsLoaded: boolean = false;
-  runtimeOptions?: Partial<import('../types').EvaluateOptions>;
+  runtimeOptions?: EvalRuntimeOptions;
   _shared: boolean = false;
   resultPersistenceFailed: boolean = false;
   private failedResults = new Map<string, EvaluateResult>();
@@ -460,7 +461,7 @@ export default class Eval {
       // Be wary, this is EvalResult[] and not EvaluateResult[]
       results?: EvalResult[];
       vars?: string[];
-      runtimeOptions?: Partial<import('../types').EvaluateOptions>;
+      runtimeOptions?: EvalRuntimeOptions;
       completedPrompts?: CompletedPrompt[];
       durationMs?: number;
       generationDurationMs?: number;
@@ -617,7 +618,7 @@ export default class Eval {
       datasetId?: string;
       persisted?: boolean;
       vars?: string[];
-      runtimeOptions?: Partial<import('../types').EvaluateOptions>;
+      runtimeOptions?: EvalRuntimeOptions;
       durationMs?: number;
       generationDurationMs?: number;
       evaluationDurationMs?: number;

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -38,7 +38,11 @@ import {
   logConfigResolutionError,
   resolveConfigs,
 } from '../util/config/load';
-import { filterProviders, getPersistedProviderFilterOptions } from '../util/eval/filterProviders';
+import {
+  filterProviders,
+  getPersistedProviderFilterOptions,
+  getProviderFilterRegexError,
+} from '../util/eval/filterProviders';
 import { filterTests } from '../util/eval/filterTests';
 import { warnIfRedteamConfigHasNoTests } from '../util/eval/redteamWarning';
 import { generateEvalSummary } from '../util/eval/summary';
@@ -103,19 +107,25 @@ async function resolveReplayConfigs(
   const providerFilterOptions = getPersistedProviderFilterOptions(
     evalRecord.runtimeOptions?.providerFilter,
   );
+  const providerFilter = providerFilterOptions.filterProviders;
 
-  try {
-    return await resolveConfigs(providerFilterOptions, evalRecord.config);
-  } catch (error) {
-    const providerFilter = providerFilterOptions.filterProviders;
-    if (!providerFilter) {
-      throw error;
-    }
-    const reason = error instanceof Error ? error.message : String(error);
+  // Validate the stored pattern up front so a regex failure is attributed to the filter,
+  // while unrelated resolution errors (missing prompt files, provider load failures)
+  // propagate unchanged with their original class and stack.
+  const regexError = providerFilter ? getProviderFilterRegexError(providerFilter) : undefined;
+  if (providerFilter && regexError) {
     throw new ConfigResolutionError(
-      `Could not apply stored provider filter "${providerFilter}" while ${action} evaluation ${evalRecord.id}: ${reason}. The evaluation was not changed.`,
+      `Could not apply stored provider filter "${providerFilter}" while ${action} evaluation ${evalRecord.id}: ${regexError}. The evaluation was not changed.`,
     );
   }
+
+  const configs = await resolveConfigs(providerFilterOptions, evalRecord.config);
+  // The original run filtered twice: raw configs in resolveConfigs, then instantiated
+  // providers by live id()/label below in doEval. Replay both stages so the resumed
+  // provider set matches the original even when an instantiated id or label diverges
+  // from its raw config reference.
+  configs.testSuite.providers = filterProviders(configs.testSuite.providers, providerFilter);
+  return configs;
 }
 
 export class EvalRunError extends Error {
@@ -378,7 +388,6 @@ export async function doEval(
             }) as any,
         );
       }
-      // Mark resume mode in CLI state so evaluator can skip completed work
     } else if (retryErrors) {
       // Check if --no-write is set with --retry-errors
       if (cmdObj.write === false) {
@@ -450,6 +459,12 @@ export async function doEval(
       ? getPersistedProviderFilterOptions(resumeEval.runtimeOptions?.providerFilter)
       : {};
     const persistedProviderFilter = persistedProviderFilterOptions.filterProviders;
+    const cliProviderFilter = cmdObj.filterProviders || cmdObj.filterTargets;
+    if (resumeEval && cliProviderFilter && cliProviderFilter !== persistedProviderFilter) {
+      logger.warn(
+        `Ignoring --filter-providers/--filter-targets "${cliProviderFilter}": ${retryErrors ? 'retrying errors for' : 'resuming'} evaluation ${resumeEval.id} with stored provider filter ${persistedProviderFilter ? `"${persistedProviderFilter}"` : '(none)'} to preserve test indices.`,
+      );
+    }
     if (resumeEval && persistedProviderFilter && testSuite.providers.length === 0) {
       return failEvalRun(
         `Stored provider filter "${persistedProviderFilter}" matched no providers while ${retryErrors ? 'retrying errors for' : 'resuming'} evaluation ${resumeEval.id}. The evaluation was not changed.`,
@@ -666,14 +681,12 @@ export async function doEval(
 
     await checkCloudPermissions(config as UnifiedConfig);
 
-    const providerFilter = resumeEval
-      ? persistedProviderFilter
-      : cmdObj.filterProviders || cmdObj.filterTargets;
+    const providerFilter = resumeEval ? persistedProviderFilter : cliProviderFilter;
 
-    const safeEvaluateOptions = { ...evaluateOptions } as InternalEvaluateOptions & {
-      providerFilter?: unknown;
-    };
-    delete safeEvaluateOptions.providerFilter;
+    // Strip any providerFilter a config file injected via evaluateOptions — only the
+    // normalized CLI/persisted value above may be persisted and replayed.
+    const { providerFilter: _ignoredProviderFilter, ...safeEvaluateOptions } =
+      evaluateOptions as InternalEvaluateOptions & { providerFilter?: unknown };
     const options: InternalEvaluateOptions = {
       ...safeEvaluateOptions,
       showProgressBar:

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -38,7 +38,7 @@ import {
   logConfigResolutionError,
   resolveConfigs,
 } from '../util/config/load';
-import { filterProviders } from '../util/eval/filterProviders';
+import { filterProviders, getPersistedProviderFilterOptions } from '../util/eval/filterProviders';
 import { filterTests } from '../util/eval/filterTests';
 import { warnIfRedteamConfigHasNoTests } from '../util/eval/redteamWarning';
 import { generateEvalSummary } from '../util/eval/summary';
@@ -96,18 +96,26 @@ function runtimeTagsForEval(
   return Object.keys(tags).length > 0 ? tags : undefined;
 }
 
-function getPersistedProviderFilter(evalRecord: Eval): string | undefined {
-  const providerFilter = evalRecord.runtimeOptions?.providerFilter;
-  return typeof providerFilter === 'string' && providerFilter.length > 0
-    ? providerFilter
-    : undefined;
-}
-
-function getPersistedProviderFilterOptions(
+async function resolveReplayConfigs(
   evalRecord: Eval,
-): Partial<Pick<CommandLineOptions, 'filterProviders'>> {
-  const providerFilter = getPersistedProviderFilter(evalRecord);
-  return providerFilter ? { filterProviders: providerFilter } : {};
+  action: 'resuming' | 'retrying errors for',
+): Promise<Awaited<ReturnType<typeof resolveConfigs>>> {
+  const providerFilterOptions = getPersistedProviderFilterOptions(
+    evalRecord.runtimeOptions?.providerFilter,
+  );
+
+  try {
+    return await resolveConfigs(providerFilterOptions, evalRecord.config);
+  } catch (error) {
+    const providerFilter = providerFilterOptions.filterProviders;
+    if (!providerFilter) {
+      throw error;
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new ConfigResolutionError(
+      `Could not apply stored provider filter "${providerFilter}" while ${action} evaluation ${evalRecord.id}: ${reason}. The evaluation was not changed.`,
+    );
+  }
 }
 
 export class EvalRunError extends Error {
@@ -333,6 +341,7 @@ export async function doEval(
 
     // If resuming, load config from existing eval and avoid CLI filters that could change indices
     let resumeEval: Eval | undefined;
+    let retryErrorResultIds: string[] | undefined;
     const resumeId =
       resumeRaw === true || resumeRaw === undefined ? 'latest' : (resumeRaw as string);
     if (resumeRaw) {
@@ -357,7 +366,7 @@ export async function doEval(
         testSuite,
         basePath: _basePath,
         commandLineOptions,
-      } = await resolveConfigs(getPersistedProviderFilterOptions(resumeEval), resumeEval.config));
+      } = await resolveReplayConfigs(resumeEval, 'resuming'));
       // Ensure prompts exactly match the previous run to preserve IDs and content
       if (Array.isArray(resumeEval.prompts) && resumeEval.prompts.length > 0) {
         testSuite.prompts = resumeEval.prompts.map(
@@ -370,7 +379,6 @@ export async function doEval(
         );
       }
       // Mark resume mode in CLI state so evaluator can skip completed work
-      cliState.resume = true;
     } else if (retryErrors) {
       // Check if --no-write is set with --retry-errors
       if (cmdObj.write === false) {
@@ -392,22 +400,19 @@ export async function doEval(
       }
 
       // Get all ERROR result IDs - capture BEFORE retry so we know what to delete on success
-      const errorResultIds = await getErrorResultIds(latestEval.id);
-      if (errorResultIds.length === 0) {
+      retryErrorResultIds = await getErrorResultIds(latestEval.id);
+      if (retryErrorResultIds.length === 0) {
         logger.info('✅ No ERROR results found in the latest evaluation');
         return latestEval;
       }
 
-      logger.info(`Found ${errorResultIds.length} ERROR results to retry`);
+      logger.info(`Found ${retryErrorResultIds.length} ERROR results to retry`);
 
       // NOTE (v0.121.0): ERROR results are deleted AFTER successful retry, not before.
       // Previously, deletion happened before evaluate(), causing data loss if retry failed.
       // Now we delete AFTER successful retry to preserve ERROR results for re-retry on failure.
-      // Store errorResultIds for post-evaluation cleanup
-      cliState._retryErrorResultIds = errorResultIds;
-
       logger.info(
-        `🔄 Running evaluation with resume mode to retry ${errorResultIds.length} test cases...`,
+        `🔄 Running evaluation with resume mode to retry ${retryErrorResultIds.length} test cases...`,
       );
 
       // Set up for resume mode
@@ -419,7 +424,7 @@ export async function doEval(
         testSuite,
         basePath: _basePath,
         commandLineOptions,
-      } = await resolveConfigs(getPersistedProviderFilterOptions(resumeEval), resumeEval.config));
+      } = await resolveReplayConfigs(resumeEval, 'retrying errors for'));
 
       // Ensure prompts exactly match the previous run to preserve IDs and content
       if (Array.isArray(resumeEval.prompts) && resumeEval.prompts.length > 0) {
@@ -432,11 +437,6 @@ export async function doEval(
             }) as any,
         );
       }
-
-      // Mark resume mode in CLI state so evaluator can skip completed work
-      // Enable retry mode so getCompletedIndexPairs excludes ERROR results
-      cliState.resume = true;
-      cliState.retryMode = true;
     } else {
       ({
         config,
@@ -444,6 +444,24 @@ export async function doEval(
         basePath: _basePath,
         commandLineOptions,
       } = await resolveConfigs(cmdObj, defaultConfig));
+    }
+
+    const persistedProviderFilterOptions = resumeEval
+      ? getPersistedProviderFilterOptions(resumeEval.runtimeOptions?.providerFilter)
+      : {};
+    const persistedProviderFilter = persistedProviderFilterOptions.filterProviders;
+    if (resumeEval && persistedProviderFilter && testSuite.providers.length === 0) {
+      return failEvalRun(
+        `Stored provider filter "${persistedProviderFilter}" matched no providers while ${retryErrors ? 'retrying errors for' : 'resuming'} evaluation ${resumeEval.id}. The evaluation was not changed.`,
+        isCliInvocation,
+      );
+    }
+    if (resumeEval) {
+      cliState.resume = true;
+      if (retryErrorResultIds) {
+        cliState.retryMode = true;
+        cliState._retryErrorResultIds = retryErrorResultIds;
+      }
     }
 
     // Phase 2: Load environment from config files if not already set via CLI
@@ -649,7 +667,7 @@ export async function doEval(
     await checkCloudPermissions(config as UnifiedConfig);
 
     const providerFilter = resumeEval
-      ? getPersistedProviderFilter(resumeEval)
+      ? persistedProviderFilter
       : cmdObj.filterProviders || cmdObj.filterTargets;
 
     const safeEvaluateOptions = { ...evaluateOptions } as InternalEvaluateOptions & {

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -59,7 +59,13 @@ import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from 
 import { notCloudEnabledShareInstructions } from './shareInstructions';
 import type { Command } from 'commander';
 
-import type { CommandLineOptions, Scenario, TestSuite, UnifiedConfig } from '../types/index';
+import type {
+  CommandLineOptions,
+  EvalRuntimeOptions,
+  Scenario,
+  TestSuite,
+  UnifiedConfig,
+} from '../types/index';
 import type { InternalEvaluateOptions } from '../types/internal';
 import type { FilterOptions } from '../util/eval/filterTests';
 
@@ -88,6 +94,20 @@ function runtimeTagsForEval(
   };
 
   return Object.keys(tags).length > 0 ? tags : undefined;
+}
+
+function getPersistedProviderFilter(evalRecord: Eval): string | undefined {
+  const providerFilter = evalRecord.runtimeOptions?.providerFilter;
+  return typeof providerFilter === 'string' && providerFilter.length > 0
+    ? providerFilter
+    : undefined;
+}
+
+function getPersistedProviderFilterOptions(
+  evalRecord: Eval,
+): Partial<Pick<CommandLineOptions, 'filterProviders'>> {
+  const providerFilter = getPersistedProviderFilter(evalRecord);
+  return providerFilter ? { filterProviders: providerFilter } : {};
 }
 
 export class EvalRunError extends Error {
@@ -337,7 +357,7 @@ export async function doEval(
         testSuite,
         basePath: _basePath,
         commandLineOptions,
-      } = await resolveConfigs({}, resumeEval.config));
+      } = await resolveConfigs(getPersistedProviderFilterOptions(resumeEval), resumeEval.config));
       // Ensure prompts exactly match the previous run to preserve IDs and content
       if (Array.isArray(resumeEval.prompts) && resumeEval.prompts.length > 0) {
         testSuite.prompts = resumeEval.prompts.map(
@@ -399,7 +419,7 @@ export async function doEval(
         testSuite,
         basePath: _basePath,
         commandLineOptions,
-      } = await resolveConfigs({}, resumeEval.config));
+      } = await resolveConfigs(getPersistedProviderFilterOptions(resumeEval), resumeEval.config));
 
       // Ensure prompts exactly match the previous run to preserve IDs and content
       if (Array.isArray(resumeEval.prompts) && resumeEval.prompts.length > 0) {
@@ -628,8 +648,16 @@ export async function doEval(
 
     await checkCloudPermissions(config as UnifiedConfig);
 
+    const providerFilter = resumeEval
+      ? getPersistedProviderFilter(resumeEval)
+      : cmdObj.filterProviders || cmdObj.filterTargets;
+
+    const safeEvaluateOptions = { ...evaluateOptions } as InternalEvaluateOptions & {
+      providerFilter?: unknown;
+    };
+    delete safeEvaluateOptions.providerFilter;
     const options: InternalEvaluateOptions = {
-      ...evaluateOptions,
+      ...safeEvaluateOptions,
       showProgressBar:
         getLogLevel() === 'debug'
           ? false
@@ -705,13 +733,18 @@ export async function doEval(
       );
     }
 
+    const runtimeOptions: EvalRuntimeOptions = {
+      ...options,
+      ...(providerFilter ? { providerFilter } : {}),
+    };
+
     // Create or load eval record
     const author = getAuthor();
     const evalRecord = resumeEval
       ? resumeEval
       : cmdObj.write
-        ? await Eval.create(config, testSuite.prompts, { author, runtimeOptions: options })
-        : new Eval(config, { author, runtimeOptions: options });
+        ? await Eval.create(config, testSuite.prompts, { author, runtimeOptions })
+        : new Eval(config, { author, runtimeOptions });
 
     // Graceful pause support via Ctrl+C (only when writing to database)
     const abortController = new AbortController();

--- a/src/node/retry.ts
+++ b/src/node/retry.ts
@@ -10,7 +10,11 @@ import { notifyEvaluationChanged } from '../models/evalMutation';
 import { createShareableUrl, isSharingEnabled } from '../share';
 import { ResultFailureReason } from '../types/index';
 import { ConfigResolutionError, resolveConfigs } from '../util/config/load';
-import { getPersistedProviderFilterOptions } from '../util/eval/filterProviders';
+import {
+  filterProviders,
+  getPersistedProviderFilterOptions,
+  getProviderFilterRegexError,
+} from '../util/eval/filterProviders';
 import { accumulateNamedMetric } from '../util/namedMetrics';
 import { writeMultipleOutputs } from '../util/output';
 import { getOutputFileFormat } from '../util/outputFormats';
@@ -62,24 +66,29 @@ async function resolveRetryConfigs(
     originalEval.runtimeOptions?.providerFilter,
   );
   const providerFilter = providerFilterOptions.filterProviders;
-  const configDescription = cmdObj.config
-    ? `retry config "${cmdObj.config}"`
-    : 'saved evaluation config';
 
-  let configs: Awaited<ReturnType<typeof resolveConfigs>>;
-  try {
-    configs = cmdObj.config
-      ? await resolveConfigs({ config: [cmdObj.config], ...providerFilterOptions }, {})
-      : await resolveConfigs(providerFilterOptions, originalEval.config);
-  } catch (error) {
-    if (!providerFilter) {
-      throw error;
-    }
-    const reason = error instanceof Error ? error.message : String(error);
+  // Validate the stored pattern up front so a regex failure is attributed to the filter,
+  // while unrelated resolution errors (missing prompt files, provider load failures)
+  // propagate unchanged with their original class and stack.
+  const regexError = providerFilter ? getProviderFilterRegexError(providerFilter) : undefined;
+  if (providerFilter && regexError) {
+    const configDescription = cmdObj.config
+      ? `retry config "${cmdObj.config}"`
+      : 'saved evaluation config';
     throw new ConfigResolutionError(
-      `Could not resolve the ${configDescription} using stored provider filter "${providerFilter}": ${reason}. Existing ERROR results were preserved.`,
+      `Could not resolve the ${configDescription} using stored provider filter "${providerFilter}": ${regexError}. Existing ERROR results were preserved.`,
     );
   }
+
+  const configs = cmdObj.config
+    ? await resolveConfigs({ config: [cmdObj.config], ...providerFilterOptions }, {})
+    : await resolveConfigs(providerFilterOptions, originalEval.config);
+
+  // The original run filtered twice: raw configs in resolveConfigs, then instantiated
+  // providers by live id()/label in doEval. Replay both stages so the retried provider
+  // set matches the original even when an instantiated id or label diverges from its
+  // raw config reference.
+  configs.testSuite.providers = filterProviders(configs.testSuite.providers, providerFilter);
 
   assertRetryProviderFilterMatched(
     providerFilter,

--- a/src/node/retry.ts
+++ b/src/node/retry.ts
@@ -9,7 +9,8 @@ import Eval from '../models/eval';
 import { notifyEvaluationChanged } from '../models/evalMutation';
 import { createShareableUrl, isSharingEnabled } from '../share';
 import { ResultFailureReason } from '../types/index';
-import { resolveConfigs } from '../util/config/load';
+import { ConfigResolutionError, resolveConfigs } from '../util/config/load';
+import { getPersistedProviderFilterOptions } from '../util/eval/filterProviders';
 import { accumulateNamedMetric } from '../util/namedMetrics';
 import { writeMultipleOutputs } from '../util/output';
 import { getOutputFileFormat } from '../util/outputFormats';
@@ -36,6 +37,56 @@ function getJsonlOutputPaths(outputPath: string | string[] | undefined): string[
   return (Array.isArray(outputPath) ? outputPath : [outputPath]).filter(
     (path): path is string => typeof path === 'string' && getOutputFileFormat(path) === 'jsonl',
   );
+}
+
+function assertRetryProviderFilterMatched(
+  providerFilter: string | undefined,
+  providerCount: number,
+  configPath?: string,
+): void {
+  if (!providerFilter || providerCount > 0) {
+    return;
+  }
+
+  const configDescription = configPath ? `retry config "${configPath}"` : 'saved evaluation config';
+  throw new ConfigResolutionError(
+    `Stored provider filter "${providerFilter}" matched no providers in the ${configDescription}. Existing ERROR results were preserved.`,
+  );
+}
+
+async function resolveRetryConfigs(
+  originalEval: Eval,
+  cmdObj: RetryCommandOptions,
+): Promise<Awaited<ReturnType<typeof resolveConfigs>>> {
+  const providerFilterOptions = getPersistedProviderFilterOptions(
+    originalEval.runtimeOptions?.providerFilter,
+  );
+  const providerFilter = providerFilterOptions.filterProviders;
+  const configDescription = cmdObj.config
+    ? `retry config "${cmdObj.config}"`
+    : 'saved evaluation config';
+
+  let configs: Awaited<ReturnType<typeof resolveConfigs>>;
+  try {
+    configs = cmdObj.config
+      ? await resolveConfigs({ config: [cmdObj.config], ...providerFilterOptions }, {})
+      : await resolveConfigs(providerFilterOptions, originalEval.config);
+  } catch (error) {
+    if (!providerFilter) {
+      throw error;
+    }
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new ConfigResolutionError(
+      `Could not resolve the ${configDescription} using stored provider filter "${providerFilter}": ${reason}. Existing ERROR results were preserved.`,
+    );
+  }
+
+  assertRetryProviderFilterMatched(
+    providerFilter,
+    configs.testSuite.providers.length,
+    cmdObj.config,
+  );
+  return configs;
 }
 
 async function restoreJsonlOutputsAfterPersistenceFailure(
@@ -294,27 +345,7 @@ export async function retryCommand(evalId: string, cmdObj: RetryCommandOptions) 
   logger.info(`Found ${errorResultIds.length} ERROR results to retry`);
 
   // Load configuration - from provided config file or from original evaluation
-  let testSuite;
-  let commandLineOptions: Record<string, unknown> | undefined;
-  let config: Record<string, unknown> | undefined;
-  const providerFilter = originalEval.runtimeOptions?.providerFilter;
-  const providerFilterOptions =
-    typeof providerFilter === 'string' && providerFilter.length > 0
-      ? { filterProviders: providerFilter }
-      : {};
-  if (cmdObj.config) {
-    // Load configuration from the provided config file
-    const configs = await resolveConfigs({ config: [cmdObj.config], ...providerFilterOptions }, {});
-    testSuite = configs.testSuite;
-    commandLineOptions = configs.commandLineOptions;
-    config = configs.config;
-  } else {
-    // Load configuration from the original evaluation
-    const configs = await resolveConfigs(providerFilterOptions, originalEval.config);
-    testSuite = configs.testSuite;
-    commandLineOptions = configs.commandLineOptions;
-    config = configs.config;
-  }
+  const { testSuite, commandLineOptions, config } = await resolveRetryConfigs(originalEval, cmdObj);
 
   // CRITICAL: We do NOT delete ERROR results here anymore!
   // Previously (before this fix), deletion happened before evaluate(), which caused data loss:

--- a/src/node/retry.ts
+++ b/src/node/retry.ts
@@ -297,15 +297,20 @@ export async function retryCommand(evalId: string, cmdObj: RetryCommandOptions) 
   let testSuite;
   let commandLineOptions: Record<string, unknown> | undefined;
   let config: Record<string, unknown> | undefined;
+  const providerFilter = originalEval.runtimeOptions?.providerFilter;
+  const providerFilterOptions =
+    typeof providerFilter === 'string' && providerFilter.length > 0
+      ? { filterProviders: providerFilter }
+      : {};
   if (cmdObj.config) {
     // Load configuration from the provided config file
-    const configs = await resolveConfigs({ config: [cmdObj.config] }, {});
+    const configs = await resolveConfigs({ config: [cmdObj.config], ...providerFilterOptions }, {});
     testSuite = configs.testSuite;
     commandLineOptions = configs.commandLineOptions;
     config = configs.config;
   } else {
     // Load configuration from the original evaluation
-    const configs = await resolveConfigs({}, originalEval.config);
+    const configs = await resolveConfigs(providerFilterOptions, originalEval.config);
     testSuite = configs.testSuite;
     commandLineOptions = configs.commandLineOptions;
     config = configs.config;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -309,6 +309,12 @@ export type EvaluateOptions = z.infer<typeof EvaluateOptionsSchema> & {
   abortSignal?: AbortSignal;
 };
 
+/** Runtime options stored with an evaluation for reproducible resume and retry behavior. */
+export type EvalRuntimeOptions = Partial<EvaluateOptions> & {
+  /** @internal Normalized value of --filter-providers or --filter-targets. */
+  providerFilter?: string;
+};
+
 const PromptMetricsSchema = z.object({
   score: z.number(),
   testPassCount: z.number(),
@@ -1434,7 +1440,7 @@ export interface OutputFile {
   shareableUrl: string | null;
   metadata?: OutputMetadata;
   vars?: string[];
-  runtimeOptions?: Partial<EvaluateOptions>;
+  runtimeOptions?: EvalRuntimeOptions;
   traces?: TraceData[];
   blobAssets?: ExportedBlobAsset[];
 }

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -1046,6 +1046,7 @@ export async function resolveConfigs(
   );
 
   cliState.config = config;
+  cliState.selectedProviderConfigs = filteredProviderConfigs;
 
   // Extract commandLineOptions from either explicit config files or default config
   // Resolve relative envPath(s) against the config file directory

--- a/src/util/eval/filterProviders.ts
+++ b/src/util/eval/filterProviders.ts
@@ -5,15 +5,37 @@ import type { ProviderOptions, ProviderOptionsMap } from '../../types/providers'
 
 /**
  * Converts an untrusted persisted provider filter into the CLI option shape used by config
- * resolution. Older evaluations may omit this value, and malformed persisted JSON must not
- * accidentally enable filtering.
+ * resolution. Older evaluations legitimately omit this value, so undefined/null mean "no
+ * filter". Anything else that is not a non-empty string can only come from tampered or
+ * corrupted persisted data (the writer never produces it); fail closed rather than silently
+ * running the eval unfiltered.
  */
 export function getPersistedProviderFilterOptions(
   providerFilter: unknown,
 ): Partial<Pick<CommandLineOptions, 'filterProviders'>> {
-  return typeof providerFilter === 'string' && providerFilter.length > 0
-    ? { filterProviders: providerFilter }
-    : {};
+  if (providerFilter === undefined || providerFilter === null) {
+    return {};
+  }
+  if (typeof providerFilter === 'string' && providerFilter.length > 0) {
+    return { filterProviders: providerFilter };
+  }
+  throw new Error(
+    `Stored provider filter is invalid (expected a non-empty string, got ${JSON.stringify(providerFilter)}). Refusing to run without the original provider selection.`,
+  );
+}
+
+/**
+ * Returns the reason a provider filter cannot be compiled as a regular expression, or
+ * undefined when it is valid. Lets replay paths attribute regex failures to the stored
+ * filter without blaming it for unrelated config resolution errors.
+ */
+export function getProviderFilterRegexError(filter: string): string | undefined {
+  try {
+    new RegExp(filter);
+    return undefined;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
 }
 
 /**

--- a/src/util/eval/filterProviders.ts
+++ b/src/util/eval/filterProviders.ts
@@ -1,7 +1,20 @@
 import { normalizeProviderRef } from '../../util/providerRef';
 
-import type { ApiProvider, TestSuiteConfig } from '../../types/index';
+import type { ApiProvider, CommandLineOptions, TestSuiteConfig } from '../../types/index';
 import type { ProviderOptions, ProviderOptionsMap } from '../../types/providers';
+
+/**
+ * Converts an untrusted persisted provider filter into the CLI option shape used by config
+ * resolution. Older evaluations may omit this value, and malformed persisted JSON must not
+ * accidentally enable filtering.
+ */
+export function getPersistedProviderFilterOptions(
+  providerFilter: unknown,
+): Partial<Pick<CommandLineOptions, 'filterProviders'>> {
+  return typeof providerFilter === 'string' && providerFilter.length > 0
+    ? { filterProviders: providerFilter }
+    : {};
+}
 
 /**
  * Extracts the id and label from a raw provider config without instantiating it.

--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -4,6 +4,8 @@
  */
 import safeStringify from 'fast-safe-stringify';
 
+import type { EvalRuntimeOptions } from '../types';
+
 const MAX_DEPTH = 4;
 const DUMMY_BASE = 'http://placeholder';
 
@@ -95,8 +97,8 @@ export function isSecretField(fieldName: string): boolean {
  * Removes non-serializable fields like AbortSignal, functions, and symbols.
  */
 export function sanitizeRuntimeOptions(
-  options?: Partial<import('../types').EvaluateOptions>,
-): Partial<import('../types').EvaluateOptions> | undefined {
+  options?: EvalRuntimeOptions,
+): EvalRuntimeOptions | undefined {
   if (!options) {
     return undefined;
   }

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -1210,7 +1210,13 @@ describe('evalCommand', () => {
     resumeEval.prompts = [
       { raw: 'saved prompt', label: 'Saved', config: { temperature: 0 } },
     ] as any;
-    (resumeEval as any).runtimeOptions = { repeat: 2, cache: false, maxConcurrency: 2, delay: 0 };
+    resumeEval.runtimeOptions = {
+      repeat: 2,
+      cache: false,
+      maxConcurrency: 2,
+      delay: 0,
+      providerFilter: 'selected-target',
+    };
     const findByIdSpy = vi.spyOn(Eval, 'findById').mockResolvedValueOnce(resumeEval);
     vi.mocked(resolveConfigs).mockResolvedValueOnce({
       config: {} as UnifiedConfig,
@@ -1238,6 +1244,10 @@ describe('evalCommand', () => {
 
       expect(result).toBe(resumeEval);
       expect(findByIdSpy).toHaveBeenCalledWith('eval-123');
+      expect(resolveConfigs).toHaveBeenCalledWith(
+        { filterProviders: 'selected-target' },
+        resumeEval.config,
+      );
     } finally {
       findByIdSpy.mockRestore();
     }
@@ -1246,6 +1256,7 @@ describe('evalCommand', () => {
   it('should retry error results from the latest eval and clean up after success', async () => {
     const latestEval = new Eval({ prompts: [] } as UnifiedConfig);
     latestEval.prompts = [{ raw: 'retry prompt', label: 'Retry', config: {} }] as any;
+    latestEval.runtimeOptions = { providerFilter: 'selected-target' };
     const latestSpy = vi.spyOn(Eval, 'latest').mockResolvedValueOnce(latestEval);
     vi.mocked(getErrorResultIds).mockResolvedValueOnce(['result-1', 'result-2']);
     vi.mocked(resolveConfigs).mockResolvedValueOnce({
@@ -1266,6 +1277,10 @@ describe('evalCommand', () => {
 
       expect(result).toBe(latestEval);
       expect(latestSpy).toHaveBeenCalledTimes(1);
+      expect(resolveConfigs).toHaveBeenCalledWith(
+        { filterProviders: 'selected-target' },
+        latestEval.config,
+      );
       expect(deleteErrorResults).toHaveBeenCalledWith(['result-1', 'result-2']);
       expect(recalculatePromptMetrics).toHaveBeenCalledWith(latestEval);
     } finally {

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -1371,7 +1371,6 @@ describe('evalCommand', () => {
     latestEval.runtimeOptions = { providerFilter: '[' };
     const latestSpy = vi.spyOn(Eval, 'latest').mockResolvedValueOnce(latestEval);
     vi.mocked(getErrorResultIds).mockResolvedValueOnce(['result-1']);
-    vi.mocked(resolveConfigs).mockRejectedValueOnce(new SyntaxError('Invalid regular expression'));
 
     try {
       await expect(
@@ -1380,6 +1379,8 @@ describe('evalCommand', () => {
         `Could not apply stored provider filter "[" while retrying errors for evaluation ${latestEval.id}: Invalid regular expression`,
       );
 
+      // The pattern is validated before any config resolution happens.
+      expect(resolveConfigs).not.toHaveBeenCalled();
       expect(evaluate).not.toHaveBeenCalled();
       expect(deleteErrorResults).not.toHaveBeenCalled();
       expect(cliState.resume).toBe(false);
@@ -1387,6 +1388,132 @@ describe('evalCommand', () => {
       expect(cliState._retryErrorResultIds).toBeUndefined();
     } finally {
       latestSpy.mockRestore();
+    }
+  });
+
+  it('should fail closed when resuming and the stored provider filter matches no providers', async () => {
+    const resumeEval = new Eval({ prompts: [] } as UnifiedConfig);
+    resumeEval.runtimeOptions = { providerFilter: 'selected-target' };
+    const findByIdSpy = vi.spyOn(Eval, 'findById').mockResolvedValueOnce(resumeEval);
+    vi.mocked(resolveConfigs).mockResolvedValueOnce({
+      config: {} as UnifiedConfig,
+      testSuite: { prompts: [], providers: [] },
+      basePath: path.resolve('/'),
+    });
+
+    try {
+      await expect(
+        doEval(
+          { resume: 'eval-123' } as Parameters<typeof doEval>[0],
+          defaultConfig,
+          defaultConfigPath,
+          {},
+        ),
+      ).rejects.toThrow(
+        `Stored provider filter "selected-target" matched no providers while resuming evaluation ${resumeEval.id}`,
+      );
+
+      expect(evaluate).not.toHaveBeenCalled();
+      expect(cliState.resume).toBe(false);
+      expect(cliState.retryMode).toBe(false);
+    } finally {
+      findByIdSpy.mockRestore();
+    }
+  });
+
+  it('should fail closed when resuming and the stored provider filter is an invalid regex', async () => {
+    const resumeEval = new Eval({ prompts: [] } as UnifiedConfig);
+    resumeEval.runtimeOptions = { providerFilter: '[' };
+    const findByIdSpy = vi.spyOn(Eval, 'findById').mockResolvedValueOnce(resumeEval);
+
+    try {
+      await expect(
+        doEval(
+          { resume: 'eval-123' } as Parameters<typeof doEval>[0],
+          defaultConfig,
+          defaultConfigPath,
+          {},
+        ),
+      ).rejects.toThrow(
+        `Could not apply stored provider filter "[" while resuming evaluation ${resumeEval.id}: Invalid regular expression`,
+      );
+
+      expect(resolveConfigs).not.toHaveBeenCalled();
+      expect(evaluate).not.toHaveBeenCalled();
+      expect(cliState.resume).toBe(false);
+    } finally {
+      findByIdSpy.mockRestore();
+    }
+  });
+
+  it('should fail closed when a persisted provider filter is not a string', async () => {
+    const resumeEval = new Eval({ prompts: [] } as UnifiedConfig);
+    resumeEval.runtimeOptions = { providerFilter: ['selected-target'] as unknown as string };
+    const findByIdSpy = vi.spyOn(Eval, 'findById').mockResolvedValueOnce(resumeEval);
+
+    try {
+      await expect(
+        doEval(
+          { resume: 'eval-123' } as Parameters<typeof doEval>[0],
+          defaultConfig,
+          defaultConfigPath,
+          {},
+        ),
+      ).rejects.toThrow('Stored provider filter is invalid');
+
+      expect(resolveConfigs).not.toHaveBeenCalled();
+      expect(evaluate).not.toHaveBeenCalled();
+      expect(cliState.resume).toBe(false);
+    } finally {
+      findByIdSpy.mockRestore();
+    }
+  });
+
+  it('should warn when CLI provider filters are passed alongside --resume', async () => {
+    const resumeEval = new Eval({ prompts: [] } as UnifiedConfig);
+    resumeEval.runtimeOptions = { providerFilter: 'selected-target' };
+    const findByIdSpy = vi.spyOn(Eval, 'findById').mockResolvedValueOnce(resumeEval);
+    // Spy without replacing the implementation or restoring: another describe block in
+    // this file holds a module-level spy on logger.warn, and mockRestore() here would
+    // tear that spy down under random test ordering.
+    const warnSpy = vi.spyOn(logger, 'warn');
+    vi.mocked(resolveConfigs).mockResolvedValueOnce({
+      config: {} as UnifiedConfig,
+      testSuite: {
+        prompts: [],
+        providers: [
+          {
+            id: () => 'echo',
+            label: 'selected-target',
+            callApi: vi.fn(),
+          } as ApiProvider,
+        ],
+      },
+      basePath: path.resolve('/'),
+    });
+    vi.mocked(evaluate).mockImplementationOnce(async (_testSuite, evalRecord) => {
+      return evalRecord as Eval;
+    });
+
+    try {
+      await doEval(
+        { resume: 'eval-123', filterProviders: 'other-target' } as Parameters<typeof doEval>[0],
+        defaultConfig,
+        defaultConfigPath,
+        {},
+      );
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        `Ignoring --filter-providers/--filter-targets "other-target": resuming evaluation ${resumeEval.id} with stored provider filter "selected-target" to preserve test indices.`,
+      );
+      // The stored filter, not the CLI value, drives config resolution.
+      expect(resolveConfigs).toHaveBeenCalledWith(
+        { filterProviders: 'selected-target' },
+        resumeEval.config,
+      );
+    } finally {
+      warnSpy.mockClear();
+      findByIdSpy.mockRestore();
     }
   });
 

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
 import { disableCache } from '../../src/cache';
+import cliState from '../../src/cliState';
 import {
   doEval as commandDoEval,
   EvalCommandSchema as commandEvalCommandSchema,
@@ -172,6 +173,9 @@ describe('evalCommand', () => {
   beforeEach(() => {
     program = new Command();
     vi.clearAllMocks();
+    cliState.resume = false;
+    cliState.retryMode = false;
+    cliState._retryErrorResultIds = undefined;
     chokidarMocks.handlers.clear();
     chokidarMocks.watcher.on
       .mockReset()
@@ -198,6 +202,12 @@ describe('evalCommand', () => {
     vi.mocked(deleteErrorResults).mockResolvedValue(undefined);
     vi.mocked(getErrorResultIds).mockResolvedValue([]);
     vi.mocked(recalculatePromptMetrics).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cliState.resume = false;
+    cliState.retryMode = false;
+    cliState._retryErrorResultIds = undefined;
   });
 
   it('should create eval command with correct options', () => {
@@ -254,7 +264,13 @@ describe('evalCommand', () => {
       config,
       testSuite: {
         prompts: [],
-        providers: [],
+        providers: [
+          {
+            id: () => 'echo',
+            label: 'selected-target',
+            callApi: vi.fn(),
+          } as ApiProvider,
+        ],
       },
       basePath: path.resolve('/'),
     });
@@ -277,7 +293,13 @@ describe('evalCommand', () => {
       config,
       testSuite: {
         prompts: [],
-        providers: [],
+        providers: [
+          {
+            id: () => 'echo',
+            label: 'selected-target',
+            callApi: vi.fn(),
+          } as ApiProvider,
+        ],
       },
       basePath: path.resolve('/'),
     });
@@ -1222,7 +1244,13 @@ describe('evalCommand', () => {
       config: {} as UnifiedConfig,
       testSuite: {
         prompts: [],
-        providers: [],
+        providers: [
+          {
+            id: () => 'echo',
+            label: 'selected-target',
+            callApi: vi.fn(),
+          } as ApiProvider,
+        ],
       },
       basePath: path.resolve('/'),
     });
@@ -1263,7 +1291,13 @@ describe('evalCommand', () => {
       config: {} as UnifiedConfig,
       testSuite: {
         prompts: [],
-        providers: [],
+        providers: [
+          {
+            id: () => 'echo',
+            label: 'selected-target',
+            callApi: vi.fn(),
+          } as ApiProvider,
+        ],
       },
       basePath: path.resolve('/'),
     });
@@ -1298,6 +1332,59 @@ describe('evalCommand', () => {
 
       expect(result).toBe(latestEval);
       expect(evaluate).not.toHaveBeenCalled();
+    } finally {
+      latestSpy.mockRestore();
+    }
+  });
+
+  it('should preserve error results when the stored provider filter matches no providers', async () => {
+    const latestEval = new Eval({ prompts: [] } as UnifiedConfig);
+    latestEval.runtimeOptions = { providerFilter: 'selected-target' };
+    const latestSpy = vi.spyOn(Eval, 'latest').mockResolvedValueOnce(latestEval);
+    vi.mocked(getErrorResultIds).mockResolvedValueOnce(['result-1']);
+    vi.mocked(resolveConfigs).mockResolvedValueOnce({
+      config: {} as UnifiedConfig,
+      testSuite: { prompts: [], providers: [] },
+      basePath: path.resolve('/'),
+    });
+
+    try {
+      await expect(
+        doEval({ retryErrors: true }, defaultConfig, defaultConfigPath, {}),
+      ).rejects.toThrow(
+        `Stored provider filter "selected-target" matched no providers while retrying errors for evaluation ${latestEval.id}`,
+      );
+
+      expect(evaluate).not.toHaveBeenCalled();
+      expect(deleteErrorResults).not.toHaveBeenCalled();
+      expect(recalculatePromptMetrics).not.toHaveBeenCalled();
+      expect(cliState.resume).toBe(false);
+      expect(cliState.retryMode).toBe(false);
+      expect(cliState._retryErrorResultIds).toBeUndefined();
+    } finally {
+      latestSpy.mockRestore();
+    }
+  });
+
+  it('should clear retry state when a stored provider filter cannot be resolved', async () => {
+    const latestEval = new Eval({ prompts: [] } as UnifiedConfig);
+    latestEval.runtimeOptions = { providerFilter: '[' };
+    const latestSpy = vi.spyOn(Eval, 'latest').mockResolvedValueOnce(latestEval);
+    vi.mocked(getErrorResultIds).mockResolvedValueOnce(['result-1']);
+    vi.mocked(resolveConfigs).mockRejectedValueOnce(new SyntaxError('Invalid regular expression'));
+
+    try {
+      await expect(
+        doEval({ retryErrors: true }, defaultConfig, defaultConfigPath, {}),
+      ).rejects.toThrow(
+        `Could not apply stored provider filter "[" while retrying errors for evaluation ${latestEval.id}: Invalid regular expression`,
+      );
+
+      expect(evaluate).not.toHaveBeenCalled();
+      expect(deleteErrorResults).not.toHaveBeenCalled();
+      expect(cliState.resume).toBe(false);
+      expect(cliState.retryMode).toBe(false);
+      expect(cliState._retryErrorResultIds).toBeUndefined();
     } finally {
       latestSpy.mockRestore();
     }

--- a/test/commands/eval/evaluateOptions.test.ts
+++ b/test/commands/eval/evaluateOptions.test.ts
@@ -592,7 +592,7 @@ describe('evaluateOptions behavior', () => {
           { id: 'echo', label: 'selected-target' },
         ],
         prompts: ['Hello'],
-        tests: [{}],
+        tests: [{ vars: {} }],
       });
 
       await doEval(
@@ -650,7 +650,7 @@ describe('evaluateOptions behavior', () => {
           { id: 'echo', label: 'selected-target' },
         ],
         prompts: ['Hello'],
-        tests: [{}],
+        tests: [{ vars: {} }],
       });
 
       await doEval({ table: false, write: false, config: [tempConfig] }, {}, undefined, {});

--- a/test/commands/eval/evaluateOptions.test.ts
+++ b/test/commands/eval/evaluateOptions.test.ts
@@ -582,6 +582,90 @@ describe('evaluateOptions behavior', () => {
       expect(options.filterRange).toBeUndefined();
     });
 
+    it.each([
+      ['--filter-targets', 'filterTargets'],
+      ['--filter-providers', 'filterProviders'],
+    ] as const)('should persist and restore %s for resumed evaluations', async (_flag, key) => {
+      const tempConfig = writeTempConfig(tmpDir, `test-${key}.yaml`, {
+        providers: [
+          { id: 'echo', label: 'excluded-target' },
+          { id: 'echo', label: 'selected-target' },
+        ],
+        prompts: ['Hello'],
+        tests: [{}],
+      });
+
+      await doEval(
+        {
+          table: false,
+          write: false,
+          config: [tempConfig],
+          [key]: 'selected-target',
+        },
+        {},
+        undefined,
+        {},
+      );
+
+      const initialSuite = evaluateMock.mock.calls.at(-1)?.[0] as TestSuite;
+      const initialEval = evaluateMock.mock.calls.at(-1)?.[1] as Eval;
+      expect(initialSuite.providers.map((provider) => provider.label)).toEqual(['selected-target']);
+      expect(initialEval.runtimeOptions?.providerFilter).toBe('selected-target');
+
+      const resumeEval = new Eval(initialEval.config, {
+        id: `eval-resume-${key}`,
+        persisted: true,
+        runtimeOptions: initialEval.runtimeOptions,
+      });
+      const findByIdSpy = vi.spyOn(Eval, 'findById').mockResolvedValue(resumeEval);
+      evaluateMock.mockClear();
+
+      try {
+        await doEval(
+          {
+            table: false,
+            resume: resumeEval.id,
+          } as any,
+          {},
+          undefined,
+          {},
+        );
+
+        const resumedSuite = evaluateMock.mock.calls.at(-1)?.[0] as TestSuite;
+        expect(resumedSuite.providers.map((provider) => provider.label)).toEqual([
+          'selected-target',
+        ]);
+      } finally {
+        findByIdSpy.mockRestore();
+      }
+    });
+
+    it('should not treat evaluateOptions.providerFilter as a provider selection', async () => {
+      const tempConfig = writeTempConfig(tmpDir, 'test-ignored-provider-filter.yaml', {
+        evaluateOptions: {
+          providerFilter: 'selected-target',
+        },
+        providers: [
+          { id: 'echo', label: 'excluded-target' },
+          { id: 'echo', label: 'selected-target' },
+        ],
+        prompts: ['Hello'],
+        tests: [{}],
+      });
+
+      await doEval({ table: false, write: false, config: [tempConfig] }, {}, undefined, {});
+
+      const testSuite = evaluateMock.mock.calls.at(-1)?.[0] as TestSuite;
+      const evalRecord = evaluateMock.mock.calls.at(-1)?.[1] as Eval;
+      const options = evaluateMock.mock.calls.at(-1)?.[2] as EvaluateOptions;
+      expect(testSuite.providers.map((provider) => provider.label)).toEqual([
+        'excluded-target',
+        'selected-target',
+      ]);
+      expect(evalRecord.runtimeOptions?.providerFilter).toBeUndefined();
+      expect(options).not.toHaveProperty('providerFilter');
+    });
+
     it('should make commandLineOptions.filterSample repeatable with a configured seed', async () => {
       const tempConfig = writeTempConfig(tmpDir, 'test-filter-sample-seed.yaml', {
         commandLineOptions: {

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { loadFromJavaScriptFile } from '../../src/assertions/utils';
 import cliState from '../../src/cliState';
 import { importModule } from '../../src/esm';
@@ -73,7 +73,8 @@ describe('matchesLlmRubric', () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue(mockFileContent);
 
-    (cliState as any).config = {};
+    cliState.config = {};
+    cliState.selectedProviderConfigs = undefined;
 
     vi.mocked(remoteGrading.doRemoteGrading).mockReset();
     vi.mocked(remoteGrading.doRemoteGrading).mockResolvedValue({
@@ -87,6 +88,10 @@ describe('matchesLlmRubric', () => {
       output: JSON.stringify({ pass: true, score: 1, reason: 'Test passed' }),
       tokenUsage: { total: 10, prompt: 5, completion: 5 },
     });
+  });
+
+  afterEach(() => {
+    cliState.selectedProviderConfigs = undefined;
   });
 
   it('should pass when the grading provider returns a passing result', async () => {
@@ -2296,11 +2301,11 @@ Evaluate the response
     const llmOutput = 'Test output';
     const remoteGeneration = await import('../../src/redteam/remoteGeneration');
     vi.mocked(remoteGeneration.shouldGenerateRemote).mockReturnValue(true);
-    (cliState as any).config = {
+    cliState.config = {
       providers: ['promptfoo://provider/excluded-target'],
       redteam: {},
     };
-    (cliState as any).selectedProviderConfigs = ['promptfoo://provider/selected-target'];
+    cliState.selectedProviderConfigs = ['promptfoo://provider/selected-target'];
 
     await matchesLlmRubric(rubric, llmOutput, {});
 

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -2291,6 +2291,28 @@ Evaluate the response
     });
   });
 
+  it('should prefer filtered providers when building remote grading context', async () => {
+    const rubric = 'Test rubric';
+    const llmOutput = 'Test output';
+    const remoteGeneration = await import('../../src/redteam/remoteGeneration');
+    vi.mocked(remoteGeneration.shouldGenerateRemote).mockReturnValue(true);
+    (cliState as any).config = {
+      providers: ['promptfoo://provider/excluded-target'],
+      redteam: {},
+    };
+    (cliState as any).selectedProviderConfigs = ['promptfoo://provider/selected-target'];
+
+    await matchesLlmRubric(rubric, llmOutput, {});
+
+    expect(remoteGrading.doRemoteGrading).toHaveBeenCalledWith({
+      task: 'llm-rubric',
+      rubric,
+      output: llmOutput,
+      vars: {},
+      targetId: 'selected-target',
+    });
+  });
+
   it('should call remote with image outputs when multimodal grading is remote-eligible', async () => {
     const rubric = 'Does the image match?';
     const llmOutput = 'Generated image';

--- a/test/matchers/similarity.test.ts
+++ b/test/matchers/similarity.test.ts
@@ -13,7 +13,8 @@ import type { GradingConfig } from '../../src/types/index';
 
 describe('matchesSimilarity', () => {
   beforeEach(() => {
-    (cliState as any).config = {};
+    cliState.config = {};
+    cliState.selectedProviderConfigs = undefined;
     vi.spyOn(DefaultEmbeddingProvider, 'callEmbeddingApi').mockImplementation((text) => {
       if (text === 'Expected output' || text === 'Sample output') {
         return Promise.resolve({
@@ -31,6 +32,7 @@ describe('matchesSimilarity', () => {
   });
 
   afterEach(() => {
+    cliState.selectedProviderConfigs = undefined;
     vi.restoreAllMocks();
   });
 
@@ -120,11 +122,11 @@ describe('matchesSimilarity', () => {
   });
 
   it('should prefer filtered providers when building remote similarity context', async () => {
-    (cliState as any).config = {
+    cliState.config = {
       providers: ['promptfoo://provider/excluded-target'],
       redteam: {},
     };
-    (cliState as any).selectedProviderConfigs = ['promptfoo://provider/selected-target'];
+    cliState.selectedProviderConfigs = ['promptfoo://provider/selected-target'];
     vi.spyOn(remoteGeneration, 'shouldGenerateRemote').mockReturnValue(true);
     vi.spyOn(remoteGrading, 'doRemoteGrading').mockResolvedValue({
       pass: true,

--- a/test/matchers/similarity.test.ts
+++ b/test/matchers/similarity.test.ts
@@ -119,6 +119,31 @@ describe('matchesSimilarity', () => {
     });
   });
 
+  it('should prefer filtered providers when building remote similarity context', async () => {
+    (cliState as any).config = {
+      providers: ['promptfoo://provider/excluded-target'],
+      redteam: {},
+    };
+    (cliState as any).selectedProviderConfigs = ['promptfoo://provider/selected-target'];
+    vi.spyOn(remoteGeneration, 'shouldGenerateRemote').mockReturnValue(true);
+    vi.spyOn(remoteGrading, 'doRemoteGrading').mockResolvedValue({
+      pass: true,
+      score: 1,
+      reason: 'remote',
+    });
+
+    await matchesSimilarity('Expected output', 'Sample output', 0.5);
+
+    expect(remoteGrading.doRemoteGrading).toHaveBeenCalledWith({
+      task: 'similar',
+      expected: 'Expected output',
+      output: 'Sample output',
+      threshold: 0.5,
+      inverse: false,
+      targetId: 'selected-target',
+    });
+  });
+
   it('should fail when inverted similarity is above the threshold', async () => {
     const expected = 'Expected output';
     const output = 'Sample output';

--- a/test/matchers/utils.test.ts
+++ b/test/matchers/utils.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { getAndCheckProvider, getGradingProvider } from '../../src/matchers/providers';
+import cliState from '../../src/cliState';
+import {
+  getAndCheckProvider,
+  getGradingProvider,
+  getRemoteGradingContext,
+} from '../../src/matchers/providers';
 import { renderLlmRubricPrompt } from '../../src/matchers/rubric';
 import {
   DefaultEmbeddingProvider,
@@ -9,6 +14,31 @@ import { createMockProvider } from '../factories/provider';
 import { mockProcessEnv } from '../util/utils';
 
 import type { ProviderTypeMap } from '../../src/types/index';
+
+describe('getRemoteGradingContext', () => {
+  beforeEach(() => {
+    cliState.config = undefined;
+    cliState.selectedProviderConfigs = undefined;
+  });
+
+  afterEach(() => {
+    cliState.config = undefined;
+    cliState.selectedProviderConfigs = undefined;
+  });
+
+  it('prefers the actively selected provider configs', () => {
+    cliState.config = { providers: ['promptfoo://provider/excluded-target'] };
+    cliState.selectedProviderConfigs = ['promptfoo://provider/selected-target'];
+
+    expect(getRemoteGradingContext()).toEqual({ targetId: 'selected-target' });
+  });
+
+  it('falls back to the configured providers', () => {
+    cliState.config = { providers: ['promptfoo://provider/configured-target'] };
+
+    expect(getRemoteGradingContext()).toEqual({ targetId: 'configured-target' });
+  });
+});
 
 describe('getGradingProvider', () => {
   it('should return the correct provider when provider is a string', async () => {

--- a/test/matchers/utils.test.ts
+++ b/test/matchers/utils.test.ts
@@ -38,6 +38,13 @@ describe('getRemoteGradingContext', () => {
 
     expect(getRemoteGradingContext()).toEqual({ targetId: 'configured-target' });
   });
+
+  it('does not fall back to configured providers when the filter matched nothing', () => {
+    cliState.config = { providers: ['promptfoo://provider/configured-target'] };
+    cliState.selectedProviderConfigs = [];
+
+    expect(getRemoteGradingContext()).toEqual({});
+  });
 });
 
 describe('getGradingProvider', () => {

--- a/test/node/retry.integration.test.ts
+++ b/test/node/retry.integration.test.ts
@@ -152,6 +152,7 @@ describe('retry command', () => {
       const artifactId = randomUUID();
       const configPath = path.join(os.tmpdir(), `promptfoo-retry-filter-${artifactId}.yaml`);
       const prompt = { raw: 'Hello {{name}}', label: 'Hello {{name}}' };
+      const completedPrompt = { ...prompt, provider: 'selected-target' };
       const evalRecord = await Eval.create(
         {
           prompts: [prompt.raw],
@@ -162,6 +163,7 @@ describe('retry command', () => {
         {
           id: uniqueEvalId(),
           runtimeOptions: { providerFilter: 'selected-target' },
+          completedPrompts: [completedPrompt],
         },
       );
       const db = await getDb();
@@ -198,6 +200,7 @@ describe('retry command', () => {
       try {
         const persistedEval = await Eval.findById(evalRecord.id);
         expect(persistedEval?.runtimeOptions?.providerFilter).toBe('selected-target');
+        expect(persistedEval?.prompts).toEqual([expect.objectContaining(completedPrompt)]);
 
         await expect(retryCommand(evalRecord.id, { config: configPath })).rejects.toThrow(
           `Stored provider filter "selected-target" matched no providers in the retry config "${configPath}"`,
@@ -205,7 +208,7 @@ describe('retry command', () => {
 
         expect(await getErrorResultIds(evalRecord.id)).toEqual([staleResultId]);
         expect((await Eval.findById(evalRecord.id))?.prompts).toEqual([
-          expect.objectContaining(prompt),
+          expect.objectContaining(completedPrompt),
         ]);
       } finally {
         fs.rmSync(configPath, { force: true });

--- a/test/node/retry.integration.test.ts
+++ b/test/node/retry.integration.test.ts
@@ -148,6 +148,70 @@ describe('retry command', () => {
   });
 
   describe('retryCommand', () => {
+    it('preserves persisted errors when an override config no longer matches the stored provider filter', async () => {
+      const artifactId = randomUUID();
+      const configPath = path.join(os.tmpdir(), `promptfoo-retry-filter-${artifactId}.yaml`);
+      const prompt = { raw: 'Hello {{name}}', label: 'Hello {{name}}' };
+      const evalRecord = await Eval.create(
+        {
+          prompts: [prompt.raw],
+          providers: [{ id: 'echo', label: 'selected-target' }],
+          tests: [{ vars: { name: 'World' } }],
+        },
+        [prompt],
+        {
+          id: uniqueEvalId(),
+          runtimeOptions: { providerFilter: 'selected-target' },
+        },
+      );
+      const db = await getDb();
+      const staleResultId = `${evalRecord.id}-stale-error`;
+      await db.insert(evalResultsTable).values({
+        id: staleResultId,
+        evalId: evalRecord.id,
+        promptIdx: 0,
+        testIdx: 0,
+        prompt,
+        testCase: { vars: { name: 'World' } },
+        provider: { id: 'echo', label: 'selected-target' },
+        response: { output: 'stale error' },
+        error: 'stale error',
+        success: false,
+        score: 0,
+        failureReason: ResultFailureReason.ERROR,
+        namedScores: {},
+      });
+      fs.writeFileSync(
+        configPath,
+        [
+          'providers:',
+          '  - id: echo',
+          '    label: replacement-target',
+          'prompts:',
+          `  - "${prompt.raw}"`,
+          'tests:',
+          '  - vars:',
+          '      name: World',
+        ].join('\n'),
+      );
+
+      try {
+        const persistedEval = await Eval.findById(evalRecord.id);
+        expect(persistedEval?.runtimeOptions?.providerFilter).toBe('selected-target');
+
+        await expect(retryCommand(evalRecord.id, { config: configPath })).rejects.toThrow(
+          `Stored provider filter "selected-target" matched no providers in the retry config "${configPath}"`,
+        );
+
+        expect(await getErrorResultIds(evalRecord.id)).toEqual([staleResultId]);
+        expect((await Eval.findById(evalRecord.id))?.prompts).toEqual([
+          expect.objectContaining(prompt),
+        ]);
+      } finally {
+        fs.rmSync(configPath, { force: true });
+      }
+    });
+
     it('rewrites the original JSONL output after partial cleanup with an override config', async () => {
       const artifactId = randomUUID();
       const jsonlOutputPath = path.join(os.tmpdir(), `promptfoo-retry-${artifactId}.JSONL`);

--- a/test/node/retry.test.ts
+++ b/test/node/retry.test.ts
@@ -290,7 +290,10 @@ describe('retryCommand', () => {
   });
 
   it('retries from the saved config, cleans up old errors, and shares the result', async () => {
-    const originalEval = createEval({ config: { sharing: false } as UnifiedConfig });
+    const originalEval = createEval({
+      config: { sharing: false } as UnifiedConfig,
+      runtimeOptions: { providerFilter: 'selected-target' },
+    });
     const retriedEval = createEval();
     vi.mocked(Eval.findById).mockResolvedValue(originalEval);
     dbMocks.errorRows.push({ id: 'error-result-1' });
@@ -319,7 +322,10 @@ describe('retryCommand', () => {
 
     await expect(retryCommand(originalEval.id, {})).resolves.toBe(retriedEval);
 
-    expect(resolveConfigs).toHaveBeenCalledWith({}, originalEval.config);
+    expect(resolveConfigs).toHaveBeenCalledWith(
+      { filterProviders: 'selected-target' },
+      originalEval.config,
+    );
     expect(dbMocks.deleteRun).toHaveBeenCalledTimes(1);
     expect(notifyEvaluationChanged).toHaveBeenCalledWith(originalEval.id);
     expect(shouldShareResults).toHaveBeenCalledWith({
@@ -334,7 +340,9 @@ describe('retryCommand', () => {
   });
 
   it('uses an explicit config and forces concurrency to one when delay is requested', async () => {
-    const originalEval = createEval();
+    const originalEval = createEval({
+      runtimeOptions: { providerFilter: 'selected-target' },
+    });
     const retriedEval = createEval();
     vi.mocked(Eval.findById).mockResolvedValue(originalEval);
     dbMocks.errorRows.push({ id: 'error-result-1' });
@@ -361,7 +369,10 @@ describe('retryCommand', () => {
       }),
     ).resolves.toBe(retriedEval);
 
-    expect(resolveConfigs).toHaveBeenCalledWith({ config: ['retry.yaml'] }, {});
+    expect(resolveConfigs).toHaveBeenCalledWith(
+      { config: ['retry.yaml'], filterProviders: 'selected-target' },
+      {},
+    );
     expect(logger.info).toHaveBeenCalledWith(
       'Running at concurrency=1 because 25ms delay was requested between API calls',
     );

--- a/test/node/retry.test.ts
+++ b/test/node/retry.test.ts
@@ -408,16 +408,33 @@ describe('retryCommand', () => {
     });
     vi.mocked(Eval.findById).mockResolvedValue(originalEval);
     dbMocks.errorRows.push({ id: 'error-result-1' });
-    vi.mocked(resolveConfigs).mockRejectedValueOnce(new SyntaxError('Invalid regular expression'));
 
     await expect(retryCommand(originalEval.id, { config: 'retry.yaml' })).rejects.toThrow(
       'Could not resolve the retry config "retry.yaml" using stored provider filter "[": Invalid regular expression',
     );
 
+    // The pattern is validated before any config resolution happens.
+    expect(resolveConfigs).not.toHaveBeenCalled();
     expect(evaluate).not.toHaveBeenCalled();
     expect(dbMocks.deleteRun).not.toHaveBeenCalled();
     expect(cliState.resume).toBe(false);
     expect(cliState.retryMode).toBe(false);
+  });
+
+  it('fails closed when the persisted provider filter is not a string', async () => {
+    const originalEval = createEval({
+      runtimeOptions: { providerFilter: ['selected-target'] as unknown as string },
+    });
+    vi.mocked(Eval.findById).mockResolvedValue(originalEval);
+    dbMocks.errorRows.push({ id: 'error-result-1' });
+
+    await expect(retryCommand(originalEval.id, {})).rejects.toThrow(
+      'Stored provider filter is invalid',
+    );
+
+    expect(resolveConfigs).not.toHaveBeenCalled();
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(dbMocks.deleteRun).not.toHaveBeenCalled();
   });
 
   it('preserves error results and clears retry state when evaluation fails', async () => {

--- a/test/node/retry.test.ts
+++ b/test/node/retry.test.ts
@@ -71,7 +71,13 @@ vi.mock('../../src/util/sharing');
 
 const testSuite = {
   prompts: [],
-  providers: [],
+  providers: [
+    {
+      id: () => 'echo',
+      label: 'selected-target',
+      callApi: vi.fn(),
+    },
+  ],
   tests: [],
 } as unknown as TestSuite;
 
@@ -90,15 +96,17 @@ function createEval(overrides: Partial<Eval> = {}): Eval {
 function mockResolvedConfig({
   commandLineOptions,
   config,
+  providers,
 }: {
   commandLineOptions?: Record<string, unknown>;
   config?: Record<string, unknown>;
+  providers?: TestSuite['providers'];
 } = {}) {
   vi.mocked(resolveConfigs).mockResolvedValue({
     basePath: '/workspace',
     commandLineOptions,
     config: (config ?? {}) as UnifiedConfig,
-    testSuite,
+    testSuite: providers ? { ...testSuite, providers } : testSuite,
   });
 }
 
@@ -376,6 +384,40 @@ describe('retryCommand', () => {
     expect(logger.info).toHaveBeenCalledWith(
       'Running at concurrency=1 because 25ms delay was requested between API calls',
     );
+  });
+
+  it('preserves error results when an explicit config no longer matches the stored filter', async () => {
+    const originalEval = createEval({
+      runtimeOptions: { providerFilter: 'selected-target' },
+    });
+    vi.mocked(Eval.findById).mockResolvedValue(originalEval);
+    dbMocks.errorRows.push({ id: 'error-result-1' });
+    mockResolvedConfig({ providers: [] });
+
+    await expect(retryCommand(originalEval.id, { config: 'retry.yaml' })).rejects.toThrow(
+      'Stored provider filter "selected-target" matched no providers in the retry config "retry.yaml"',
+    );
+
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(dbMocks.deleteRun).not.toHaveBeenCalled();
+  });
+
+  it('preserves error results when the stored filter cannot be applied to the config', async () => {
+    const originalEval = createEval({
+      runtimeOptions: { providerFilter: '[' },
+    });
+    vi.mocked(Eval.findById).mockResolvedValue(originalEval);
+    dbMocks.errorRows.push({ id: 'error-result-1' });
+    vi.mocked(resolveConfigs).mockRejectedValueOnce(new SyntaxError('Invalid regular expression'));
+
+    await expect(retryCommand(originalEval.id, { config: 'retry.yaml' })).rejects.toThrow(
+      'Could not resolve the retry config "retry.yaml" using stored provider filter "[": Invalid regular expression',
+    );
+
+    expect(evaluate).not.toHaveBeenCalled();
+    expect(dbMocks.deleteRun).not.toHaveBeenCalled();
+    expect(cliState.resume).toBe(false);
+    expect(cliState.retryMode).toBe(false);
   });
 
   it('preserves error results and clears retry state when evaluation fails', async () => {

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -1532,6 +1532,7 @@ describe('resolveConfigs', () => {
     vi.mocked(fs.readFileSync).mockReset();
     vi.mocked(globSync).mockReset();
     vi.spyOn(process, 'cwd').mockReturnValue('/mock/cwd');
+    cliState.selectedProviderConfigs = undefined;
 
     // Reset path.parse to use actual implementation (other tests may have mocked it)
     const actualPath = await vi.importActual<typeof import('path')>('path');
@@ -1539,6 +1540,7 @@ describe('resolveConfigs', () => {
   });
 
   afterEach(() => {
+    cliState.selectedProviderConfigs = undefined;
     vi.restoreAllMocks();
   });
 
@@ -1575,6 +1577,7 @@ describe('resolveConfigs', () => {
     );
 
     expect(result.selectedProviderConfigs).toEqual([providers[1]]);
+    expect(cliState.selectedProviderConfigs).toEqual([providers[1]]);
     expect(loadApiProviders).toHaveBeenCalledWith([providers[1]], expect.any(Object));
   });
 

--- a/test/util/eval/filterProviders.test.ts
+++ b/test/util/eval/filterProviders.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { filterProviderConfigs, filterProviders } from '../../../src/util/eval/filterProviders';
+import {
+  filterProviderConfigs,
+  filterProviders,
+  getPersistedProviderFilterOptions,
+} from '../../../src/util/eval/filterProviders';
 
 import type { ApiProvider, TestSuiteConfig } from '../../../src/types/index';
 import type { ProviderOptions, ProviderOptionsMap } from '../../../src/types/providers';
+
+describe('getPersistedProviderFilterOptions', () => {
+  it('converts a persisted filter into config resolution options', () => {
+    expect(getPersistedProviderFilterOptions('selected-target')).toEqual({
+      filterProviders: 'selected-target',
+    });
+  });
+
+  it.each([undefined, null, '', 42, {}])('ignores invalid persisted filters: %j', (value) => {
+    expect(getPersistedProviderFilterOptions(value)).toEqual({});
+  });
+});
 
 describe('filterProviders', () => {
   const mockProviders: ApiProvider[] = [

--- a/test/util/eval/filterProviders.test.ts
+++ b/test/util/eval/filterProviders.test.ts
@@ -3,6 +3,7 @@ import {
   filterProviderConfigs,
   filterProviders,
   getPersistedProviderFilterOptions,
+  getProviderFilterRegexError,
 } from '../../../src/util/eval/filterProviders';
 
 import type { ApiProvider, TestSuiteConfig } from '../../../src/types/index';
@@ -15,8 +16,24 @@ describe('getPersistedProviderFilterOptions', () => {
     });
   });
 
-  it.each([undefined, null, '', 42, {}])('ignores invalid persisted filters: %j', (value) => {
+  it.each([undefined, null])('treats a missing persisted filter as no filter: %j', (value) => {
     expect(getPersistedProviderFilterOptions(value)).toEqual({});
+  });
+
+  it.each(['', 42, {}, ['echo']])('fails closed on a tampered persisted filter: %j', (value) => {
+    expect(() => getPersistedProviderFilterOptions(value)).toThrow(
+      'Stored provider filter is invalid',
+    );
+  });
+});
+
+describe('getProviderFilterRegexError', () => {
+  it('returns undefined for a valid pattern', () => {
+    expect(getProviderFilterRegexError('selected-.*')).toBeUndefined();
+  });
+
+  it('returns the reason for an invalid pattern', () => {
+    expect(getProviderFilterRegexError('[')).toContain('Invalid regular expression');
   });
 });
 

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -4,6 +4,7 @@ import {
   restoreAzureBlobSasTokens,
   sanitizeBody,
   sanitizeObject,
+  sanitizeRuntimeOptions,
   sanitizeUrl,
 } from '../../src/util/sanitizer';
 
@@ -19,6 +20,18 @@ afterEach(() => {
 afterAll(() => {
   consoleErrorSpy.mockRestore();
   consoleWarnSpy.mockRestore();
+});
+
+describe('sanitizeRuntimeOptions', () => {
+  it('preserves the provider filter while removing non-serializable runtime state', () => {
+    expect(
+      sanitizeRuntimeOptions({
+        abortSignal: new AbortController().signal,
+        progressCallback: vi.fn(),
+        providerFilter: 'selected-target',
+      }),
+    ).toEqual({ providerFilter: 'selected-target' });
+  });
 });
 
 describe('sanitizeObject', () => {


### PR DESCRIPTION
## Summary
- derive remote similarity and llm-rubric target context from the provider configs selected by `--filter-targets` / `--filter-providers`
- centralize remote matcher eligibility and target-context lookup in the matcher provider layer
- persist the normalized provider filter as sanitized internal runtime metadata and restore it across resume, `eval --retry-errors`, and standalone retry
- fail closed before evaluation or cleanup when a stored filter is invalid or no longer matches, preserving existing ERROR rows and prompt summaries
- add matcher, config, sanitizer, resume, retry, and database-backed recovery regressions

## Testing
- [exact-head CI](https://github.com/promptfoo/promptfoo/actions/runs/27389006087): 28 jobs passed, including Node 20/22/24/26, Windows, macOS, integration, smoke, web UI, docs, style, architecture, and code scan; 2 expected jobs skipped
- `npm run f`
- `npm run l`
- `git diff --check`
- Node syntax checks for all locally changed TypeScript files

Local dependency installation remains blocked by the repository's Socket policy for `undici@7.27.2`; the exact-head GitHub run installed dependencies and passed the full test matrix.
