### PR TITLE
fix(deps): pin undici to 7.27.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41586,9 +41586,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
## Summary

- resolve the root `undici` lockfile entry from `7.27.2` to `7.27.1`
- preserve the intended `>=7.27.1 <8` dependency range
- keep installs behind Socket's security registry working without bypassing policy

## Root cause

Socket currently blocks the newly published `undici@7.27.2` tarball under its package-age policy, so both `npm install` and `npm ci` fail with E403. `undici@7.27.1` is old enough to be served and remains the minimum release required by the Node 26 decompression fix from #9683.

## Impact

Developers using the Socket registry can install the repository again while retaining the Node 26 fix and the existing guard against undici 8.

## Validation

- `npm ci` (2,707 packages installed successfully through Socket)
- `npm run build`
- `npx vitest run test/fetch.compression.test.ts test/util/fetch/stripDecompressionHeaders.test.ts --reporter=verbose` (30 passed)
- `npm test` (19,931 passed; one unrelated OTLP receiver test timed out under full-suite load)
- isolated OTLP timeout rerun passed in 25 ms
- `npx prettier --check package-lock.json`
- pre-commit lint checks