### PR TITLE
fix(providers): flatten Moonshot config options

### DIFF
--- a/site/docs/providers/moonshot.md
+++ b/site/docs/providers/moonshot.md
@@ -47,7 +47,7 @@ The provider accepts every option the [OpenAI provider](/docs/providers/openai/)
 - `stream`
 - `response_format` (JSON mode), `tools` / `tool_choice` (function calling)
 - `showThinking` — set to `false` to drop a thinking model's reasoning from the graded output (default `true`)
-- `cost`, `inputCost`, `outputCost`, `cacheReadCost` — Moonshot ships no built-in price table, so set these to track cost. `inputCost`/`outputCost` take precedence over the flat `cost`; `cacheReadCost` prices cached prompt tokens.
+- `cost`, `inputCost`, `outputCost`, `cacheReadCost` — Moonshot ships no built-in price table, so set these to track cost. Use Moonshot's pricing/billing docs (start at [Moonshot API docs](https://platform.kimi.ai/docs/api)) and your account billing page to find current per-model rates, including cached-token read pricing for `cacheReadCost`. `inputCost`/`outputCost` take precedence over the flat `cost`; `cacheReadCost` prices cached prompt tokens.
 
 Any other parameter supported by the OpenAI provider is forwarded as-is.
 

--- a/src/providers/moonshot.ts
+++ b/src/providers/moonshot.ts
@@ -25,11 +25,7 @@ type MoonshotConfig = OpenAiCompletionOptions & {
 };
 
 type MoonshotProviderOptions = Omit<ProviderOptions, 'config'> & {
-  config?: {
-    config?: MoonshotConfig;
-    id?: string;
-    env?: EnvOverrides;
-  };
+  config?: MoonshotConfig;
 };
 
 function getProviderEnvString(env: EnvOverrides | undefined, key: EnvVarKey): string | undefined {
@@ -94,7 +90,7 @@ class MoonshotProvider extends OpenAiChatCompletionProvider {
   config: MoonshotConfig;
 
   constructor(modelName: string, providerOptions: MoonshotProviderOptions) {
-    const moonshotConfig = providerOptions.config?.config ?? {};
+    const moonshotConfig = providerOptions.config ?? {};
     const resolvedConfig: MoonshotConfig = {
       ...moonshotConfig,
       apiKeyEnvar: moonshotConfig.apiKeyEnvar ?? MOONSHOT_API_KEY_ENVAR,
@@ -104,8 +100,7 @@ class MoonshotProvider extends OpenAiChatCompletionProvider {
     };
 
     super(modelName, {
-      id: providerOptions.config?.id ?? providerOptions.id,
-      env: providerOptions.config?.env ?? providerOptions.env,
+      ...providerOptions,
       config: resolvedConfig,
     });
 

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -799,8 +799,8 @@ export const providerMap: ProviderFactory[] = [
       context: LoadApiProviderContext,
     ) => {
       return createMoonshotProvider(providerPath, {
-        config: providerOptions,
-        env: context.env,
+        ...providerOptions,
+        env: providerOptions.env ?? context.env,
       });
     },
   },

--- a/test/providers/moonshot.test.ts
+++ b/test/providers/moonshot.test.ts
@@ -62,7 +62,7 @@ describe('MoonshotProvider configuration', () => {
   it('lets the user override the base URL (e.g. the China endpoint)', () => {
     const provider = asChat(
       createMoonshotProvider('moonshot:moonshot-v1-8k', {
-        config: { config: { apiBaseUrl: 'https://api.moonshot.cn/v1' } },
+        config: { apiBaseUrl: 'https://api.moonshot.cn/v1' },
       }),
     );
     expect(provider.config.apiBaseUrl).toBe('https://api.moonshot.cn/v1');
@@ -72,7 +72,7 @@ describe('MoonshotProvider configuration', () => {
   it('passes through standard OpenAI options without dropping them', () => {
     const provider = asChat(
       createMoonshotProvider('moonshot:moonshot-v1-8k', {
-        config: { config: { temperature: 0.2, max_tokens: 256 } },
+        config: { temperature: 0.2, max_tokens: 256 },
       }),
     );
     expect(provider.config.temperature).toBe(0.2);
@@ -91,7 +91,7 @@ describe('MoonshotProvider configuration', () => {
   it('redacts an explicit apiKey from toJSON output', () => {
     const provider = asChat(
       createMoonshotProvider('moonshot:moonshot-v1-8k', {
-        config: { config: { apiKey: 'sk-secret', temperature: 0.2 } },
+        config: { apiKey: 'sk-secret', temperature: 0.2 },
       }),
     );
     const json = provider.toJSON();
@@ -104,7 +104,7 @@ describe('MoonshotProvider configuration', () => {
 describe('MoonshotProvider key resolution', () => {
   it('resolves apiKey from config', () => {
     const provider = createMoonshotProvider('moonshot:moonshot-v1-8k', {
-      config: { config: { apiKey: 'sk-from-config' } },
+      config: { apiKey: 'sk-from-config' },
     });
     expect((provider as any).getApiKey()).toBe('sk-from-config');
   });
@@ -137,7 +137,7 @@ describe('MoonshotProvider key resolution', () => {
     const restore = mockProcessEnv({ CUSTOM_MOONSHOT_KEY: 'sk-custom' });
     try {
       const provider = createMoonshotProvider('moonshot:moonshot-v1-8k', {
-        config: { config: { apiKeyEnvar: 'CUSTOM_MOONSHOT_KEY' } },
+        config: { apiKeyEnvar: 'CUSTOM_MOONSHOT_KEY' },
       });
       expect((provider as any).getApiKey()).toBe('sk-custom');
     } finally {
@@ -161,7 +161,7 @@ describe('MoonshotProvider sampling-param handling', () => {
   it('preserves explicit sampling/token params for Kimi models', async () => {
     const provider = asChat(
       createMoonshotProvider('moonshot:kimi-k2.6', {
-        config: { config: { temperature: 1, max_tokens: 2048 } },
+        config: { temperature: 1, max_tokens: 2048 },
       }),
     );
     const { body } = await provider.getOpenAiBody('Hello');
@@ -172,7 +172,7 @@ describe('MoonshotProvider sampling-param handling', () => {
   it('maps max_completion_tokens to Moonshot max_tokens for Kimi (not the injected 1024 default)', async () => {
     const provider = asChat(
       createMoonshotProvider('moonshot:kimi-k2.6', {
-        config: { config: { max_completion_tokens: 4096 } },
+        config: { max_completion_tokens: 4096 },
       }),
     );
     const { body } = await provider.getOpenAiBody('Hello');
@@ -262,7 +262,7 @@ describe('MoonshotProvider callApi cost', () => {
   it('fills in cost from user-supplied rates (incl. cached tokens)', async () => {
     vi.mocked(fetchWithCache).mockResolvedValueOnce(okResponse as any);
     const provider = createMoonshotProvider('moonshot:moonshot-v1-8k', {
-      config: { config: { apiKey: 'k', inputCost: 0.000002, outputCost: 0.000004 } },
+      config: { apiKey: 'k', inputCost: 0.000002, outputCost: 0.000004 },
     });
     const result = await provider.callApi('Say hi');
     expect(result.cost).toBe(
@@ -273,7 +273,7 @@ describe('MoonshotProvider callApi cost', () => {
   it('leaves cost undefined when no pricing is configured', async () => {
     vi.mocked(fetchWithCache).mockResolvedValueOnce(okResponse as any);
     const provider = createMoonshotProvider('moonshot:moonshot-v1-8k', {
-      config: { config: { apiKey: 'k' } },
+      config: { apiKey: 'k' },
     });
     const result = await provider.callApi('Say hi');
     expect(result.cost).toBeUndefined();

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -293,8 +293,6 @@ describe('Provider Registry', () => {
       );
       expect(provider).toBeDefined();
       expect(provider.id()).toBe('moonshot:moonshot-v1-8k');
-      // The registry double-nests config (createMoonshotProvider reads
-      // options.config.config); assert the user config survives end-to-end.
       const config = (provider as any).config;
       expect(config.temperature).toBe(0.42);
       expect(config.apiKey).toBe('moonshot-test-key');


### PR DESCRIPTION
## Summary
- flatten Moonshot provider config handling so ProviderOptions.config reaches the provider directly
- keep registry env precedence while removing the confusing options.config.config path
- add Moonshot pricing guidance for cacheReadCost

## Validation
- source ~/.nvm/nvm.sh && nvm use && npm_config_cache=/tmp/daily-ai-findings-pr-npm-cache npx vitest run test/providers/moonshot.test.ts test/providers/registry.test.ts
- source ~/.nvm/nvm.sh && nvm use && npm_config_cache=/tmp/daily-ai-findings-pr-npm-cache npm run tsc
- source ~/.nvm/nvm.sh && nvm use && npm_config_cache=/tmp/daily-ai-findings-pr-npm-cache npm run l
- source ~/.nvm/nvm.sh && nvm use && npm_config_cache=/tmp/daily-ai-findings-pr-npm-cache npm run f
- source ~/.nvm/nvm.sh && nvm use && npm_config_cache=/tmp/daily-ai-findings-pr-npm-cache SKIP_OG_GENERATION=true npm run build in site/

## Notes
- Local npm ci was blocked by Socket policy on esbuild@0.28.1, so validation reused the existing locked Promptfoo checkout toolchain.
- Local root npm run build completed backend bundling but the app leg remained blocked by missing local frontend deps (posthog-js, diff) in that reused toolchain.
