### PR TITLE
fix(csv): reject __expected0 instead of silently dropping its config

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -226,7 +226,13 @@ export function testCaseFromCsvRow(row: CsvRow): TestCase {
           // Extract the numeric index (e.g., __expected1 -> 0, __expected2 -> 1)
           const indexMatch = expectedKey.match(/^__expected(\d+)$/);
           if (indexMatch) {
-            targetIndex = Number.parseInt(indexMatch[1], 10) - 1; // Convert to 0-based index
+            const oneBasedIndex = Number.parseInt(indexMatch[1], 10);
+            // Indices are 1-based (__expected1 -> 0). Reject 0 so it falls
+            // through to the "positive integer" error below instead of
+            // silently writing the config to assertionConfigs[-1].
+            if (oneBasedIndex >= 1) {
+              targetIndex = oneBasedIndex - 1;
+            }
           }
         }
 

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -332,6 +332,21 @@ describe('testCaseFromCsvRow', () => {
       );
     });
 
+    it('throws on __expected0 since indices are 1-based', () => {
+      const key = '__config:__expected0:threshold';
+      const row: CsvRow = {
+        __expected1: 'equals:foo',
+        [key]: '0.5',
+      } as any;
+
+      expect(() => testCaseFromCsvRow(row)).toThrow(
+        'Invalid expected key "__expected0" in __config column',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        'Invalid expected key "__expected0" in __config column "__config:__expected0:threshold". Must be __expected or __expected<N> where N is a positive integer.',
+      );
+    });
+
     it('throws on invalid config key in __config column', () => {
       const key = '__config:__expected1:bogus';
       const row: CsvRow = {


### PR DESCRIPTION
## What

A `__config:__expected0:threshold` column is silently dropped instead of being rejected.

`__expected<N>` indices are 1-based (`__expected1` → assertion 0). The parser runs `Number.parseInt(n, 10) - 1`, so `__expected0` becomes `-1`. That isn't `undefined`, so it slips past the "must be a positive integer" guard, and the config is written to `assertionConfigs[-1]` — a property the apply loop (`for i = 0..asserts.length`) never reads. The threshold just vanishes with no error.

This is inconsistent with `__expectedX` (non-numeric), which already throws `Invalid expected key ... Must be __expected or __expected<N> where N is a positive integer.` This change makes `__expected0` take that same path by only assigning `targetIndex` when the index is `>= 1`.

## Why

The error message already promises that `N` must be a positive integer, but `0` was accepted and then silently no-op'd. A user who indexes from 0 loses their threshold config without any signal. Erroring matches the documented contract and the existing `__expectedX` behavior.

## Testing

Added a `test/csv.test.ts` case asserting `__config:__expected0:threshold` throws the same "positive integer" error as `__expectedX`. It fails on `main` (`expected [Function] to throw an error`, since the config is silently dropped) and passes with this change. `npx vitest run test/csv.test.ts` is green; `tsc --noEmit` and prettier/biome are clean (the pre-existing complexity warning on `testCaseFromCsvRow` is unrelated).
