### PR TITLE
test: address ai findings

### DIFF
--- a/test/assertions/sql.test.ts
+++ b/test/assertions/sql.test.ts
@@ -485,8 +485,8 @@ describe('is-sql assertion', () => {
     });
   });
 
-  // ------------------------------------------- White Table/Column List Tests ------------------------------------------- //
-  describe('White Table/Column List Tests', () => {
+  // ------------------------------------------ Allowed Table/Column List Tests ------------------------------------------ //
+  describe('Allowed Table/Column List Tests', () => {
     it('should fail if the output SQL statement violate allowedTables', async () => {
       const renderedValue = {
         databaseType: 'MySQL',

--- a/test/csv.test.ts
+++ b/test/csv.test.ts
@@ -14,6 +14,16 @@ vi.mock('../src/logger', () => ({
 import type { Assertion, CsvRow, TestCase } from '../src/types/index';
 
 describe('testCaseFromCsvRow', () => {
+  const INVALID_THRESHOLD_VALUES = [
+    'not-a-number',
+    'abc',
+    '0abc',
+    '0,8',
+    'Infinity',
+    '1e309',
+    '0x10',
+  ] as const;
+
   afterEach(() => {
     vi.resetAllMocks();
   });
@@ -364,11 +374,9 @@ describe('testCaseFromCsvRow', () => {
       );
     });
 
-    it.each([
-      'not-a-number',
-      '0abc',
-      '0,8',
-    ])('throws on invalid threshold value %s', (thresholdValue) => {
+    it.each(
+      INVALID_THRESHOLD_VALUES.slice(0, 3),
+    )('throws on invalid threshold value %s', (thresholdValue) => {
       const key = '__config:__expected1:threshold';
       const row: CsvRow = {
         __expected1: 'similar:foo',
@@ -396,13 +404,13 @@ describe('testCaseFromCsvRow', () => {
 
   it.each([
     ['empty', ''],
-    ['non-numeric', 'abc'],
+    ['non-numeric', INVALID_THRESHOLD_VALUES[1]],
     ['whitespace', '   '],
-    ['numeric prefix', '0abc'],
-    ['comma decimal', '0,8'],
-    ['non-finite literal', 'Infinity'],
-    ['overflow', '1e309'],
-    ['hexadecimal', '0x10'],
+    ['numeric prefix', INVALID_THRESHOLD_VALUES[2]],
+    ['comma decimal', INVALID_THRESHOLD_VALUES[3]],
+    ['non-finite literal', INVALID_THRESHOLD_VALUES[4]],
+    ['overflow', INVALID_THRESHOLD_VALUES[5]],
+    ['hexadecimal', INVALID_THRESHOLD_VALUES[6]],
   ])('should omit threshold for a %s __threshold cell', (_label, thresholdValue) => {
     const row: CsvRow = {
       __expected: 'equals:ok',
@@ -464,6 +472,8 @@ describe('assertionFromString', () => {
   });
 
   it('should create an is-json assertion with value', () => {
+    // Intentionally uses YAML-like `key:value` (without a space after `:`) to verify
+    // that assertionFromString preserves the original formatting exactly.
     const expected = `is-json:
       required: ['color']
       type:object

--- a/test/providers/xai/responses.test.ts
+++ b/test/providers/xai/responses.test.ts
@@ -6,6 +6,24 @@ const mockMaybeLoadToolsFromExternalFile = vi.hoisted(() => vi.fn());
 const mockFetchWithCache = vi.hoisted(() => vi.fn());
 const mockFetchWithProxy = vi.hoisted(() => vi.fn());
 
+const DEFAULT_TEST_MODEL = 'grok-4.3';
+const createMockResponseData = (model: string = DEFAULT_TEST_MODEL) => ({
+  id: 'resp_123',
+  model,
+  output: [
+    {
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'hello' }],
+    },
+  ],
+  usage: {
+    input_tokens: 10,
+    output_tokens: 5,
+    total_tokens: 15,
+  },
+});
+
 class TestableXAIResponsesProvider extends XAIResponsesProvider {
   public getResolvedApiKey(): string | undefined {
     return this.getApiKey();
@@ -51,22 +69,7 @@ describe('XAIResponsesProvider', () => {
     // Default passthrough: return whatever tools array is passed in
     mockMaybeLoadToolsFromExternalFile.mockImplementation((tools: any) => Promise.resolve(tools));
     mockFetchWithCache.mockResolvedValue({
-      data: {
-        id: 'resp_123',
-        model: 'grok-4.3',
-        output: [
-          {
-            type: 'message',
-            role: 'assistant',
-            content: [{ type: 'output_text', text: 'hello' }],
-          },
-        ],
-        usage: {
-          input_tokens: 10,
-          output_tokens: 5,
-          total_tokens: 15,
-        },
-      },
+      data: createMockResponseData(),
       cached: false,
       status: 200,
       statusText: 'OK',
@@ -216,6 +219,59 @@ describe('XAIResponsesProvider', () => {
     expect(result.cost).toBe(1.25);
   });
 
+  it('uses fallback pricing for Grok 4.20 responses', async () => {
+    mockFetchWithCache.mockResolvedValueOnce({
+      data: createMockResponseData('grok-4.20'),
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    });
+
+    const provider = new XAIResponsesProvider('grok-4.20', {
+      config: { apiKey: 'test-key' },
+    });
+
+    const result = await provider.callApi('hello');
+
+    expect(result.cost).toBeCloseTo(0.000025, 8);
+  });
+
+  it('prefers billed cost ticks over calculated cost when reasoning tokens are present', async () => {
+    mockFetchWithCache.mockResolvedValueOnce({
+      data: {
+        ...createMockResponseData(),
+        id: 'resp_124',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'hello with reasoning' }],
+          },
+        ],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+          output_tokens_details: {
+            reasoning_tokens: 100,
+          },
+          cost_in_usd_ticks: 12_500_000_000,
+        },
+      },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    });
+
+    const provider = new XAIResponsesProvider(DEFAULT_TEST_MODEL, {
+      config: { apiKey: 'test-key' },
+    });
+
+    const result = await provider.callApi('hello');
+
+    expect(result.cost).toBe(1.25);
+  });
+
   it('falls back to calculated xAI pricing when cost ticks are absent', async () => {
     mockFetchWithCache.mockResolvedValueOnce({
       data: {
@@ -250,7 +306,7 @@ describe('XAIResponsesProvider', () => {
 
     // output_tokens (5) already includes the 3 reasoning tokens, so they are
     // not billed twice: 10 input @ $1.25/M + 5 output @ $2.50/M.
-    expect(result.cost).toBeCloseTo(0.000025, 10);
+    expect(result.cost).toBeCloseTo(0.000025, 8);
     expect(result.tokenUsage?.completionDetails?.reasoning).toBe(3);
   });
 

--- a/test/util/file.test.ts
+++ b/test/util/file.test.ts
@@ -25,8 +25,16 @@ import {
 } from '../../src/util/fileExtensions';
 import { mockProcessEnv } from './utils';
 
+const hasGlobMagic = (candidatePath: string) => {
+  return /[*?[\]{}()!+@]/.test(candidatePath) || candidatePath.includes('\\');
+};
+
 vi.mock('proxy-agent', () => ({
-  ProxyAgent: vi.fn().mockImplementation(() => ({})),
+  ProxyAgent: vi.fn().mockImplementation(() => ({
+    isMockProxyAgent: true,
+    addRequest: vi.fn(),
+    connect: vi.fn(),
+  })),
 }));
 
 vi.mock('fs', async () => {
@@ -52,9 +60,7 @@ vi.mock('fs/promises', async () => {
 
 vi.mock('glob', () => ({
   globSync: vi.fn(),
-  hasMagic: vi.fn((path: string) => {
-    return /[*?[\]{}]/.test(path) && !path.includes('\\');
-  }),
+  hasMagic: vi.fn((candidatePath: string) => hasGlobMagic(candidatePath)),
 }));
 
 vi.mock('../../src/esm', () => ({
@@ -145,7 +151,7 @@ describe('file utilities', () => {
       vi.mocked(fs.readFileSync).mockReturnValue(mockFileContent);
       vi.mocked(hasMagic).mockImplementation((pattern: string | string[]) => {
         const p = Array.isArray(pattern) ? pattern.join('') : pattern;
-        return p.includes('*') || p.includes('?') || p.includes('[') || p.includes('{');
+        return hasGlobMagic(p);
       });
       cliState.basePath = '/mock/base/path';
     });

--- a/test/util/text.test.ts
+++ b/test/util/text.test.ts
@@ -22,11 +22,16 @@ describe('ellipsize', () => {
     expect(ellipsize(str, 4)).toBe('h...');
   });
 
+  it('should return an empty string for negative maxLen', () => {
+    expect(ellipsize('hello', -1)).toBe('');
+    expect(ellipsize('hello', -5)).toBe('');
+  });
+
   it('should handle empty string', () => {
     expect(ellipsize('', 5)).toBe('');
   });
 
-  it('should stay within maxLen when maxLen is too small for an ellipsis', () => {
+  it('should hard-truncate when maxLen is less than 3', () => {
     // maxLen < 3 has no room for "..."; the result must still respect maxLen
     // (previously slice(0, maxLen - 3) used a negative index and overflowed).
     expect(ellipsize('hello', 2)).toBe('he');


### PR DESCRIPTION
## Summary
- address all 11 visible GitHub AI findings across 5 test files
- add focused xAI coverage for Grok 4.20 pricing and billed-cost precedence
- clarify and deduplicate recent CSV, file utility, SQL, and text utility tests

## Validation
- `NPM_CONFIG_CACHE=/tmp/daily-ai-findings-npm-cache npm run f`
- `NPM_CONFIG_CACHE=/tmp/daily-ai-findings-npm-cache npm run l`
- `git diff --check`

## Notes
- `npm ci` is locally blocked by Socket Security Policy on `undici@7.28.0`, so focused Vitest could not run in this fresh worktree.
