### PR TITLE
docs(site): add provider eligibility criteria for new providers

### DIFF
--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -238,9 +238,25 @@ tests:
 
 ## Adding a New Provider
 
-Providers are defined in TypeScript. We also provide language bindings for Python and Go. To contribute a new provider:
+Providers are defined in TypeScript. We also provide language bindings for Python and Go.
 
-1. Ensure your provider doesn't already exist in promptfoo and fits its scope. For OpenAI-compatible providers, you may be able to re-use the openai provider and override the base URL and other settings. If your provider is OpenAI compatible, feel free to skip to step 4.
+Before writing any code: **any OpenAI-compatible endpoint already works without a dedicated provider** — point the `openai` provider at it with `apiBaseUrl` (or set `OPENAI_BASE_URL`). We're glad to document a service this way, and for many integrations that's all that's needed.
+
+A _dedicated, named provider_ (its own `id:` prefix, docs page, and registry entry) is different: we maintain it, and listing it signals a baseline of trust to our users. We welcome new ones, but to keep the registry useful and trustworthy we ask that a dedicated provider meet the following before we merge it.
+
+### Provider eligibility
+
+- **Legitimate access to the models it serves.** The service must run its own models or have authorized access to the ones it offers (a first-party API, or a partner / reseller agreement). We don't accept integrations that resell or proxy another provider's models in violation of that provider's terms — for example "relay" gateways that resell Anthropic, OpenAI, or Google models below cost without authorization. If you resell third-party models, be ready to confirm you're permitted to.
+- **An accountable operator.** A real, identifiable company or an established open-source project, reachable for maintenance questions, with its own terms of service and privacy policy. Anonymous services with no identifiable owner aren't a good fit.
+- **Evidence it will last.** Some signal that the service is durable and will be maintained — for instance funding, paying customers, an established track record, or substantial _organic_ adoption (real usage, not inflated stars or followers). Brand-new services with no track record may be asked to wait, or to start with the generic `openai`-compatible path above.
+- **Clear data handling.** Because evals send prompts and outputs through the provider, your docs or terms should state whether request and response content is logged, how long it's retained, and whether it's used for training.
+- **Real value over the generic path.** A dedicated provider should add something beyond a base URL — its own API-key handling, non-OpenAI auth or headers, custom model routing, embeddings, or extra parameters. Pure pass-throughs are better served by the `openai` + `apiBaseUrl` route above.
+
+We review aggregators, gateways, and resellers case by case against this same bar. Meeting these criteria doesn't guarantee a merge, and we may decline or later remove a provider that stops meeting them.
+
+To contribute a new provider:
+
+1. Confirm it meets the eligibility criteria above and doesn't already exist in promptfoo. For OpenAI-compatible providers you may be able to re-use the `openai` provider and override the base URL rather than write a new one — if so, skip to step 4 and contribute docs and an example instead.
 
 2. Implement the provider in `src/providers/yourProviderName.ts` following our [Custom API Provider Docs](/docs/providers/custom-api/). Please use our cache `src/cache.ts` to store responses. If your provider requires a new dependency, please add it as an optional dependency.
 

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -240,23 +240,23 @@ tests:
 
 Providers are defined in TypeScript. We also provide language bindings for Python and Go.
 
-Before writing any code: **any OpenAI-compatible endpoint already works without a dedicated provider** — point the `openai` provider at it with `apiBaseUrl` (or set `OPENAI_BASE_URL`). We're glad to document a service this way, and for many integrations that's all that's needed.
+Before writing code, check whether the service already works through the `openai` provider. For an OpenAI-compatible endpoint, set `apiBaseUrl`, `OPENAI_API_BASE_URL`, or `OPENAI_BASE_URL`. If that is all the service needs, contribute docs or an example that uses the generic path; do not add a new provider prefix or registry entry.
 
-A _dedicated, named provider_ (its own `id:` prefix, docs page, and registry entry) is different: we maintain it, and listing it signals a baseline of trust to our users. We welcome new ones, but to keep the registry useful and trustworthy we ask that a dedicated provider meet the following before we merge it.
+A _dedicated provider_ adds its own `id:` prefix and registry entry. Promptfoo maintains that code, and a dedicated name signals a baseline of trust to users. To keep the registry useful, dedicated providers must meet the following bar.
 
 ### Provider eligibility
 
