### PR TITLE
fix(redteam): surface remote generation body read failures

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -625,12 +625,13 @@ async function fetchAndReadBody(
       // Surface the URL and HTTP response context so opaque body-read failures
       // (e.g. "TypeError: terminated" from a Cloudflare-originated 403) include
       // actionable diagnostics instead of a bare platform error.
-      throw new Error(
+      const wrappedError = new Error(
         `Error reading response body from ${url}: ${
           (err as Error).message
         }. HTTP ${resp.status} ${resp.statusText}`,
-        { cause: err },
-      );
+      ) as Error & { cause?: unknown };
+      wrappedError.cause = err;
+      throw wrappedError;
     }
   }
   // Unreachable: loop always returns or throws, but TypeScript needs this

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -11,14 +11,15 @@ import logger from './logger';
 import { getRequestTimeoutMs } from './providers/shared';
 import { getConfigDirectoryPath } from './util/config/manage';
 import { sha256 } from './util/createHash';
-import { isTransientConnectionError } from './util/fetch/errors';
+import { isAbortError, isTransientConnectionError } from './util/fetch/errors';
 import { fetchWithRetries, getFetchWithProxyHeaders } from './util/fetch/index';
 import {
   getCloudBearerToken,
   getCloudTaskTeamId,
+  getRequestUrlString,
   PROMPTFOO_TEAM_ID_HEADER,
 } from './util/fetch/monkeyPatchFetch';
-import { isSecretField, looksLikeSecret } from './util/sanitizer';
+import { isSecretField, looksLikeSecret, sanitizeUrl } from './util/sanitizer';
 import { sleep } from './util/time';
 import type { Cache } from 'cache-manager';
 
@@ -622,11 +623,19 @@ async function fetchAndReadBody(
         await sleep(backoffMs);
         continue;
       }
+      // Preserve cancellation: an aborted body read rejects with an AbortError, and
+      // callers (e.g. evaluator.ts) suppress expected cancellation by checking
+      // `err.name === 'AbortError'`. Wrapping it would reset the name to 'Error' and
+      // turn cancelled evals into ordinary provider failures, so rethrow aborts as-is.
+      if (isAbortError(err)) {
+        throw err;
+      }
       // Surface the URL and HTTP response context so opaque body-read failures
       // (e.g. "TypeError: terminated" from a Cloudflare-originated 403) include
