### PR TITLE
fix(assertions): make not-similar with an array require dissimilarity to all values

### DIFF
--- a/site/docs/configuration/expected-outputs/similar.md
+++ b/site/docs/configuration/expected-outputs/similar.md
@@ -32,6 +32,8 @@ assert:
     threshold: 0.8
 ```
 
+The negated `not-similar` assertion is the logical inverse: with an array of values it passes only when the output is dissimilar to **every** value (and fails as soon as it is too similar to any one of them). This is the natural way to assert that an output does not resemble any item in a list of forbidden or canned answers.
+
 ## Similarity Metrics
 
 You can specify which metric to use by including it in the assertion type. The default is `similar` (cosine similarity).

--- a/src/assertions/similar.ts
+++ b/src/assertions/similar.ts
@@ -40,6 +40,42 @@ export const handleSimilar = async ({
   }
 
   if (Array.isArray(renderedValue)) {
+    if (inverse) {
+      // `not-similar` is the negation of the positive "similar to at least one"
+      // semantics, so it must pass only when the output is dissimilar to EVERY
+      // value. Fail (return early) on the first value the output is too similar
+      // to, reporting that value's score. If the output clears all of them,
+      // report the lowest score — the value it came closest to (the tightest
+      // margin). matchesSimilarity already normalizes the inverse score so
+      // higher is always better.
+      let closestResult: Omit<GradingResult, 'assertion'> | undefined;
+      for (const value of renderedValue) {
+        const result = await matchesSimilarity(
+          value,
+          outputString,
+          threshold,
+          inverse,
+          test.options,
+          metric,
+        );
+        if (!result.pass) {
+          return {
+            assertion,
+            ...result,
+          };
+        }
+        if (!closestResult || result.score < closestResult.score) {
+          closestResult = result;
+        }
+      }
+      // renderedValue is non-empty (invariant above), so closestResult is set.
+      invariant(closestResult, 'Similarity result missing');
+      return {
+        assertion,
+        ...closestResult,
+      };
+    }
+
     // The assertion passes if the output matches ANY of the values (we return
     // early on the first pass), so when none pass, report the best (highest)
     // score — how close the output got to its closest value — not the worst.

--- a/test/assertions/similar.test.ts
+++ b/test/assertions/similar.test.ts
@@ -254,6 +254,89 @@ describe('handleSimilar', () => {
     expect(result.score).toBe(0.6);
   });
 
+  it('should FAIL not-similar with an array when the output is similar to ANY value', async () => {
+    // not-similar means "dissimilar to ALL". The output is too similar to the
+    // first value (inverse check fails there) but dissimilar to the second.
+    // It must fail — not pass on the strength of the second value.
+    vi.mocked(matchesSimilarity)
+      .mockResolvedValueOnce({ pass: false, score: 0.05, reason: 'too similar' } as any)
+      .mockResolvedValueOnce({ pass: true, score: 0.9, reason: 'dissimilar' } as any);
+
+    const result = await handleSimilar({
+      assertion: {
+        type: 'similar',
+        value: ['forbidden answer A', 'unrelated answer B'],
+        threshold: 0.75,
+      },
+      baseType: 'similar' as any,
+      renderedValue: ['forbidden answer A', 'unrelated answer B'],
+      outputString: 'forbidden answer A',
+      inverse: true,
+      test: {
+        description: 'test',
+        vars: {},
+        assert: [],
+        options: {},
+      },
+      assertionValueContext: {
+        prompt: 'test prompt',
+        vars: {},
+        test: { description: 'test', vars: {}, assert: [], options: {} },
+        logProbs: undefined,
+        // @ts-ignore
+        provider: createMockProvider({ response: {} }),
+        providerResponse: { output: 'forbidden answer A' },
+      },
+      output: 'forbidden answer A',
+      providerResponse: { output: 'forbidden answer A' },
+    });
+
+    // Before the fix this returned pass: true (dissimilar to the second value
+    // short-circuited the loop). The output is identical to value A, so it must fail.
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0.05);
+  });
+
+  it('should PASS not-similar with an array only when dissimilar to ALL values', async () => {
+    // Dissimilar to every value → not-similar passes; report the lowest score
+    // (the value it came closest to / tightest margin).
+    vi.mocked(matchesSimilarity)
+      .mockResolvedValueOnce({ pass: true, score: 0.8, reason: 'dissimilar' } as any)
+      .mockResolvedValueOnce({ pass: true, score: 0.95, reason: 'dissimilar' } as any);
+
+    const result = await handleSimilar({
+      assertion: {
+        type: 'similar',
+        value: ['forbidden answer A', 'forbidden answer B'],
+        threshold: 0.75,
+      },
+      baseType: 'similar' as any,
+      renderedValue: ['forbidden answer A', 'forbidden answer B'],
+      outputString: 'a totally different response',
+      inverse: true,
+      test: {
+        description: 'test',
+        vars: {},
+        assert: [],
+        options: {},
+      },
+      assertionValueContext: {
+        prompt: 'test prompt',
+        vars: {},
+        test: { description: 'test', vars: {}, assert: [], options: {} },
+        logProbs: undefined,
+        // @ts-ignore
+        provider: createMockProvider({ response: {} }),
+        providerResponse: { output: 'a totally different response' },
+      },
+      output: 'a totally different response',
+      providerResponse: { output: 'a totally different response' },
+    });
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(0.8);
+  });
+
   it('should throw error for invalid renderedValue type', async () => {
     await expect(
       handleSimilar({

--- a/test/assertions/similar.test.ts
+++ b/test/assertions/similar.test.ts
@@ -256,11 +256,15 @@ describe('handleSimilar', () => {
 
   it('should FAIL not-similar with an array when the output is similar to ANY value', async () => {
     // not-similar means "dissimilar to ALL". The output is too similar to the
-    // first value (inverse check fails there) but dissimilar to the second.
-    // It must fail — not pass on the strength of the second value.
-    vi.mocked(matchesSimilarity)
-      .mockResolvedValueOnce({ pass: false, score: 0.05, reason: 'too similar' } as any)
-      .mockResolvedValueOnce({ pass: true, score: 0.9, reason: 'dissimilar' } as any);
+    // first value, so the inverse check fails there and the assertion returns
+    // immediately — it must fail rather than continue and pass on a later value.
+    // Only the first value is evaluated, so we queue a single result (queuing a
+    // second would leak into the next test, which runs in random order).
+    vi.mocked(matchesSimilarity).mockResolvedValueOnce({
+      pass: false,
+      score: 0.05,
+      reason: 'too similar',
+    } as any);
 
     const result = await handleSimilar({
       assertion: {

--- a/test/assertions/similar.test.ts
+++ b/test/assertions/similar.test.ts
@@ -341,6 +341,28 @@ describe('handleSimilar', () => {
     expect(result.score).toBe(0.8);
   });
 
+  it('should report the closest (lowest) score across 3+ values when dissimilar to ALL (not-similar)', async () => {
+    // Dissimilar to all three; the lowest score is in the MIDDLE, proving the
+    // min-selection picks the tightest margin regardless of position (not just
+    // first/last). The full closest result (score + reason) is propagated.
+    vi.mocked(matchesSimilarity)
+      .mockResolvedValueOnce({ pass: true, score: 0.9, reason: 'dissimilar to A' } as any)
+      .mockResolvedValueOnce({ pass: true, score: 0.78, reason: 'closest to B' } as any)
+      .mockResolvedValueOnce({ pass: true, score: 0.95, reason: 'dissimilar to C' } as any);
+
+    const result = await handleSimilar({
+      assertion: { type: 'similar', value: ['A', 'B', 'C'], threshold: 0.75 },
+      renderedValue: ['A', 'B', 'C'],
+      outputString: 'a totally different response',
+      inverse: true,
+      test: { description: 'test', vars: {}, assert: [], options: {} },
+    } as any);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(0.78);
+    expect(result.reason).toBe('closest to B');
+  });
+
   it('should throw error for invalid renderedValue type', async () => {
     await expect(
       handleSimilar({


### PR DESCRIPTION
## Summary

For a `similar` assertion with an **array** of values, the documented behavior is "the test passes if the output is similar to **at least one** of them" — an OR. The handler implements this by returning on the first per-value pass.

The bug: the **same loop** is used for `not-similar`. For an inverse assertion, `matchesSimilarity` returns `pass: true` when the output is **dissimilar to that single value**, so returning on the first pass means `not-similar` passes as soon as the output is dissimilar to **any one** value:

```ts
// src/assertions/similar.ts (before)
for (const value of renderedValue) {
  const result = await matchesSimilarity(value, outputString, threshold, inverse, ...);
  if (result.pass) {            // for inverse: "dissimilar to THIS value"
    return { assertion, ...result };  // ← passes on the FIRST dissimilar value
  }
  ...
}
```

So `not-similar: [A, B]` effectively means "dissimilar to A **OR** dissimilar to B", when the correct negation of "similar to at least one" is "dissimilar to A **AND** dissimilar to B" (dissimilar to **all**). The practical consequence: a `not-similar` guardrail listing forbidden/canned/leaked answers gets **weaker with every value you add**, and becomes almost impossible to fail — the opposite of the intent.

## Concrete example

```yaml
assert:
  - type: not-similar
    threshold: 0.75
    value:
      - 'forbidden answer A'
      - 'unrelated answer B'
```

Output = `"forbidden answer A"` (an exact copy of value A):

| value | cosine | inverse check (`sim <= 0.75`) | per-value pass |
|---|---|---|---|
| A | ~1.0 | no | **fail** (too similar) |
| B | ~0.1 | yes | pass (dissimilar) |

| | result |
|---|---|
| **Before** | **pass** ❌ (returns on B, ignoring that the output is identical to A) |
| **After**  | **fail** ✅ (output is too similar to A) |

## Fix

Branch the array logic on `inverse`:

- **`not-similar`** passes only when the output is dissimilar to **every** value. It returns a failing result on the first value the output is too similar to (reporting that value's score), and if the output clears all of them, reports the **lowest** score — the value it came closest to (the tightest margin).
- The positive **`similar`** "match ANY" path is unchanged (returns on first pass; on all-fail reports the highest score, per #9721).

## Test plan

- Added two regression tests:
  - `should FAIL not-similar with an array when the output is similar to ANY value` — **fails before** the fix (`expected true to be false`), passes after.
  - `should PASS not-similar with an array only when dissimilar to ALL values`.
- Ran the suite 5× in random order to confirm no mock-queue leakage; `similar` suite passes (13 tests). `npm run tsc`, `npm run l`, `npm run f` all clean.