### PR TITLE
fix(scheduler): fall back from invalid retry-after-ms

### DIFF
--- a/src/scheduler/headerParser.ts
+++ b/src/scheduler/headerParser.ts
@@ -101,7 +101,9 @@ export function parseRateLimitHeaders(headers: Record<string, string>): ParsedRa
         result.resetAt = Date.now() + ms;
       }
     }
-  } else if (h['retry-after'] !== undefined) {
+  }
+
+  if (result.retryAfterMs === undefined && h['retry-after'] !== undefined) {
     const parsed = parseRetryAfter(h['retry-after']);
     if (parsed !== null) {
       result.retryAfterMs = parsed;

--- a/test/scheduler/headerParser.test.ts
+++ b/test/scheduler/headerParser.test.ts
@@ -266,6 +266,23 @@ describe('parseRateLimitHeaders', () => {
 
       vi.restoreAllMocks();
     });
+
+    it('should fall back to retry-after when retry-after-ms is invalid', () => {
+      const now = Date.now();
+      vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      const headers = {
+        'retry-after-ms': 'Infinity',
+        'retry-after': '30',
+      };
+
+      const result = parseRateLimitHeaders(headers);
+
+      expect(result.retryAfterMs).toBe(30000);
+      expect(result.resetAt).toBe(now + 30000);
+
+      vi.restoreAllMocks();
+    });
   });
 
   describe('Duration parsing', () => {


### PR DESCRIPTION
## Summary

- fall back to `Retry-After` when `retry-after-ms` is present but invalid
- keep valid `retry-after-ms` precedence unchanged
- add regression coverage for malformed millisecond metadata with a valid standard header

## Validation

- `./node_modules/.bin/vitest run test/scheduler/headerParser.test.ts -t 'should fall back to retry-after when retry-after-ms is invalid' --sequence.shuffle=false` (fails before fix, passes after)
- `./node_modules/.bin/vitest run test/scheduler/headerParser.test.ts --sequence.shuffle=false`
- `npm run l`
- `npm run f`
- `npm run tsc`
