### PR TITLE
fix(assertions): stop BLEU collapsing scores for short candidates

### DIFF
--- a/src/assertions/bleu.ts
+++ b/src/assertions/bleu.ts
@@ -88,11 +88,24 @@ export function calculateBleuScore(
 
   const maxN = 4;
   const precisions: number[] = [];
+  const usableWeights: number[] = [];
 
   for (let n = 1; n <= maxN; n++) {
     const candidateNGrams = getNGrams(candidateWords, n);
-    const candidateNGramCounts = countNGrams(candidateNGrams);
     const totalCount = candidateNGrams.length;
+
+    // If the candidate is shorter than n tokens, no n-grams of this order can
+    // exist. Skip the order and renormalize the weights over the remaining
+    // orders, rather than recording precision 0 — that would be smoothed to a
+    // tiny value and collapse the whole score (e.g. a perfect 1-3 word match
+    // scoring ~0). This matches NLTK, which reweights when higher orders are
+    // unavailable. A genuine zero-overlap precision (n-grams exist but none
+    // match) is still kept and smoothed below.
+    if (totalCount === 0) {
+      continue;
+    }
+
+    const candidateNGramCounts = countNGrams(candidateNGrams);
 
     // Clipped n-gram count against the best-matching reference
     let maxClippedCount = 0;
@@ -107,15 +120,20 @@ export function calculateBleuScore(
       maxClippedCount = Math.max(maxClippedCount, clippedCount);
     }
 
-    precisions.push(totalCount > 0 ? maxClippedCount / totalCount : 0);
+    precisions.push(maxClippedCount / totalCount);
+    usableWeights.push(weights[n - 1]);
   }
 
   const bp = calculateBrevityPenalty(candidateWords.length, closestRefLength);
 
+  // Renormalize the usable weights to sum to 1 so dropping unavailable higher
+  // orders does not shrink the geometric mean.
+  const weightSum = usableWeights.reduce((acc, w) => acc + w, 0);
+
   // Apply weights and calculate final score
   const weightedScore = precisions.reduce((acc, p, i) => {
     const smoothedP = p === 0 ? 1e-7 : p; // smoothing
-    return acc + weights[i] * Math.log(smoothedP);
+    return acc + (usableWeights[i] / weightSum) * Math.log(smoothedP);
   }, 0);
 
   return bp * Math.exp(weightedScore);

--- a/src/assertions/bleu.ts
+++ b/src/assertions/bleu.ts
@@ -57,9 +57,10 @@ function countNGrams(ngrams: string[]): Map<string, number> {
  *
  * @param candidate - The string to evaluate
  * @param references - Array of reference strings to compare against
- * @param weights - Weights for each n-gram precision (1-gram to 4-gram)
+ * @param weights - Weights for each n-gram precision (1-gram to 4-gram). Must be
+ *   non-negative and sum to 1 (BLEU weights are non-negative by definition).
  * @returns BLEU score between 0 and 1
- * @throws When inputs are invalid or weights don't sum to 1
+ * @throws When inputs are invalid, weights are negative, or weights don't sum to 1
  */
 export function calculateBleuScore(
   candidate: string,
@@ -68,6 +69,14 @@ export function calculateBleuScore(
 ): number {
   if (!candidate || references.length === 0 || weights.length !== 4) {
     throw new Error('Invalid inputs');
+  }
+  // BLEU weights are non-negative by definition. Rejecting negatives keeps the
+  // score within the documented [0, 1] range (a negative weight on a smoothed
+  // zero-precision order would otherwise blow the geometric mean far above 1)
+  // and prevents the renormalization below from dividing by a usable-weight sum
+  // that cancels to zero.
+  if (weights.some((w) => w < 0)) {
+    throw new Error('Weights must be non-negative');
   }
   if (Math.abs(weights.reduce((a, b) => a + b) - 1) > 1e-4) {
     throw new Error('Weights must sum to 1');
@@ -87,8 +96,10 @@ export function calculateBleuScore(
   });
 
   const maxN = 4;
-  const precisions: number[] = [];
-  const usableWeights: number[] = [];
+  // One entry per scorable n-gram order, pairing its modified precision with its
+  // weight. Kept as a single array (rather than two parallel ones) so a precision
+  // can never become misaligned with its weight.
+  const usableOrders: { precision: number; weight: number }[] = [];
 
   for (let n = 1; n <= maxN; n++) {
     const candidateNGrams = getNGrams(candidateWords, n);
@@ -123,20 +134,25 @@ export function calculateBleuScore(
       maxClippedCount = Math.max(maxClippedCount, clippedCount);
     }
 
-    precisions.push(maxClippedCount / totalCount);
-    usableWeights.push(weights[n - 1]);
+    usableOrders.push({ precision: maxClippedCount / totalCount, weight: weights[n - 1] });
   }
 
   const bp = calculateBrevityPenalty(candidateWords.length, closestRefLength);
 
   // Renormalize the usable weights to sum to 1 so dropping unavailable higher
-  // orders does not shrink the geometric mean.
-  const weightSum = usableWeights.reduce((acc, w) => acc + w, 0);
+  // orders does not shrink the geometric mean. If every weighted order was
+  // dropped — all weight sits on orders the candidate is too short to contain,
+  // e.g. weights [0, 0, 0, 1] on a 3-word candidate — there is no scorable
+  // signal, so the score is 0.
+  const weightSum = usableOrders.reduce((acc, o) => acc + o.weight, 0);
+  if (weightSum === 0) {
+    return 0;
+  }
 
   // Apply weights and calculate final score
-  const weightedScore = precisions.reduce((acc, p, i) => {
-    const smoothedP = p === 0 ? 1e-7 : p; // smoothing
-    return acc + (usableWeights[i] / weightSum) * Math.log(smoothedP);
+  const weightedScore = usableOrders.reduce((acc, { precision, weight }) => {
+    const smoothedP = precision === 0 ? 1e-7 : precision; // smoothing
+    return acc + (weight / weightSum) * Math.log(smoothedP);
   }, 0);
 
   return bp * Math.exp(weightedScore);

--- a/src/assertions/bleu.ts
+++ b/src/assertions/bleu.ts
@@ -98,9 +98,12 @@ export function calculateBleuScore(
     // exist. Skip the order and renormalize the weights over the remaining
     // orders, rather than recording precision 0 — that would be smoothed to a
     // tiny value and collapse the whole score (e.g. a perfect 1-3 word match
-    // scoring ~0). This matches NLTK, which reweights when higher orders are
-    // unavailable. A genuine zero-overlap precision (n-grams exist but none
-    // match) is still kept and smoothed below.
+    // scoring ~0). This mirrors NLTK's opt-in `auto_reweigh` option, which
+    // renormalizes the weights when higher-order n-grams are unavailable.
+    // (NLTK's default instead returns 0 for such short hypotheses; reweighting
+    // is the more useful behavior for a thresholded assertion.) A genuine
+    // zero-overlap precision (n-grams exist but none match) is still kept and
+    // smoothed below.
     if (totalCount === 0) {
       continue;
     }

--- a/test/assertions/bleu.test.ts
+++ b/test/assertions/bleu.test.ts
@@ -47,6 +47,26 @@ describe('BLEU score calculation', () => {
     expect(score).toBeGreaterThan(0.0);
   });
 
+  it('should score a perfect short match ~1.0 regardless of token count', () => {
+    // A candidate shorter than the 4-gram order has no 4-grams (and a 1-2 word
+    // candidate has no 3-/2-grams). Those unavailable orders must be dropped and
+    // the weights renormalized, not treated as zero-precision. Before the fix an
+    // exact 1-word match scored ~0.00001 and a 3-word match ~0.018, failing the
+    // default 0.5 threshold; only candidates of >= 4 tokens could ever pass.
+    expect(calculateBleuScore('cat', ['cat'])).toBeCloseTo(1, 5);
+    expect(calculateBleuScore('good dog', ['good dog'])).toBeCloseTo(1, 5);
+    expect(calculateBleuScore('the good dog', ['the good dog'])).toBeCloseTo(1, 5);
+  });
+
+  it('should still penalize an imperfect short match', () => {
+    // 2-token candidate, one of two unigrams matches; only orders 1-2 exist.
+    // The score should be well below 1 but non-zero (not collapsed by missing
+    // higher orders).
+    const score = calculateBleuScore('good cat', ['good dog']);
+    expect(score).toBeGreaterThan(0.0);
+    expect(score).toBeLessThan(1.0);
+  });
+
   it('should handle sentences with different lengths', () => {
     const references = ['The cat sat on the mat.'];
     const candidate = 'The cat sat.';

--- a/test/assertions/bleu.test.ts
+++ b/test/assertions/bleu.test.ts
@@ -60,11 +60,81 @@ describe('BLEU score calculation', () => {
 
   it('should still penalize an imperfect short match', () => {
     // 2-token candidate, one of two unigrams matches; only orders 1-2 exist.
-    // The score should be well below 1 but non-zero (not collapsed by missing
-    // higher orders).
+    // unigram precision = 1/2, bigram precision = 0 (smoothed to 1e-7), weights
+    // renormalized to 0.5 each over the two usable orders:
+    //   exp(0.5*ln(0.5) + 0.5*ln(1e-7)) ≈ 0.00022360679. Pin the exact value so
+    // the renormalization math is locked in; the old smoothed-zero behavior
+    // returned ~4.7e-6 (every missing order dragged the score down), so the
+    // > 1e-4 guard below fails on origin/main.
     const score = calculateBleuScore('good cat', ['good dog']);
-    expect(score).toBeGreaterThan(0.0);
+    expect(score).toBeCloseTo(Math.exp(0.5 * Math.log(0.5) + 0.5 * Math.log(1e-7)), 10);
+    expect(score).toBeGreaterThan(1e-4);
     expect(score).toBeLessThan(1.0);
+  });
+
+  it('should reduce a perfect short match to the brevity penalty when shorter than the reference', () => {
+    // Perfect n-gram precision on every usable order (product 1), so the score
+    // equals the brevity penalty alone. The candidate is shorter than the
+    // reference, so the penalty pulls it below 1 — but it no longer collapses to
+    // ~0 the way it did before short orders were dropped and renormalized.
+    expect(calculateBleuScore('cat', ['cat sat down'])).toBeCloseTo(Math.exp(1 - 3 / 1), 10);
+    expect(calculateBleuScore('good dog', ['good dog runs fast'])).toBeCloseTo(
+      Math.exp(1 - 4 / 2),
+      10,
+    );
+  });
+
+  it('should pick the best matching reference for a short candidate', () => {
+    // The renormalized short-candidate path must still take the best match across
+    // references: the exact reference yields a perfect score.
+    expect(calculateBleuScore('good dog', ['bad dog', 'good dog', 'the dog'])).toBeCloseTo(1, 5);
+  });
+
+  it('should be unchanged for candidates with all four n-gram orders (renormalization is a no-op)', () => {
+    // Every order 1-4 is present, so weightSum === 1 and dividing by it is a
+    // no-op: the result must match the pre-renormalization formula exactly,
+    // including non-uniform weights. Precisions are 5/6, 3/5, 2/4, 1/3.
+    const score = calculateBleuScore(
+      'the dog sat on the mat',
+      ['the cat sat on the mat'],
+      [0.4, 0.3, 0.2, 0.1],
+    );
+    expect(score).toBeCloseTo(
+      Math.exp(
+        0.4 * Math.log(5 / 6) +
+          0.3 * Math.log(3 / 5) +
+          0.2 * Math.log(2 / 4) +
+          0.1 * Math.log(1 / 3),
+      ),
+      10,
+    );
+  });
+
+  it('should not return NaN for a short candidate with custom n-gram weights', () => {
+    // Regression guard: dropping unavailable orders and renormalizing divides by
+    // the sum of the *usable* weights. With weights concentrated on higher orders
+    // a short candidate can have no usable weighted order. That must not divide by
+    // zero (NaN); it scores 0 (no scorable signal under these weights). A >= 4
+    // token candidate still has its 4-grams, so the same weights score normally.
+    expect(calculateBleuScore('cat', ['cat'], [0, 0, 0, 1])).toBe(0);
+    expect(calculateBleuScore('the good dog', ['the good dog'], [0, 0, 0, 1])).toBe(0);
+    expect(
+      calculateBleuScore('the very good dog', ['the very good dog'], [0, 0, 0, 1]),
+    ).toBeCloseTo(1, 5);
+    // A partially-weighted short candidate still scores finitely (not NaN).
+    expect(calculateBleuScore('good dog', ['good dog'], [0.5, 0.5, 0, 0])).not.toBeNaN();
+  });
+
+  it('should reject negative weights', () => {
+    // BLEU weights are non-negative by definition. Negatives would push the score
+    // far outside [0, 1] (a negative weight on a smoothed zero-precision order) and
+    // can make the usable-weight sum cancel to zero. Reject them outright.
+    expect(() => calculateBleuScore('a b', ['a b'], [1, -1, 0.5, 0.5])).toThrow(
+      'Weights must be non-negative',
+    );
+    expect(() => calculateBleuScore('a b c x', ['a b c d'], [0.5, 0.5, 1, -1])).toThrow(
+      'Weights must be non-negative',
+    );
   });
 
   it('should handle sentences with different lengths', () => {


### PR DESCRIPTION
## Summary

For BLEU, when the candidate is **shorter than the n-gram order** (e.g. a 3-word output has no 4-grams), that order has zero possible n-grams. The code recorded its precision as `0`, which is then smoothed to `1e-7` and multiplied into the geometric mean — collapsing the whole score. This conflates "no n-grams of this order can exist" with "n-grams exist but none matched."

```ts
// src/assertions/bleu.ts (before)
precisions.push(totalCount > 0 ? maxClippedCount / totalCount : 0);  // totalCount===0 → 0
...
const smoothedP = p === 0 ? 1e-7 : p;                                // → 1e-7, dominates
```

The result: a **perfect, identical** short output fails the default `0.5` threshold. Only candidates of ≥ 4 tokens can ever pass.

## Concrete example (exact match, candidate === reference)

| candidate | tokens | BLEU before | default 0.5 |
|---|---|---|---|
| `"cat"` | 1 | **0.00001** | FAIL ❌ |
| `"good dog"` | 2 | **0.00032** | FAIL ❌ |
| `"the good dog"` | 3 | **0.01778** | FAIL ❌ |
| `"the very good dog"` | 4 | 1.00000 | PASS |

After the fix all of these score **1.0**.

## Fix

Skip n-gram orders the candidate is too short to contain, and **renormalize the weights** over the remaining orders:

```ts
if (totalCount === 0) {
  continue; // no n-grams of this order can exist; drop it and reweight
}
precisions.push(maxClippedCount / totalCount);
usableWeights.push(weights[n - 1]);
...
const weightSum = usableWeights.reduce((acc, w) => acc + w, 0);
const weightedScore = precisions.reduce(
  (acc, p, i) => acc + (usableWeights[i] / weightSum) * Math.log(p === 0 ? 1e-7 : p),
  0,
);
```

Key distinction preserved: a **genuine zero-overlap** precision (n-grams of that order *do* exist but none match) is still recorded as `0` and smoothed to `1e-7` — that is a real miss and should be penalized. Only *impossible* orders (candidate too short) are dropped. For candidates of ≥ 4 tokens, every order is present, `weightSum === 1`, and behavior is identical to before.

### Relationship to NLTK

This mirrors NLTK's opt-in [`auto_reweigh`](https://www.nltk.org/api/nltk.translate.bleu_score.html) option, which renormalizes the weights uniformly when higher-order n-grams are unavailable. For the default uniform weights `[0.25]*4` the two are equivalent (dropping one of four equal weights and renormalizing → `1/3` each, matching NLTK's `(1/hyp_len,)*hyp_len`).

To be precise: NLTK's **default** (`auto_reweigh=False`) instead returns `0.0` for a hypothesis shorter than the n-gram order (emitting a "no n-gram overlaps" warning). This PR deliberately chooses the reweighting behavior because returning ~0 for a *perfect* short match is surprising and unhelpful for a thresholded assertion — but it is the `auto_reweigh` behavior, not NLTK's default, and the code comment now says so.

## Test plan

- Added `should score a perfect short match ~1.0 regardless of token count` — **fails before** the fix (`expected 0.0000056 to be close to 1`), passes after.
- Added `should still penalize an imperfect short match` (2-token partial match → `0 < score < 1`).
- All existing BLEU tests still pass (25 total), including brevity-penalty, closest-reference tie-break, and multi-reference cases. `npm run tsc`, `npm run l`, `npm run f` clean.