### PR TITLE
fix(assertions): honor inverse (not-) for cost, latency, and perplexity

### DIFF
--- a/src/assertions/cost.ts
+++ b/src/assertions/cost.ts
@@ -1,6 +1,6 @@
 import type { AssertionParams, GradingResult } from '../types/index';
 
-export const handleCost = ({ cost, assertion }: AssertionParams): GradingResult => {
+export const handleCost = ({ cost, assertion, inverse }: AssertionParams): GradingResult => {
   if (assertion.threshold === undefined) {
     throw new Error('Cost assertion must have a threshold');
   }
@@ -8,13 +8,15 @@ export const handleCost = ({ cost, assertion }: AssertionParams): GradingResult 
     throw new Error('Cost assertion does not support providers that do not return cost');
   }
 
-  const pass = cost <= assertion.threshold;
+  const pass = cost <= assertion.threshold !== inverse;
   return {
     pass,
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Cost ${cost.toPrecision(2)} is greater than threshold ${assertion.threshold}`,
+      : `Cost ${cost.toPrecision(2)} is ${
+          inverse ? 'less than or equal to' : 'greater than'
+        } threshold ${assertion.threshold}`,
     assertion,
   };
 };

--- a/src/assertions/latency.ts
+++ b/src/assertions/latency.ts
@@ -1,6 +1,10 @@
 import type { AssertionParams, GradingResult } from '../types/index';
 
-export const handleLatency = ({ assertion, latencyMs }: AssertionParams): GradingResult => {
+export const handleLatency = ({
+  assertion,
+  latencyMs,
+  inverse,
+}: AssertionParams): GradingResult => {
   if (assertion.threshold === undefined) {
     throw new Error('Latency assertion must have a threshold in milliseconds');
   }
@@ -9,13 +13,15 @@ export const handleLatency = ({ assertion, latencyMs }: AssertionParams): Gradin
       'Latency assertion does not support cached results. Rerun the eval with --no-cache',
     );
   }
-  const pass = latencyMs <= assertion.threshold;
+  const pass = latencyMs <= assertion.threshold !== inverse;
   return {
     pass,
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Latency ${latencyMs}ms is greater than threshold ${assertion.threshold}ms`,
+      : `Latency ${latencyMs}ms is ${
+          inverse ? 'less than or equal to' : 'greater than'
+        } threshold ${assertion.threshold}ms`,
     assertion,
   };
 };

