### PR TITLE
fix: restore Docker CLI links and validate rate-limit reset metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -158,6 +158,12 @@ jobs:
             exit 1
           fi
 
+          echo "Checking pf alias:"
+          if ! docker exec promptfoo-container pf --version; then
+            echo "pf alias check failed"
+            exit 1
+          fi
+
       - name: Use Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ COPY --from=builder --chown=promptfoo:promptfoo /app/dist ./dist
 
 RUN ln -s /app /app/node_modules/promptfoo && \
     chown -h promptfoo:promptfoo /app/node_modules/promptfoo && \
+    ln -s /app/dist/src/entrypoint.js /usr/local/bin/promptfoo && \
+    ln -s /app/dist/src/entrypoint.js /usr/local/bin/pf && \
     mkdir -p /home/promptfoo/.promptfoo && chown promptfoo:promptfoo /home/promptfoo/.promptfoo
 
 ENV API_PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,11 @@ RUN npm run build
 FROM base AS server
 WORKDIR /app
 COPY --from=builder --chown=promptfoo:promptfoo /app/node_modules ./node_modules
+COPY --from=builder --chown=promptfoo:promptfoo /app/package.json ./package.json
 COPY --from=builder --chown=promptfoo:promptfoo /app/dist ./dist
 
-RUN npm link promptfoo && \
-    chown promptfoo:promptfoo /app/node_modules/promptfoo && \
+RUN ln -s /app /app/node_modules/promptfoo && \
+    chown -h promptfoo:promptfoo /app/node_modules/promptfoo && \
     mkdir -p /home/promptfoo/.promptfoo && chown promptfoo:promptfoo /home/promptfoo/.promptfoo
 
 ENV API_PORT=3000

