### PR TITLE
fix(bleu): return pass:false for empty output instead of throwing

### DIFF
--- a/src/assertions/bleu.ts
+++ b/src/assertions/bleu.ts
@@ -67,8 +67,11 @@ export function calculateBleuScore(
   references: string[],
   weights: number[] = [0.25, 0.25, 0.25, 0.25],
 ): number {
-  if (!candidate || references.length === 0 || weights.length !== 4) {
+  if (candidate == null || references.length === 0 || weights.length !== 4) {
     throw new Error('Invalid inputs');
+  }
+  if (candidate === '') {
+    return 0;
   }
   // BLEU weights are non-negative by definition. Rejecting negatives keeps the
   // score within the documented [0, 1] range (a negative weight on a smoothed

--- a/src/assertions/bleu.ts
+++ b/src/assertions/bleu.ts
@@ -59,8 +59,9 @@ function countNGrams(ngrams: string[]): Map<string, number> {
  * @param references - Array of reference strings to compare against
  * @param weights - Weights for each n-gram precision (1-gram to 4-gram). Must be
  *   non-negative and sum to 1 (BLEU weights are non-negative by definition).
- * @returns BLEU score between 0 and 1
- * @throws When inputs are invalid, weights are negative, or weights don't sum to 1
+ * @returns BLEU score between 0 and 1 (0 for an empty or whitespace-only candidate)
+ * @throws When the candidate is null/undefined, references is empty, weights are
+ *   negative, or weights don't sum to 1
  */
 export function calculateBleuScore(
   candidate: string,
@@ -70,7 +71,11 @@ export function calculateBleuScore(
   if (candidate == null || references.length === 0 || weights.length !== 4) {
     throw new Error('Invalid inputs');
   }
-  if (candidate === '') {
+  // An empty or whitespace-only candidate (a refusal or truncated generation) has
+  // zero n-gram overlap with any reference, so its BLEU score is 0. Return early to
+  // avoid throwing — which would crash the eval — or letting `tokenize('   ')` (which
+  // yields `['']`) smooth to a misleadingly tiny nonzero score.
+  if (candidate.trim() === '') {
     return 0;
   }
   // BLEU weights are non-negative by definition. Rejecting negatives keeps the

--- a/test/assertions/bleu.test.ts
+++ b/test/assertions/bleu.test.ts
@@ -377,4 +377,23 @@ describe('handleBleuScore', () => {
       assertion: expect.any(Object),
     });
   });
+
+  it('should return pass:false score:0 for empty output, not throw', () => {
+    expect(() =>
+      handleBleuScore({
+        assertion: { type: 'bleu' },
+        renderedValue: 'some reference',
+        outputString: '',
+        inverse: false,
+      } as AssertionParams),
+    ).not.toThrow();
+    const result = handleBleuScore({
+      assertion: { type: 'bleu' },
+      renderedValue: 'some reference',
+      outputString: '',
+      inverse: false,
+    } as AssertionParams);
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+  });
 });

--- a/test/assertions/bleu.test.ts
+++ b/test/assertions/bleu.test.ts
@@ -232,6 +232,22 @@ describe('BLEU score calculation', () => {
     }).toThrow('Invalid inputs');
   });
 
+  it('should return 0 for an empty candidate instead of throwing', () => {
+    expect(calculateBleuScore('', ['some reference'])).toBe(0);
+  });
+
+  it('should return 0 for a whitespace-only candidate', () => {
+    expect(calculateBleuScore('   ', ['some reference'])).toBe(0);
+    expect(calculateBleuScore('\n\t', ['some reference'])).toBe(0);
+  });
+
+  it('should still throw for a null or undefined candidate', () => {
+    expect(() => calculateBleuScore(null as never, ['some reference'])).toThrow('Invalid inputs');
+    expect(() => calculateBleuScore(undefined as never, ['some reference'])).toThrow(
+      'Invalid inputs',
+    );
+  });
+
   it('should throw error for invalid weights', () => {
     const references = ['The cat sat on the mat.'];
     const invalidWeights = [0.5, 0.5, 0.5, 0.5];
@@ -378,15 +394,7 @@ describe('handleBleuScore', () => {
     });
   });
 
-  it('should return pass:false score:0 for empty output, not throw', () => {
-    expect(() =>
-      handleBleuScore({
-        assertion: { type: 'bleu' },
-        renderedValue: 'some reference',
-        outputString: '',
-        inverse: false,
-      } as AssertionParams),
-    ).not.toThrow();
+  it('should return pass:false score:0 for empty output instead of throwing', () => {
     const result = handleBleuScore({
       assertion: { type: 'bleu' },
       renderedValue: 'some reference',
@@ -395,5 +403,27 @@ describe('handleBleuScore', () => {
     } as AssertionParams);
     expect(result.pass).toBe(false);
     expect(result.score).toBe(0);
+  });
+
+  it('should treat whitespace-only output like empty output', () => {
+    const result = handleBleuScore({
+      assertion: { type: 'bleu' },
+      renderedValue: 'some reference',
+      outputString: '   \n\t',
+      inverse: false,
+    } as AssertionParams);
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+  });
+
+  it('should pass an inverse assertion for empty output (score inverts to 1)', () => {
+    const result = handleBleuScore({
+      assertion: { type: 'bleu' },
+      renderedValue: 'some reference',
+      outputString: '',
+      inverse: true,
+    } as AssertionParams);
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(1);
   });
 });


### PR DESCRIPTION
An LLM outputting an empty string is a valid scenario — the model may have refused or had its generation truncated. The current guard in `calculateBleuScore`:

```ts
if (!candidate || references.length === 0 || weights.length !== 4) {
  throw new Error('Invalid inputs');
}
```

treats `""` as invalid because empty string is falsy in JavaScript, and throws `Error('Invalid inputs')`. The caller `handleBleuScore` has no try/catch around this call, so the exception propagates and crashes the entire evaluation run.

Every other assertion handler (`handleLevenshtein`, `handleRougeScore`, etc.) returns `{pass:false, score:0}` for any string-typed output — none throw.

**Fix:** change the guard to `candidate == null` (catches only null/undefined, not empty string) and add an explicit early return of `0` for empty-string input. An empty candidate has zero matching n-grams against any reference, so a score of 0 is semantically correct.

**Test:** adds a regression case verifying that `handleBleuScore` with `outputString: ''` does not throw, returns `pass: false`, and returns `score: 0`.
