### PR TITLE
fix(assertions): default answer-relevance threshold to 0.7

### DIFF
--- a/examples/provider-llama-cpp/promptfooconfig.yaml
+++ b/examples/provider-llama-cpp/promptfooconfig.yaml
@@ -26,3 +26,4 @@ tests:
       - type: icontains
         value: 'San Francisco'
       - type: answer-relevance
+        threshold: 0.7

--- a/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
@@ -14,7 +14,7 @@ To use the `answer-relevance` assertion type, add it to your test configuration 
 ```yaml
 assert:
   - type: answer-relevance
-    threshold: 0.7 # Score between 0 and 1
+    threshold: 0.7 # Optional, defaults to 0.7. Score between 0 and 1
 ```
 
 ### How it works
@@ -25,7 +25,7 @@ The answer relevance checker:
 2. Compares these questions with the original query using embedding similarity
 3. Calculates a relevance score based on the similarity scores
 
-A higher threshold requires the output to be more closely related to the original query.
+The assertion passes if the relevance score meets or exceeds the threshold (default 0.7). A higher threshold requires the output to be more closely related to the original query.
 
 ### Example Configuration
 

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -679,6 +679,10 @@ Model-graded assertions like `llm-rubric` determine PASS/FAIL using two mechanis
 
 This means a result like `{"pass": true, "score": 0}` will pass without a threshold, but fail with `threshold: 1`.
 
+:::note
+Mechanism 1 does not apply to assertions that carry a built-in default threshold. `answer-relevance` (0.7), `g-eval` (0.7), and `similar` (0.75) apply their default when you omit `threshold`, so a low score fails even with no threshold configured.
+:::
+
 **Common issue**: Tests show PASS even when scores are low
 
 ```yaml

--- a/src/assertions/answerRelevance.ts
+++ b/src/assertions/answerRelevance.ts
@@ -22,7 +22,10 @@ export const handleAnswerRelevance = async ({
     ...(await matchesAnswerRelevance(
       input,
       output,
-      assertion.threshold ?? 0,
+      // Default to 0.7 (the value shown in the docs' primary example) rather than 0.
+      // A 0 default made answer-relevance a no-op that always passed, since the
+      // relevance score is >= 0 for any answer.
+      assertion.threshold ?? 0.7,
       test.options,
       providerCallContext,
     )),

--- a/src/assertions/answerRelevance.ts
+++ b/src/assertions/answerRelevance.ts
@@ -22,9 +22,6 @@ export const handleAnswerRelevance = async ({
     ...(await matchesAnswerRelevance(
       input,
       output,
-      // Default to 0.7 (the value shown in the docs' primary example) rather than 0.
-      // A 0 default made answer-relevance a no-op that always passed, since the
-      // relevance score is >= 0 for any answer.
       assertion.threshold ?? 0.7,
       test.options,
       providerCallContext,

--- a/test/assertions/answerRelevance.test.ts
+++ b/test/assertions/answerRelevance.test.ts
@@ -163,10 +163,7 @@ describe('handleAnswerRelevance', () => {
   });
 
   it('should use a default threshold of 0.7 when not specified', async () => {
-    // A missing threshold previously defaulted to 0, which made answer-relevance a
-    // no-op that always passed (any relevance >= 0 cleared the bar). It now defaults
-    // to 0.7 — the value shown in the docs' primary example, and in line with the
-    // other graded assertions' non-zero defaults. See issue #9848.
+    // Regression test for #9848.
     const mockMatchesAnswerRelevance = vi.mocked(matchesAnswerRelevance);
     mockMatchesAnswerRelevance.mockResolvedValue({
       pass: true,

--- a/test/assertions/answerRelevance.test.ts
+++ b/test/assertions/answerRelevance.test.ts
@@ -162,7 +162,11 @@ describe('handleAnswerRelevance', () => {
     ).rejects.toThrow('answer-relevance assertion type must have a prompt');
   });
 
-  it('should use default threshold of 0 if not specified', async () => {
+  it('should use a default threshold of 0.7 when not specified', async () => {
+    // A missing threshold previously defaulted to 0, which made answer-relevance a
+    // no-op that always passed (any relevance >= 0 cleared the bar). It now defaults
+    // to 0.7 — the value shown in the docs' primary example, and in line with the
+    // other graded assertions' non-zero defaults. See issue #9848.
     const mockMatchesAnswerRelevance = vi.mocked(matchesAnswerRelevance);
     mockMatchesAnswerRelevance.mockResolvedValue({
       pass: true,
@@ -193,7 +197,7 @@ describe('handleAnswerRelevance', () => {
     expect(mockMatchesAnswerRelevance).toHaveBeenCalledWith(
       'test prompt',
       'test output',
-      0,
+      0.7,
       {},
       undefined,
     );


### PR DESCRIPTION
Fixes #9848

## Summary

`answer-relevance` defaulted to a threshold of **`0`** when none was set (`assertion.threshold ?? 0` in `src/assertions/answerRelevance.ts`). Because the relevance score is always `>= 0`, the pass check `relevance >= 0` is always true — so an `answer-relevance` assertion **with no `threshold` was a no-op that always passed**, even for a completely irrelevant answer.

Every other graded assertion already defaults to a meaningful value (`similar` 0.75, `rouge` 0.75, `bleu`/`gleu`/`meteor` 0.5). This changes `answer-relevance` to default to **`0.7`** — the value shown in the docs' primary example.

## Proof (live, gpt-4o-mini + text-embedding-3-small)

Query *"What is the capital of France?"*, answer *"Bananas are yellow and grow on trees…"*, no threshold:

| | before | after |
|---|---|---|
| score | 0.077 | 0.076 |
| verdict | **PASS** ("greater than threshold 0") | **FAIL** ("less than threshold 0.7") |

The irrelevant answer now correctly fails instead of silently passing.

## Tests

`test/assertions/answerRelevance.test.ts` — the existing "default threshold" test asserted the old `0`; it's updated to assert `0.7` (it fails on `main`, passes here). Explicit thresholds still override. Full handler + matcher suites pass.

## Backward compatibility

This is a **behavior change**: existing `answer-relevance` assertions written without an explicit `threshold` will now actually evaluate (relevance `< 0.7` fails) instead of always passing. That is the point of the fix — those assertions were previously no-ops — but it's called out here for reviewers. Any assertion with an explicit `threshold` is unaffected.

Happy to also add a sentence to the docs stating the default if preferred.