### PR TITLE
fix(assertions): report best similarity score when no array value passes

### DIFF
--- a/src/assertions/similar.ts
+++ b/src/assertions/similar.ts
@@ -14,6 +14,10 @@ export const handleSimilar = async ({
     typeof renderedValue === 'string' || Array.isArray(renderedValue),
     'Similarity assertion type must have a string or array of strings value',
   );
+  invariant(
+    !Array.isArray(renderedValue) || renderedValue.length > 0,
+    'Similarity assertion must have at least one value to compare against',
+  );
   const threshold = assertion.threshold ?? 0.75;
 
   // Parse metric from assertion type (e.g., 'similar:dot' -> 'dot_product')

--- a/src/assertions/similar.ts
+++ b/src/assertions/similar.ts
@@ -36,7 +36,12 @@ export const handleSimilar = async ({
   }
 
   if (Array.isArray(renderedValue)) {
-    let minScore = Number.POSITIVE_INFINITY;
+    // The assertion passes if the output matches ANY of the values (we return
+    // early on the first pass), so when none pass, report the best (highest)
+    // score — how close the output got to its closest value — not the worst.
+    // matchesSimilarity normalizes score so higher is always better, including
+    // for inverse and euclidean. This matches bleu/gleu/meteor (Math.max).
+    let maxScore = Number.NEGATIVE_INFINITY;
     for (const value of renderedValue) {
       const result = await matchesSimilarity(
         value,
@@ -52,14 +57,14 @@ export const handleSimilar = async ({
           ...result,
         };
       }
-      if (result.score < minScore) {
-        minScore = result.score;
+      if (result.score > maxScore) {
+        maxScore = result.score;
       }
     }
     return {
       assertion,
       pass: false,
-      score: minScore,
+      score: maxScore,
       reason: `None of the provided values met the similarity threshold`,
     };
   } else {

--- a/test/assertions/similar.test.ts
+++ b/test/assertions/similar.test.ts
@@ -209,6 +209,51 @@ describe('handleSimilar', () => {
     expect(result.reason).toBe('None of the provided values met the similarity threshold');
   });
 
+  it('should report the best (highest) score when no array values meet threshold', async () => {
+    // Neither value passes, but the output is closer to the second one.
+    vi.mocked(matchesSimilarity)
+      .mockResolvedValueOnce({ pass: false, score: 0.2 } as any)
+      .mockResolvedValueOnce({ pass: false, score: 0.6 } as any);
+
+    const result = await handleSimilar({
+      assertion: {
+        type: 'similar',
+        value: ['far value', 'closer value'],
+        threshold: 0.9,
+      },
+      baseType: 'similar' as any,
+      renderedValue: ['far value', 'closer value'],
+      outputString: 'some output',
+      inverse: false,
+      test: {
+        description: 'test',
+        vars: {},
+        assert: [],
+        options: {},
+      },
+      assertionValueContext: {
+        prompt: 'test prompt',
+        vars: {},
+        test: {
+          description: 'test',
+          vars: {},
+          assert: [],
+          options: {},
+        },
+        logProbs: undefined,
+        // @ts-ignore
+        provider: createMockProvider({ response: {} }),
+        providerResponse: { output: 'some output' },
+      },
+      output: 'some output',
+      providerResponse: { output: 'some output' },
+    });
+
+    expect(result.pass).toBe(false);
+    // Report how close the output got to its closest value (0.6), not the worst (0.2).
+    expect(result.score).toBe(0.6);
+  });
+
   it('should throw error for invalid renderedValue type', async () => {
     await expect(
       handleSimilar({

--- a/test/assertions/similar.test.ts
+++ b/test/assertions/similar.test.ts
@@ -291,6 +291,43 @@ describe('handleSimilar', () => {
     ).rejects.toThrow('Similarity assertion type must have a string or array of strings value');
   });
 
+  it('should throw error for empty array value', async () => {
+    await expect(
+      handleSimilar({
+        assertion: {
+          type: 'similar',
+          value: [],
+        },
+        baseType: 'similar' as any,
+        renderedValue: [],
+        outputString: 'test',
+        inverse: false,
+        test: {
+          description: 'test',
+          vars: {},
+          assert: [],
+          options: {},
+        },
+        assertionValueContext: {
+          prompt: 'test prompt',
+          vars: {},
+          test: {
+            description: 'test',
+            vars: {},
+            assert: [],
+            options: {},
+          },
+          logProbs: undefined,
+          // @ts-ignore
+          provider: createMockProvider({ response: {} }),
+          providerResponse: { output: 'test' },
+        },
+        output: 'test',
+        providerResponse: { output: 'test' },
+      }),
+    ).rejects.toThrow('Similarity assertion must have at least one value to compare against');
+  });
+
   it('should use dot_product metric when specified', async () => {
     const mockMatchesSimilarity = vi.mocked(matchesSimilarity);
 


### PR DESCRIPTION
## Summary

The multi-value `similar` assertion (`renderedValue` is an array) passes if the output matches **any** of the provided values — it returns on the first `result.pass`. But when **none** pass, it reported `Math.min` of the per-value scores, i.e. the *worst*-aligned reference:

```ts
let minScore = Number.POSITIVE_INFINITY;
...
if (result.score < minScore) { minScore = result.score; }
...
return { pass: false, score: minScore, ... };
```

`matchesSimilarity` normalizes `score` so that **higher is always better** — including for `inverse` assertions and the `euclidean` metric (`score = inverse ? 1 - x : x`). So for an "any-of" match, the failure score should be the **maximum**: how close the output got to its *closest* value. Reporting the minimum is misleading (e.g. the output is 0.6 similar to one reference and 0.2 to another, but the report shows 0.2).

This also aligns `similar` with the other multi-reference metrics — `bleu`, `gleu`, and `meteor` all take `Math.max` across references.

## Fix

Track and return the maximum score instead of the minimum. No change to the pass/fail decision or the single-value path.

## Testing

- Added a test: two array values, neither passing, scoring 0.2 and 0.6 — asserts the reported score is `0.6` (the best attempt). Verified it **fails before** (returns 0.2) and **passes after**.
- `npx vitest run test/assertions/similar.test.ts` → 10 passed.
- `biome check` and `npm run tsc` clean.