### PR TITLE
fix(sanitizer): stop over-redacting benign url values that mention a credential keyword

### DIFF
--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -79,14 +79,18 @@ function hasSecretFormSegment(text: string): boolean {
  * non-URL strings (bare domains, relative paths, prose), which also flow through
  * sanitizeObject for any field literally named `url` and would otherwise be
  * destroyed in persisted eval results.
+ *
+ * Detection is structural — a `user:pass@` userinfo password, a whole value that
+ * looks like a secret, or a `key=value` form segment that carries one. We do NOT
+ * fail closed on a bare credential keyword appearing anywhere in the string:
+ * substring-matching `token`/`secret`/`sig`/etc. redacts benign values such as
+ * `my-tokenizer-model`, `secrets/config.yaml`, or `design-system` (contains `sig`),
+ * which is data loss with no corresponding leak. Genuine credential shapes all
+ * carry one of the structural markers above (the secret-named-key case is covered
+ * by `hasSecretFormSegment`, which normalizes keys like `api_key` before matching).
  */
 function unparseableUrlMightLeakSecret(url: string): boolean {
-  return (
-    SENSITIVE_URL_PARAM_NAMES.test(url) ||
-    hasUrlUserinfoPassword(url) ||
-    looksLikeSecret(url.trim()) ||
-    hasSecretFormSegment(url)
-  );
+  return hasUrlUserinfoPassword(url) || looksLikeSecret(url.trim()) || hasSecretFormSegment(url);
 }
 
 /**

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -1357,6 +1357,11 @@ describe('sanitizeObject url-keyed fields', () => {
     expect(sanitizeObject({ vars: { url: '/relative/path' } })).toEqual({
       vars: { url: '/relative/path' },
     });
+    // A `url` value that only mentions a credential keyword (here `token`) is not a
+    // secret and must survive — substring matching would wrongly redact it.
+    expect(sanitizeObject({ vars: { url: 'my-tokenizer-model' } })).toEqual({
+      vars: { url: 'my-tokenizer-model' },
+    });
   });
 
   it('still redacts url values that carry credentials', () => {
@@ -1427,9 +1432,29 @@ describe('sanitizeUrl', () => {
     });
 
     it('should redact unparseable URLs that carry credential indicators', () => {
+      // Secret-named key (`api_key`) carrying any value: the `key=value` form scan
+      // fails closed even though the value itself is not secret-looking.
       expect(sanitizeUrl('not-a-valid-url?api_key=secret123')).toBe('[REDACTED]');
-      // `ht!tp://...` fails new URL(); the `token` indicator forces fail-closed.
+      // `ht!tp://...` fails new URL(); the `token=sk-...` form segment forces
+      // fail-closed (a secret-named key with a secret-looking value).
       expect(sanitizeUrl('ht!tp://x?token=sk-1234567890abcdefghij')).toBe('[REDACTED]');
+    });
+
+    it('should preserve unparseable values that merely mention a credential keyword', () => {
+      // A bare keyword substring (`token`, `secret`, `sig`, `auth`) is NOT a leak —
+      // these are ordinary `url`-named var values in persisted eval results, and
+      // wholesale redaction would be silent data loss. None carries a structural
+      // credential marker (userinfo password, secret-looking value, or `key=value`).
+      for (const benign of [
+        'my-tokenizer-model',
+        'secrets/config.yaml',
+        'gpt-4-32k-token-limit',
+        'design-system',
+        'authentication-guide',
+        'signature-pad-component',
+      ]) {
+        expect(sanitizeUrl(benign)).toBe(benign);
+      }
     });
 
     it('should redact a secret-looking value under a benign key in a malformed URL', () => {


### PR DESCRIPTION
## Summary

Release-audit follow-up (`0.121.16`). The fail-closed branch for unparseable URLs in `sanitizeUrl` substring-matched the credential-name regex (`token`/`secret`/`password`/`sig`/`auth`/…) against the **entire** value. Because `sanitizeObject` runs `sanitizeUrl` on any field literally named `url`, ordinary non-URL values that merely *mention* one of those words were replaced wholesale with `[REDACTED]` in debug/error logs and persisted output config.

### Examples of benign values that were wrongly destroyed
- `my-tokenizer-model` (contains `token`)
- `secrets/config.yaml` (contains `secret`)
- `gpt-4-32k-token-limit` (contains `token`)
- `design-system` (contains `sig`)
- `authentication-guide` (contains `auth`)

This is silent **data loss**, not a credential leak — there is no secret in these strings.

## Fix

Drop the bare keyword clause in `unparseableUrlMightLeakSecret` and rely on the structural checks that actually identify a credential:
- `hasUrlUserinfoPassword` — a `user:pass@` userinfo password
- `looksLikeSecret` — a whole value matching a known key/token shape
- `hasSecretFormSegment` — a `key=value` form segment carrying a secret-looking value **or** a secret-named key (`api_key` etc. are normalized before matching)

Every previously-redacted genuine-leak shape still fails closed — verified against the existing fail-closed tests (`?api_key=…`, `?token=sk-…`, `;`-delimited credentials, `user:pass@` userinfo), each of which carries a structural marker independent of the removed keyword clause.

## Tests

- New: benign keyword-bearing unparseable values are preserved (`sanitizeUrl` + `sanitizeObject` paths). These fail on `main` (return `[REDACTED]`) and pass here.
- Existing credential-bearing cases still redact.
- Full `test/util/sanitizer.test.ts`: **216 passed**.