### PR TITLE
fix(assertions): make BLEU closest-reference tie-break order-independent

### DIFF
--- a/src/assertions/bleu.ts
+++ b/src/assertions/bleu.ts
@@ -53,11 +53,15 @@ export function calculateBleuScore(
 
   const candidateWords = candidate.toLowerCase().trim().split(/\s+/);
 
-  // Find reference with closest length to candidate
+  // Find reference with closest length to candidate. On ties, prefer the shorter
+  // reference (BLEU / NLTK `closest_ref_length` convention) so the score does not
+  // depend on the order references are provided in.
   const refLengths = references.map((ref) => ref.toLowerCase().trim().split(/\s+/).length);
-  const closestRefLength = refLengths.reduce((prev, curr) =>
-    Math.abs(curr - candidateWords.length) < Math.abs(prev - candidateWords.length) ? curr : prev,
-  );
+  const closestRefLength = refLengths.reduce((prev, curr) => {
+    const distCurr = Math.abs(curr - candidateWords.length);
+    const distPrev = Math.abs(prev - candidateWords.length);
+    return distCurr < distPrev || (distCurr === distPrev && curr < prev) ? curr : prev;
+  });
 
   const maxN = 4;
   const precisions: number[] = [];

--- a/test/assertions/bleu.test.ts
+++ b/test/assertions/bleu.test.ts
@@ -76,6 +76,20 @@ describe('BLEU score calculation', () => {
     expect(score).toBeGreaterThan(0.999);
   });
 
+  it('should not depend on the order of equidistant references', () => {
+    const candidate = 'a b c d'; // 4 tokens
+    const shorterRef = 'a b c'; // 3 tokens (distance 1 from candidate)
+    const longerRef = 'a b c d e'; // 5 tokens (distance 1 from candidate)
+
+    // When two references are equally close to the candidate length, BLEU breaks the
+    // tie toward the shorter reference (Papineni et al. / NLTK `closest_ref_length`),
+    // so the score must be independent of the order the references are provided in.
+    const scoreShorterFirst = calculateBleuScore(candidate, [shorterRef, longerRef]);
+    const scoreLongerFirst = calculateBleuScore(candidate, [longerRef, shorterRef]);
+
+    expect(scoreLongerFirst).toBeCloseTo(scoreShorterFirst, 10);
+  });
+
   it('should throw error for empty reference array', () => {
     expect(() => {
       calculateBleuScore('test', []);


### PR DESCRIPTION
## What
When references are equidistant in length from the candidate, the BLEU score depends on the **order** the references are listed in.

## Why
`calculateBleuScore` selects the brevity penalty's "closest reference length" with:

```ts
const closestRefLength = refLengths.reduce((prev, curr) =>
  Math.abs(curr - candidateWords.length) < Math.abs(prev - candidateWords.length) ? curr : prev,
);
```

On a tie (`abs(curr - c) === abs(prev - c)`) it keeps `prev` (first-seen), so the chosen length depends on reference order. BLEU (Papineni et al.; NLTK `closest_ref_length`) breaks such ties toward the **shorter** reference. Result: e.g. candidate of 4 tokens with references of length 3 and 5 scores differently depending on which is listed first.

## Fix
Prefer the shorter reference length on ties, making the score order-independent:

```ts
const closestRefLength = refLengths.reduce((prev, curr) => {
  const distCurr = Math.abs(curr - candidateWords.length);
  const distPrev = Math.abs(prev - candidateWords.length);
  return distCurr < distPrev || (distCurr === distPrev && curr < prev) ? curr : prev;
});
```

## Test
Adds `should not depend on the order of equidistant references`. Verified it **fails before** the fix and **passes after**.

## Validation
- `npx vitest run test/assertions/bleu.test.ts` → **18 passed**
- `npm run l` (Biome) + `npm run f` clean · `tsc --noEmit` clean · lockfile drift reverted (diff is the two files only)

Independent of #9717 (different lines: that PR fixes the brevity-penalty formula; this fixes the closest-reference selection).