### PR TITLE
fix(csv): unescape all escaped commas in array metadata values

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -196,7 +196,7 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
           const values = value
             .split(/(?<!\\),/)
             .map((v) => v.trim())
-            .map((v) => v.replace('\\,', ','));
+            .map((v) => v.replace(/\\,/g, ','));
           metadata[arrayKey] = values;
         }
       } else {

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -170,6 +170,27 @@ describe('testCaseFromCsvRow', () => {
     expect(result).toEqual(expectedTestCase);
   });
 
+  it('should split on unescaped commas while unescaping multiple escaped commas per value', () => {
+    const row: CsvRow = {
+      '__metadata:tags[]': 'a\\,b\\,c,d\\,e',
+      var1: 'value1',
+    };
+
+    const expectedTestCase: TestCase = {
+      vars: {
+        var1: 'value1',
+      },
+      assert: [],
+      options: {},
+      metadata: {
+        tags: ['a,b,c', 'd,e'],
+      },
+    };
+
+    const result = testCaseFromCsvRow(row);
+    expect(result).toEqual(expectedTestCase);
+  });
+
   it('should handle single value metadata', () => {
     const row: CsvRow = {
       '__metadata:category': 'test-category',

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -149,6 +149,27 @@ describe('testCaseFromCsvRow', () => {
     expect(result).toEqual(expectedTestCase);
   });
 
+  it('should unescape every escaped comma within an array metadata value', () => {
+    const row: CsvRow = {
+      '__metadata:tags[]': 'a\\,b\\,c',
+      var1: 'value1',
+    };
+
+    const expectedTestCase: TestCase = {
+      vars: {
+        var1: 'value1',
+      },
+      assert: [],
+      options: {},
+      metadata: {
+        tags: ['a,b,c'],
+      },
+    };
+
+    const result = testCaseFromCsvRow(row);
+    expect(result).toEqual(expectedTestCase);
+  });
+
   it('should handle single value metadata', () => {
     const row: CsvRow = {
       '__metadata:category': 'test-category',


### PR DESCRIPTION
The array-metadata CSV columns (`__metadata:foo[]`) let you escape a comma inside a value with `\,`. The split regex `/(?<!\\),/` correctly keeps escaped commas from acting as separators, but the unescape step uses `value.replace('\\,', ',')`. With a string as the first argument, `String.prototype.replace` only replaces the first match, so any value containing more than one escaped comma keeps every `\,` after the first.

Example: a cell `a\,b\,c` should parse to the single tag `a,b,c`, but today it yields `a,b\,c`.

The fix is a one-liner: use a global regex so every escaped comma is unescaped.

```diff
-            .map((v) => v.replace('\\,', ','));
+            .map((v) => v.replace(/\\,/g, ','));
```

Behavior is identical for values with at most one escaped comma, so the existing escaped-comma test is unaffected. I added a regression test covering the multi-escape case.

Verified with `npx vitest run test/csv.test.ts`: the new test fails on `main` and passes with the fix, 65 tests pass total.
