### PR TITLE
fix(share): preserve blob refs per result row

### DIFF
--- a/src/blobs/shareUpload.ts
+++ b/src/blobs/shareUpload.ts
@@ -16,6 +16,12 @@ export function createRemoteBlobUploadCache(): RemoteBlobUploadCache {
   return new Map();
 }
 
+// Key uploads by result-row coordinates, not just by hash: the remote records the
+// (promptIdx, testIdx) of each upload, so a blob referenced from multiple rows must
+// upload once per row to preserve each row's provenance. Re-uploading the same bytes
+// per row is intentional — the remote dedupes storage by content. Use `?? null` (not
+// `||`) so a falsy index 0 (the first row of every eval) stays distinct from a
+// coordinate-less reference.
 function getUploadCacheKey(hash: string, context: ShareBlobUploadContext): string {
   return JSON.stringify({
     hash,
@@ -73,8 +79,8 @@ function uploadBlobForShare(
   let pending = cache.get(cacheKey);
   if (!pending) {
     // Cache the whole authorize-and-upload flow synchronously so concurrent and
-    // repeated references to the same blob within one result row share one
-    // authorization check and one upload without collapsing distinct row provenance.
+    // repeated references that share a cache key (same blob, same row coordinates)
+    // reuse one authorization check and one upload without collapsing row provenance.
     pending = uploadAuthorizedBlob(hash, context);
     cache.set(cacheKey, pending);
   }

--- a/src/blobs/shareUpload.ts
+++ b/src/blobs/shareUpload.ts
@@ -16,6 +16,15 @@ export function createRemoteBlobUploadCache(): RemoteBlobUploadCache {
   return new Map();
 }
 
+function getUploadCacheKey(hash: string, context: ShareBlobUploadContext): string {
+  return JSON.stringify({
+    hash,
+    remoteEvalId: context.remoteEvalId,
+    promptIdx: context.promptIdx ?? null,
+    testIdx: context.testIdx ?? null,
+  });
+}
+
 async function uploadAuthorizedBlob(
   hash: string,
   context: ShareBlobUploadContext,
@@ -60,12 +69,14 @@ function uploadBlobForShare(
   cache: RemoteBlobUploadCache,
   context: ShareBlobUploadContext,
 ): Promise<boolean> {
-  let pending = cache.get(hash);
+  const cacheKey = getUploadCacheKey(hash, context);
+  let pending = cache.get(cacheKey);
   if (!pending) {
     // Cache the whole authorize-and-upload flow synchronously so concurrent and
-    // repeated references to the same hash share one authorization check and one upload.
+    // repeated references to the same blob within one result row share one
+    // authorization check and one upload without collapsing distinct row provenance.
     pending = uploadAuthorizedBlob(hash, context);
-    cache.set(hash, pending);
+    cache.set(cacheKey, pending);
   }
   return pending;
 }

--- a/test/blobs/shareUpload.test.ts
+++ b/test/blobs/shareUpload.test.ts
@@ -115,6 +115,43 @@ describe('share-time blob upload', () => {
     });
   });
 
+  it('keeps a zero-index result row distinct from a coordinate-less reference', async () => {
+    // Pins the `?? null` (not `||`) choice in getUploadCacheKey: promptIdx/testIdx
+    // of 0 is the first row of every eval and must not collapse into a reference
+    // that carries no coordinates. A regression to `|| null` would dedupe these two
+    // into a single upload, dropping the (0, 0) row's provenance.
+    const hash = '0'.repeat(64);
+    const cache = createRemoteBlobUploadCache();
+
+    await uploadBlobRefsForShare(`promptfoo://blob/${hash}`, cache, {
+      localEvalId: 'local-eval-zero',
+      remoteEvalId: 'remote-eval-zero',
+      promptIdx: 0,
+      testIdx: 0,
+    });
+    await uploadBlobRefsForShare(`promptfoo://blob/${hash}`, cache, {
+      localEvalId: 'local-eval-zero',
+      remoteEvalId: 'remote-eval-zero',
+    });
+
+    expect(getShareAuthorizedBlob).toHaveBeenCalledTimes(2);
+    expect(uploadBlobRemote).toHaveBeenCalledTimes(2);
+    expect(uploadBlobRemote).toHaveBeenNthCalledWith(1, Buffer.from('image-bytes'), 'image/png', {
+      evalId: 'remote-eval-zero',
+      kind: 'image',
+      location: 'share',
+      promptIdx: 0,
+      testIdx: 0,
+    });
+    expect(uploadBlobRemote).toHaveBeenNthCalledWith(2, Buffer.from('image-bytes'), 'image/png', {
+      evalId: 'remote-eval-zero',
+      kind: 'image',
+      location: 'share',
+      promptIdx: undefined,
+      testIdx: undefined,
+    });
+  });
+
   it('does not upload a copied blob URI that is not share-authorized for the eval', async () => {
     const hash = 'd'.repeat(64);
     vi.mocked(getShareAuthorizedBlob).mockResolvedValue(null);

--- a/test/blobs/shareUpload.test.ts
+++ b/test/blobs/shareUpload.test.ts
@@ -47,7 +47,7 @@ describe('share-time blob upload', () => {
     });
   });
 
-  it('uploads each referenced blob only once across chunks', async () => {
+  it('uploads each referenced blob only once when the share context is unchanged', async () => {
     const hash = 'a'.repeat(64);
     const cache = createRemoteBlobUploadCache();
 
@@ -62,8 +62,8 @@ describe('share-time blob upload', () => {
     await uploadBlobRefsForShare(`promptfoo://blob/${hash}`, cache, {
       localEvalId: 'local-eval-123',
       remoteEvalId: 'remote-eval-123',
-      promptIdx: 4,
-      testIdx: 3,
+      promptIdx: 2,
+      testIdx: 1,
     });
 
     expect(getShareAuthorizedBlob).toHaveBeenCalledOnce();
@@ -75,6 +75,43 @@ describe('share-time blob upload', () => {
       location: 'share',
       promptIdx: 2,
       testIdx: 1,
+    });
+  });
+
+  it('uploads the same blob again when it appears in a different result row', async () => {
+    const hash = '7'.repeat(64);
+    const cache = createRemoteBlobUploadCache();
+
+    await uploadBlobRefsForShare(`promptfoo://blob/${hash}`, cache, {
+      localEvalId: 'local-eval-123',
+      remoteEvalId: 'remote-eval-123',
+      promptIdx: 2,
+      testIdx: 1,
+    });
+    await uploadBlobRefsForShare(`promptfoo://blob/${hash}`, cache, {
+      localEvalId: 'local-eval-123',
+      remoteEvalId: 'remote-eval-123',
+      promptIdx: 4,
+      testIdx: 3,
+    });
+
+    expect(getShareAuthorizedBlob).toHaveBeenCalledTimes(2);
+    expect(getShareAuthorizedBlob).toHaveBeenNthCalledWith(1, hash, 'local-eval-123');
+    expect(getShareAuthorizedBlob).toHaveBeenNthCalledWith(2, hash, 'local-eval-123');
+    expect(uploadBlobRemote).toHaveBeenCalledTimes(2);
+    expect(uploadBlobRemote).toHaveBeenNthCalledWith(1, Buffer.from('image-bytes'), 'image/png', {
+      evalId: 'remote-eval-123',
+      kind: 'image',
+      location: 'share',
+      promptIdx: 2,
+      testIdx: 1,
+    });
+    expect(uploadBlobRemote).toHaveBeenNthCalledWith(2, Buffer.from('image-bytes'), 'image/png', {
+      evalId: 'remote-eval-123',
+      kind: 'image',
+      location: 'share',
+      promptIdx: 4,
+      testIdx: 3,
     });
   });
 


### PR DESCRIPTION
## Summary
- preserve separate remote blob-reference uploads when the same hash appears in different result rows during cloud sharing
- keep dedupe for repeated references within the same result context so one row still shares one authorize+upload flow
- add a regression test that fails if later result-row coordinates are collapsed into the first upload

## Validation
- `npm_config_cache=/tmp/promptfoo-npm-cache npx vitest@4.0.4 run --config <temporary minimal config> test/blobs/shareUpload.test.ts`
- `npm_config_cache=/tmp/promptfoo-npm-cache npx @biomejs/biome@2.4.16 lint src/blobs/shareUpload.ts test/blobs/shareUpload.test.ts`

## Notes
- Full repo `npm ci` in this worktree is blocked by Socket policy on `esbuild@0.28.1`, so validation used a standalone Vitest run against the touched unit with a temporary minimal config.
