### PR TITLE
chore(deps): hold tsdown on 0.21.x while Node 20 is supported

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,11 @@
       "enabled": false
     },
     {
+      "description": "Hold tsdown on 0.21.x while Node 20 is supported: tsdown 0.22+ sets engines node ^22.18.0 || >=24.0.0 (drops Node 20.19/20.20), but the repo still builds/tests on Node 20.20 with engine-strict, so 0.22+ aborts npm ci. Revisit when the Node 20 floor is dropped.",
+      "matchPackageNames": ["tsdown"],
+      "allowedVersions": "<0.22.0"
+    },
+    {
       "description": "Group Anthropic packages together across all dependency types",
       "matchPackagePatterns": ["^@anthropic-ai/"],
       "matchDepTypes": [


### PR DESCRIPTION
## Summary

Pins Renovate to `tsdown` `<0.22.0` so it stops re-proposing the Node-20-incompatible bump (#9719, now closed).

`tsdown@0.22.0+` (incl. 0.22.2) changed its `engines.node` to `^22.18.0 || >=24.0.0`, **dropping Node 20 support** that `tsdown@0.21.9` had (`>=20.19.0`). This repo's floor is `^20.20.0 || >=22.22.0` and CI builds/tests on **Node 20.20** with `engine-strict=true`, so `npm ci` aborts on Node 20.20 with `EBADENGINE` — on `tsdown` itself plus its deps `dts-resolver`, `rolldown-plugin-dts`, `import-without-cache`, and the `@babel/*@8.0.0-rc.6` that `rolldown-plugin-dts@0.25.2` pins (rc.6 also requires Node 22.18+/24.11+).

A scoped npm `overrides` entry can pin the transitive babel back to Node-20-compatible `8.0.0-rc.3`, but tsdown's **own** `engines` field can't be overridden — so 0.22.x is unmergeable while Node 20 is supported.

This mirrors the existing "Disable Chevrotain major updates while Node 20 is supported" rule.

## Revisit

Drop this hold (and `#9719` can be re-attempted) once the repo drops its Node 20 floor — Node 20 reached EOL ~April 2026.

## Test plan

- `renovate-config-validator renovate.json` → "Config validated successfully"
- JSON valid; `npm run f` clean