### PR TITLE
test: pin BLEU and ellipsize boundary behavior

### DIFF
--- a/test/assertions/bleu.test.ts
+++ b/test/assertions/bleu.test.ts
@@ -4,12 +4,12 @@ import { calculateBleuScore, handleBleuScore } from '../../src/assertions/bleu';
 import type { AssertionParams } from '../../src/types/index';
 
 describe('BLEU score calculation', () => {
-  it('identical sentences should have BLEU score close to, but not equal to one due to smoothing', () => {
+  it('identical sentences should have BLEU score equal to one', () => {
     const references = ['The cat sat on the mat.'];
     const candidate = 'The cat sat on the mat.';
 
     const score = calculateBleuScore(candidate, references);
-    expect(score).toBeGreaterThan(0.999);
+    expect(score).toBe(1);
   });
 
   it('completely different sentences should have very low but non-zero BLEU score due to smoothing', () => {
@@ -250,19 +250,19 @@ describe('BLEU score calculation', () => {
 
   it('should throw error for invalid weights', () => {
     const references = ['The cat sat on the mat.'];
-    const invalidWeights = [0.5, 0.5, 0.5, 0.5];
+    const weightsNotSummingToOne = [0.5, 0.5, 0.5, 0.5];
 
     expect(() => {
-      calculateBleuScore('test', references, invalidWeights);
+      calculateBleuScore('test', references, weightsNotSummingToOne);
     }).toThrow('Weights must sum to 1');
   });
 
   it('should throw error for wrong number of weights', () => {
     const references = ['The cat sat on the mat.'];
-    const invalidWeights = [0.5, 0.5];
+    const incorrectLengthWeights = [0.5, 0.5];
 
     expect(() => {
-      calculateBleuScore('test', references, invalidWeights);
+      calculateBleuScore('test', references, incorrectLengthWeights);
     }).toThrow('Invalid inputs');
   });
 

--- a/test/util/text.test.ts
+++ b/test/util/text.test.ts
@@ -37,8 +37,9 @@ describe('ellipsize', () => {
     expect(ellipsize('hello', 2)).toBe('he');
     expect(ellipsize('hello', 1)).toBe('h');
     expect(ellipsize('hello', 0)).toBe('');
-    for (const maxLen of [0, 1, 2, 3]) {
+    for (const maxLen of [0, 1, 2]) {
       expect(ellipsize('hello', maxLen).length).toBeLessThanOrEqual(maxLen);
     }
+    expect(ellipsize('hello', 3)).toBe('...');
   });
 });

--- a/test/util/text.test.ts
+++ b/test/util/text.test.ts
@@ -37,9 +37,6 @@ describe('ellipsize', () => {
     expect(ellipsize('hello', 2)).toBe('he');
     expect(ellipsize('hello', 1)).toBe('h');
     expect(ellipsize('hello', 0)).toBe('');
-    for (const maxLen of [0, 1, 2]) {
-      expect(ellipsize('hello', maxLen).length).toBeLessThanOrEqual(maxLen);
-    }
     expect(ellipsize('hello', 3)).toBe('...');
   });
 });


### PR DESCRIPTION
## Summary

- require an identical BLEU candidate/reference pair to score exactly `1`, replacing the stale claim that smoothing lowers a perfect match
- name the two invalid-weight fixtures by the validation failure each one exercises
- pin the `ellipsize(..., 3)` boundary to `...` and remove weaker duplicate length checks already implied by exact assertions for lengths 0–2
- keep production behavior unchanged

## Regression value

- The `maxLen=3` assertion uniquely catches an off-by-one change from `maxLen < 3` to `maxLen <= 3`; the previous length-only check accepted the incorrect `hel` result.
- The exact BLEU check is mathematically correct and fixes a misleading legacy assertion, though the suite also has another exact perfect-match guard.
- The weight-fixture renames improve test intent without changing coverage.

## Relationship to #9858

PR #9858 is complementary rather than superseding: it fixes BLEU weight validation for empty candidates, while this PR tightens separate existing assertions. A three-way merge simulation at the current heads completed without conflicts, preserved both sets of tests, and passed the combined focused suite and TypeScript check.

## Validation

- `npx vitest run test/assertions/bleu.test.ts test/util/text.test.ts --sequence.shuffle=false`
- the same focused suite with shuffle seeds `9865`, `19865`, `29865`, `39865`, and `49865`
- `npm run tsc`
- `npm run l`
- `npx @biomejs/biome check test/assertions/bleu.test.ts test/util/text.test.ts`
- independent programmatic BLEU and ellipsize boundary probe
- controlled mutation checks for the BLEU exact score and `ellipsize` branch boundary
- two-pass native pre-publish review gate with zero findings