-- **Legitimate access to the models it serves.** The service must run its own models or have authorized access to the ones it offers (a first-party API, or a partner / reseller agreement). We don't accept integrations that resell or proxy another provider's models in violation of that provider's terms — for example "relay" gateways that resell Anthropic, OpenAI, or Google models below cost without authorization. If you resell third-party models, be ready to confirm you're permitted to.
-- **An accountable operator.** A real, identifiable company or an established open-source project, reachable for maintenance questions, with its own terms of service and privacy policy. Anonymous services with no identifiable owner aren't a good fit.
-- **Evidence it will last.** Some signal that the service is durable and will be maintained — for instance funding, paying customers, an established track record, or substantial _organic_ adoption (real usage, not inflated stars or followers). Brand-new services with no track record may be asked to wait, or to start with the generic `openai`-compatible path above.
-- **Clear data handling.** Because evals send prompts and outputs through the provider, your docs or terms should state whether request and response content is logged, how long it's retained, and whether it's used for training.
-- **Real value over the generic path.** A dedicated provider should add something beyond a base URL — its own API-key handling, non-OpenAI auth or headers, custom model routing, embeddings, or extra parameters. Pure pass-throughs are better served by the `openai` + `apiBaseUrl` route above.
+- **Legitimate model access.** The provider must serve models it owns, models its users are licensed to run, or models it can access through a first-party API, partner agreement, or reseller agreement. We do not accept unauthorized relays that resell or proxy another provider's models. If you resell third-party models, be ready to confirm that you are permitted to do so.
+- **Accountable ownership.** A hosted service must have an identifiable operator, a maintenance contact, and its own terms of service and privacy policy. For a self-hosted open-source project, established maintainers and a clear maintenance or security contact satisfy this requirement. Anonymous services with no identifiable owner are not a good fit.
+- **Evidence it will last.** We look for a practical signal that the provider will be maintained, such as funding, paying customers, an established track record, or substantial _organic_ adoption (real usage, not inflated stars or followers). Brand-new services may be asked to wait or start with the generic `openai` path.
+- **Clear data handling.** Hosted services must document whether they log prompt or response content, how long they retain it, and whether they use it for training. Self-hosted projects must document whether they send data outside the user's deployment and what telemetry they collect.
+- **Value beyond the generic path.** A dedicated provider should add behavior that would otherwise require provider-specific setup or code, such as non-OpenAI authentication, required headers, custom routing, or provider-specific endpoints and response handling. A base URL and API-key environment variable alone are not enough.
 
 We review aggregators, gateways, and resellers case by case against this same bar. Meeting these criteria doesn't guarantee a merge, and we may decline or later remove a provider that stops meeting them.
 
-To contribute a new provider:
+To contribute a dedicated provider:
 
-1. Confirm it meets the eligibility criteria above and doesn't already exist in promptfoo. For OpenAI-compatible providers you may be able to re-use the `openai` provider and override the base URL rather than write a new one — if so, skip to step 4 and contribute docs and an example instead.
+1. Confirm it meets the eligibility criteria above and doesn't already exist in Promptfoo.
 
 2. Implement the provider in `src/providers/yourProviderName.ts` following our [Custom API Provider Docs](/docs/providers/custom-api/). Please use our cache `src/cache.ts` to store responses. If your provider requires a new dependency, please add it as an optional dependency.
 
@@ -264,7 +264,7 @@ To contribute a new provider:
 
 4. Document your provider in `site/docs/providers/yourProviderName.md`, including a description, setup instructions, configuration options, and usage examples. You can also add examples to the `examples/` directory. Consider writing a guide comparing your provider to others or highlighting unique features or benefits.
 
-5. Update `src/providers/index.ts` and `site/docs/providers/index.md` to include your new provider. Update `src/envars.ts` to include any new environment variables your provider may need.
+5. Update `src/providers/registry.ts` and `site/docs/providers/index.md` to include your new provider. Update `src/envars.ts` to include any new environment variables your provider may need.
 
 6. Ensure all tests pass (`npm test`) and fix any linting issues (`npm run lint`).
 

--- a/src/providers/AGENTS.md
+++ b/src/providers/AGENTS.md
@@ -118,7 +118,7 @@ Every provider needs tests in `test/providers/`:
 
 ## Adding a Provider
 
-First confirm the service clears the eligibility bar in `site/docs/contributing.md` ("Provider eligibility"): legitimate model access (no ToS-violating resale), an accountable operator, durability, clear data handling, and real value over `openai` + `apiBaseUrl`. A pure pass-through is better documented under the `openai` provider than added as a new prefix.
+The eligibility bar in `site/docs/contributing.md` ("Provider eligibility") applies only to dedicated provider prefixes. Before adding one, confirm authorized model access, accountable ownership, durability, clear data handling, and provider-specific value beyond what `openai` + `apiBaseUrl` can express. A service that needs only a base URL and API-key environment variable should use the generic `openai` path and contribute docs or an example instead.
 
 **All seven items are required** before a provider is complete:
 

--- a/src/providers/AGENTS.md
+++ b/src/providers/AGENTS.md
@@ -118,6 +118,8 @@ Every provider needs tests in `test/providers/`:
 
 ## Adding a Provider
 
+First confirm the service clears the eligibility bar in `site/docs/contributing.md` ("Provider eligibility"): legitimate model access (no ToS-violating resale), an accountable operator, durability, clear data handling, and real value over `openai` + `apiBaseUrl`. A pure pass-through is better documented under the `openai` provider than added as a new prefix.
+
 **All seven items are required** before a provider is complete:
 
 1. Implement `ApiProvider` interface


### PR DESCRIPTION
## Summary

Adds a clear two-path rule for provider contributions:

- OpenAI-compatible services that need only a base URL and API key should use the existing `openai` provider. We welcome docs and examples for this path, but it does not need a new prefix or registry entry.
- Dedicated provider prefixes must meet an eligibility bar because Promptfoo maintains that code and a dedicated name signals a baseline of trust to users.

The eligibility bar asks for:

- authorized access to the models the provider serves;
- accountable ownership, with requirements tailored to hosted services and self-hosted open-source projects;
- evidence that the provider will be maintained;
- clear data-handling and telemetry documentation; and
- provider-specific behavior beyond a base URL and API-key environment variable.

This gives maintainers a consistent reason to decline unauthorized relays and thin pass-through integrations without excluding bootstrapped or open-source providers.

## Changes

- `site/docs/contributing.md` documents the generic path, the dedicated-provider eligibility bar, and a dedicated-only implementation checklist. It also points registry changes at `src/providers/registry.ts`.
- `src/providers/AGENTS.md` gives coding agents the same two-path rule before the provider build checklist.

## Verification

- `npm run f`
- `npm run l`
- `SKIP_OG_GENERATION=true npm run build` from `site/`

## Notes

- Docs only; no application behavior changes.
- Funding is one possible durability signal, not a hard requirement.