--- a/examples/integration-langchain/README.md
+++ b/examples/integration-langchain/README.md
@@ -20,6 +20,12 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+Set the OpenAI API key used by both providers:
+
+```sh
+export OPENAI_API_KEY=your-api-key
+```
+
 Then run the eval:
 
 ```bash

--- a/examples/integration-langchain/langchain_example.py
+++ b/examples/integration-langchain/langchain_example.py
@@ -1,32 +1,41 @@
 import os
 import sys
 
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import PromptTemplate
-from langchain_openai import OpenAI
 
-if len(sys.argv) < 2:
-    print(f"Usage: {sys.argv[0]} <question>", file=sys.stderr)
-    sys.exit(1)
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <question>", file=sys.stderr)
+        return 1
 
-api_key = os.getenv("OPENAI_API_KEY")
-if not api_key:
-    print("OPENAI_API_KEY environment variable is required.", file=sys.stderr)
-    sys.exit(1)
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("OPENAI_API_KEY environment variable is required.", file=sys.stderr)
+        return 1
 
-llm = OpenAI(temperature=0, api_key=api_key)
-math_chain = (
-    PromptTemplate.from_template(
-        "Solve the following math problem carefully. Return only the final answer.\n\n{question}"
+    # Validate CLI inputs before importing optional dependencies so usage and
+    # configuration errors stay concise even before the example is installed.
+    from langchain_core.output_parsers import StrOutputParser
+    from langchain_core.prompts import PromptTemplate
+    from langchain_openai import OpenAI
+
+    llm = OpenAI(temperature=0, api_key=api_key)
+    math_chain = (
+        PromptTemplate.from_template(
+            "Solve the following math problem carefully. Return only the final answer.\n\n{question}"
+        )
+        | llm
+        | StrOutputParser()
     )
-    | llm
-    | StrOutputParser()
-)
 
-prompt = sys.argv[1]
-try:
-    result = math_chain.invoke({"question": prompt})
+    try:
+        result = math_chain.invoke({"question": sys.argv[1]})
+    except Exception as error:
+        print(f"Error invoking math chain: {error}", file=sys.stderr)
+        return 1
+
     print(result)
-except Exception as error:
-    print(f"Error invoking math chain: {error}", file=sys.stderr)
-    sys.exit(1)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/integration-langchain/langchain_example.py
+++ b/examples/integration-langchain/langchain_example.py
@@ -5,6 +5,10 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import PromptTemplate
 from langchain_openai import OpenAI
 
+if len(sys.argv) < 2:
+    print(f"Usage: {sys.argv[0]} <question>", file=sys.stderr)
+    sys.exit(1)
+
 api_key = os.getenv("OPENAI_API_KEY")
 if not api_key:
     raise ValueError("OPENAI_API_KEY environment variable is required.")
@@ -17,10 +21,6 @@ math_chain = (
     | llm
     | StrOutputParser()
 )
-
-if len(sys.argv) < 2:
-    print(f"Usage: {sys.argv[0]} <question>", file=sys.stderr)
-    sys.exit(1)
 
 prompt = sys.argv[1]
 try:

--- a/examples/integration-langchain/langchain_example.py
+++ b/examples/integration-langchain/langchain_example.py
@@ -11,7 +11,8 @@ if len(sys.argv) < 2:
 
 api_key = os.getenv("OPENAI_API_KEY")
 if not api_key:
-    raise ValueError("OPENAI_API_KEY environment variable is required.")
+    print("OPENAI_API_KEY environment variable is required.", file=sys.stderr)
+    sys.exit(1)
 
 llm = OpenAI(temperature=0, api_key=api_key)
 math_chain = (

--- a/examples/integration-langchain/langchain_example.py
+++ b/examples/integration-langchain/langchain_example.py
@@ -5,7 +5,11 @@ from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import PromptTemplate
 from langchain_openai import OpenAI
 
-llm = OpenAI(temperature=0, api_key=os.getenv("OPENAI_API_KEY"))
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise ValueError("OPENAI_API_KEY environment variable is required.")
+
+llm = OpenAI(temperature=0, api_key=api_key)
 math_chain = (
     PromptTemplate.from_template(
         "Solve the following math problem carefully. Return only the final answer.\n\n{question}"
@@ -14,5 +18,14 @@ math_chain = (
     | StrOutputParser()
 )
 
+if len(sys.argv) < 2:
+    print(f"Usage: {sys.argv[0]} <question>", file=sys.stderr)
+    sys.exit(1)
+
 prompt = sys.argv[1]
-print(math_chain.invoke({"question": prompt}))
+try:
+    result = math_chain.invoke({"question": prompt})
+    print(result)
+except Exception as error:
+    print(f"Error invoking math chain: {error}", file=sys.stderr)
+    sys.exit(1)

--- a/src/scheduler/headerParser.ts
+++ b/src/scheduler/headerParser.ts
@@ -93,9 +93,9 @@ export function parseRateLimitHeaders(headers: Record<string, string>): ParsedRa
 
   // --- Retry-After ---
   if (h['retry-after-ms'] !== undefined) {
-    const ms = parseInt(h['retry-after-ms'], 10);
+    const ms = Number.parseInt(h['retry-after-ms'], 10);
     // Accept 0 as valid (means "retry immediately")
-    if (!isNaN(ms) && ms >= 0) {
+    if (Number.isFinite(ms) && ms >= 0) {
       result.retryAfterMs = ms;
       if (result.resetAt === undefined) {
         result.resetAt = Date.now() + ms;
@@ -121,9 +121,15 @@ export function parseRateLimitHeaders(headers: Record<string, string>): ParsedRa
  */
 export function parseRetryAfter(value: string): number | null {
   // Try as integer seconds (must be non-negative)
-  const seconds = parseInt(value, 10);
-  if (!isNaN(seconds) && seconds >= 0 && String(seconds) === value.trim()) {
-    return seconds * 1000;
+  const seconds = Number.parseInt(value, 10);
+  const durationMs = seconds * 1000;
+  if (
+    Number.isFinite(seconds) &&
+    seconds >= 0 &&
+    String(seconds) === value.trim() &&
+    Number.isFinite(durationMs)
+  ) {
+    return durationMs;
   }
 
   // Try HTTP-date format
@@ -139,8 +145,8 @@ function parseFirstMatch(headers: Record<string, string>, names: string[]): numb
   for (const name of names) {
     const value = headers[name];
     if (value !== undefined) {
-      const num = parseInt(value, 10);
-      if (!isNaN(num) && num >= 0) {
+      const num = Number.parseInt(value, 10);
+      if (Number.isFinite(num) && num >= 0) {
         return num;
       }
     }
@@ -160,8 +166,8 @@ function parseResetTime(value: string): number | null {
   }
 
   // Try as numeric
-  const num = parseFloat(value);
-  if (!isNaN(num)) {
+  const num = Number.parseFloat(value);
+  if (Number.isFinite(num) && num >= 0) {
     // Disambiguate by magnitude:
     // - < 1 billion: relative seconds
     // - 1-10 billion: Unix seconds (10 digits)
@@ -189,7 +195,7 @@ function parseResetTime(value: string): number | null {
  */
 function parseHttpDate(value: string): number | null {
   const timestamp = Date.parse(value);
-  if (!isNaN(timestamp)) {
+  if (Number.isFinite(timestamp)) {
     // Sanity check: within reasonable range (not too far past or future)
     const now = Date.now();
     const oneYearMs = 365 * 24 * 60 * 60 * 1000;
@@ -228,17 +234,17 @@ function parseDuration(value: string): number | null {
   let ms = 0;
 
   if (hours) {
-    ms += parseInt(hours, 10) * 3600_000;
+    ms += Number.parseInt(hours, 10) * 3600_000;
   }
   if (minutes) {
-    ms += parseInt(minutes, 10) * 60_000;
+    ms += Number.parseInt(minutes, 10) * 60_000;
   }
   if (secondsValue) {
-    const num = parseFloat(secondsValue);
+    const num = Number.parseFloat(secondsValue);
     ms += secondsUnit === 'ms' ? num : num * 1000;
   }
 
-  return ms;
+  return Number.isFinite(ms) ? ms : null;
 }
 
 function lowercaseKeys(obj: Record<string, string>): Record<string, string> {

--- a/src/scheduler/providerWrapper.ts
+++ b/src/scheduler/providerWrapper.ts
@@ -57,8 +57,8 @@ export function createProviderRateLimitOptions(): RateLimitExecuteOptions<Provid
         }
         // Check retry-after-ms first (milliseconds)
         if (headers['retry-after-ms']) {
-          const ms = parseInt(headers['retry-after-ms'], 10);
-          if (!isNaN(ms) && ms >= 0) {
+          const ms = Number.parseInt(headers['retry-after-ms'], 10);
+          if (Number.isFinite(ms) && ms >= 0) {
             return ms;
           }
         }
@@ -73,7 +73,8 @@ export function createProviderRateLimitOptions(): RateLimitExecuteOptions<Provid
       // Try to extract from error message (some providers include it)
       const match = error?.message?.match(/\bretry after (\d+)\b/i);
       if (match) {
-        return parseInt(match[1], 10) * 1000;
+        const retryAfterMs = Number.parseInt(match[1], 10) * 1000;
+        return Number.isFinite(retryAfterMs) ? retryAfterMs : undefined;
       }
       return undefined;
     },

--- a/src/util/fetch/errors.ts
+++ b/src/util/fetch/errors.ts
@@ -63,9 +63,15 @@ export type RateLimitKind = 'quota' | 'rate_limit';
 export interface HttpRateLimitErrorInit {
   status: number;
   statusText?: string;
-  /** Parsed `Retry-After` (or equivalent) in milliseconds, if known. */
+  /**
+   * Parsed `Retry-After` (or equivalent) in milliseconds, if known. Negative or
+   * non-numeric values are rejected (treated as absent).
+   */
   retryAfterMs?: number;
-  /** Absolute reset timestamp (ms since epoch), if known. */
+  /**
+   * Absolute reset timestamp (ms since epoch), if known. Validated independently
+   * of {@link retryAfterMs}; negative or non-numeric values are rejected.
+   */
   resetAt?: number;
   /** Body-level error code (e.g. `insufficient_quota`, `rate_limit_exceeded`). */
   code?: string;
@@ -73,6 +79,15 @@ export interface HttpRateLimitErrorInit {
   headers?: Record<string, string>;
   /** Parsed body — JSON object if parseable, else raw string. */
   body?: unknown;
+}
+
+/**
+ * Normalize a caller-supplied millisecond duration / timestamp: a non-negative
+ * number passes through; anything else (negative, `NaN`, or — for untyped
+ * callers — a non-number) maps to `undefined`.
+ */
+function normalizeNonNegativeMs(value: number | undefined): number | undefined {
+  return typeof value === 'number' && value >= 0 ? value : undefined;
 }
 
 /**
@@ -107,16 +122,11 @@ export class HttpRateLimitError extends Error {
   constructor(init: HttpRateLimitErrorInit) {
     const status = init.status;
     const statusText = init.statusText || 'Too Many Requests';
-    const retryAfterMs =
-      typeof init.retryAfterMs === 'number' && init.retryAfterMs >= 0
-        ? init.retryAfterMs
-        : undefined;
-    const resetAt =
-      retryAfterMs === undefined && init.retryAfterMs !== undefined
-        ? undefined
-        : typeof init.resetAt === 'number' && init.resetAt >= 0
-          ? init.resetAt
-          : undefined;
+    // `retryAfterMs` (Retry-After) and `resetAt` (X-RateLimit-Reset) come from
+    // independent headers, so each is validated on its own merits — a malformed
+    // value in one must not discard a valid value in the other.
+    const retryAfterMs = normalizeNonNegativeMs(init.retryAfterMs);
+    const resetAt = normalizeNonNegativeMs(init.resetAt);
 
     // A hard-quota body code normally implies `kind: 'quota'`. But Azure
     // OpenAI is known to return `insufficient_quota` for per-minute

--- a/src/util/fetch/errors.ts
+++ b/src/util/fetch/errors.ts
@@ -64,13 +64,13 @@ export interface HttpRateLimitErrorInit {
   status: number;
   statusText?: string;
   /**
-   * Parsed `Retry-After` (or equivalent) in milliseconds, if known. Negative or
-   * non-numeric values are rejected (treated as absent).
+   * Parsed `Retry-After` (or equivalent) in milliseconds, if known. Negative,
+   * non-finite, or non-numeric values are rejected (treated as absent).
    */
   retryAfterMs?: number;
   /**
    * Absolute reset timestamp (ms since epoch), if known. Validated independently
-   * of {@link retryAfterMs}; negative or non-numeric values are rejected.
+   * of {@link retryAfterMs}; negative, non-finite, or non-numeric values are rejected.
    */
   resetAt?: number;
   /** Body-level error code (e.g. `insufficient_quota`, `rate_limit_exceeded`). */
@@ -82,12 +82,11 @@ export interface HttpRateLimitErrorInit {
 }
 
 /**
- * Normalize a caller-supplied millisecond duration / timestamp: a non-negative
- * number passes through; anything else (negative, `NaN`, or — for untyped
- * callers — a non-number) maps to `undefined`.
+ * Normalize a caller-supplied millisecond duration / timestamp: a finite,
+ * non-negative number passes through; anything else maps to `undefined`.
  */
 function normalizeNonNegativeMs(value: number | undefined): number | undefined {
-  return typeof value === 'number' && value >= 0 ? value : undefined;
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 /**
@@ -122,9 +121,8 @@ export class HttpRateLimitError extends Error {
   constructor(init: HttpRateLimitErrorInit) {
     const status = init.status;
     const statusText = init.statusText || 'Too Many Requests';
-    // `retryAfterMs` (Retry-After) and `resetAt` (X-RateLimit-Reset) come from
-    // independent headers, so each is validated on its own merits — a malformed
-    // value in one must not discard a valid value in the other.
+    // These are independent metadata fields, so each is validated on its own
+    // merits — a malformed value in one must not discard a valid value in the other.
     const retryAfterMs = normalizeNonNegativeMs(init.retryAfterMs);
     const resetAt = normalizeNonNegativeMs(init.resetAt);
 

--- a/src/util/fetch/errors.ts
+++ b/src/util/fetch/errors.ts
@@ -106,11 +106,17 @@ export class HttpRateLimitError extends Error {
 
   constructor(init: HttpRateLimitErrorInit) {
     const status = init.status;
-    const statusText = init.statusText ?? 'Too Many Requests';
+    const statusText = init.statusText || 'Too Many Requests';
     const retryAfterMs =
       typeof init.retryAfterMs === 'number' && init.retryAfterMs >= 0
         ? init.retryAfterMs
         : undefined;
+    const resetAt =
+      retryAfterMs === undefined && init.retryAfterMs !== undefined
+        ? undefined
+        : typeof init.resetAt === 'number' && init.resetAt >= 0
+          ? init.resetAt
+          : undefined;
 
     // A hard-quota body code normally implies `kind: 'quota'`. But Azure
     // OpenAI is known to return `insufficient_quota` for per-minute
@@ -133,7 +139,7 @@ export class HttpRateLimitError extends Error {
     this.status = status;
     this.statusText = statusText;
     this.retryAfterMs = retryAfterMs;
-    this.resetAt = init.resetAt;
+    this.resetAt = resetAt;
     this.code = init.code;
     this.kind = kind;
     // Shallow-copy reference fields so post-construction mutations on the

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -349,22 +349,21 @@ export function computeRateLimitWaitMs(response: Response): number {
     response.headers.get('x-ratelimit-reset-requests') ||
     response.headers.get('x-ratelimit-reset-tokens');
 
-  let waitTime = 60_000;
-
   if (openaiReset) {
     const parsedHeaders = parseRateLimitHeaders(Object.fromEntries(response.headers.entries()));
     if (parsedHeaders.resetAt !== undefined) {
-      waitTime = Math.max(parsedHeaders.resetAt - Date.now(), 0);
+      return Math.max(parsedHeaders.resetAt - Date.now(), 0);
     }
-  } else if (rateLimitReset) {
-    const resetTime = new Date(Number.parseInt(rateLimitReset) * 1000);
-    const now = new Date();
-    waitTime = Math.max(resetTime.getTime() - now.getTime() + 1000, 0);
-  } else if (retryAfter) {
-    waitTime = parseRetryAfter(retryAfter) ?? waitTime;
   }
 
-  return waitTime;
+  if (rateLimitReset) {
+    const resetAt = Number.parseInt(rateLimitReset, 10) * 1000;
+    if (Number.isFinite(resetAt) && resetAt >= 0) {
+      return Math.max(resetAt - Date.now() + 1000, 0);
+    }
+  }
+
+  return retryAfter ? (parseRetryAfter(retryAfter) ?? 60_000) : 60_000;
 }
 
 /**

--- a/test/examples/integrationLangchain.test.ts
+++ b/test/examples/integrationLangchain.test.ts
@@ -1,0 +1,140 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const EXAMPLE_PATH = path.join(
+  process.cwd(),
+  'examples',
+  'integration-langchain',
+  'langchain_example.py',
+);
+
+function findPythonPath(): string | undefined {
+  const probe = 'import sys; print(sys.executable)';
+  const candidates: Array<[string, string[]]> = [];
+
+  if (process.env.PROMPTFOO_PYTHON) {
+    candidates.push([process.env.PROMPTFOO_PYTHON, ['-c', probe]]);
+  }
+  if (process.platform === 'win32') {
+    candidates.push(['py', ['-3', '-c', probe]]);
+  }
+  candidates.push(['python3', ['-c', probe]], ['python', ['-c', probe]]);
+
+  for (const [command, args] of candidates) {
+    const result = spawnSync(command, args, { encoding: 'utf8', timeout: 5000 });
+    if (result.status === 0 && result.stdout.trim()) {
+      return result.stdout.trim();
+    }
+  }
+
+  return undefined;
+}
+
+const PYTHON_PATH = findPythonPath();
+
+describe('integration-langchain example', () => {
+  let stubRoot: string;
+
+  beforeAll(() => {
+    const scratchRoot = path.join(process.cwd(), 'scratch', 'langchain-example-tests');
+    fs.mkdirSync(scratchRoot, { recursive: true });
+    stubRoot = fs.mkdtempSync(path.join(scratchRoot, 'case-'));
+
+    const langchainCore = path.join(stubRoot, 'langchain_core');
+    fs.mkdirSync(langchainCore, { recursive: true });
+    fs.writeFileSync(path.join(langchainCore, '__init__.py'), '');
+    fs.writeFileSync(
+      path.join(langchainCore, 'output_parsers.py'),
+      'class StrOutputParser:\n    pass\n',
+    );
+    fs.writeFileSync(
+      path.join(langchainCore, 'prompts.py'),
+      `
+import os
+
+class _FakeChain:
+    def __or__(self, _other):
+        return self
+
+    def invoke(self, _payload):
+        if os.getenv("PROMPTFOO_LANGCHAIN_STUB_ERROR"):
+            raise RuntimeError("stubbed invocation failure")
+        return "stubbed answer"
+
+class PromptTemplate:
+    @staticmethod
+    def from_template(_template):
+        return _FakeChain()
+`,
+    );
+    fs.writeFileSync(
+      path.join(stubRoot, 'langchain_openai.py'),
+      'class OpenAI:\n    def __init__(self, **_kwargs):\n        pass\n',
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(stubRoot, { force: true, recursive: true });
+  });
+
+  function runExample(
+    args: string[],
+    envOverrides: NodeJS.ProcessEnv = {},
+  ): { status: number | null; stdout: string; stderr: string } {
+    if (!PYTHON_PATH) {
+      throw new Error('Python is not available');
+    }
+
+    const childEnv = { ...process.env };
+    delete childEnv.OPENAI_API_KEY;
+    delete childEnv.PROMPTFOO_LANGCHAIN_STUB_ERROR;
+    childEnv.PYTHONPATH = [stubRoot, childEnv.PYTHONPATH].filter(Boolean).join(path.delimiter);
+
+    const result = spawnSync(PYTHON_PATH, [EXAMPLE_PATH, ...args], {
+      encoding: 'utf8',
+      env: { ...childEnv, ...envOverrides },
+      timeout: 10_000,
+    });
+
+    return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+  }
+
+  it.skipIf(!PYTHON_PATH)('prints usage and exits non-zero when the question is missing', () => {
+    const result = runExample([]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Usage:');
+    expect(result.stderr).toContain('<question>');
+  });
+
+  it.skipIf(!PYTHON_PATH)('reports a missing API key without importing LangChain', () => {
+    const result = runExample(['What is 2 + 2?'], { PYTHONPATH: '' });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('OPENAI_API_KEY environment variable is required.\n');
+  });
+
+  it.skipIf(!PYTHON_PATH)('prints the LangChain result to stdout', () => {
+    const result = runExample(['What is 2 + 2?'], { OPENAI_API_KEY: 'test-key' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('stubbed answer\n');
+    expect(result.stderr).toBe('');
+  });
+
+  it.skipIf(!PYTHON_PATH)('reports invocation failures on stderr and exits non-zero', () => {
+    const result = runExample(['What is 2 + 2?'], {
+      OPENAI_API_KEY: 'test-key',
+      PROMPTFOO_LANGCHAIN_STUB_ERROR: 'true',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('Error invoking math chain: stubbed invocation failure\n');
+  });
+});

--- a/test/examples/integrationLangchain.test.ts
+++ b/test/examples/integrationLangchain.test.ts
@@ -102,7 +102,7 @@ class PromptTemplate:
     return { status: result.status, stdout: result.stdout, stderr: result.stderr };
   }
 
-  it.skipIf(!PYTHON_PATH)('prints usage and exits non-zero when the question is missing', () => {
+  it('prints usage and exits non-zero when the question is missing', () => {
     const result = runExample([]);
 
     expect(result.status).toBe(1);
@@ -111,7 +111,7 @@ class PromptTemplate:
     expect(result.stderr).toContain('<question>');
   });
 
-  it.skipIf(!PYTHON_PATH)('reports a missing API key without importing LangChain', () => {
+  it('reports a missing API key without importing LangChain', () => {
     const result = runExample(['What is 2 + 2?'], { PYTHONPATH: '' });
 
     expect(result.status).toBe(1);
@@ -119,7 +119,7 @@ class PromptTemplate:
     expect(result.stderr.trim()).toBe('OPENAI_API_KEY environment variable is required.');
   });
 
-  it.skipIf(!PYTHON_PATH)('prints the LangChain result to stdout', () => {
+  it('prints the LangChain result to stdout', () => {
     const result = runExample(['What is 2 + 2?'], { OPENAI_API_KEY: 'test-key' });
 
     expect(result.status).toBe(0);
@@ -127,7 +127,7 @@ class PromptTemplate:
     expect(result.stderr).toBe('');
   });
 
-  it.skipIf(!PYTHON_PATH)('reports invocation failures on stderr and exits non-zero', () => {
+  it('reports invocation failures on stderr and exits non-zero', () => {
     const result = runExample(['What is 2 + 2?'], {
       OPENAI_API_KEY: 'test-key',
       PROMPTFOO_LANGCHAIN_STUB_ERROR: 'true',

--- a/test/examples/integrationLangchain.test.ts
+++ b/test/examples/integrationLangchain.test.ts
@@ -116,14 +116,14 @@ class PromptTemplate:
 
     expect(result.status).toBe(1);
     expect(result.stdout).toBe('');
-    expect(result.stderr).toBe('OPENAI_API_KEY environment variable is required.\n');
+    expect(result.stderr.trim()).toBe('OPENAI_API_KEY environment variable is required.');
   });
 
   it.skipIf(!PYTHON_PATH)('prints the LangChain result to stdout', () => {
     const result = runExample(['What is 2 + 2?'], { OPENAI_API_KEY: 'test-key' });
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toBe('stubbed answer\n');
+    expect(result.stdout.trim()).toBe('stubbed answer');
     expect(result.stderr).toBe('');
   });
 
@@ -135,6 +135,6 @@ class PromptTemplate:
 
     expect(result.status).toBe(1);
     expect(result.stdout).toBe('');
-    expect(result.stderr).toBe('Error invoking math chain: stubbed invocation failure\n');
+    expect(result.stderr.trim()).toBe('Error invoking math chain: stubbed invocation failure');
   });
 });

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1251,6 +1251,17 @@ describe('computeRateLimitWaitMs', () => {
     expect(wait).toBeGreaterThanOrEqual(2_900);
     expect(wait).toBeLessThanOrEqual(3_100);
   });
+
+  it('falls back to Retry-After when a reset header is non-finite', () => {
+    const response = createMockResponse({
+      headers: new Headers({
+        'X-RateLimit-Reset': 'Infinity',
+        'Retry-After': '7',
+      }),
+    });
+
+    expect(computeRateLimitWaitMs(response)).toBe(7_000);
+  });
 });
 
 describe('fetchWithRetries', () => {

--- a/test/scheduler/headerParser.test.ts
+++ b/test/scheduler/headerParser.test.ts
@@ -394,6 +394,27 @@ describe('parseRateLimitHeaders', () => {
       expect(result.limitTokens).toBeUndefined();
     });
 
+    it('should ignore non-finite numeric values', () => {
+      const overflowingNumber = '9'.repeat(400);
+      const headers = {
+        'x-ratelimit-remaining-requests': overflowingNumber,
+        'x-ratelimit-reset': 'Infinity',
+        'retry-after-ms': overflowingNumber,
+      };
+
+      const result = parseRateLimitHeaders(headers);
+
+      expect(result.remainingRequests).toBeUndefined();
+      expect(result.resetAt).toBeUndefined();
+      expect(result.retryAfterMs).toBeUndefined();
+    });
+
+    it('should ignore negative reset values', () => {
+      const result = parseRateLimitHeaders({ 'x-ratelimit-reset': '-1' });
+
+      expect(result.resetAt).toBeUndefined();
+    });
+
     it('should ignore negative values', () => {
       const headers = {
         'x-ratelimit-remaining-requests': '-5',
@@ -577,6 +598,11 @@ describe('parseRetryAfter', () => {
       const result = parseRetryAfter('invalid');
 
       expect(result).toBeNull();
+    });
+
+    it('should reject non-finite seconds', () => {
+      expect(parseRetryAfter('Infinity')).toBeNull();
+      expect(parseRetryAfter('9'.repeat(400))).toBeNull();
     });
 
     it('should return null for empty string', () => {

--- a/test/scheduler/providerWrapper.test.ts
+++ b/test/scheduler/providerWrapper.test.ts
@@ -201,5 +201,29 @@ describe('providerWrapper', () => {
       const retryAfter = capturedOptions.getRetryAfter(result, undefined);
       expect(retryAfter).toBe(30000); // 30 seconds in ms
     });
+
+    it('should ignore non-finite retry-after-ms and fall back to retry-after', async () => {
+      let capturedOptions: any;
+      mockExecute.mockImplementation(async (_provider, callFn, options) => {
+        capturedOptions = options;
+        return callFn();
+      });
+
+      const wrappedProvider = wrapProviderWithRateLimiting(mockProvider, mockRegistry);
+      await wrappedProvider.callApi('test');
+
+      const result: ProviderResponse = {
+        output: 'test',
+        metadata: {
+          http: {
+            status: 429,
+            statusText: 'Too Many Requests',
+            headers: { 'retry-after-ms': '9'.repeat(400), 'retry-after': '30' },
+          },
+        },
+      };
+
+      expect(capturedOptions.getRetryAfter(result, undefined)).toBe(30000);
+    });
   });
 });

--- a/test/util/fetch/errors.test.ts
+++ b/test/util/fetch/errors.test.ts
@@ -314,6 +314,12 @@ describe('HttpRateLimitError', () => {
     expect(err.statusText).toBe('Too Many Requests');
   });
 
+  it('defaults empty statusText to "Too Many Requests"', () => {
+    const err = new HttpRateLimitError({ status: 429, statusText: '' });
+    expect(err.statusText).toBe('Too Many Requests');
+    expect(formatRateLimitErrorMessage(err)).toContain('Too Many Requests');
+  });
+
   it('produces a message containing the substrings legacy classifiers match on', () => {
     const err = new HttpRateLimitError({ status: 429, code: 'rate_limit_exceeded' });
     const lowered = err.message.toLowerCase();
@@ -340,6 +346,16 @@ describe('HttpRateLimitError', () => {
   it('rejects negative retryAfterMs', () => {
     const err = new HttpRateLimitError({ status: 429, retryAfterMs: -100 });
     expect(err.retryAfterMs).toBeUndefined();
+  });
+
+  it('rejects resetAt metadata paired with negative retryAfterMs', () => {
+    const err = new HttpRateLimitError({
+      status: 429,
+      retryAfterMs: -100,
+      resetAt: Date.now() + 30_000,
+    });
+    expect(err.retryAfterMs).toBeUndefined();
+    expect(err.resetAt).toBeUndefined();
   });
 });
 

--- a/test/util/fetch/errors.test.ts
+++ b/test/util/fetch/errors.test.ts
@@ -373,6 +373,18 @@ describe('HttpRateLimitError', () => {
     });
     expect(err.resetAt).toBeUndefined();
   });
+
+  it('drops non-finite retry metadata', () => {
+    const err = new HttpRateLimitError({
+      status: 429,
+      retryAfterMs: Number.POSITIVE_INFINITY,
+      resetAt: Number.POSITIVE_INFINITY,
+    });
+
+    expect(err.retryAfterMs).toBeUndefined();
+    expect(err.resetAt).toBeUndefined();
+    expect(formatRateLimitDetail(err)).toBe('');
+  });
 });
 
 describe('formatRateLimitDetail', () => {

--- a/test/util/fetch/errors.test.ts
+++ b/test/util/fetch/errors.test.ts
@@ -348,13 +348,29 @@ describe('HttpRateLimitError', () => {
     expect(err.retryAfterMs).toBeUndefined();
   });
 
-  it('rejects resetAt metadata paired with negative retryAfterMs', () => {
+  it('keeps a valid resetAt even when retryAfterMs is negative (independent validation)', () => {
+    const resetAt = Date.now() + 30_000;
     const err = new HttpRateLimitError({
       status: 429,
       retryAfterMs: -100,
-      resetAt: Date.now() + 30_000,
+      resetAt,
     });
     expect(err.retryAfterMs).toBeUndefined();
+    expect(err.resetAt).toBe(resetAt);
+  });
+
+  it('drops a negative resetAt when retryAfterMs is valid', () => {
+    const err = new HttpRateLimitError({ status: 429, retryAfterMs: 5000, resetAt: -1 });
+    expect(err.retryAfterMs).toBe(5000);
+    expect(err.resetAt).toBeUndefined();
+  });
+
+  it('drops a non-number resetAt (e.g. string) regardless of retryAfterMs', () => {
+    // Exercises the runtime typeof guard for untyped / `any` callers.
+    const err = new HttpRateLimitError({
+      status: 429,
+      resetAt: '1700000000000' as unknown as number,
+    });
     expect(err.resetAt).toBeUndefined();
   });
 });
@@ -371,6 +387,15 @@ describe('formatRateLimitDetail', () => {
       resetAt: Date.now() + 30_000,
     });
     expect(formatRateLimitDetail(err)).toMatch(/resets in \d+s/);
+  });
+
+  it('prefers retry-after over resetAt when both are present', () => {
+    const err = new HttpRateLimitError({
+      status: 429,
+      retryAfterMs: 12_000,
+      resetAt: Date.now() + 999_000,
+    });
+    expect(formatRateLimitDetail(err)).toBe(' [retry after 12s]');
   });
 
   it('returns empty string when no metadata is present', () => {

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -287,32 +287,32 @@ describe('sanitizeObject', () => {
   });
 
   describe('function handling', () => {
-    it('should lose named functions during JSON serialization', () => {
+    it('should omit named functions during JSON serialization', () => {
       function namedFunction() {
         return 'test';
       }
       const result = sanitizeObject({ func: namedFunction });
-      // Functions get lost during JSON.parse/stringify cycle
+      // Functions are omitted during JSON.parse/stringify cycle
       expect(result.func).toBeUndefined();
     });
 
-    it('should lose anonymous functions during JSON serialization', () => {
+    it('should omit anonymous functions during JSON serialization', () => {
       const anonymousFunc = function () {
         return 'test';
       };
       const result = sanitizeObject({ func: anonymousFunc });
-      // Functions get lost during JSON.parse/stringify cycle
+      // Functions are omitted during JSON.parse/stringify cycle
       expect(result.func).toBeUndefined();
     });
 
-    it('should lose arrow functions during JSON serialization', () => {
+    it('should omit arrow functions during JSON serialization', () => {
       const arrowFunc = () => 'test';
       const result = sanitizeObject({ func: arrowFunc });
-      // Functions get lost during JSON.parse/stringify cycle
+      // Functions are omitted during JSON.parse/stringify cycle
       expect(result.func).toBeUndefined();
     });
 
-    it('should handle functions at multiple nesting levels', () => {
+    it('should omit functions at multiple nesting levels during JSON serialization', () => {
       const input = {
         level1: {
           func: () => 'test',
@@ -324,7 +324,7 @@ describe('sanitizeObject', () => {
         },
       };
       const result = sanitizeObject(input);
-      // Functions get lost during JSON.parse/stringify cycle
+      // Functions are omitted during JSON.parse/stringify cycle
       expect(result.level1.func).toBeUndefined();
       expect(result.level1.level2.func).toBeUndefined();
     });
@@ -629,7 +629,7 @@ describe('sanitizeObject', () => {
       ];
       const result = sanitizeObject(input);
       expect(result[0]).toBe(1);
-      // Functions get lost during JSON.parse/stringify cycle
+      // Functions are omitted during JSON.parse/stringify cycle
       expect(result[1]).toBeNull();
       expect(result[2]).toBe(3);
     });

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -619,7 +619,7 @@ describe('sanitizeObject', () => {
       expect(sanitizeObject([])).toEqual([]);
     });
 
-    it('should handle arrays with functions', () => {
+    it('should replace functions in arrays with null during JSON serialization', () => {
       const input = [
         1,
         function test() {
@@ -629,7 +629,7 @@ describe('sanitizeObject', () => {
       ];
       const result = sanitizeObject(input);
       expect(result[0]).toBe(1);
-      // Functions are omitted during JSON.parse/stringify cycle
+      // JSON serialization preserves the array slot by replacing the function with null.
       expect(result[1]).toBeNull();
       expect(result[2]).toBe(3);
     });


### PR DESCRIPTION
## Summary

Addresses the GitHub AI code-quality findings and the follow-up review feedback:

- **Docker** — restore the `promptfoo`/`pf` CLI links in the server image. The server stage copies `package.json` and creates explicit symlinks (`node_modules/promptfoo -> /app`, `/usr/local/bin/{promptfoo,pf} -> dist/src/entrypoint.js`) instead of resolving a published registry build through `npm link promptfoo`.
- **Rate-limit errors** — validate `resetAt` and `retryAfterMs` independently and accept only finite, non-negative metadata. Raw header parsing and scheduler wrappers now reject non-finite values consistently, while the fetch retry path falls back to a valid `Retry-After` when reset metadata is malformed.
- **LangChain example** — validate CLI arguments and `OPENAI_API_KEY` before importing optional dependencies, return consistent exit codes, surface invocation errors on stderr, and document the required environment variable.
- **CI** — smoke-test both `promptfoo --version` and `pf --version` in the built Docker image.
- **Tests** — add executable success/error coverage for the LangChain script, malformed rate-limit header regressions across parser/wrapper/fetch boundaries, and accurate sanitizer serialization wording.

## Validation

- `npm run tsc` — clean
- Focused Vitest suites — 479 passing
- `ruff format --check` and `ruff check --select F401,F841,I` on the example — clean
- `python3 -m py_compile examples/integration-langchain/langchain_example.py`
- `npm run l` and `npm run f` — clean
- Direct runtime check confirms non-finite rate-limit metadata is rejected
- Docker CI builds the image and exercises the server, both CLI aliases, and a shared eval
