### PR TITLE
chore(release-please): bump last-release-sha to clear drift guard

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-v-in-tag": false,
   "include-v-in-release-name": false,
   "commit-batch-size": 1,
-  "last-release-sha": "4860e990c7e9a2f8f677173fb92cf9867b34d03f",
+  "last-release-sha": "8be17c32d44b17f4ddbd618fcaca87769e674abc",
   "separate-pull-requests": true,
   "packages": {
     ".": {


### PR DESCRIPTION
## What

The scheduled `release-please-sha-drift` check started failing on `main`: `last-release-sha` in `release-please-config.json` was **253 commits behind HEAD**, over the 250 threshold.

This PR advances the pin from `4860e99` to `8be17c3`, the release commit for root `promptfoo 0.121.17`.

## Why this SHA

The guard requires the pin be the **oldest current package release commit** — never newer than any package's last release, or that package loses its unreleased commits in release-please's next run.

- root `promptfoo 0.121.17` → `8be17c3` (2026-06-16 12:58)
- `code-scan-action 0.1.8` → `af7ec0b` (2026-06-16 13:45)

`8be17c3` is an ancestor of `af7ec0b`, so it is the oldest of the two. Drift drops from 253 → **60**, well under threshold.

## Verification

Ran the workflow's drift check locally against the new pin: commit reachable, drift 60 ≤ 250, PASS.
