### PR TITLE
fix(code-scan): run GitHub Action on Node 24 runtime

### DIFF
--- a/code-scan-action/action.yml
+++ b/code-scan-action/action.yml
@@ -43,5 +43,5 @@ outputs:
     description: 'Path to the SARIF file when a scan completes and sarif-output-path is configured'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## What

Switch the code-scan GitHub Action runtime from `node20` → `node24` in `code-scan-action/action.yml`.

## Why

GitHub force-migrates Node 20 actions to Node 24 by default starting **2026-06-16** and removes the Node 20 runner on **2026-09-16**. Workflows pinning `promptfoo/code-scan-action` currently get a Node 20 deprecation warning, and downstream consumers (e.g. promptfoo-cloud) can't drop their last Node 20 action until this ships.

## Risk

Minimal — runtime declaration only:
- `dist/index.js` is built with esbuild `--target=node20`, which runs unchanged on Node 24.
- `engines.node` (`>=20.20.1`) is already satisfied by Node 24.

Bumping the esbuild `--target` / `engines` to node24 is left out intentionally to keep this a zero-rebuild change; can be a follow-up if desired.
