### PR TITLE
fix(util): keep ellipsize within maxLen when maxLen is below 3

### DIFF
--- a/src/util/text.ts
+++ b/src/util/text.ts
@@ -6,6 +6,11 @@
  */
 export function ellipsize(str: string, maxLen: number): string {
   if (str.length > maxLen) {
+    if (maxLen < 3) {
+      // Not enough room for the ellipsis; hard-truncate so the result still
+      // respects maxLen instead of slicing with a negative index.
+      return str.slice(0, Math.max(0, maxLen));
+    }
     return str.slice(0, maxLen - 3) + '...';
   }
   return str;

--- a/test/util/text.test.ts
+++ b/test/util/text.test.ts
@@ -25,4 +25,15 @@ describe('ellipsize', () => {
   it('should handle empty string', () => {
     expect(ellipsize('', 5)).toBe('');
   });
+
+  it('should stay within maxLen when maxLen is too small for an ellipsis', () => {
+    // maxLen < 3 has no room for "..."; the result must still respect maxLen
+    // (previously slice(0, maxLen - 3) used a negative index and overflowed).
+    expect(ellipsize('hello', 2)).toBe('he');
+    expect(ellipsize('hello', 1)).toBe('h');
+    expect(ellipsize('hello', 0)).toBe('');
+    for (const maxLen of [0, 1, 2, 3]) {
+      expect(ellipsize('hello', maxLen).length).toBeLessThanOrEqual(maxLen);
+    }
+  });
 });


### PR DESCRIPTION
### Summary

`ellipsize` truncates with `str.slice(0, maxLen - 3) + '...'`. When `maxLen < 3`, `maxLen - 3` is negative, so `slice` keeps all but the last few characters and the result ends up *longer* than `maxLen`:

```
ellipsize('hello', 2) // 'hell...' (length 7)
ellipsize('hello', 1) // 'hel...'  (length 6)
ellipsize('hello', 0) // 'he...'   (length 5)
```

This is reachable: `tableCellMaxLength` is a user-configurable positive integer (`z.coerce.number().int().positive()` in `src/types/index.ts`), so a value of 1 or 2 feeds straight into `ellipsize` and overflows the table cell instead of fitting it.

### Fix

When there's no room for the ellipsis (`maxLen < 3`), hard-truncate to `maxLen` instead. `maxLen >= 3` is unchanged (`maxLen === 3` already yields `'...'`).

### Tests

Extended `test/util/text.test.ts` to cover `maxLen` of 0/1/2 and to assert the result never exceeds `maxLen` for `maxLen` in 0..3. It fails before this change and passes after.
