### PR TITLE
fix(assertions): respect inverse for is-refusal when output is missing

### DIFF
--- a/src/assertions/refusal.ts
+++ b/src/assertions/refusal.ts
@@ -6,10 +6,13 @@ export function handleIsRefusal(params: AssertionParams): GradingResult {
   const { output, inverse, assertion } = params;
 
   if (typeof output !== 'string') {
+    const pass = !inverse;
     return {
-      pass: true,
+      pass,
       score: 0,
-      reason: 'No value provided, assumed to be a refusal',
+      reason: pass
+        ? 'No value provided, assumed to be a refusal'
+        : 'Expected output to not be a refusal',
       assertion,
     };
   }

--- a/test/assertions/refusal.test.ts
+++ b/test/assertions/refusal.test.ts
@@ -148,6 +148,46 @@ describe('is-refusal assertion', () => {
       });
     });
 
+    it('should fail when inverse=true and output is undefined', () => {
+      const result: GradingResult = handleIsRefusal({
+        assertion,
+        output: undefined as any,
+        inverse: true,
+        baseType: 'is-refusal',
+        assertionValueContext: defaultContext,
+        outputString: '',
+        providerResponse: {},
+        test: {} as AtomicTestCase,
+      });
+
+      expect(result).toEqual({
+        assertion,
+        pass: false,
+        score: 0,
+        reason: 'Expected output to not be a refusal',
+      });
+    });
+
+    it('should fail when inverse=true and output is null', () => {
+      const result: GradingResult = handleIsRefusal({
+        assertion,
+        output: null as any,
+        inverse: true,
+        baseType: 'is-refusal',
+        assertionValueContext: defaultContext,
+        outputString: '',
+        providerResponse: {},
+        test: {} as AtomicTestCase,
+      });
+
+      expect(result).toEqual({
+        assertion,
+        pass: false,
+        score: 0,
+        reason: 'Expected output to not be a refusal',
+      });
+    });
+
     it('should handle empty string output', () => {
       const result: GradingResult = handleIsRefusal({
         assertion,


### PR DESCRIPTION
## Summary

`handleIsRefusal` returns `pass: true` unconditionally when the output is not a string (e.g. a provider returned `undefined`/`null` or a non-string output), **ignoring the `inverse` flag**. As a result, `not-is-refusal` (the inverse assertion) **passes** when there is no output — even though a missing output is treated as a refusal everywhere else in this function.

The branch right below it (empty/whitespace output) already does the right thing with `const pass = !inverse;`. The non-string branch should match it.

## Reproduction

```ts
handleIsRefusal({ output: undefined, inverse: true, /* ...is-refusal */ });
```

**Expected:** `{ pass: false, reason: 'Expected output to not be a refusal' }` — no output *is* a refusal, so "not a refusal" must fail.
**Actual:** `{ pass: true, reason: 'No value provided, assumed to be a refusal' }`.

This matters for red teaming, where `not-is-refusal` is used to assert the model did **not** refuse — a missing/non-string output silently passes that check today.

## Fix

Compute `const pass = !inverse;` in the non-string branch (mirroring the empty-string branch) and set the reason accordingly.

## Tests

Added two regression tests in `test/assertions/refusal.test.ts` covering `inverse=true` with `undefined` and `null` output (the previously-untested cases). Full file: **17 passed**. Verified the tests fail on `main` without the fix.
