### PR TITLE
fix(matchers): drop stranded list markers in RAGAS context-relevance segmentation

### DIFF
--- a/src/matchers/shared.ts
+++ b/src/matchers/shared.ts
@@ -116,9 +116,19 @@ export function splitIntoSentences(text: string) {
  * edge case (e.g. decimals like "3.14", abbreviations); full segmentation would
  * need an NLP tokenizer. It is a substantial improvement over newline-only
  * splitting for the common prose case.
+ *
+ * Bare enumeration markers are dropped: splitting an inline numbered list such as
+ * "1. Paris is the capital. 2. France is in Europe." on the sentence boundary
+ * strands the "1." / "2." markers as their own segments, which would inflate
+ * sentence-level counts (e.g. the RAGAS context-relevance numerator). A segment
+ * that is only a list marker carries no content, so it is not a unit.
  */
+const ENUMERATION_MARKER_ONLY = /^\d+[.)]$/;
+
 export function splitTextIntoSentences(text: string): string[] {
   const lines = text.split('\n').filter((line) => line.trim() !== '');
   const segments = lines.length > 1 ? lines : text.split(/(?<=[.!?])\s+/);
-  return segments.map((sentence) => sentence.trim()).filter((sentence) => sentence.length > 0);
+  return segments
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence.length > 0 && !ENUMERATION_MARKER_ONLY.test(sentence));
 }

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -148,6 +148,31 @@ describe('matchesContextRelevance (RAGAS Context Relevance)', () => {
     expect(result.metadata?.relevantSentenceCount).toBe(2);
   });
 
+  it('should not inflate the score for an inline (single-line) numbered list grader output', async () => {
+    // Regression: when the grader returns the numbered list on ONE line (no newlines),
+    // sentence-splitting strands each "1."/"2." marker as its own segment. Counting
+    // those markers inflated the numerator to 4, capping the score at 1.0. The bare
+    // markers must be dropped so only the two real sentences count.
+    const input = 'What is the capital of France?';
+    const context =
+      'Paris is the capital of France. France is in Europe. The weather is nice today.';
+    const threshold = 0.5;
+
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: '1. Paris is the capital of France. 2. France is in Europe.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, threshold);
+
+    // 2 relevant sentences out of 3 → 2/3 ≈ 0.67 (was 3/3 = 1.0 when the stranded
+    // "1." and "2." markers were counted as relevant units).
+    expect(result.score).toBeCloseTo(0.67, 2);
+    expect(result.metadata?.totalContextUnits).toBe(3);
+    expect(result.metadata?.relevantSentenceCount).toBe(2);
+  });
+
   it('should count the grader output by line, not sentence, against a multi-line context', async () => {
     // Regression: for a multi-line (pre-segmented) string context, a prose grader
     // response (no newlines) was sentence-split while the context was line-split.

--- a/test/matchers/shared.test.ts
+++ b/test/matchers/shared.test.ts
@@ -62,6 +62,29 @@ describe('splitTextIntoSentences', () => {
     expect(splitTextIntoSentences('Line one.\n\n\nLine two.')).toEqual(['Line one.', 'Line two.']);
   });
 
+  it('drops bare enumeration markers stranded from an inline numbered list', () => {
+    // Sentence-splitting "1. Paris ... 2. France ..." strands the "1." / "2."
+    // markers as their own segments; counting them would inflate sentence-level
+    // metrics (e.g. the RAGAS context-relevance numerator). Only real units remain.
+    expect(splitTextIntoSentences('1. Paris is the capital. 2. France is in Europe.')).toEqual([
+      'Paris is the capital.',
+      'France is in Europe.',
+    ]);
+    // A `)`-style marker on a sentence boundary is likewise dropped when stranded.
+    expect(splitTextIntoSentences('1. First fact. 2. Second fact.')).toEqual([
+      'First fact.',
+      'Second fact.',
+    ]);
+  });
+
+  it('keeps numbers that are part of a sentence, not bare markers', () => {
+    // A decimal or a number embedded in prose is content, never a stray marker.
+    expect(splitTextIntoSentences('Pi is 3.14 here. There are 42 items.')).toEqual([
+      'Pi is 3.14 here.',
+      'There are 42 items.',
+    ]);
+  });
+
   it('returns an empty array for empty or whitespace-only text', () => {
     expect(splitTextIntoSentences('')).toEqual([]);
     expect(splitTextIntoSentences('   \n  \n ')).toEqual([]);


### PR DESCRIPTION
## Summary

Release-audit follow-up (`0.121.16`). When the context-relevance grader returns the relevant sentences as an **inline (single-line) numbered list** — e.g. `1. Paris is the capital. 2. France is in Europe.` — `splitTextIntoSentences` splits on the sentence boundary and strands each `1.` / `2.` marker as its own segment. Those bare markers were counted as relevant units, inflating the numerator (4 units against a 3-sentence context) and capping the score at `1.0` regardless of actual relevance.

This is the inline-list variant of the case the newline-delimited regression test (`should not inflate the score when the grader returns a numbered list`) already covers — that path keeps markers attached to their line and was already correct; only the single-line path was affected.

## Fix

Drop segments that consist solely of an enumeration marker (`\d+[.)]`) during sentence segmentation in `splitTextIntoSentences`, so only real sentences count. Applies symmetrically to the numerator and denominator.

- Newline-delimited lists: unchanged (markers stay attached to their line, never stranded).
- Numbers embedded in prose (decimals like `3.14`, counts like `42 items`): never bare markers, unaffected.

## Tests

- Unit: `splitTextIntoSentences` drops stranded `1.`/`2.` markers from an inline list; keeps in-sentence numbers.
- End-to-end: inline numbered-list grader output against a single-line prose context now scores `0.67` (2/3), not `1.0`. Fails on `main`, passes here.
- `test/matchers/shared.test.ts`, `test/matchers/context-relevance.test.ts`, `test/assertions/contextRelevance.test.ts`: **33 passed**.

## Context

Surfaced by the pre-release regression audit. Not a `0.121.16` regression (the new sentence-segmentation refactor is never worse than the prior newline-only behavior for this input) — this hardens a residual heuristic limitation it exposed.