### PR TITLE
chore: address ai findings

### DIFF
--- a/src/assertions/sql.ts
+++ b/src/assertions/sql.ts
@@ -139,8 +139,8 @@ export const handleIsSql = async ({
 }: AssertionParams): Promise<GradingResult> => {
   let pass = false;
   let databaseType: string = 'MySQL';
-  let whiteTableList: string[] | undefined;
-  let whiteColumnList: string[] | undefined;
+  let allowedTables: string[] | undefined;
+  let allowedColumns: string[] | undefined;
   if (renderedValue && typeof renderedValue === 'object') {
     const value = renderedValue as {
       databaseType?: string;
@@ -149,8 +149,8 @@ export const handleIsSql = async ({
     };
 
     databaseType = value.databaseType || 'MySQL';
-    whiteTableList = value.allowedTables;
-    whiteColumnList = value.allowedColumns;
+    allowedTables = value.allowedTables;
+    allowedColumns = value.allowedColumns;
   }
 
   if (renderedValue && typeof renderedValue !== 'object') {
@@ -205,10 +205,10 @@ export const handleIsSql = async ({
     pass = inverse;
   }
 
-  if (whiteTableList) {
+  if (allowedTables) {
     opt.type = 'table';
     try {
-      sqlParser.whiteListCheck(outputString, whiteTableList, opt);
+      sqlParser.whiteListCheck(outputString, allowedTables, opt);
     } catch (err) {
       pass = inverse;
       const error = err as Error;
@@ -224,7 +224,7 @@ export const handleIsSql = async ({
         failureReasons.push(
           `SQL references unauthorized table(s). ` +
             `Found: [${actualTables.join(', ')}]. ` +
-            `Allowed: [${whiteTableList.join(', ')}].`,
+            `Allowed: [${allowedTables.join(', ')}].`,
         );
       } else {
         failureReasons.push(`SQL validation failed: ${error.message}.`);
@@ -232,20 +232,20 @@ export const handleIsSql = async ({
     }
   }
 
-  if (whiteColumnList) {
+  if (allowedColumns) {
     opt.type = 'column';
-    const normalizedWhiteList = [...whiteColumnList];
-    for (const item of whiteColumnList) {
+    const normalizedAllowedColumns = [...allowedColumns];
+    for (const item of allowedColumns) {
       const parts = item.split('::');
       if (parts.length === 3 && parts[1] !== 'null') {
         const alt = `${parts[0]}::null::${parts[2]}`;
-        if (!normalizedWhiteList.includes(alt)) {
-          normalizedWhiteList.push(alt);
+        if (!normalizedAllowedColumns.includes(alt)) {
+          normalizedAllowedColumns.push(alt);
         }
       }
     }
     try {
-      sqlParser.whiteListCheck(outputString, normalizedWhiteList, opt);
+      sqlParser.whiteListCheck(outputString, normalizedAllowedColumns, opt);
     } catch (err) {
       pass = inverse;
       const error = err as Error;
@@ -261,7 +261,7 @@ export const handleIsSql = async ({
         failureReasons.push(
           `SQL references unauthorized column(s). ` +
             `Found: [${actualColumns.join(', ')}]. ` +
-            `Allowed: [${whiteColumnList.join(', ')}].`,
+            `Allowed: [${allowedColumns.join(', ')}].`,
         );
       } else {
         failureReasons.push(`SQL validation failed: ${error.message}.`);

--- a/src/providers/bedrock/mantle.ts
+++ b/src/providers/bedrock/mantle.ts
@@ -10,7 +10,12 @@ export function isBedrockOpenAiResponsesModel(modelName: string): boolean {
   return modelName.startsWith('openai.') && !modelName.includes('gpt-oss');
 }
 
-/** Whether a Bedrock model id is a bare xAI Grok id (for example, `xai.grok-4.3`). */
+/**
+ * Whether a Bedrock model id is a bare xAI Grok id (for example, `xai.grok-4.3`).
+ *
+ * @param modelName The Bedrock model identifier to evaluate.
+ * @returns `true` when the model id is an xAI Grok model served as `xai.grok-*`; otherwise `false`.
+ */
 export function isBedrockGrokModel(modelName: string): boolean {
   return modelName.startsWith('xai.grok-');
 }

--- a/test/assertions/sql.test.ts
+++ b/test/assertions/sql.test.ts
@@ -176,6 +176,7 @@ describe('is-sql assertion', () => {
     it.each([
       { databaseType: 'BigQuery', outputString: "SELECT r'hello' value FROM t" },
       { databaseType: 'TransactSQL', outputString: "SELECT N'hello' value FROM t" },
+      // Intentionally `Sqlite` (not `SQLite`) to match node-sql-parser dialect naming.
       { databaseType: 'Sqlite', outputString: "SELECT X'53514C697465' value FROM t" },
     ])('should preserve prefixed literals in $databaseType', async ({
       databaseType,
@@ -485,8 +486,8 @@ describe('is-sql assertion', () => {
     });
   });
 
-  // ------------------------------------------- White Table/Column List Tests ------------------------------------------- //
-  describe('White Table/Column List Tests', () => {
+  // ------------------------------------------ Allowed Table/Column List Tests ------------------------------------------ //
+  describe('Allowed Table/Column List Tests', () => {
     it('should fail if the output SQL statement violate allowedTables', async () => {
       const renderedValue = {
         databaseType: 'MySQL',

--- a/test/providers/azure/util.test.ts
+++ b/test/providers/azure/util.test.ts
@@ -104,27 +104,113 @@ describe('AZURE_MODELS cost coverage', () => {
   });
 
   it.each([
-    ['gpt-5.4', 1000, 1000, 0.0125, 'GPT-5.x'],
-    ['gpt-4.1', 1000, 1000, 0.01, 'GPT-4.1'],
-    ['gpt-4o', 1000, 1000, 0.0125, 'GPT-4o'],
-    ['o3', 1000, 1000, 0.05, 'o-series reasoning'],
-    ['text-embedding-3-large', 1000, 0, 0.00013, 'embeddings'],
-    ['gpt-image-1', 1000, 1000, 0.045, 'image'],
-    ['claude-opus-4-7', 1000, 1000, 0.03, 'Anthropic Claude'],
-    ['Llama-3.3-70B-Instruct', 1000, 1000, 0.00074, 'Meta Llama'],
-    ['DeepSeek-R1', 1000, 1000, 0.00274, 'DeepSeek'],
-    ['grok-4', 1000, 1000, 0.018, 'xAI Grok'],
-    ['Kimi-K2-Thinking', 1000, 1000, 0.0031, 'MoonshotAI Kimi'],
-    ['Phi-4', 1000, 1000, 0.00021, 'Microsoft Phi'],
-    ['Mistral-Large-3', 1000, 1000, 0.002, 'Mistral'],
-    ['Cohere-command-r', 1000, 1000, 0.00075, 'Cohere'],
-    ['AI21-Jamba-1.5-Large', 1000, 1000, 0.001, 'AI21'],
-    ['MAI-DS-R1', 1000, 1000, 0.00274, 'Microsoft MAI'],
-  ])('computes expected representative cost for %s (%s)', (id, inputTokens, outputTokens, expectedCost) => {
-    expect(calculateAzureCost(id, {}, inputTokens as number, outputTokens as number)).toBeCloseTo(
-      expectedCost as number,
-      12,
-    );
+    {
+      id: 'gpt-5.4',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.0125,
+      family: 'GPT-5.x',
+    },
+    { id: 'gpt-4.1', inputTokens: 1000, outputTokens: 1000, expectedCost: 0.01, family: 'GPT-4.1' },
+    { id: 'gpt-4o', inputTokens: 1000, outputTokens: 1000, expectedCost: 0.0125, family: 'GPT-4o' },
+    {
+      id: 'o3',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.05,
+      family: 'o-series reasoning',
+    },
+    {
+      id: 'text-embedding-3-large',
+      inputTokens: 1000,
+      outputTokens: 0,
+      expectedCost: 0.00013,
+      family: 'embeddings',
+    },
+    {
+      id: 'gpt-image-1',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.045,
+      family: 'image',
+    },
+    {
+      id: 'claude-opus-4-7',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.03,
+      family: 'Anthropic Claude',
+    },
+    {
+      id: 'Llama-3.3-70B-Instruct',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.00074,
+      family: 'Meta Llama',
+    },
+    {
+      id: 'DeepSeek-R1',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.00274,
+      family: 'DeepSeek',
+    },
+    {
+      id: 'grok-4',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.018,
+      family: 'xAI Grok',
+    },
+    {
+      id: 'Kimi-K2-Thinking',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.0031,
+      family: 'MoonshotAI Kimi',
+    },
+    {
+      id: 'Phi-4',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.00021,
+      family: 'Microsoft Phi',
+    },
+    {
+      id: 'Mistral-Large-3',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.002,
+      family: 'Mistral',
+    },
+    {
+      id: 'Cohere-command-r',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.00075,
+      family: 'Cohere',
+    },
+    {
+      id: 'AI21-Jamba-1.5-Large',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.001,
+      family: 'AI21',
+    },
+    {
+      id: 'MAI-DS-R1',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      expectedCost: 0.00274,
+      family: 'Microsoft MAI',
+    },
+  ])('computes expected representative cost for $family ($id)', ({
+    id,
+    inputTokens,
+    outputTokens,
+    expectedCost,
+  }) => {
+    expect(calculateAzureCost(id, {}, inputTokens, outputTokens)).toBeCloseTo(expectedCost, 12);
   });
 
   // Spot-check that a representative of each supported family is priced (documents coverage and

--- a/test/providers/azure/util.test.ts
+++ b/test/providers/azure/util.test.ts
@@ -103,6 +103,30 @@ describe('AZURE_MODELS cost coverage', () => {
     expect(dupes).toEqual([]);
   });
 
+  it.each([
+    ['gpt-5.4', 1000, 1000, 0.0125, 'GPT-5.x'],
+    ['gpt-4.1', 1000, 1000, 0.01, 'GPT-4.1'],
+    ['gpt-4o', 1000, 1000, 0.0125, 'GPT-4o'],
+    ['o3', 1000, 1000, 0.05, 'o-series reasoning'],
+    ['text-embedding-3-large', 1000, 0, 0.00013, 'embeddings'],
+    ['gpt-image-1', 1000, 1000, 0.045, 'image'],
+    ['claude-opus-4-7', 1000, 1000, 0.03, 'Anthropic Claude'],
+    ['Llama-3.3-70B-Instruct', 1000, 1000, 0.00074, 'Meta Llama'],
+    ['DeepSeek-R1', 1000, 1000, 0.00274, 'DeepSeek'],
+    ['grok-4', 1000, 1000, 0.018, 'xAI Grok'],
+    ['Kimi-K2-Thinking', 1000, 1000, 0.0031, 'MoonshotAI Kimi'],
+    ['Phi-4', 1000, 1000, 0.00021, 'Microsoft Phi'],
+    ['Mistral-Large-3', 1000, 1000, 0.002, 'Mistral'],
+    ['Cohere-command-r', 1000, 1000, 0.00075, 'Cohere'],
+    ['AI21-Jamba-1.5-Large', 1000, 1000, 0.001, 'AI21'],
+    ['MAI-DS-R1', 1000, 1000, 0.00274, 'Microsoft MAI'],
+  ])('computes expected representative cost for %s (%s)', (id, inputTokens, outputTokens, expectedCost) => {
+    expect(calculateAzureCost(id, {}, inputTokens as number, outputTokens as number)).toBeCloseTo(
+      expectedCost as number,
+      12,
+    );
+  });
+
   // Spot-check that a representative of each supported family is priced (documents coverage and
   // fails loudly if a whole family is dropped from the table).
   it.each([

--- a/test/redteam/plugins/unsafebench.test.ts
+++ b/test/redteam/plugins/unsafebench.test.ts
@@ -70,8 +70,7 @@ vi.mock('../../../src/redteam/plugins/unsafebench', async () => {
         );
         if (invalidCategories.length > 0) {
           logger.warn(
-            `[unsafebench] Invalid categories: ${invalidCategories.join(', ')}. 
-          Valid categories are: ${originalModule.VALID_CATEGORIES.join(', ')}`,
+            `[unsafebench] Invalid categories: ${invalidCategories.join(', ')}. Valid categories are: ${originalModule.VALID_CATEGORIES.join(', ')}`,
           );
         }
       }
@@ -262,7 +261,7 @@ describe('UnsafeBenchPlugin', () => {
 
     // Create plugin with an invalid category
     new UnsafeBenchPlugin({ type: 'test' }, 'testing purposes', 'image', {
-      categories: ['InvalidCategory' as any],
+      categories: ['InvalidCategory' as unknown as (typeof VALID_CATEGORIES)[number]],
     });
 
     expect(loggerWarnSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- rename flagged SQL allowlist locals and test wording
- document the Bedrock Grok helper and tighten AI-flagged tests
- add concrete Azure representative pricing assertions

## Testing
- source ~/.nvm/nvm.sh && nvm use >/dev/null && node node_modules/vitest/vitest.mjs run test/assertions/sql.test.ts test/providers/azure/util.test.ts test/redteam/plugins/unsafebench.test.ts --sequence.shuffle=false --configLoader runner
- source ~/.nvm/nvm.sh && nvm use >/dev/null && node node_modules/typescript/bin/tsc --noEmit
- source ~/.nvm/nvm.sh && nvm use >/dev/null && npm run l
- source ~/.nvm/nvm.sh && nvm use >/dev/null && npm run f

## Notes
- Fresh worktree npm ci was blocked by Socket Security Policy on undici@7.28.0, so focused validation reused an existing Promptfoo worktree dependency tree.