### PR TITLE
fix(matchers): segment prose context into sentences for RAGAS context relevance

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/context-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/context-relevance.md
@@ -97,7 +97,7 @@ assert:
 ## Limitations
 
 - Only identifies minimum sufficient content
-- Single context strings split by lines (use arrays for better accuracy)
+- A single-paragraph (prose) context string is split into sentences on `.`/`!`/`?` boundaries; a context with two or more non-empty lines, or an array of chunks, is treated as already segmented and split by line/chunk. Sentence splitting is a lightweight heuristic that does not handle every abbreviation or decimal edge case — provide an array of chunks for the most precise denominator.
 - Score interpretation varies by use case
 
 ## Related metrics

--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -19,6 +19,7 @@ import {
   fail,
   normalizeMatcherTokenUsage,
   splitIntoSentences,
+  splitTextIntoSentences,
   tryParse,
 } from './shared';
 
@@ -262,13 +263,22 @@ export async function matchesContextRelevance(
 
   invariant(typeof resp.output === 'string', 'context-relevance produced malformed response');
 
-  // Split context into units: use chunks if provided, otherwise split into sentences
-  const contextUnits = Array.isArray(context)
+  // Split context into units: use chunks if provided, otherwise segment the
+  // prose context into sentences. We must split on sentence boundaries (not just
+  // newlines) — a retrieved context is typically a single prose paragraph with
+  // no newlines, and splitting on newlines alone would yield one unit, making
+  // the denominator 1 and forcing the score to ~1.0 regardless of relevance.
+  const isArrayContext = Array.isArray(context);
+  const contextUnits = isArrayContext
     ? context.filter((chunk) => chunk.trim().length > 0)
-    : splitIntoSentences(context);
+    : splitTextIntoSentences(context);
   const totalContextUnits = contextUnits.length;
 
-  const extractedSentences = splitIntoSentences(resp.output);
+  // Segment the grader's extracted sentences the same way the context was
+  // segmented so the numerator and denominator use consistent units.
+  const extractedSentences = isArrayContext
+    ? splitIntoSentences(resp.output)
+    : splitTextIntoSentences(resp.output);
   const relevantSentences: string[] = [];
   const insufficientInformation = resp.output.includes(CONTEXT_RELEVANCE_BAD);
 

--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -16,7 +16,6 @@ import { callProviderWithContext, getAndCheckProvider } from './providers';
 import { loadRubricPrompt, renderLlmRubricPrompt } from './rubric';
 import {
   cosineSimilarity,
-  detectSentenceSegmentMode,
   fail,
   normalizeMatcherTokenUsage,
   splitIntoSentences,
@@ -264,42 +263,26 @@ export async function matchesContextRelevance(
 
   invariant(typeof resp.output === 'string', 'context-relevance produced malformed response');
 
-  // Split context into units, then segment the grader's extracted sentences the
-  // SAME way so the numerator and denominator use consistent units.
-  const isArrayContext = Array.isArray(context);
-  let contextUnits: string[];
-  let extractedSentences: string[];
-  if (isArrayContext) {
-    // Each chunk is already a unit; the grader echoes back relevant chunks one per line.
-    contextUnits = context.filter((chunk) => chunk.trim().length > 0);
-    extractedSentences = splitIntoSentences(resp.output);
-  } else {
-    // A retrieved context is typically a single prose paragraph with no newlines.
-    // Splitting on newlines alone would yield one unit, making the denominator 1
-    // and forcing the score to ~1.0 regardless of relevance, so we segment on
-    // sentence boundaries. The mode is derived once from the context and reused
-    // for the grader output: the grading prompt does not constrain its output
-    // format, so segmenting both independently could measure them in different
-    // units (e.g. a multi-line context vs. a single-line prose response) and
-    // inflate the numerator above the true relevant count.
-    const mode = detectSentenceSegmentMode(context);
-    contextUnits = splitTextIntoSentences(context, mode);
-    extractedSentences = splitTextIntoSentences(resp.output, mode);
-  }
+  // Denominator (total context units): chunks if provided, otherwise the prose
+  // context segmented into sentences. A retrieved context is typically a single
+  // paragraph with no newlines; splitting on newlines alone would yield one unit,
+  // forcing the score to ~1.0 regardless of relevance.
+  const contextUnits = Array.isArray(context)
+    ? context.filter((chunk) => chunk.trim().length > 0)
+    : splitTextIntoSentences(context);
   const totalContextUnits = contextUnits.length;
-  const relevantSentences: string[] = [];
-  const insufficientInformation = resp.output.includes(CONTEXT_RELEVANCE_BAD);
 
-  let numerator = 0;
-  if (insufficientInformation) {
-    // If the entire response is "Insufficient Information", no sentences are relevant
-    numerator = 0;
-  } else {
-    // Count the extracted sentences as relevant
-    const uniqueRelevantSentences = [...new Set(extractedSentences)];
-    numerator = Math.min(uniqueRelevantSentences.length, totalContextUnits);
-    relevantSentences.push(...uniqueRelevantSentences);
-  }
+  // Numerator (relevant units): the grader lists the relevant sentences/chunks one
+  // per line, so count its non-empty lines. We intentionally do NOT sentence-split
+  // the grader output — the prompt does not constrain its format, and an LLM often
+  // returns a numbered list ("1. ...\n2. ..."), where sentence-splitting would
+  // count each "1." marker as its own unit and inflate the score.
+  const insufficientInformation = resp.output.includes(CONTEXT_RELEVANCE_BAD);
+  const relevantSentences = insufficientInformation
+    ? []
+    : [...new Set(splitIntoSentences(resp.output))];
+  // Cap at the total so the score never exceeds 1.
+  const numerator = Math.min(relevantSentences.length, totalContextUnits);
 
   // RAGAS CONTEXT RELEVANCE FORMULA: relevant units / total context units
   const score = totalContextUnits > 0 ? numerator / totalContextUnits : 0;
@@ -312,7 +295,7 @@ export async function matchesContextRelevance(
     extractedSentences: relevantSentences,
     totalContextUnits,
     totalContextSentences: totalContextUnits, // Backward compatibility
-    contextUnits: contextUnits,
+    contextUnits,
     relevantSentenceCount: numerator,
     insufficientInformation,
     score,

--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -263,24 +263,30 @@ export async function matchesContextRelevance(
 
   invariant(typeof resp.output === 'string', 'context-relevance produced malformed response');
 
-  // Denominator (total context units): chunks if provided, otherwise the prose
-  // context segmented into sentences. A retrieved context is typically a single
-  // paragraph with no newlines; splitting on newlines alone would yield one unit,
-  // forcing the score to ~1.0 regardless of relevance.
+  // The context is segmented into "units": chunks if provided, otherwise — for a
+  // string — by line when it is already segmented (multiple non-empty lines) or by
+  // sentence when it is a single prose block. A retrieved context is typically a
+  // single paragraph with no newlines; splitting on newlines alone would yield one
+  // unit, forcing the score to ~1.0 regardless of relevance.
+  const contextIsPreSegmented =
+    Array.isArray(context) || context.split('\n').filter((line) => line.trim() !== '').length > 1;
   const contextUnits = Array.isArray(context)
     ? context.filter((chunk) => chunk.trim().length > 0)
     : splitTextIntoSentences(context);
   const totalContextUnits = contextUnits.length;
 
-  // Numerator (relevant units): the grader lists the relevant sentences/chunks one
-  // per line, so count its non-empty lines. We intentionally do NOT sentence-split
-  // the grader output — the prompt does not constrain its format, and an LLM often
-  // returns a numbered list ("1. ...\n2. ..."), where sentence-splitting would
-  // count each "1." marker as its own unit and inflate the score.
+  // Numerator (relevant units): segment the grader output into the SAME kind of
+  // units as the context so the two are comparable — by line when the context is
+  // pre-segmented (chunk array or multi-line), otherwise by sentence. The grader
+  // echoes relevant sentences verbatim; for a prose context that is continuous
+  // text with no newlines, so counting by line alone would treat a multi-sentence
+  // answer as one unit and undercount relevance (e.g. echoing the whole context
+  // would score 1/N instead of 1.0).
   const insufficientInformation = resp.output.includes(CONTEXT_RELEVANCE_BAD);
+  const segmentRelevant = contextIsPreSegmented ? splitIntoSentences : splitTextIntoSentences;
   const relevantSentences = insufficientInformation
     ? []
-    : [...new Set(splitIntoSentences(resp.output))];
+    : [...new Set(segmentRelevant(resp.output))];
   // Cap at the total so the score never exceeds 1.
   const numerator = Math.min(relevantSentences.length, totalContextUnits);
 

--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -16,6 +16,7 @@ import { callProviderWithContext, getAndCheckProvider } from './providers';
 import { loadRubricPrompt, renderLlmRubricPrompt } from './rubric';
 import {
   cosineSimilarity,
+  detectSentenceSegmentMode,
   fail,
   normalizeMatcherTokenUsage,
   splitIntoSentences,
@@ -263,22 +264,29 @@ export async function matchesContextRelevance(
 
   invariant(typeof resp.output === 'string', 'context-relevance produced malformed response');
 
-  // Split context into units: use chunks if provided, otherwise segment the
-  // prose context into sentences. We must split on sentence boundaries (not just
-  // newlines) — a retrieved context is typically a single prose paragraph with
-  // no newlines, and splitting on newlines alone would yield one unit, making
-  // the denominator 1 and forcing the score to ~1.0 regardless of relevance.
+  // Split context into units, then segment the grader's extracted sentences the
+  // SAME way so the numerator and denominator use consistent units.
   const isArrayContext = Array.isArray(context);
-  const contextUnits = isArrayContext
-    ? context.filter((chunk) => chunk.trim().length > 0)
-    : splitTextIntoSentences(context);
+  let contextUnits: string[];
+  let extractedSentences: string[];
+  if (isArrayContext) {
+    // Each chunk is already a unit; the grader echoes back relevant chunks one per line.
+    contextUnits = context.filter((chunk) => chunk.trim().length > 0);
+    extractedSentences = splitIntoSentences(resp.output);
+  } else {
+    // A retrieved context is typically a single prose paragraph with no newlines.
+    // Splitting on newlines alone would yield one unit, making the denominator 1
+    // and forcing the score to ~1.0 regardless of relevance, so we segment on
+    // sentence boundaries. The mode is derived once from the context and reused
+    // for the grader output: the grading prompt does not constrain its output
+    // format, so segmenting both independently could measure them in different
+    // units (e.g. a multi-line context vs. a single-line prose response) and
+    // inflate the numerator above the true relevant count.
+    const mode = detectSentenceSegmentMode(context);
+    contextUnits = splitTextIntoSentences(context, mode);
+    extractedSentences = splitTextIntoSentences(resp.output, mode);
+  }
   const totalContextUnits = contextUnits.length;
-
-  // Segment the grader's extracted sentences the same way the context was
-  // segmented so the numerator and denominator use consistent units.
-  const extractedSentences = isArrayContext
-    ? splitIntoSentences(resp.output)
-    : splitTextIntoSentences(resp.output);
   const relevantSentences: string[] = [];
   const insufficientInformation = resp.output.includes(CONTEXT_RELEVANCE_BAD);
 

--- a/src/matchers/shared.ts
+++ b/src/matchers/shared.ts
@@ -92,3 +92,28 @@ export function tryParse(content: string) {
 export function splitIntoSentences(text: string) {
   return text.split('\n').filter((sentence) => sentence.trim() !== '');
 }
+
+/**
+ * Segments text into units for sentence-level metrics (e.g. RAGAS context
+ * relevance).
+ *
+ * If the text already uses newlines as separators — line-formatted LLM grader
+ * output, or a context passed one chunk/sentence per line — each line is treated
+ * as a unit. This preserves existing behavior and avoids mis-splitting
+ * abbreviations (e.g. "i.e.", "U.S.").
+ *
+ * Otherwise the text is a single prose block (the common shape of a retrieved
+ * RAG passage), so it is segmented on sentence boundaries (`.`, `!`, `?`
+ * followed by whitespace). This is the important case: {@link splitIntoSentences}
+ * splits on newlines only, so a prose passage with no newlines collapses to a
+ * single unit, forcing sentence-level denominators to 1.
+ *
+ * Note: the sentence split is a lightweight heuristic and does not handle every
+ * edge case (e.g. decimals like "3.14"); full segmentation would need an NLP
+ * tokenizer. It is a substantial improvement over newline-only splitting for the
+ * common prose case.
+ */
+export function splitTextIntoSentences(text: string): string[] {
+  const segments = /\n/.test(text) ? text.split('\n') : text.split(/(?<=[.!?])\s+/);
+  return segments.map((sentence) => sentence.trim()).filter((sentence) => sentence.length > 0);
+}

--- a/src/matchers/shared.ts
+++ b/src/matchers/shared.ts
@@ -94,61 +94,31 @@ export function splitIntoSentences(text: string) {
 }
 
 /**
- * How {@link splitTextIntoSentences} should segment text.
+ * Segments text into units for sentence-level metrics (e.g. the RAGAS context
+ * relevance denominator).
  *
- * - `lines`: split on newlines. The text is already segmented one unit per line.
- * - `prose`: split on sentence boundaries (`.`, `!`, `?` followed by whitespace).
- */
-export type SentenceSegmentMode = 'lines' | 'prose';
-
-/**
- * Decide how to segment text for sentence-level metrics.
+ * Text that spans **two or more** non-empty lines is treated as already segmented
+ * (one unit per line) — a context passed one chunk/sentence per line. This also
+ * avoids mis-splitting abbreviations (e.g. "i.e.", "U.S.") in pre-formatted text.
  *
- * Text that spans **two or more** non-empty lines is treated as already
- * segmented (`lines`) — line-formatted LLM grader output, or a context passed one
- * chunk/sentence per line. Anything else (a single line, possibly carrying an
- * incidental leading/trailing newline) is a single prose block (`prose`).
+ * Otherwise the text is a single prose block (the common shape of a retrieved RAG
+ * passage) and is segmented on sentence boundaries (`.`, `!`, `?` followed by
+ * whitespace). This is the important case: {@link splitIntoSentences} splits on
+ * newlines only, so a prose passage with no newlines collapses to a single unit,
+ * forcing the denominator to 1 and the score to ~1.0 regardless of relevance.
  *
- * The "two or more lines" threshold is deliberate: keying off the mere *presence*
- * of a newline would misclassify a prose paragraph with a single trailing newline
- * (extremely common when a context is loaded from a file, a template, or a YAML
- * block scalar) as pre-segmented, collapsing it to one unit.
- */
-export function detectSentenceSegmentMode(text: string): SentenceSegmentMode {
-  let nonEmptyLines = 0;
-  for (const line of text.split('\n')) {
-    if (line.trim() !== '' && ++nonEmptyLines > 1) {
-      return 'lines';
-    }
-  }
-  return 'prose';
-}
-
-/**
- * Segments text into units for sentence-level metrics (e.g. RAGAS context
- * relevance).
- *
- * `mode` defaults to {@link detectSentenceSegmentMode}. Pass an explicit mode to
- * segment two related texts (e.g. a context and the grader's extracted sentences)
- * the same way, so a ratio between them uses consistent units.
- *
- * - `lines` preserves pre-segmented input and avoids mis-splitting abbreviations
- *   (e.g. "i.e.", "U.S.") in already-formatted text.
- * - `prose` segments a single block on sentence boundaries. This is the important
- *   case: {@link splitIntoSentences} splits on newlines only, so a prose passage
- *   with no newlines collapses to a single unit, forcing sentence-level
- *   denominators to 1. Incidental leading/trailing newlines are tolerated — the
- *   sentence boundary regex consumes them and the trim/filter drops the remnants.
+ * The "two or more lines" threshold (rather than the mere presence of a newline)
+ * is deliberate: it keeps a prose paragraph carrying an incidental leading/trailing
+ * newline — common when a context is loaded from a file, a template, or a YAML
+ * block scalar — in the prose branch instead of collapsing it to one unit.
  *
  * Note: the sentence split is a lightweight heuristic and does not handle every
  * edge case (e.g. decimals like "3.14", abbreviations); full segmentation would
  * need an NLP tokenizer. It is a substantial improvement over newline-only
  * splitting for the common prose case.
  */
-export function splitTextIntoSentences(
-  text: string,
-  mode: SentenceSegmentMode = detectSentenceSegmentMode(text),
-): string[] {
-  const segments = mode === 'lines' ? text.split('\n') : text.split(/(?<=[.!?])\s+/);
+export function splitTextIntoSentences(text: string): string[] {
+  const lines = text.split('\n').filter((line) => line.trim() !== '');
+  const segments = lines.length > 1 ? lines : text.split(/(?<=[.!?])\s+/);
   return segments.map((sentence) => sentence.trim()).filter((sentence) => sentence.length > 0);
 }

--- a/src/matchers/shared.ts
+++ b/src/matchers/shared.ts
@@ -94,26 +94,61 @@ export function splitIntoSentences(text: string) {
 }
 
 /**
+ * How {@link splitTextIntoSentences} should segment text.
+ *
+ * - `lines`: split on newlines. The text is already segmented one unit per line.
+ * - `prose`: split on sentence boundaries (`.`, `!`, `?` followed by whitespace).
+ */
+export type SentenceSegmentMode = 'lines' | 'prose';
+
+/**
+ * Decide how to segment text for sentence-level metrics.
+ *
+ * Text that spans **two or more** non-empty lines is treated as already
+ * segmented (`lines`) — line-formatted LLM grader output, or a context passed one
+ * chunk/sentence per line. Anything else (a single line, possibly carrying an
+ * incidental leading/trailing newline) is a single prose block (`prose`).
+ *
+ * The "two or more lines" threshold is deliberate: keying off the mere *presence*
+ * of a newline would misclassify a prose paragraph with a single trailing newline
+ * (extremely common when a context is loaded from a file, a template, or a YAML
+ * block scalar) as pre-segmented, collapsing it to one unit.
+ */
+export function detectSentenceSegmentMode(text: string): SentenceSegmentMode {
+  let nonEmptyLines = 0;
+  for (const line of text.split('\n')) {
+    if (line.trim() !== '' && ++nonEmptyLines > 1) {
+      return 'lines';
+    }
+  }
+  return 'prose';
+}
+
+/**
  * Segments text into units for sentence-level metrics (e.g. RAGAS context
  * relevance).
  *
- * If the text already uses newlines as separators — line-formatted LLM grader
- * output, or a context passed one chunk/sentence per line — each line is treated
- * as a unit. This preserves existing behavior and avoids mis-splitting
- * abbreviations (e.g. "i.e.", "U.S.").
+ * `mode` defaults to {@link detectSentenceSegmentMode}. Pass an explicit mode to
+ * segment two related texts (e.g. a context and the grader's extracted sentences)
+ * the same way, so a ratio between them uses consistent units.
  *
- * Otherwise the text is a single prose block (the common shape of a retrieved
- * RAG passage), so it is segmented on sentence boundaries (`.`, `!`, `?`
- * followed by whitespace). This is the important case: {@link splitIntoSentences}
- * splits on newlines only, so a prose passage with no newlines collapses to a
- * single unit, forcing sentence-level denominators to 1.
+ * - `lines` preserves pre-segmented input and avoids mis-splitting abbreviations
+ *   (e.g. "i.e.", "U.S.") in already-formatted text.
+ * - `prose` segments a single block on sentence boundaries. This is the important
+ *   case: {@link splitIntoSentences} splits on newlines only, so a prose passage
+ *   with no newlines collapses to a single unit, forcing sentence-level
+ *   denominators to 1. Incidental leading/trailing newlines are tolerated — the
+ *   sentence boundary regex consumes them and the trim/filter drops the remnants.
  *
  * Note: the sentence split is a lightweight heuristic and does not handle every
- * edge case (e.g. decimals like "3.14"); full segmentation would need an NLP
- * tokenizer. It is a substantial improvement over newline-only splitting for the
- * common prose case.
+ * edge case (e.g. decimals like "3.14", abbreviations); full segmentation would
+ * need an NLP tokenizer. It is a substantial improvement over newline-only
+ * splitting for the common prose case.
  */
-export function splitTextIntoSentences(text: string): string[] {
-  const segments = /\n/.test(text) ? text.split('\n') : text.split(/(?<=[.!?])\s+/);
+export function splitTextIntoSentences(
+  text: string,
+  mode: SentenceSegmentMode = detectSentenceSegmentMode(text),
+): string[] {
+  const segments = mode === 'lines' ? text.split('\n') : text.split(/(?<=[.!?])\s+/);
   return segments.map((sentence) => sentence.trim()).filter((sentence) => sentence.length > 0);
 }

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -43,6 +43,37 @@ describe('matchesContextRelevance (RAGAS Context Relevance)', () => {
     expect(result.metadata?.relevantSentenceCount).toBe(1);
   });
 
+  it('should segment a single-paragraph prose context into sentences', async () => {
+    // Regression: a retrieved context is usually one prose paragraph with no
+    // newlines. Splitting it on newlines alone yields a single context unit, so
+    // the denominator is 1 and the score is forced to ~1.0 regardless of how
+    // little of the context is actually relevant. Segmenting on sentence
+    // boundaries restores a meaningful denominator.
+    const input = 'What is the capital of France?';
+    const context =
+      'Paris is the capital of France. France is in Europe. The weather is nice today.';
+    const threshold = 0.3;
+
+    // Mock LLM extracting 1 relevant sentence out of the 3 in the context.
+    const mockCallApi = vi.fn().mockImplementation(() => {
+      return Promise.resolve({
+        output: 'Paris is the capital of France.',
+        tokenUsage: { total: 10, prompt: 5, completion: 5 },
+      });
+    });
+
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, threshold);
+
+    // 3 sentences in the context, 1 relevant → score = 1/3 ≈ 0.33.
+    // Before the fix this returned 1.0 (the whole paragraph counted as one unit).
+    expect(result.score).toBeCloseTo(0.33, 2);
+    expect(result.pass).toBe(true); // 0.33 >= 0.3
+    expect(result.metadata?.totalContextUnits).toBe(3);
+    expect(result.metadata?.relevantSentenceCount).toBe(1);
+  });
+
   it('should handle insufficient information responses', async () => {
     const input = 'What is quantum computing?';
     const context =

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -98,11 +98,35 @@ describe('matchesContextRelevance (RAGAS Context Relevance)', () => {
     expect(result.metadata?.relevantSentenceCount).toBe(1);
   });
 
-  it('should segment grader output with the same mode as the context', async () => {
+  it('should not inflate the score when the grader returns a numbered list', async () => {
+    // Regression: the grading prompt does not constrain output format, and an LLM
+    // commonly returns the relevant sentences as a numbered list. Sentence-splitting
+    // the grader output would count each "1."/"2." marker as its own unit, inflating
+    // the numerator. The grader output must be counted by line instead.
+    const input = 'What is the capital of France?';
+    const context =
+      'Paris is the capital of France. France is in Europe. The weather is nice today.';
+    const threshold = 0.5;
+
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: '1. Paris is the capital of France.\n2. France is in Europe.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, threshold);
+
+    // 2 relevant lines out of 3 context sentences → 2/3 ≈ 0.67 (not 1.0).
+    expect(result.score).toBeCloseTo(0.67, 2);
+    expect(result.metadata?.totalContextUnits).toBe(3);
+    expect(result.metadata?.relevantSentenceCount).toBe(2);
+  });
+
+  it('should count the grader output by line, not sentence, against a multi-line context', async () => {
     // Regression: for a multi-line (pre-segmented) string context, a prose grader
-    // response (no newlines) was split on sentence boundaries while the context was
-    // split on newlines. The mismatched units inflated the numerator and forced the
-    // score to 1.0. Both must be segmented in the context's mode.
+    // response (no newlines) was sentence-split while the context was line-split.
+    // The mismatched units inflated the numerator and forced the score to 1.0. The
+    // grader output is now counted by non-empty line, matching the context units.
     const input = 'What is the capital of France?';
     const context =
       'Paris is the capital of France. France is in Europe.\nBerlin is the capital of Germany. Germany is in Europe.';
@@ -117,7 +141,8 @@ describe('matchesContextRelevance (RAGAS Context Relevance)', () => {
 
     const result = await matchesContextRelevance(input, context, threshold);
 
-    // Context is 2 lines; 1 line relevant → 1/2 = 0.5 (was 1.0 before the fix).
+    // Context is 2 lines; the grader's single line is 1 relevant unit → 1/2 = 0.5
+    // (was 1.0 before the fix, when the grader's two sentences were counted).
     expect(result.score).toBe(0.5);
     expect(result.metadata?.totalContextUnits).toBe(2);
     expect(result.metadata?.relevantSentenceCount).toBe(1);

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -74,6 +74,55 @@ describe('matchesContextRelevance (RAGAS Context Relevance)', () => {
     expect(result.metadata?.relevantSentenceCount).toBe(1);
   });
 
+  it('should still segment prose when the context carries an incidental trailing newline', async () => {
+    // Regression: a context loaded from a file/template/YAML block scalar almost
+    // always carries a trailing newline. Keying segmentation off the mere presence
+    // of a newline collapsed such a context back to a single unit, reviving the
+    // forced ~1.0 score. The mode must key off two-or-more non-empty lines instead.
+    const input = 'What is the capital of France?';
+    const context =
+      'Paris is the capital of France. France is in Europe. The weather is nice today.\n';
+    const threshold = 0.3;
+
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: 'Paris is the capital of France.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, threshold);
+
+    // Still 3 sentences despite the trailing newline → 1/3 ≈ 0.33 (not 1.0).
+    expect(result.score).toBeCloseTo(0.33, 2);
+    expect(result.metadata?.totalContextUnits).toBe(3);
+    expect(result.metadata?.relevantSentenceCount).toBe(1);
+  });
+
+  it('should segment grader output with the same mode as the context', async () => {
+    // Regression: for a multi-line (pre-segmented) string context, a prose grader
+    // response (no newlines) was split on sentence boundaries while the context was
+    // split on newlines. The mismatched units inflated the numerator and forced the
+    // score to 1.0. Both must be segmented in the context's mode.
+    const input = 'What is the capital of France?';
+    const context =
+      'Paris is the capital of France. France is in Europe.\nBerlin is the capital of Germany. Germany is in Europe.';
+    const threshold = 0.5;
+
+    // Grader returns one line verbatim (prose with two sentences, no newline).
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: 'Paris is the capital of France. France is in Europe.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, threshold);
+
+    // Context is 2 lines; 1 line relevant → 1/2 = 0.5 (was 1.0 before the fix).
+    expect(result.score).toBe(0.5);
+    expect(result.metadata?.totalContextUnits).toBe(2);
+    expect(result.metadata?.relevantSentenceCount).toBe(1);
+  });
+
   it('should handle insufficient information responses', async () => {
     const input = 'What is quantum computing?';
     const context =

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -74,6 +74,32 @@ describe('matchesContextRelevance (RAGAS Context Relevance)', () => {
     expect(result.metadata?.relevantSentenceCount).toBe(1);
   });
 
+  it('should count multiple relevant sentences in a prose grader response (single-line context)', async () => {
+    // For a single-paragraph prose context the grader echoes the relevant sentences
+    // verbatim as continuous prose (no newlines). The numerator must be segmented
+    // the same way as the denominator (by sentence here), otherwise a multi-sentence
+    // answer counts as a single relevant unit and undercounts relevance — e.g.
+    // echoing two of three sentences scored 1/3 instead of 2/3.
+    const input = 'What is the capital of France?';
+    const context =
+      'Paris is the capital of France. France is in Europe. The weather is nice today.';
+    const threshold = 0.5;
+
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: 'Paris is the capital of France. France is in Europe.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, threshold);
+
+    // 2 relevant sentences out of 3 → 2/3 ≈ 0.67 (was 1/3 ≈ 0.33 when the prose
+    // answer was counted as a single line).
+    expect(result.score).toBeCloseTo(0.67, 2);
+    expect(result.metadata?.totalContextUnits).toBe(3);
+    expect(result.metadata?.relevantSentenceCount).toBe(2);
+  });
+
   it('should still segment prose when the context carries an incidental trailing newline', async () => {
     // Regression: a context loaded from a file/template/YAML block scalar almost
     // always carries a trailing newline. Keying segmentation off the mere presence

--- a/test/matchers/shared.test.ts
+++ b/test/matchers/shared.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  detectSentenceSegmentMode,
-  splitIntoSentences,
-  splitTextIntoSentences,
-} from '../../src/matchers/shared';
+import { splitIntoSentences, splitTextIntoSentences } from '../../src/matchers/shared';
 
 describe('splitIntoSentences', () => {
   it('splits on newlines and drops blank lines', () => {
@@ -13,27 +9,12 @@ describe('splitIntoSentences', () => {
   it('treats a single prose paragraph as one unit (newline-only behavior)', () => {
     expect(splitIntoSentences('One. Two. Three.')).toEqual(['One. Two. Three.']);
   });
-});
 
-describe('detectSentenceSegmentMode', () => {
-  it('treats a single prose line as prose', () => {
-    expect(detectSentenceSegmentMode('One. Two. Three.')).toBe('prose');
-  });
-
-  it('treats prose with only an incidental trailing newline as prose', () => {
-    expect(detectSentenceSegmentMode('One. Two. Three.\n')).toBe('prose');
-    expect(detectSentenceSegmentMode('\nOne. Two. Three.')).toBe('prose');
-    expect(detectSentenceSegmentMode('One. Two. Three.\r\n')).toBe('prose');
-  });
-
-  it('treats text with two or more non-empty lines as pre-segmented', () => {
-    expect(detectSentenceSegmentMode('Line one.\nLine two.')).toBe('lines');
-    expect(detectSentenceSegmentMode('Line one.\n\n\nLine two.')).toBe('lines');
-  });
-
-  it('treats empty/whitespace-only text as prose', () => {
-    expect(detectSentenceSegmentMode('')).toBe('prose');
-    expect(detectSentenceSegmentMode('   \n  ')).toBe('prose');
+  it('does not sentence-split a numbered list (markers stay attached to their line)', () => {
+    expect(splitIntoSentences('1. Paris is the capital.\n2. France is in Europe.')).toEqual([
+      '1. Paris is the capital.',
+      '2. France is in Europe.',
+    ]);
   });
 });
 
@@ -72,22 +53,17 @@ describe('splitTextIntoSentences', () => {
     ]);
   });
 
-  it('treats multi-line text as pre-segmented (one unit per line, no abbreviation mis-splits)', () => {
+  it('treats text with two or more non-empty lines as pre-segmented (one unit per line)', () => {
+    // No abbreviation mis-splits ("i.e.") and no collapsing of multi-sentence lines.
     expect(splitTextIntoSentences('All employees i.e. engineers.\nThey get leave.')).toEqual([
       'All employees i.e. engineers.',
       'They get leave.',
     ]);
+    expect(splitTextIntoSentences('Line one.\n\n\nLine two.')).toEqual(['Line one.', 'Line two.']);
   });
 
   it('returns an empty array for empty or whitespace-only text', () => {
     expect(splitTextIntoSentences('')).toEqual([]);
     expect(splitTextIntoSentences('   \n  \n ')).toEqual([]);
-  });
-
-  it('honors an explicit mode override', () => {
-    // Forcing prose mode on multi-line text splits each line on sentence boundaries.
-    expect(splitTextIntoSentences('A. B.\nC. D.', 'prose')).toEqual(['A.', 'B.', 'C.', 'D.']);
-    // Forcing lines mode on a single prose block keeps it as one unit.
-    expect(splitTextIntoSentences('A. B. C.', 'lines')).toEqual(['A. B. C.']);
   });
 });

--- a/test/matchers/shared.test.ts
+++ b/test/matchers/shared.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectSentenceSegmentMode,
+  splitIntoSentences,
+  splitTextIntoSentences,
+} from '../../src/matchers/shared';
+
+describe('splitIntoSentences', () => {
+  it('splits on newlines and drops blank lines', () => {
+    expect(splitIntoSentences('a\n\nb\n  \nc')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('treats a single prose paragraph as one unit (newline-only behavior)', () => {
+    expect(splitIntoSentences('One. Two. Three.')).toEqual(['One. Two. Three.']);
+  });
+});
+
+describe('detectSentenceSegmentMode', () => {
+  it('treats a single prose line as prose', () => {
+    expect(detectSentenceSegmentMode('One. Two. Three.')).toBe('prose');
+  });
+
+  it('treats prose with only an incidental trailing newline as prose', () => {
+    expect(detectSentenceSegmentMode('One. Two. Three.\n')).toBe('prose');
+    expect(detectSentenceSegmentMode('\nOne. Two. Three.')).toBe('prose');
+    expect(detectSentenceSegmentMode('One. Two. Three.\r\n')).toBe('prose');
+  });
+
+  it('treats text with two or more non-empty lines as pre-segmented', () => {
+    expect(detectSentenceSegmentMode('Line one.\nLine two.')).toBe('lines');
+    expect(detectSentenceSegmentMode('Line one.\n\n\nLine two.')).toBe('lines');
+  });
+
+  it('treats empty/whitespace-only text as prose', () => {
+    expect(detectSentenceSegmentMode('')).toBe('prose');
+    expect(detectSentenceSegmentMode('   \n  ')).toBe('prose');
+  });
+});
+
+describe('splitTextIntoSentences', () => {
+  it('segments a single prose paragraph on sentence boundaries', () => {
+    expect(
+      splitTextIntoSentences('Paris is the capital of France. France is in Europe. Nice weather.'),
+    ).toEqual(['Paris is the capital of France.', 'France is in Europe.', 'Nice weather.']);
+  });
+
+  it('is unaffected by an incidental leading/trailing newline (regression for the prose fix)', () => {
+    const expected = ['Paris is the capital of France.', 'France is in Europe.'];
+    expect(
+      splitTextIntoSentences('Paris is the capital of France. France is in Europe.\n'),
+    ).toEqual(expected);
+    expect(
+      splitTextIntoSentences('\nParis is the capital of France. France is in Europe.'),
+    ).toEqual(expected);
+    expect(
+      splitTextIntoSentences('Paris is the capital of France. France is in Europe.\r\n'),
+    ).toEqual(expected);
+  });
+
+  it('splits ! and ? boundaries', () => {
+    expect(splitTextIntoSentences('Really? Yes! Absolutely.')).toEqual([
+      'Really?',
+      'Yes!',
+      'Absolutely.',
+    ]);
+  });
+
+  it('does not split decimals', () => {
+    expect(splitTextIntoSentences('Pi is about 3.14 in value. It is irrational.')).toEqual([
+      'Pi is about 3.14 in value.',
+      'It is irrational.',
+    ]);
+  });
+
+  it('treats multi-line text as pre-segmented (one unit per line, no abbreviation mis-splits)', () => {
+    expect(splitTextIntoSentences('All employees i.e. engineers.\nThey get leave.')).toEqual([
+      'All employees i.e. engineers.',
+      'They get leave.',
+    ]);
+  });
+
+  it('returns an empty array for empty or whitespace-only text', () => {
+    expect(splitTextIntoSentences('')).toEqual([]);
+    expect(splitTextIntoSentences('   \n  \n ')).toEqual([]);
+  });
+
+  it('honors an explicit mode override', () => {
+    // Forcing prose mode on multi-line text splits each line on sentence boundaries.
+    expect(splitTextIntoSentences('A. B.\nC. D.', 'prose')).toEqual(['A.', 'B.', 'C.', 'D.']);
+    // Forcing lines mode on a single prose block keeps it as one unit.
+    expect(splitTextIntoSentences('A. B. C.', 'lines')).toEqual(['A. B. C.']);
+  });
+});


### PR DESCRIPTION
## Summary

`context-relevance` (RAGAS Context Relevance) scores how much of the retrieved context is actually relevant to the query: an LLM extracts the relevant sentences, and the score is `relevant_sentences / total_context_sentences`.

The denominator is computed by splitting the context into "sentences", but for a **string** context that split is done on **newlines only**:

```ts
// src/matchers/shared.ts
export function splitIntoSentences(text: string) {
  return text.split('\n').filter((sentence) => sentence.trim() !== '');
}
```

A retrieved RAG context is almost always a **single prose paragraph with no newlines**. Splitting it on newlines yields exactly **one** unit, so `totalContextUnits === 1`, the numerator is clamped to that, and the score collapses to **~1.0 no matter how little of the context is relevant**.

This defeats the whole point of the metric: a context that is 90% irrelevant still scores 1.0.

### Concrete example

```
query:   "What is the capital of France?"
context: "Paris is the capital of France. France is in Europe. The weather is nice today."
```

The grader correctly extracts the single relevant sentence (`"Paris is the capital of France."`). Expected RAGAS score: `1/3 ≈ 0.33`.

| | `totalContextUnits` | score |
|---|---|---|
| **Before** | 1 (whole paragraph) | **1.00** ❌ |
| **After**  | 3 (sentences)       | **0.33** ✅ |

## Fix

Add `splitTextIntoSentences` in `shared.ts`. It segments a **single prose block** on sentence boundaries (`.`, `!`, `?` + whitespace), but still treats newline-separated input as **pre-segmented** (one unit per line):

```ts
export function splitTextIntoSentences(text: string): string[] {
  const segments = /\n/.test(text) ? text.split('\n') : text.split(/(?<=[.!?])\s+/);
  return segments.map((s) => s.trim()).filter((s) => s.length > 0);
}
```

Keeping the newline branch is deliberate:
- **Line-formatted grader output** (the LLM returns one extracted sentence per line) stays correctly segmented.
- **Contexts already formatted one sentence/chunk per line** keep their existing unit count.
- It avoids mis-splitting abbreviations (e.g. `"i.e."`, `"U.S."`) in that already-segmented text.

`splitTextIntoSentences` is applied in `matchesContextRelevance` to **both** the context and the grader's extracted sentences, so the numerator and denominator are segmented the same way. **Array (chunk) context behavior is unchanged** — chunks are still counted as-is via `splitIntoSentences`.

> Note: the sentence split is a lightweight heuristic (it won't perfectly handle decimals like `3.14` or every abbreviation); full segmentation would need an NLP tokenizer. It is a large improvement over newline-only splitting for the common single-paragraph case, with no regression for the line-formatted cases.

## Test plan

- Added a regression test, `should segment a single-paragraph prose context into sentences`, that exercises the exact failing case above.
  - **Fails before** the fix: `expected 1 to be close to 0.33` (the old behavior returned `1.0`).
  - **Passes after**: `0.33`.
- All existing `context-relevance` tests still pass, including the line-formatted and formatted-policy cases that rely on newline segmentation.

```
npx vitest run test/matchers/context-relevance.test.ts   # 11 passed
npx vitest run test/matchers/similarity.test.ts          # shared.ts consumers — passed
npm run tsc                                               # clean
npm run l && npm run f                                    # clean
```

## References

- RAGAS context relevance: Es et al., 2023, *RAGAS: Automated Evaluation of Retrieval Augmented Generation* — the metric is defined as the ratio of relevant sentences to total sentences in the retrieved context.