### PR TITLE
docs(site): clarify Moonshot pricing units

### DIFF
--- a/site/docs/providers/moonshot.md
+++ b/site/docs/providers/moonshot.md
@@ -47,7 +47,18 @@ The provider accepts every option the [OpenAI provider](/docs/providers/openai/)
 - `stream`
 - `response_format` (JSON mode), `tools` / `tool_choice` (function calling)
 - `showThinking` — set to `false` to drop a thinking model's reasoning from the graded output (default `true`)
-- `cost`, `inputCost`, `outputCost`, `cacheReadCost` — Moonshot ships no built-in price table, so set these to track cost. Use Moonshot's pricing/billing docs (start at [Moonshot API docs](https://platform.kimi.ai/docs/api)) and your account billing page to find current per-model rates, including cached-token read pricing for `cacheReadCost`. `inputCost`/`outputCost` take precedence over the flat `cost`; `cacheReadCost` prices cached prompt tokens.
+- `cost`, `inputCost`, `outputCost`, `cacheReadCost` — Moonshot ships no built-in price table, so set these to track cost. Every override is in USD per token. Moonshot's [official pricing page](https://platform.kimi.ai/docs/pricing/chat) publishes rates in USD per 1 million tokens, so divide each published rate by `1,000,000` before configuring it. `inputCost`/`outputCost` take precedence over the flat `cost`; `cacheReadCost` prices cached prompt tokens.
+
+For example, these illustrative per-million rates convert to per-token overrides. Check the official pricing page for the current rates for your model before using them.
+
+```yaml
+providers:
+  - id: moonshot:kimi-k2.6
+    config:
+      inputCost: 0.00000095 # $0.95 per 1M tokens divided by 1,000,000
+      cacheReadCost: 0.00000016 # $0.16 per 1M tokens divided by 1,000,000
+      outputCost: 0.000004 # $4.00 per 1M tokens divided by 1,000,000
+```
 
 Any other parameter supported by the OpenAI provider is forwarded as-is.
 

--- a/test/providers/index.test.ts
+++ b/test/providers/index.test.ts
@@ -917,6 +917,15 @@ describe('loadApiProvider', () => {
     expect((provider as any).apiKey).toBe('provider-key');
   });
 
+  it('loadApiProvider with moonshot prefers provider-level env over context env', async () => {
+    const provider = (await loadApiProvider('moonshot:kimi-k2.6', {
+      options: { env: { MOONSHOT_API_KEY: 'provider-key' } },
+      env: { MOONSHOT_API_KEY: 'context-key' },
+    })) as OpenAiChatCompletionProvider;
+
+    expect(provider.getApiKey()).toBe('provider-key');
+  });
+
   it('loadApiProvider with file://*.py', async () => {
     const provider = await loadApiProvider('file://script.py:function_name');
     expect(provider).toBeInstanceOf(PythonProvider);

--- a/test/providers/moonshot.test.ts
+++ b/test/providers/moonshot.test.ts
@@ -231,15 +231,20 @@ describe('calculateMoonshotCost', () => {
     expect(cost).toBeCloseTo(1000 * 0.000001 + 500 * 0.000004, 10);
   });
 
-  it('bills cached prompt tokens at cacheReadCost when supplied', () => {
+  it('uses per-token rates converted from per-million pricing for mixed cached input', () => {
     const cost = calculateMoonshotCost(
-      { inputCost: 0.000002, outputCost: 0.000004, cacheReadCost: 0.0000005 },
-      1000,
+      {
+        inputCost: 0.95 / 1_000_000,
+        cacheReadCost: 0.16 / 1_000_000,
+        outputCost: 4 / 1_000_000,
+      },
+      1_000,
       500,
       400,
     );
-    const expected = 600 * 0.000002 + 400 * 0.0000005 + 500 * 0.000004;
-    expect(cost).toBeCloseTo(expected, 10);
+
+    // 600 uncached input, 400 cached input, and 500 output tokens.
+    expect(cost).toBe(0.002634);
   });
 });
 


### PR DESCRIPTION
## Summary

- clarify that Moonshot cost overrides are USD per token and that published per-million rates must be divided by 1,000,000
- link the official pricing page and add an explicitly converted illustrative YAML example
- add focused regressions for mixed cached/uncached cost calculation and provider-level `MOONSHOT_API_KEY` precedence

This is a docs/tests-only follow-up to merged #9803. It preserves the existing per-token calculator contract and does not add volatile built-in price defaults.

## Testing

- `git diff --check`
- high-risk native prepublish review gate: 3 independent passes plus a fresh verifier, clean with zero candidates
- focused Vitest, `npm run l`, `npm run format:check`, `npm run tsc`, and the docs build were attempted locally but could not start because the environment's Socket policy rejects the lockfile-pinned `esbuild@0.28.1` tarball; GitHub CI is the authoritative execution surface
