### PR TITLE
fix(testCaseReader): preserve JSONL row description instead of overwriting

### DIFF
--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -364,7 +364,7 @@ function parseJsonlTestCases(fileContent: string): TestCase[] {
       const row = JSON.parse(line);
       return {
         ...row,
-        description: `Row #${idx + 1}`,
+        description: row.description || `Row #${idx + 1}`,
       };
     });
 }

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -310,6 +310,17 @@ describe('readStandaloneTestsFile', () => {
     ]);
   });
 
+  it('should preserve existing description from JSONL rows', async () => {
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      `{"description":"Custom Desc","vars":{"x":"y"}}
+{"vars":{"a":"b"}}`,
+    );
+    const result = await readStandaloneTestsFile('test.jsonl');
+
+    expect(result[0].description).toBe('Custom Desc');
+    expect(result[1].description).toBe('Row #2');
+  });
+
   it('should read YAML file and return test cases', async () => {
     vi.mocked(fs.readFileSync).mockReturnValue(dedent`
       - var1: value1

--- a/test/util/testCaseReader.test.ts
+++ b/test/util/testCaseReader.test.ts
@@ -313,12 +313,16 @@ describe('readStandaloneTestsFile', () => {
   it('should preserve existing description from JSONL rows', async () => {
     vi.mocked(fs.readFileSync).mockReturnValue(
       `{"description":"Custom Desc","vars":{"x":"y"}}
-{"vars":{"a":"b"}}`,
+{"vars":{"a":"b"}}
+{"description":"","vars":{"c":"d"}}`,
     );
     const result = await readStandaloneTestsFile('test.jsonl');
 
     expect(result[0].description).toBe('Custom Desc');
+    // Missing and empty-string descriptions both fall back to the row label,
+    // matching the JSON/YAML/CSV parsers' `||` behavior.
     expect(result[1].description).toBe('Row #2');
+    expect(result[2].description).toBe('Row #3');
   });
 
   it('should read YAML file and return test cases', async () => {


### PR DESCRIPTION
`parseJsonlTestCases` in `src/util/testCaseReader.ts` unconditionally overwrites the `description` field with `"Row #N"` even when the row already has one:

```ts
return {
  ...row,
  description: `Row #${idx + 1}`,  // always overwrites
};
```

The three other parsers in the same file (`parseJsonTestCases`, `parseYamlTestCases`, `csvRowsToTestCases`) all use `row.description || \`Row #${idx + 1}\`` as a fallback. JSONL was the odd one out.

So a file like:
```jsonl
{"description":"My custom test","vars":{"prompt":"hello"}}
```
would silently produce `description: "Row #1"` instead of `"My custom test"`.

Fix is one word: change the explicit override to a `||` fallback, consistent with the rest of the file. Added a test to cover the preserved-description case.