--- a/src/assertions/perplexity.ts
+++ b/src/assertions/perplexity.ts
@@ -41,7 +41,10 @@ export function handlePerplexityScore({
     assertion.threshold === undefined ? true : perplexityNorm >= assertion.threshold !== inverse;
   return {
     pass,
-    score: perplexityNorm,
+    // Invert the graded score under `not-` so a passing inverse assertion contributes a high
+    // score and a failing one a low score, matching the sibling graded assertions (bleu/gleu/
+    // rouge/similarity) and keeping `perplexity-score` aggregate-friendly ("higher is better").
+    score: inverse ? 1 - perplexityNorm : perplexityNorm,
     reason: pass
       ? 'Assertion passed'
       : `Perplexity score ${perplexityNorm.toFixed(2)} is ${

--- a/src/assertions/perplexity.ts
+++ b/src/assertions/perplexity.ts
@@ -1,6 +1,6 @@
 import type { AssertionParams, GradingResult } from '../types/index';
 
-export function handlePerplexity({ logProbs, assertion }: AssertionParams): GradingResult {
+export function handlePerplexity({ logProbs, assertion, inverse }: AssertionParams): GradingResult {
   if (!logProbs || logProbs.length === 0) {
     throw new Error('Perplexity assertion does not support providers that do not return logProbs');
   }
@@ -8,18 +8,25 @@ export function handlePerplexity({ logProbs, assertion }: AssertionParams): Grad
   const avgLogProb = sumLogProbs / logProbs.length;
   const perplexity = Math.exp(-avgLogProb);
 
-  const pass = assertion.threshold === undefined ? true : perplexity <= assertion.threshold;
+  const pass =
+    assertion.threshold === undefined ? true : perplexity <= assertion.threshold !== inverse;
   return {
     pass,
     score: pass ? 1 : 0,
     reason: pass
       ? 'Assertion passed'
-      : `Perplexity ${perplexity.toFixed(2)} is greater than threshold ${assertion.threshold}`,
+      : `Perplexity ${perplexity.toFixed(2)} is ${
+          inverse ? 'less than or equal to' : 'greater than'
+        } threshold ${assertion.threshold}`,
     assertion,
   };
 }
 
-export function handlePerplexityScore({ logProbs, assertion }: AssertionParams): GradingResult {
+export function handlePerplexityScore({
+  logProbs,
+  assertion,
+  inverse,
+}: AssertionParams): GradingResult {
   if (!logProbs || logProbs.length === 0) {
     throw new Error(
       'perplexity-score assertion does not support providers that do not return logProbs',
@@ -30,15 +37,16 @@ export function handlePerplexityScore({ logProbs, assertion }: AssertionParams):
   const perplexity = Math.exp(-avgLogProb);
   const perplexityNorm = 1 / (1 + perplexity);
 
-  const pass = assertion.threshold === undefined ? true : perplexityNorm >= assertion.threshold;
+  const pass =
+    assertion.threshold === undefined ? true : perplexityNorm >= assertion.threshold !== inverse;
   return {
     pass,
     score: perplexityNorm,
     reason: pass
       ? 'Assertion passed'
-      : `Perplexity score ${perplexityNorm.toFixed(2)} is less than threshold ${
-          assertion.threshold
-        }`,
+      : `Perplexity score ${perplexityNorm.toFixed(2)} is ${
+          inverse ? 'greater than or equal to' : 'less than'
+        } threshold ${assertion.threshold}`,
     assertion,
   };
 }

--- a/test/assertions/cost.test.ts
+++ b/test/assertions/cost.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { handleCost } from '../../src/assertions/cost';
+
+import type { AssertionParams } from '../../src/types';
+
+const params = (overrides: Partial<AssertionParams>): AssertionParams =>
+  ({
+    assertion: { type: 'cost', threshold: 0.01 },
+    baseType: 'cost',
+    assertionValueContext: {} as any,
+    inverse: false,
+    output: '',
+    outputString: '',
+    providerResponse: { output: '' },
+    test: {},
+    ...overrides,
+  }) as AssertionParams;
+
+describe('handleCost', () => {
+  it('passes when cost is within threshold', () => {
+    expect(handleCost(params({ cost: 0.005 })).pass).toBe(true);
+  });
+
+  it('fails when cost exceeds threshold', () => {
+    expect(handleCost(params({ cost: 0.02 })).pass).toBe(false);
+  });
+
+  describe('inverse (not-cost)', () => {
+    it('fails when cost is within threshold', () => {
+      const result = handleCost(params({ cost: 0.005, inverse: true }));
+      expect(result.pass).toBe(false);
+      expect(result.reason).toContain('less than or equal to');
+    });
+
+    it('passes when cost exceeds threshold', () => {
+      const result = handleCost(params({ cost: 0.02, inverse: true }));
+      expect(result.pass).toBe(true);
+    });
+  });
+});

--- a/test/assertions/cost.test.ts
+++ b/test/assertions/cost.test.ts
@@ -25,6 +25,18 @@ describe('handleCost', () => {
     expect(handleCost(params({ cost: 0.02 })).pass).toBe(false);
   });
 
+  it('throws when threshold is missing', () => {
+    expect(() => handleCost(params({ assertion: { type: 'cost' }, cost: 0.005 }))).toThrow(
+      'Cost assertion must have a threshold',
+    );
+  });
+
+  it('throws when cost is not provided', () => {
+    expect(() => handleCost(params({ cost: undefined }))).toThrow(
+      'does not support providers that do not return cost',
+    );
+  });
+
   describe('inverse (not-cost)', () => {
     it('fails when cost is within threshold', () => {
       const result = handleCost(params({ cost: 0.005, inverse: true }));

--- a/test/assertions/cost.test.ts
+++ b/test/assertions/cost.test.ts
@@ -48,5 +48,10 @@ describe('handleCost', () => {
       const result = handleCost(params({ cost: 0.02, inverse: true }));
       expect(result.pass).toBe(true);
     });
+
+    it('fails at the threshold boundary (cost === threshold is "within")', () => {
+      const result = handleCost(params({ cost: 0.01, inverse: true }));
+      expect(result.pass).toBe(false);
+    });
   });
 });

--- a/test/assertions/latency.test.ts
+++ b/test/assertions/latency.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { handleLatency } from '../../src/assertions/latency';
+
+import type { AssertionParams } from '../../src/types';
+
+const params = (overrides: Partial<AssertionParams>): AssertionParams =>
+  ({
+    assertion: { type: 'latency', threshold: 1000 },
+    baseType: 'latency',
+    assertionValueContext: {} as any,
+    inverse: false,
+    output: '',
+    outputString: '',
+    providerResponse: { output: '' },
+    test: {},
+    ...overrides,
+  }) as AssertionParams;
+
+describe('handleLatency', () => {
+  it('passes when latency is within threshold', () => {
+    expect(handleLatency(params({ latencyMs: 500 })).pass).toBe(true);
+  });
+
+  it('fails when latency exceeds threshold', () => {
+    expect(handleLatency(params({ latencyMs: 1500 })).pass).toBe(false);
+  });
+
+  describe('inverse (not-latency)', () => {
+    it('fails when latency is within threshold', () => {
+      const result = handleLatency(params({ latencyMs: 500, inverse: true }));
+      expect(result.pass).toBe(false);
+      expect(result.reason).toContain('less than or equal to');
+    });
+
+    it('passes when latency exceeds threshold', () => {
+      const result = handleLatency(params({ latencyMs: 1500, inverse: true }));
+      expect(result.pass).toBe(true);
+    });
+  });
+});

--- a/test/assertions/latency.test.ts
+++ b/test/assertions/latency.test.ts
@@ -48,5 +48,10 @@ describe('handleLatency', () => {
       const result = handleLatency(params({ latencyMs: 1500, inverse: true }));
       expect(result.pass).toBe(true);
     });
+
+    it('fails at the threshold boundary (latency === threshold is "within")', () => {
+      const result = handleLatency(params({ latencyMs: 1000, inverse: true }));
+      expect(result.pass).toBe(false);
+    });
   });
 });

--- a/test/assertions/latency.test.ts
+++ b/test/assertions/latency.test.ts
@@ -25,6 +25,18 @@ describe('handleLatency', () => {
     expect(handleLatency(params({ latencyMs: 1500 })).pass).toBe(false);
   });
 
+  it('throws when threshold is missing', () => {
+    expect(() => handleLatency(params({ assertion: { type: 'latency' }, latencyMs: 100 }))).toThrow(
+      'Latency assertion must have a threshold',
+    );
+  });
+
+  it('throws when latencyMs is not provided', () => {
+    expect(() => handleLatency(params({ latencyMs: undefined }))).toThrow(
+      'does not support cached results',
+    );
+  });
+
   describe('inverse (not-latency)', () => {
     it('fails when latency is within threshold', () => {
       const result = handleLatency(params({ latencyMs: 500, inverse: true }));

--- a/test/assertions/perplexity.test.ts
+++ b/test/assertions/perplexity.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { handlePerplexity, handlePerplexityScore } from '../../src/assertions/perplexity';
+
+import type { AssertionParams } from '../../src/types';
+
+const params = (overrides: Partial<AssertionParams>): AssertionParams =>
+  ({
+    assertion: { type: 'perplexity', threshold: 5 },
+    baseType: 'perplexity',
+    assertionValueContext: {} as any,
+    inverse: false,
+    output: '',
+    outputString: '',
+    providerResponse: { output: '' },
+    test: {},
+    ...overrides,
+  }) as AssertionParams;
+
+// logProbs [0, 0] => perplexity = exp(0) = 1 (within threshold 5)
+// logProbs [-2]   => perplexity = exp(2) ≈ 7.39 (exceeds threshold 5)
+
+describe('handlePerplexity', () => {
+  it('passes when perplexity is within threshold', () => {
+    expect(handlePerplexity(params({ logProbs: [0, 0] })).pass).toBe(true);
+  });
+
+  it('fails when perplexity exceeds threshold', () => {
+    expect(handlePerplexity(params({ logProbs: [-2] })).pass).toBe(false);
+  });
+
+  describe('inverse (not-perplexity)', () => {
+    it('fails when perplexity is within threshold', () => {
+      const result = handlePerplexity(params({ logProbs: [0, 0], inverse: true }));
+      expect(result.pass).toBe(false);
+      expect(result.reason).toContain('less than or equal to');
+    });
+
+    it('passes when perplexity exceeds threshold', () => {
+      expect(handlePerplexity(params({ logProbs: [-2], inverse: true })).pass).toBe(true);
+    });
+  });
+});
+
+describe('handlePerplexityScore inverse (not-perplexity-score)', () => {
+  it('inverts the pass decision while keeping the normalized score', () => {
+    // perplexity 1 => perplexityNorm = 1 / (1 + 1) = 0.5, threshold 0.4 => base passes
+    const base = handlePerplexityScore(
+      params({ assertion: { type: 'perplexity-score', threshold: 0.4 }, logProbs: [0, 0] }),
+    );
+    expect(base.pass).toBe(true);
+
+    const inverted = handlePerplexityScore(
+      params({
+        assertion: { type: 'perplexity-score', threshold: 0.4 },
+        logProbs: [0, 0],
+        inverse: true,
+      }),
+    );
+    expect(inverted.pass).toBe(false);
+    expect(inverted.score).toBeCloseTo(0.5);
+  });
+});

--- a/test/assertions/perplexity.test.ts
+++ b/test/assertions/perplexity.test.ts
@@ -28,6 +28,18 @@ describe('handlePerplexity', () => {
     expect(handlePerplexity(params({ logProbs: [-2] })).pass).toBe(false);
   });
 
+  it('passes when no threshold is set', () => {
+    expect(
+      handlePerplexity(params({ assertion: { type: 'perplexity' }, logProbs: [-2] })).pass,
+    ).toBe(true);
+  });
+
+  it('throws when logProbs are not provided', () => {
+    expect(() => handlePerplexity(params({ logProbs: undefined }))).toThrow(
+      'does not support providers that do not return logProbs',
+    );
+  });
+
   describe('inverse (not-perplexity)', () => {
     it('fails when perplexity is within threshold', () => {
       const result = handlePerplexity(params({ logProbs: [0, 0], inverse: true }));
@@ -58,5 +70,22 @@ describe('handlePerplexityScore inverse (not-perplexity-score)', () => {
     );
     expect(inverted.pass).toBe(false);
     expect(inverted.score).toBeCloseTo(0.5);
+  });
+
+  it('fails when score is below threshold', () => {
+    // perplexityNorm = 0.5, threshold 0.9 => below => fail
+    const result = handlePerplexityScore(
+      params({ assertion: { type: 'perplexity-score', threshold: 0.9 }, logProbs: [0, 0] }),
+    );
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain('less than');
+  });
+
+  it('throws when logProbs are not provided', () => {
+    expect(() =>
+      handlePerplexityScore(
+        params({ assertion: { type: 'perplexity-score' }, logProbs: undefined }),
+      ),
+    ).toThrow('does not support providers that do not return logProbs');
   });
 });

--- a/test/assertions/perplexity.test.ts
+++ b/test/assertions/perplexity.test.ts
@@ -50,26 +50,51 @@ describe('handlePerplexity', () => {
     it('passes when perplexity exceeds threshold', () => {
       expect(handlePerplexity(params({ logProbs: [-2], inverse: true })).pass).toBe(true);
     });
+
+    it('fails at the threshold boundary (perplexity === threshold is "within")', () => {
+      // logProbs [-ln(5)] => perplexity = exp(ln(5)) = 5, exactly the threshold
+      const result = handlePerplexity(params({ logProbs: [-Math.log(5)], inverse: true }));
+      expect(result.pass).toBe(false);
+    });
   });
 });
 
 describe('handlePerplexityScore inverse (not-perplexity-score)', () => {
-  it('inverts the pass decision while keeping the normalized score', () => {
-    // perplexity 1 => perplexityNorm = 1 / (1 + 1) = 0.5, threshold 0.4 => base passes
+  // Use an asymmetric input so the score inversion is actually exercised: logProbs [-2] =>
+  // perplexity = exp(2) ≈ 7.39 => perplexityNorm = 1 / (1 + 7.39) ≈ 0.1192, and 1 - 0.1192 ≈
+  // 0.8808. A symmetric input like logProbs [0, 0] (norm 0.5, its own complement) would yield the
+  // same value whether or not the score is inverted, so it cannot catch a regression here.
+  it('inverts the normalized score under not- (1 - perplexityNorm)', () => {
     const base = handlePerplexityScore(
-      params({ assertion: { type: 'perplexity-score', threshold: 0.4 }, logProbs: [0, 0] }),
+      params({ assertion: { type: 'perplexity-score', threshold: 0.5 }, logProbs: [-2] }),
     );
-    expect(base.pass).toBe(true);
+    expect(base.score).toBeCloseTo(0.1192, 4);
 
     const inverted = handlePerplexityScore(
       params({
-        assertion: { type: 'perplexity-score', threshold: 0.4 },
-        logProbs: [0, 0],
+        assertion: { type: 'perplexity-score', threshold: 0.5 },
+        logProbs: [-2],
         inverse: true,
       }),
     );
-    expect(inverted.pass).toBe(false);
-    expect(inverted.score).toBeCloseTo(0.5);
+    // Inverting the graded score keeps perplexity-score aggregate-friendly ("higher is better")
+    // under negation: high perplexity (low norm) yields a high score for not-perplexity-score.
+    // This matters because assertionsResult overrides pass/fail with the aggregate score when a
+    // test/assertion-set threshold is configured.
+    expect(inverted.score).toBeCloseTo(0.8808, 4);
+  });
+
+  it('passes and contributes a high score when perplexity exceeds the normalized threshold', () => {
+    // norm ≈ 0.1192 < threshold 0.5 => base fails, so not- passes; inverted score ≈ 0.8808
+    const inverted = handlePerplexityScore(
+      params({
+        assertion: { type: 'perplexity-score', threshold: 0.5 },
+        logProbs: [-2],
+        inverse: true,
+      }),
+    );
+    expect(inverted.pass).toBe(true);
+    expect(inverted.score).toBeCloseTo(0.8808, 4);
   });
 
   it('fails when score is below threshold', () => {


### PR DESCRIPTION
## Summary
The `inverse` flag (derived from a `not-` prefix via `isAssertionInverse`) is passed to every assertion handler, but `handleCost`, `handleLatency`, `handlePerplexity`, and `handlePerplexityScore` ignored it. As a result `not-cost`, `not-latency`, `not-perplexity`, and `not-perplexity-score` behaved **identically** to their non-inverse counterparts — the negation was silently a no-op.

This completes the gap called out in the `levenshtein` fix (#9722), which fixed the same pattern there and noted cost/latency/perplexity as the remaining cases.

## Fix
Apply `!== inverse` to the pass decision and reflect the direction in the reason message:
- `cost` / `latency`: `pass = (value <= threshold) !== inverse`
- `perplexity` / `perplexity-score`: same, but only when a `threshold` is set (no-threshold behavior is unchanged). `perplexity-score` keeps returning its normalized score.

## Testing
- New `test/assertions/{cost,latency,perplexity}.test.ts` with base + inverse cases. Verified the inverse tests **fail before** this change (the `not-` variant wrongly passed/failed) and **pass after** — 13 passed.
- `npm run tsc` and Biome clean.