### PR TITLE
fix(docker): bump pinned Python to 3.14 to match the Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@ FROM node:24.16.0-alpine AS base
 RUN apk upgrade --no-cache
 
 RUN addgroup -S promptfoo && adduser -S promptfoo -G promptfoo
-# Make Python version configurable with a default of 3.12
-ARG PYTHON_VERSION=3.12
+# Make Python version configurable with a default matching the Alpine base.
+# `node:24.16.0-alpine` + `apk upgrade` now ships Python 3.14, and py3-pip /
+# py3-setuptools depend on `python3~3.14`, so pinning an older minor (e.g. 3.12)
+# makes `apk add` unsatisfiable. Keep this aligned with the base image's Python.
+ARG PYTHON_VERSION=3.14
 
 # Install Python for python providers, prompts, asserts, etc.
 RUN apk add --no-cache python3~=${PYTHON_VERSION} py3-pip py3-setuptools curl && \


### PR DESCRIPTION
## Summary

The `0.121.16` release Docker build failed at the `apk add` step:

```
ERROR: unable to select packages:
  python3-3.14.5-r0:
    breaks: world[python3~3.12]
    satisfies: py3-pip-26.1.2-r0[python3~3.14]
               py3-setuptools-82.0.1-r1[python3~3.14]
...
ERROR: failed to solve: process "apk add --no-cache python3~=${PYTHON_VERSION} py3-pip py3-setuptools curl ..." did not complete successfully: exit code: 7
```

`node:24.16.0-alpine` + `apk upgrade --no-cache` now resolves to an Alpine base that ships **python3-3.14**, and `py3-pip` / `py3-setuptools` / `py3-packaging` all depend on `python3~3.14`. Pinning the older 3.12 minor (`python3~=3.12`) makes the install unsatisfiable, so the image fails to build and push.

This is **Alpine base-image drift, not a `0.121.16` code regression** — the prior release-please runs skipped the docker job (no release was cut), so this release run is simply the first real image build to hit the drift. A re-run is deterministic and won't help; the pin must move.

## Fix

Bump the default `PYTHON_VERSION` pin from `3.12` → `3.14` to match the Alpine base. promptfoo already supports and CI-tests Python 3.14 (the `Check Python (3.14)` job), so the runtime is unaffected.

## Verification

No local Docker daemon available; relying on this PR's `docker / test` CI job (the same job that failed on the release) to confirm the image builds.

## Note on the published `0.121.16`

The npm package `promptfoo@0.121.16` published successfully and is live. Only the Docker image lagged. Once this lands, the Docker image can be (re)built — either by a maintainer re-running the release docker job against a patched tag, or it will be covered by the next release.