-      // actionable diagnostics instead of a bare platform error.
+      // actionable diagnostics instead of a bare platform error. Sanitize the URL so
+      // credential-bearing userinfo / query params are not leaked into logs.
       const wrappedError = new Error(
-        `Error reading response body from ${url}: ${
+        `Error reading response body from ${sanitizeUrl(getRequestUrlString(url))}: ${
           (err as Error).message
         }. HTTP ${resp.status} ${resp.statusText}`,
       ) as Error & { cause?: unknown };

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -622,7 +622,15 @@ async function fetchAndReadBody(
         await sleep(backoffMs);
         continue;
       }
-      throw err;
+      // Surface the URL and HTTP response context so opaque body-read failures
+      // (e.g. "TypeError: terminated" from a Cloudflare-originated 403) include
+      // actionable diagnostics instead of a bare platform error.
+      throw new Error(
+        `Error reading response body from ${url}: ${
+          (err as Error).message
+        }. HTTP ${resp.status} ${resp.statusText}`,
+        { cause: err },
+      );
     }
   }
   // Unreachable: loop always returns or throws, but TypeScript needs this

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -68,7 +68,7 @@ import {
   type TestSuite,
 } from './types/index';
 import { type ApiProvider, isApiProvider } from './types/providers';
-import { isNonTransientHttpStatus } from './util/fetch/errors';
+import { isAbortError, isNonTransientHttpStatus } from './util/fetch/errors';
 import { filterByRange } from './util/filterRange';
 import { warnEmptyFilterRange } from './util/filterRangeWarn';
 import { loadFunction, parseFileUrl } from './util/functions/loadFunction';
@@ -587,16 +587,12 @@ function applyGradingResult(row: EvaluateResult, checkResult: GradingResult) {
 
 const ABORTED_GRADING_PREFIX = 'Aborted: ';
 
-function isAbortShapedError(error: unknown): boolean {
-  return error instanceof Error && (error.name === 'AbortError' || error.name === 'AbortException');
-}
-
 function applyGradingError(row: EvaluateResult, error: unknown, abortSignal?: AbortSignal) {
   const errorAsError = error instanceof Error ? error : undefined;
   // Require both signals: a third-party SDK that throws `AbortError` during a
   // non-aborted run is a real bug, and a real SyntaxError caught microseconds
   // after an unrelated abort is also a real bug.
-  const aborted = Boolean(abortSignal?.aborted) && isAbortShapedError(error);
+  const aborted = Boolean(abortSignal?.aborted) && isAbortError(error);
 
   if (aborted) {
     // Skip stack serialization on the abort path — debug logs usually go

--- a/src/util/fetch/errors.ts
+++ b/src/util/fetch/errors.ts
@@ -303,3 +303,12 @@ export function isTransientConnectionError(error: Error | undefined): boolean {
     message.includes('socket hang up')
   );
 }
+
+/**
+ * True when an error represents an aborted/cancelled operation (an AbortController
+ * signal firing). Callers use this to suppress expected cancellation rather than
+ * treating it as a real failure, so the abort's `.name` must be preserved upstream.
+ */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'AbortException');
+}

--- a/src/util/fetch/monkeyPatchFetch.ts
+++ b/src/util/fetch/monkeyPatchFetch.ts
@@ -22,7 +22,7 @@ function isConnectionError(error: Error) {
 }
 
 /** Extracts the request URL as a string. A `Request`'s `toString()` is "[object Request]", so read `.url`. */
-function getRequestUrlString(url: string | URL | Request): string {
+export function getRequestUrlString(url: string | URL | Request): string {
   return url instanceof Request ? url.url : url.toString();
 }
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1347,6 +1347,33 @@ describe('fetchWithCache', () => {
       expect(mockFetchWithRetries).toHaveBeenCalledTimes(1);
     });
 
+    it('should surface URL and HTTP context when body read fails for non-idempotent requests', async () => {
+      // Simulate a Cloudflare-style 403 where the response body stream is already
+      // terminated before it can be read. The raw error "TypeError: terminated"
+      // alone gives no clue about the endpoint or HTTP status.
+      mockFetchWithRetries.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        text: () => Promise.reject(new TypeError('terminated')),
+        headers: new Headers({ 'content-type': 'text/html' }),
+      } as unknown as Response);
+
+      const error = await fetchWithCache(url, { method: 'POST', body: '{}' }, 1000).catch(
+        (err: unknown) => err,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain(`Error reading response body from ${url}:`);
+      expect((error as Error).message).toContain('terminated');
+      expect((error as Error).message).toContain('HTTP 403 Forbidden');
+      // Preserve the original error as cause for downstream inspection
+      expect((error as Error).cause).toBeInstanceOf(TypeError);
+      expect(((error as Error).cause as Error).message).toBe('terminated');
+      // Only 1 fetch — no body retry for non-idempotent methods
+      expect(mockFetchWithRetries).toHaveBeenCalledTimes(1);
+    });
+
     it('should not catch fetchWithRetries errors in body retry loop', async () => {
       // fetchWithRetries itself throws — should propagate directly, not retry
       mockFetchWithRetries.mockRejectedValueOnce(new Error('ECONNRESET from fetch'));

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1374,6 +1374,56 @@ describe('fetchWithCache', () => {
       expect(mockFetchWithRetries).toHaveBeenCalledTimes(1);
     });
 
+    it('should preserve AbortError when the body read is aborted (no wrapping)', async () => {
+      // A signal that fires after headers but before the body is consumed rejects
+      // resp.text() with an AbortError. evaluator.ts suppresses expected cancellation
+      // via `err.name === 'AbortError'`, so the name must survive — wrapping it in a
+      // plain Error would turn a cancelled eval into an ordinary provider failure.
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetchWithRetries.mockResolvedValueOnce({
+        ok: false,
+        status: 200,
+        statusText: 'OK',
+        text: () => Promise.reject(abortError),
+        headers: new Headers(),
+      } as unknown as Response);
+
+      const error = await fetchWithCache(url, { method: 'POST', body: '{}' }, 1000).catch(
+        (err: unknown) => err,
+      );
+
+      // Rethrown unchanged — same instance, name intact (not collapsed to 'Error').
+      expect(error).toBe(abortError);
+      expect((error as Error).name).toBe('AbortError');
+      expect(mockFetchWithRetries).toHaveBeenCalledTimes(1);
+    });
+
+    it('should sanitize credential-bearing URLs in body-read failure messages', async () => {
+      // The error message is logged/surfaced, so secrets in the URL (query tokens,
+      // userinfo) must be redacted via sanitizeUrl rather than echoed verbatim.
+      mockFetchWithRetries.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        text: () => Promise.reject(new TypeError('terminated')),
+        headers: new Headers({ 'content-type': 'text/html' }),
+      } as unknown as Response);
+
+      const secretUrl = 'https://api.example.com/task?api_key=SUPER_SECRET_TOKEN';
+      const error = await fetchWithCache(secretUrl, { method: 'POST', body: '{}' }, 1000).catch(
+        (err: unknown) => err,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain('Error reading response body from');
+      expect((error as Error).message).toContain('HTTP 403 Forbidden');
+      // The secret must not leak into the (logged) error message.
+      expect((error as Error).message).not.toContain('SUPER_SECRET_TOKEN');
+      // Original error preserved as cause.
+      expect((error as Error).cause).toBeInstanceOf(TypeError);
+    });
+
     it('should not catch fetchWithRetries errors in body retry loop', async () => {
       // fetchWithRetries itself throws — should propagate directly, not retry
       mockFetchWithRetries.mockRejectedValueOnce(new Error('ECONNRESET from fetch'));

--- a/test/util/fetch/errors.test.ts
+++ b/test/util/fetch/errors.test.ts
@@ -5,11 +5,31 @@ import {
   formatRateLimitDetail,
   formatRateLimitErrorMessage,
   HttpRateLimitError,
+  isAbortError,
   isHardQuotaCode,
   isHttpRateLimitError,
   isNonTransientHttpStatus,
   isTransientConnectionError,
 } from '../../../src/util/fetch/errors';
+
+describe('isAbortError', () => {
+  it('returns true for AbortError and AbortException', () => {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    const abortException = new Error('aborted');
+    abortException.name = 'AbortException';
+    expect(isAbortError(abortError)).toBe(true);
+    expect(isAbortError(abortException)).toBe(true);
+  });
+
+  it('returns false for other errors and non-errors', () => {
+    expect(isAbortError(new TypeError('terminated'))).toBe(false);
+    expect(isAbortError(new Error('boom'))).toBe(false);
+    expect(isAbortError({ name: 'AbortError' })).toBe(false);
+    expect(isAbortError('AbortError')).toBe(false);
+    expect(isAbortError(undefined)).toBe(false);
+  });
+});
 
 describe('isNonTransientHttpStatus', () => {
   it('returns true for 401 Unauthorized', () => {


### PR DESCRIPTION
## Summary

Promptfoo's hosted redteam generation currently fails opaquely when the remote endpoint returns a response whose body cannot be read cleanly, such as the Cloudflare-blocked `403 Forbidden` HTML challenge reported in #9679.

The fetch/cache layer already has the request URL and HTTP status in scope at the moment `resp.text()` fails, but it rethrows the raw platform error (for example `TypeError: terminated`) without any context. That leaves redteam extraction logging with an unhelpful warning and makes the issue look like a generic transport crash instead of an actionable remote-generation failure.

This PR keeps behavior the same, but upgrades the diagnostics:

- wraps body-read failures with the request URL
- includes `HTTP <status> <statusText>` when available
- preserves the original error as `cause`
- adds a focused regression test for the non-idempotent POST path

## Verification

- `npx vitest run test/cache.test.ts`
- `npx vitest run test/redteam/extraction/util.test.ts`
- `npx vitest run test/redteam/extraction/purpose.test.ts test/redteam/extraction/entities.test.ts`
- Manual network check on current upstream behavior:
  - `GET https://api.promptfoo.app/health` -> `200 OK`
  - `POST https://api.promptfoo.app/api/v1/task` -> Cloudflare `403` HTML block from this network

## Notes

This is intentionally a diagnostics-only fix. It does not attempt to bypass or change the remote service / Cloudflare policy itself.
