### PR TITLE
ci(codecov): make project coverage status informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,10 +5,15 @@ coverage:
   status:
     project:
       default:
-        # Require overall project coverage to not decrease
+        # Overall coverage is gated in-repo by the coverage ratchet
+        # (`npm run test:coverage:ratchet`, run in CI as the "Check Backend/
+        # Frontend Coverage Ratchets" steps), not by Codecov. Keep this status
+        # informational so Codecov measurement noise — carryforward flags,
+        # sharded/partial uploads — can't fail PRs that don't change source
+        # (e.g. a dependency bump reporting a spurious -0.01%).
         target: auto
         threshold: 0%
-        informational: false
+        informational: true
     patch:
       default:
         # Require new code in PRs to have reasonable coverage
@@ -39,9 +44,13 @@ flag_management:
   default_rules:
     carryforward: true
     statuses:
+      # Per-flag project status is informational for the same reason as the
+      # default project status above: overall coverage is gated by the in-repo
+      # ratchet, so this status only needs to surface info, not block merges.
       - type: project
         target: auto
         threshold: 0%
+        informational: true
       - type: patch
         target: 50%
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,12 +5,14 @@ coverage:
   status:
     project:
       default:
-        # Overall coverage is gated in-repo by the coverage ratchet
-        # (`npm run test:coverage:ratchet`, run in CI as the "Check Backend/
-        # Frontend Coverage Ratchets" steps), not by Codecov. Keep this status
-        # informational so Codecov measurement noise — carryforward flags,
-        # sharded/partial uploads — can't fail PRs that don't change source
-        # (e.g. a dependency bump reporting a spurious -0.01%).
+        # Backend (`src/`) and frontend (`src/app/src/`) coverage are gated
+        # in-repo by the coverage ratchet (`npm run test:coverage:ratchet`, run
+        # in CI as the "Check Backend/Frontend Coverage Ratchets" steps), not by
+        # Codecov. (The `site` flag has no ratchet, so it is informational-only
+        # — no in-repo gate.) Keep this status informational so Codecov
+        # measurement noise — carryforward flags, sharded/partial uploads —
+        # can't fail PRs that don't change source (e.g. a dependency bump
+        # reporting a spurious -0.01%). codecov/project is not a required check.
         target: auto
         threshold: 0%
         informational: true
@@ -44,9 +46,10 @@ flag_management:
   default_rules:
     carryforward: true
     statuses:
-      # Per-flag project status is informational for the same reason as the
-      # default project status above: overall coverage is gated by the in-repo
-      # ratchet, so this status only needs to surface info, not block merges.
+      # Per-flag project status is informational. The backend and frontend
+      # flags are gated in-repo by the coverage ratchet, so a blocking Codecov
+      # status would be redundant; the site flag has no ratchet, so we accept it
+      # as informational-only rather than block PRs on Codecov measurement noise.
       - type: project
         target: auto
         threshold: 0%


### PR DESCRIPTION
## Summary

Removes the frequent, spurious `codecov/project` check failures on PRs that change no source code (most visibly Renovate dependency bumps).

The `codecov/project` status was configured with `target: auto`, `threshold: 0%`, and `informational: false`, so it reported a red ✗ on **any** overall-coverage decrease — including sub-0.1% measurement noise. Codecov's project total drifts by hundredths of a percent across runs (carryforward flags + sharded/partial uploads, where coverage uploads from only one job), so a deps-only PR routinely shows a `-0.01%` and goes red even though it can't change real coverage.

Example: #9753 (esbuild 0.28.0 → 0.28.1) — only failing check was `codecov/project — 79.05% (-0.01%)`.

> Note: `codecov/project` is **not** a required status check (verified against the repo's "Status Checks" ruleset), so it never actually blocked merge — it was review noise / a misleading red ✗ on every source-less PR. This change removes that noise.

## What changed

- `coverage.status.project.default.informational` → `true`
- `flag_management.default_rules.statuses` project entry → `informational: true`
- `codecov/patch` (new-code coverage ≥ 50%) is **left blocking** — it isn't redundant with the ratchet and doesn't flake on source-less PRs (it reports "Coverage not affected" → passes).

Codecov still posts the project status; it just reports informationally instead of red.

## Why informational (not a bigger threshold)

Backend (`src/`) and frontend (`src/app/src/`) coverage are already gated **deterministically in-repo** by the coverage ratchet (`npm run test:coverage:ratchet`, run in CI as the *Check Backend/Frontend Coverage Ratchets* steps). The CI workflow comments already say `Codecov upload is informational (coverage is gated in-repo, not by Codecov)` — this PR makes the *status* consistent with the stance the *uploads* already took. A larger `threshold` would only reduce the flake rate; carryforward + sharded uploads can still drift past any fixed band, so informational eliminates the false failures rather than just thinning them.

## Known tradeoff: `site` coverage

The in-repo ratchet covers **only** backend and frontend — there is **no `site` ratchet** (`main.yml`: *"Site has no coverage ratchet, so the Codecov upload is the only consumer of this report."*). So for the `site` flag (`site/src/`), the now-informational Codecov project status was the only (already non-required, already flaky) coverage signal. After this change, `site/src/` coverage is not gated by anything.

This is acceptable for a noise-reduction change — that gate was non-required and flaky anyway — but it's called out here honestly. The clean follow-up, if site coverage should be enforced, is to add a `site` entry to `COVERAGE_RATCHET_REPORTS` in `scripts/checkCoverageRatchets.ts` and wire a "Check Site Coverage Ratchets" step, rather than relying on a Codecov status. Out of scope for this PR.

## Validation

Validated against Codecov's schema endpoint (`POST https://codecov.io/validate`) → **Valid!**, parsed result confirming `project.default.informational: true` and `patch.default.informational: false`.
