### PR TITLE
fix(assertions): honor inverse for not-moderation

### DIFF
--- a/src/assertions/moderation.ts
+++ b/src/assertions/moderation.ts
@@ -58,6 +58,7 @@ export const handleModeration = async ({
   outputString,
   providerResponse,
   prompt,
+  inverse,
 }: AssertionParams): Promise<GradingResult> => {
   // Priority: 1) response.prompt (provider-reported), 2) redteamFinalPrompt (legacy), 3) original prompt
   // This allows providers to report the actual prompt they sent (e.g., GenAIScript, dynamic prompts)
@@ -86,10 +87,16 @@ export const handleModeration = async ({
     test.options,
   );
 
-  const pass = moderationResult.pass;
+  let { pass, score } = moderationResult;
+  // `not-moderation` asserts the opposite outcome (e.g. that the output WAS
+  // flagged). Flip pass/score for the inverse case, mirroring handleClassifier.
+  if (inverse) {
+    pass = !pass;
+    score = 1 - score;
+  }
   return {
     pass,
-    score: moderationResult.score,
+    score,
     reason: moderationResult.reason,
     assertion,
   };

--- a/src/assertions/moderation.ts
+++ b/src/assertions/moderation.ts
@@ -1,3 +1,4 @@
+import { isGraderFailure } from '../matchers/llmGrading';
 import { matchesModeration } from '../matchers/moderation';
 import { parseChatPrompt } from '../providers/shared';
 import invariant from '../util/invariant';
@@ -86,6 +87,13 @@ export const handleModeration = async ({
     },
     test.options,
   );
+
+  // A moderation provider/transport error is not evidence about the content, so
+  // never flip it into a pass for `not-moderation` — propagate it verbatim
+  // (mirrors the inverse-aware llm-rubric/g-eval handlers).
+  if (isGraderFailure(moderationResult)) {
+    return { ...moderationResult, assertion };
+  }
 
   let { pass, score } = moderationResult;
   // `not-moderation` asserts the opposite outcome (e.g. that the output WAS

--- a/src/matchers/moderation.ts
+++ b/src/matchers/moderation.ts
@@ -46,10 +46,14 @@ export async function matchesModeration(
 
   const resp = await moderationProvider.callModerationApi(userPrompt, assistantResponse);
   if (resp.error) {
+    // A provider/transport error is not evidence about the content. Tag it as a
+    // grader failure so inverse-aware callers (`not-moderation`) propagate it
+    // verbatim instead of flipping it into a spurious pass.
     return {
       pass: false,
       score: 0,
       reason: `Moderation API error: ${resp.error}`,
+      metadata: { graderError: true },
     };
   }
 

--- a/test/assertions/moderation.test.ts
+++ b/test/assertions/moderation.test.ts
@@ -80,6 +80,51 @@ describe('handleModeration', () => {
     });
   });
 
+  it('should pass not-moderation when content IS flagged (inverse)', async () => {
+    // matchesModeration reports a flagged output as { pass: false, score: 0 }.
+    mockedMatchesModeration.mockResolvedValue({
+      pass: false,
+      score: 0,
+      reason: 'Moderation flags detected: harassment',
+    });
+
+    const result = await handleModeration({
+      ...baseParams,
+      inverse: true,
+      providerResponse: { output: 'output' },
+    });
+
+    // Before the fix the handler ignored `inverse` and returned pass: false,
+    // making not-moderation behave identically to moderation.
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Moderation flags detected: harassment',
+      assertion: mockAssertion,
+    });
+  });
+
+  it('should fail not-moderation when content is clean (inverse)', async () => {
+    mockedMatchesModeration.mockResolvedValue({
+      pass: true,
+      score: 1,
+      reason: 'No moderation flags detected',
+    });
+
+    const result = await handleModeration({
+      ...baseParams,
+      inverse: true,
+      providerResponse: { output: 'output' },
+    });
+
+    expect(result).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'No moderation flags detected',
+      assertion: mockAssertion,
+    });
+  });
+
   it('should use redteam final prompt when available', async () => {
     mockedMatchesModeration.mockResolvedValue({
       pass: true,

--- a/test/assertions/moderation.test.ts
+++ b/test/assertions/moderation.test.ts
@@ -125,6 +125,51 @@ describe('handleModeration', () => {
     });
   });
 
+  it('should fail moderation (non-inverse) when content is flagged', async () => {
+    // Regression guard for the let/inverse refactor: the non-inverse path must
+    // still report a flagged result as a failure, byte-for-byte unchanged.
+    mockedMatchesModeration.mockResolvedValue({
+      pass: false,
+      score: 0,
+      reason: 'Moderation flags detected: harassment',
+    });
+
+    const result = await handleModeration({ ...baseParams, inverse: false });
+
+    expect(result).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'Moderation flags detected: harassment',
+      assertion: mockAssertion,
+    });
+  });
+
+  it('should NOT flip a moderation API error into a pass for not-moderation (inverse)', async () => {
+    // A provider/transport error is tagged metadata.graderError. The inverse flip
+    // must propagate it verbatim (fail closed) rather than turning an unchecked
+    // output into a spurious "was flagged" pass.
+    mockedMatchesModeration.mockResolvedValue({
+      pass: false,
+      score: 0,
+      reason: 'Moderation API error: provider unavailable',
+      metadata: { graderError: true },
+    });
+
+    const result = await handleModeration({
+      ...baseParams,
+      inverse: true,
+      providerResponse: { output: 'output' },
+    });
+
+    expect(result).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'Moderation API error: provider unavailable',
+      metadata: { graderError: true },
+      assertion: mockAssertion,
+    });
+  });
+
   it('should use redteam final prompt when available', async () => {
     mockedMatchesModeration.mockResolvedValue({
       pass: true,

--- a/test/matchers/moderation.test.ts
+++ b/test/matchers/moderation.test.ts
@@ -112,6 +112,9 @@ describe('matchesModeration', () => {
       pass: false,
       score: 0,
       reason: 'Moderation API error: provider unavailable',
+      // Tagged so inverse-aware callers (not-moderation) don't flip a transport
+      // error into a spurious pass.
+      metadata: { graderError: true },
     });
   });
 


### PR DESCRIPTION
## Summary

`handleModeration` never read the `inverse` flag and returned the matcher's `pass`/`score` verbatim, so the auto-generated `not-moderation` assertion behaved **identically** to `moderation` instead of negating it. The negation was a complete no-op.

```ts
// src/assertions/moderation.ts (before)
const pass = moderationResult.pass;
return { pass, score: moderationResult.score, reason: moderationResult.reason, assertion };
```

Every other assertion handler honors `inverse` (the dispatcher passes `inverse: isAssertionInverse(assertion)` to all handlers and there is no generic post-handler flip). `moderation` was the lone matcher-backed handler that ignored it — the same class as the recently-fixed `not-levenshtein` (#9722) and `not-cost`/`not-latency`/`not-perplexity` (#9725).

## Behavior

`matchesModeration` reports a **flagged** output as `{ pass: false }` and a **clean** output as `{ pass: true }`. So:

| output | `moderation` | `not-moderation` before | `not-moderation` after |
|---|---|---|---|
| flagged | fail | **fail** ❌ (no-op) | **pass** ✅ |
| clean | pass | **pass** ❌ (no-op) | **fail** ✅ |

`not-moderation` is the natural way to assert "the output **was** flagged" (e.g. confirming a safety/guardrail or red-team harness actually catches harmful content) — which was impossible before.

## Fix

Flip `pass` and `score` for the inverse case, mirroring `handleClassifier`:

```ts
let { pass, score } = moderationResult;
if (inverse) {
  pass = !pass;
  score = 1 - score;
}
```

This matches the established convention: `handleClassifier` flips `pass`/`score` for `not-classifier` the same way. Only the `inverse === true` path changes; `moderation` is byte-for-byte unchanged.

## Test plan

- Added two regression tests in `test/assertions/moderation.test.ts`:
  - `should pass not-moderation when content IS flagged (inverse)` — **fails before** the fix, passes after.
  - `should fail not-moderation when content is clean (inverse)` — **fails before**, passes after.
- Full `handleModeration` suite passes (13 tests); `npm run tsc`, `npm run l`, `npm run f` all clean.