### PR TITLE
fix(docker): unpin Python minor by default so Alpine drift can't break the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,16 @@ FROM node:24.16.0-alpine AS base
 RUN apk upgrade --no-cache
 
 RUN addgroup -S promptfoo && adduser -S promptfoo -G promptfoo
-# Make Python version configurable with a default matching the Alpine base.
-# `node:24.16.0-alpine` + `apk upgrade` now ships Python 3.14, and py3-pip /
-# py3-setuptools depend on `python3~3.14`, so pinning an older minor (e.g. 3.12)
-# makes `apk add` unsatisfiable. Keep this aligned with the base image's Python.
-ARG PYTHON_VERSION=3.14
+# Python version pin. Empty by default so `apk` installs whatever python3 the
+# Alpine base ships — py3-pip/py3-setuptools depend on that exact minor, so any
+# fixed minor goes stale and makes `apk add` unsatisfiable when the base advances
+# (e.g. Alpine moving 3.12 -> 3.14 broke the release build). Self-hosters can pin a
+# specific minor for reproducibility with `--build-arg PYTHON_VERSION=3.14`.
+ARG PYTHON_VERSION=
 
-# Install Python for python providers, prompts, asserts, etc.
-RUN apk add --no-cache python3~=${PYTHON_VERSION} py3-pip py3-setuptools curl && \
+# Install Python for python providers, prompts, asserts, etc. The `${VAR:+~=$VAR}`
+# expansion adds the `~=<minor>` constraint only when PYTHON_VERSION is set.
+RUN apk add --no-cache "python3${PYTHON_VERSION:+~=${PYTHON_VERSION}}" py3-pip py3-setuptools curl && \
     ln -sf python3 /usr/bin/python
 
 # Install dependencies only when needed


### PR DESCRIPTION
## Summary

Follow-up to #9769. That PR bumped the Docker Python pin `3.12 → 3.14` to unblock the `0.121.16` release build, but a **fixed** minor is inherently fragile: the base `node:24.16.0-alpine` + `apk upgrade` tracks Alpine's current `python3`, and `py3-pip` / `py3-setuptools` depend on that **exact** minor. Whenever the base image advances, the stale pin makes `apk add` unsatisfiable and the release Docker build dies with:

```
ERROR: unable to select packages:
  python3-3.14.5-r0: breaks: world[python3~3.12]
... exit code: 7
```

Bumping the pin just defers the next break to the next Alpine Python bump.

## Fix

Default `PYTHON_VERSION` to **empty**, so `apk` installs whatever `python3` the Alpine base ships — which is always internally consistent with the `py3-*` packages. This removes the "unable to select packages" failure class permanently.

```dockerfile
ARG PYTHON_VERSION=
RUN apk add --no-cache "python3${PYTHON_VERSION:+~=${PYTHON_VERSION}}" py3-pip py3-setuptools curl && \
    ln -sf python3 /usr/bin/python
```

The `${PYTHON_VERSION:+~=$PYTHON_VERSION}` expansion preserves the optional override — self-hosters who want a reproducible minor can still build with `--build-arg PYTHON_VERSION=3.14`.

### Why this is safe
- `PYTHON_VERSION` is only referenced inside the Dockerfile; no workflow passes it as a build-arg, so nothing depends on the old default.
- promptfoo supports Python 3.9–3.14 (all CI-tested), and Alpine only ships supported minors, so the unpinned default always lands on a supported interpreter.
- Verified the expansion under POSIX `sh` (Alpine `ash`): empty → `python3`, set → `python3~=3.14`, no stray args in either case.

## Verification

This PR touches `Dockerfile`, so `docker.yml` runs on the PR and **actually builds + health-checks the image** (the same `test` job that gates the release). Green CI here proves the unpinned default builds.