### PR TITLE
fix(csv): preserve quoted commas in contains-any/all assertion values

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -136,14 +136,19 @@ assert:
 
 For case insensitive matching, use `icontains-any`.
 
-When `contains-any`, `contains-all`, or their case-insensitive and inverse variants are written as assertion strings, separate values with commas. Wrap a value that contains a comma in double quotes:
+Use the structured assertion form in YAML configs:
 
 ```yaml
 assert:
-  - 'contains-all:"1,000",in stock'
+  - type: contains-all
+    value:
+      - '1,000'
+      - in stock
 ```
 
-This checks for the two values `1,000` and `in stock`. See [CSV test cases](/docs/configuration/test-cases#csv-with-assertions) for the additional escaping needed inside a CSV cell.
+This checks for the two values `1,000` and `in stock`.
+
+Compact assertion strings in CSV, XLSX, and Google Sheets `__expected` columns use comma-separated values. Quote values containing commas; see [CSV test cases](/docs/configuration/test-cases#csv-with-assertions) for escaping details.
 
 ### Regex
 

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -136,6 +136,15 @@ assert:
 
 For case insensitive matching, use `icontains-any`.
 
+When `contains-any`, `contains-all`, or their case-insensitive and inverse variants are written as assertion strings, separate values with commas. Wrap a value that contains a comma in double quotes:
+
+```yaml
+assert:
+  - 'contains-all:"1,000",in stock'
+```
+
+This checks for the two values `1,000` and `in stock`. See [CSV test cases](/docs/configuration/test-cases#csv-with-assertions) for the additional escaping needed inside a CSV cell.
+
 ### Regex
 
 The `regex` assertion checks if the LLM output matches the provided regular expression.

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -405,25 +405,27 @@ All assertion types can be used in `__expected`. The column supports exactly one
 
 The general format is `type:value` or `type(threshold):value`. Values without a prefix default to `equals`.
 
-| Syntax                     | Type            | Example                                     |
-| -------------------------- | --------------- | ------------------------------------------- |
-| `value`                    | `equals`        | `Paris`                                     |
-| `contains:value`           | `contains`      | `contains:Paris`                            |
-| `icontains:value`          | `icontains`     | `icontains:paris`                           |
-| `starts-with:value`        | `starts-with`   | `starts-with:The answer`                    |
-| `regex:pattern`            | `regex`         | `regex:^Hello.*world$`                      |
-| `is-json`                  | `is-json`       | `is-json`                                   |
-| `contains-json`            | `contains-json` | `contains-json`                             |
-| `similar(threshold):value` | `similar`       | `similar(0.8):Hello world`                  |
-| `llm-rubric:criteria`      | `llm-rubric`    | `llm-rubric:Is helpful and accurate`        |
-| `grade:criteria`           | `llm-rubric`    | `grade:Does not mention being an AI`        |
-| `factuality:reference`     | `factuality`    | `factuality:Paris is the capital of France` |
-| `javascript:code`          | `javascript`    | `javascript:output.length < 100`            |
-| `fn:code`                  | `javascript`    | `fn:output.includes('hello')`               |
-| `python:code`              | `python`        | `python:len(output) > 10`                   |
-| `file://path`              | External file   | `file://assertions/custom.js`               |
-| `not-type:value`           | Negated         | `not-contains:error`                        |
-| `levenshtein(N):value`     | `levenshtein`   | `levenshtein(5):expected text`              |
+| Syntax                       | Type            | Example                                     |
+| ---------------------------- | --------------- | ------------------------------------------- |
+| `value`                      | `equals`        | `Paris`                                     |
+| `contains:value`             | `contains`      | `contains:Paris`                            |
+| `icontains:value`            | `icontains`     | `icontains:paris`                           |
+| `contains-any:value1,value2` | `contains-any`  | `contains-any:Paris,London`                 |
+| `contains-all:value1,value2` | `contains-all`  | `contains-all:Paris,France`                 |
+| `starts-with:value`          | `starts-with`   | `starts-with:The answer`                    |
+| `regex:pattern`              | `regex`         | `regex:^Hello.*world$`                      |
+| `is-json`                    | `is-json`       | `is-json`                                   |
+| `contains-json`              | `contains-json` | `contains-json`                             |
+| `similar(threshold):value`   | `similar`       | `similar(0.8):Hello world`                  |
+| `llm-rubric:criteria`        | `llm-rubric`    | `llm-rubric:Is helpful and accurate`        |
+| `grade:criteria`             | `llm-rubric`    | `grade:Does not mention being an AI`        |
+| `factuality:reference`       | `factuality`    | `factuality:Paris is the capital of France` |
+| `javascript:code`            | `javascript`    | `javascript:output.length < 100`            |
+| `fn:code`                    | `javascript`    | `fn:output.includes('hello')`               |
+| `python:code`                | `python`        | `python:len(output) > 10`                   |
+| `file://path`                | External file   | `file://assertions/custom.js`               |
+| `not-type:value`             | Negated         | `not-contains:error`                        |
+| `levenshtein(N):value`       | `levenshtein`   | `levenshtein(5):expected text`              |
 
 When the `__expected` field is provided, the success and failure statistics in the evaluation summary will be based on whether the expected criteria are met.
 

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -336,7 +336,7 @@ translated_text,__expected
 
 If you write `"contains-any: <b> </span>"`, promptfoo treats `<b> </span>` as a single search term rather than two separate tags.
 
-To match a value that itself contains a comma, wrap that value in double quotes. Escape a double quote inside a quoted value by doubling it (`""`) or with a backslash (`\"`):
+To match a value that itself contains a comma, wrap that value in double quotes. Because the assertion is inside a quoted CSV cell, write each of those wrapping quotes twice:
 
 ```csv title="test_cases.csv"
 text,__expected
@@ -344,6 +344,8 @@ text,__expected
 ```
 
 Here `"1,000"` is a single search term (the comma is preserved), while `in stock` is a second term. The same quoting rules apply when these assertions are written as a plain string anywhere else (for example via `__expected` in JSON test files).
+
+At the assertion-string level, escape a literal double quote inside a quoted value as `\"` or `""`. In a CSV file, remember to apply CSV escaping as well by doubling every double quote in the cell.
 :::
 
 ### Special CSV Columns

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -327,7 +327,7 @@ question,__expected1,__expected2,__expected3
 ```
 
 :::note
-**contains-any** and **contains-all** expect comma-delimited values inside the `__expected` column.
+**contains-any**, **icontains-any**, **contains-all**, and **icontains-all** expect comma-delimited values inside the `__expected` column. Surrounding whitespace around each value is trimmed.
 
 ```csv title="test_cases.csv"
 translated_text,__expected
@@ -335,6 +335,15 @@ translated_text,__expected
 ```
 
 If you write `"contains-any: <b> </span>"`, promptfoo treats `<b> </span>` as a single search term rather than two separate tags.
+
+To match a value that itself contains a comma, wrap that value in double quotes. Escape a double quote inside a quoted value by doubling it (`""`) or with a backslash (`\"`):
+
+```csv title="test_cases.csv"
+text,__expected
+"1,000 items in stock","contains-all: ""1,000"",in stock"
+```
+
+Here `"1,000"` is a single search term (the comma is preserved), while `in stock` is a second term. The same quoting rules apply when these assertions are written as a plain string anywhere else (for example via `__expected` in JSON test files).
 :::
 
 ### Special CSV Columns

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -343,7 +343,7 @@ text,__expected
 "1,000 items in stock","contains-all: ""1,000"",in stock"
 ```
 
-Here `"1,000"` is a single search term (the comma is preserved), while `in stock` is a second term. The same quoting rules apply when these assertions are written as a plain string anywhere else (for example via `__expected` in JSON test files).
+Here `"1,000"` is a single search term (the comma is preserved), while `in stock` is a second term. These quoting rules apply to `__expected` columns in CSV, XLSX, and Google Sheets. JSON and JSONL test files should use the structured `assert` object form instead.
 
 At the assertion-string level, escape a literal double quote inside a quoted value as `\"` or `""`. In a CSV file, remember to apply CSV escaping as well by doubling every double quote in the cell.
 :::

--- a/src/assertions/contains.ts
+++ b/src/assertions/contains.ts
@@ -82,7 +82,7 @@ function parseUnquotedField(value: string, startIndex: number): ParsedField {
 /**
  * Split a contains-any string into fields while preserving quoted commas.
  */
-function parseCommaSeparatedValues(value: string): string[] {
+export function parseCommaSeparatedValues(value: string): string[] {
   const results: string[] = [];
   let i = 0;
   while (i < value.length) {

--- a/src/assertions/contains.ts
+++ b/src/assertions/contains.ts
@@ -82,7 +82,7 @@ function parseUnquotedField(value: string, startIndex: number): ParsedField {
 /**
  * Split a contains-any string into fields while preserving quoted commas.
  */
-export function parseCommaSeparatedValues(value: string): string[] {
+function parseCommaSeparatedValues(value: string): string[] {
   const results: string[] = [];
   let i = 0;
   while (i < value.length) {

--- a/src/assertions/contains.ts
+++ b/src/assertions/contains.ts
@@ -81,8 +81,12 @@ function parseUnquotedField(value: string, startIndex: number): ParsedField {
 
 /**
  * Split a contains-any string into fields while preserving quoted commas.
+ *
+ * Exported so the duplicated copy in `src/csv.ts` (kept separate to avoid the
+ * frontend bundling the assertion handlers) can be drift-checked against this
+ * canonical implementation in tests.
  */
-function parseCommaSeparatedValues(value: string): string[] {
+export function parseCommaSeparatedValues(value: string): string[] {
   const results: string[] = [];
   let i = 0;
   while (i < value.length) {

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -8,6 +8,8 @@ import type { Assertion, AssertionType, BaseAssertionTypes, CsvRow, TestCase } f
 
 const DEFAULT_SEMANTIC_SIMILARITY_THRESHOLD = 0.8;
 
+// Keep this parser local: importing the assertion handler would widen the
+// legacy-runtime -> core dependency edge beyond its architecture baseline.
 interface ParsedAssertionField {
   field: string;
   nextIndex: number;

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -1,4 +1,5 @@
 // Helpers for parsing CSV eval files, shared by frontend and backend. Cannot import native modules.
+import { parseCommaSeparatedValues } from './assertions/contains';
 import logger from './logger';
 import { BaseAssertionTypesSchema } from './types/index';
 import { isJavascriptFile } from './util/fileExtensions';
@@ -100,7 +101,7 @@ export function assertionFromString(expected: string): Assertion {
     ) {
       return {
         type: fullType as AssertionType,
-        value: value ? value.split(',').map((s) => s.trim()) : value,
+        value: value ? parseCommaSeparatedValues(value) : value,
       };
     } else if (type === 'contains-json' || type === 'is-json') {
       return {

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -8,8 +8,12 @@ import type { Assertion, AssertionType, BaseAssertionTypes, CsvRow, TestCase } f
 
 const DEFAULT_SEMANTIC_SIMILARITY_THRESHOLD = 0.8;
 
-// Keep this parser local: importing the assertion handler would widen the
-// legacy-runtime -> core dependency edge beyond its architecture baseline.
+// Keep this parser local rather than importing it from src/assertions/contains.ts:
+// this module is bundled into the frontend (see the app layer's allowedImportPaths
+// in architecture/layers.json), so importing the assertion handlers would pull the
+// backend-only assertion code into the browser bundle and widen the
+// legacy-runtime -> core edge past its baseline. A drift-guard test in
+// test/csv.test.ts keeps this copy in sync with the canonical implementation.
 interface ParsedAssertionField {
   field: string;
   nextIndex: number;

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -1,5 +1,4 @@
 // Helpers for parsing CSV eval files, shared by frontend and backend. Cannot import native modules.
-import { parseCommaSeparatedValues } from './assertions/contains';
 import logger from './logger';
 import { BaseAssertionTypesSchema } from './types/index';
 import { isJavascriptFile } from './util/fileExtensions';
@@ -8,6 +7,90 @@ import invariant from './util/invariant';
 import type { Assertion, AssertionType, BaseAssertionTypes, CsvRow, TestCase } from './types/index';
 
 const DEFAULT_SEMANTIC_SIMILARITY_THRESHOLD = 0.8;
+
+interface ParsedAssertionField {
+  field: string;
+  nextIndex: number;
+}
+
+function skipAssertionWhitespace(value: string, startIndex: number): number {
+  let i = startIndex;
+  while (i < value.length && /\s/.test(value[i])) {
+    i++;
+  }
+  return i;
+}
+
+function skipAssertionSeparators(value: string, startIndex: number): number {
+  let i = startIndex;
+  while (i < value.length) {
+    i = skipAssertionWhitespace(value, i);
+    if (value[i] !== ',') {
+      break;
+    }
+    i++;
+  }
+  return i;
+}
+
+function parseQuotedAssertionField(value: string, startIndex: number): ParsedAssertionField {
+  let i = startIndex + 1;
+  let field = '';
+  let terminated = false;
+
+  while (i < value.length) {
+    if (value[i] === '\\' && i + 1 < value.length && ['"', '\\'].includes(value[i + 1])) {
+      field += value[i + 1];
+      i += 2;
+    } else if (value[i] === '"' && i + 1 < value.length && value[i + 1] === '"') {
+      field += '"';
+      i += 2;
+    } else if (value[i] === '"') {
+      i++;
+      terminated = true;
+      break;
+    } else {
+      field += value[i];
+      i++;
+    }
+  }
+
+  invariant(terminated, 'Unterminated quoted field in contains assertion value');
+  return { field, nextIndex: i };
+}
+
+function parseUnquotedAssertionField(value: string, startIndex: number): ParsedAssertionField {
+  let i = startIndex;
+  while (i < value.length && value[i] !== ',') {
+    i++;
+  }
+  return { field: value.substring(startIndex, i).trim(), nextIndex: i };
+}
+
+function parseCommaSeparatedAssertionValues(value: string): string[] {
+  const results: string[] = [];
+  let i = 0;
+
+  while (i < value.length) {
+    i = skipAssertionSeparators(value, i);
+    if (i >= value.length) {
+      break;
+    }
+
+    const isQuotedField = value[i] === '"';
+    const parsed = isQuotedField
+      ? parseQuotedAssertionField(value, i)
+      : parseUnquotedAssertionField(value, i);
+    results.push(parsed.field);
+    i = isQuotedField ? skipAssertionWhitespace(value, parsed.nextIndex) : parsed.nextIndex;
+    invariant(
+      !isQuotedField || i >= value.length || value[i] === ',',
+      'Expected comma after quoted field in contains assertion value',
+    );
+  }
+
+  return results;
+}
 
 let _assertionRegex: RegExp | null = null;
 function getAssertionRegex(): RegExp {
@@ -101,7 +184,7 @@ export function assertionFromString(expected: string): Assertion {
     ) {
       return {
         type: fullType as AssertionType,
-        value: value ? parseCommaSeparatedValues(value) : value,
+        value: value ? parseCommaSeparatedAssertionValues(value) : value,
       };
     } else if (type === 'contains-json' || type === 'is-json') {
       return {

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -554,6 +554,12 @@ describe('assertionFromString', () => {
     expect(result.value).toEqual(['say "hello, world"', 'a "quoted" value', 'plain']);
   });
 
+  it('should match runtime handling of whitespace and repeated delimiters', () => {
+    const result: Assertion = assertionFromString('icontains-any: alpha, , beta,, ');
+
+    expect(result.value).toEqual(['alpha', 'beta']);
+  });
+
   it('should reject malformed quoted contains assertion values', () => {
     expect(() => assertionFromString('icontains-any:"unterminated')).toThrow(
       'Unterminated quoted field in contains assertion value',

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -1,3 +1,4 @@
+import { parse as parseCsv } from 'csv-parse/sync';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { assertionFromString, serializeObjectArrayAsCSV, testCaseFromCsvRow } from '../src/csv';
 import logger from '../src/logger';
@@ -531,12 +532,35 @@ describe('assertionFromString', () => {
     expect(result.value).toEqual(['substring1', 'substring2']);
   });
 
-  it('should preserve quoted commas in a contains-any assertion', () => {
-    const expected = 'contains-any:"hello, world",foo';
+  it.each([
+    'contains-any',
+    'contains-all',
+    'icontains-any',
+    'icontains-all',
+  ])('should preserve quoted commas in a %s assertion read from a CSV row', (type) => {
+    const [row] = parseCsv<CsvRow>(`__expected\n"${type}:""hello, world"",foo"`, {
+      columns: true,
+    });
+
+    const result = testCaseFromCsvRow(row);
+    expect(result.assert?.[0]?.type).toBe(type);
+    expect(result.assert?.[0]?.value).toEqual(['hello, world', 'foo']);
+  });
+
+  it('should preserve escaped and doubled quotes in contains assertion values', () => {
+    const expected = String.raw`contains-all:"say \"hello, world\"","a ""quoted"" value", plain`;
 
     const result: Assertion = assertionFromString(expected);
-    expect(result.type).toBe('contains-any');
-    expect(result.value).toEqual(['hello, world', 'foo']);
+    expect(result.value).toEqual(['say "hello, world"', 'a "quoted" value', 'plain']);
+  });
+
+  it('should reject malformed quoted contains assertion values', () => {
+    expect(() => assertionFromString('icontains-any:"unterminated')).toThrow(
+      'Unterminated quoted field in contains assertion value',
+    );
+    expect(() => assertionFromString('contains-all:"hello"world')).toThrow(
+      'Expected comma after quoted field in contains assertion value',
+    );
   });
 
   it('should create a contains-all assertion', () => {

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -538,6 +538,10 @@ describe('assertionFromString', () => {
     'contains-all',
     'icontains-any',
     'icontains-all',
+    'not-contains-any',
+    'not-contains-all',
+    'not-icontains-any',
+    'not-icontains-all',
   ])('should preserve quoted commas in a %s assertion read from a CSV row', (type) => {
     const [row] = parseCsv<CsvRow>(`__expected\n"${type}:""hello, world"",foo"`, {
       columns: true,
@@ -562,9 +566,9 @@ describe('assertionFromString', () => {
 
   // csv.ts intentionally keeps a private copy of the contains-assertion value
   // parser (it cannot import the assertion handlers without bundling backend code
-  // into the frontend; see the comment in src/csv.ts). This drift guard fails if
-  // the two implementations ever diverge so the copies are kept byte-for-byte
-  // equivalent.
+  // into the frontend; see the comment in src/csv.ts). This drift guard covers
+  // representative valid and malformed inputs so changes to either implementation
+  // have to preserve the same behavior.
   it.each([
     '"hello, world",foo',
     String.raw`"say \"hi\"",b`,

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -531,6 +531,14 @@ describe('assertionFromString', () => {
     expect(result.value).toEqual(['substring1', 'substring2']);
   });
 
+  it('should preserve quoted commas in a contains-any assertion', () => {
+    const expected = 'contains-any:"hello, world",foo';
+
+    const result: Assertion = assertionFromString(expected);
+    expect(result.type).toBe('contains-any');
+    expect(result.value).toEqual(['hello, world', 'foo']);
+  });
+
   it('should create a contains-all assertion', () => {
     const expected = 'contains-all:substring1,substring2';
 

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -1,5 +1,6 @@
 import { parse as parseCsv } from 'csv-parse/sync';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { parseCommaSeparatedValues } from '../src/assertions/contains';
 import { assertionFromString, serializeObjectArrayAsCSV, testCaseFromCsvRow } from '../src/csv';
 import logger from '../src/logger';
 
@@ -557,6 +558,55 @@ describe('assertionFromString', () => {
     const result: Assertion = assertionFromString('icontains-any: alpha, , beta,, ');
 
     expect(result.value).toEqual(['alpha', 'beta']);
+  });
+
+  // csv.ts intentionally keeps a private copy of the contains-assertion value
+  // parser (it cannot import the assertion handlers without bundling backend code
+  // into the frontend; see the comment in src/csv.ts). This drift guard fails if
+  // the two implementations ever diverge so the copies are kept byte-for-byte
+  // equivalent.
+  it.each([
+    '"hello, world",foo',
+    String.raw`"say \"hi\"",b`,
+    'a ""quoted"" value, plain',
+    'alpha, , beta,, ',
+    '  spaced  ,  next  ',
+    '"only one"',
+    'no-quotes-at-all',
+    '"trailing"   ',
+    'a,b,c',
+    '""',
+    '" ",x',
+    'x,"y,z"',
+    '"a","b"',
+    '"a" , "b"',
+    String.raw`"\n",x`,
+    String.raw`"\\",x`,
+    'a,',
+    ',a',
+    ',,,',
+    '"comma,inside","another, one"',
+    'mix,"quoted, field",bare',
+    '"a""b""c"',
+    '"a"b,c',
+    '"unterminated',
+  ])('csv parser matches the canonical contains parser for %j', (input) => {
+    const parseViaCsv = () => assertionFromString(`contains-any:${input}`).value;
+    const parseViaContains = () => parseCommaSeparatedValues(input);
+
+    let canonical: string[] | undefined;
+    let canonicalError: Error | undefined;
+    try {
+      canonical = parseViaContains();
+    } catch (error) {
+      canonicalError = error as Error;
+    }
+
+    if (canonicalError) {
+      expect(parseViaCsv).toThrow(canonicalError.message);
+    } else {
+      expect(parseViaCsv()).toEqual(canonical);
+    }
   });
 
   it('should reject malformed quoted contains assertion values', () => {

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -543,8 +543,7 @@ describe('assertionFromString', () => {
     });
 
     const result = testCaseFromCsvRow(row);
-    expect(result.assert?.[0]?.type).toBe(type);
-    expect(result.assert?.[0]?.value).toEqual(['hello, world', 'foo']);
+    expect(result.assert).toEqual([{ type, value: ['hello, world', 'foo'] }]);
   });
 
   it('should preserve escaped and doubled quotes in contains assertion values', () => {


### PR DESCRIPTION
## Summary

CSV `__expected` values for `contains-any`, `contains-all`, and their case-insensitive or inverse variants now preserve commas inside quoted search terms.

The runtime contains handlers already had a parser for quoted values, but importing those handlers from `src/csv.ts` would pull backend assertion code into the frontend bundle. This keeps an architecture-neutral copy beside the CSV loader and adds a drift guard that checks it against the canonical runtime parser for valid, escaped, whitespace-heavy, repeated-delimiter, and malformed inputs.

The docs now distinguish assertion-string quoting from CSV cell escaping and document the syntax in both the test-case and expected-output references.

## Validation

- `npx vitest run test/csv.test.ts test/assertions/contains.test.ts` — 155 passed
- `npm run test:app -- src/pages/eval-creator/components/TestCasesSection.test.tsx --run` — 20 passed
- Differential parser oracle — 100,000 randomized non-empty inputs matched, including thrown errors
- Real local CLI eval from CSV with quoted commas, case-insensitive assertions, and inverse assertions — 4/4 passed; exported JSON inspected for parsed values, scores, and errors
- `npm run tsc`
- `npm run l && npm run f`
- `npm run architecture:check`
- `SKIP_OG_GENERATION=true npm run build` from `site/`

Reviewed after merging `origin/main` at `58e7c8326867d470689f1f9978660c6f73e6f7c0`.
