### PR TITLE
fix(redteam): bound output tokens on the attack/grading providers

### DIFF
--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -821,6 +821,13 @@ You can force 100% local generation by setting the `PROMPTFOO_DISABLE_REDTEAM_RE
 Custom plugins and strategies require an OpenAI key or your own provider configuration.
 :::
 
+Local OpenAI-family calls used for iterative attacks and grading have a default output cap of
+4,096 tokens. This prevents a short decision or grading request from inheriting a large
+`OPENAI_MAX_TOKENS` value intended for batch test generation. Set
+`PROMPTFOO_REDTEAM_PROVIDER_MAX_TOKENS` to a positive integer to change the default cap. An
+explicit provider-specific output limit still takes precedence, and normal plugin test-case
+generation keeps the provider's usual output budget.
+
 ### Changing the model
 
 To use the `openai:chat:gpt-5-mini` model, you can override the provider on the command line:

--- a/src/redteam/mcpTargetProvider.ts
+++ b/src/redteam/mcpTargetProvider.ts
@@ -84,7 +84,10 @@ class RedteamMcpTargetProvider implements ApiProvider {
           }`,
         );
 
-        const materializerProvider = await redteamProviderManager.getProvider({ jsonOnly: true });
+        const materializerProvider = await redteamProviderManager.getProvider({
+          jsonOnly: true,
+          purpose: 'attack',
+        });
         materializedPrompt = await materializeMcpValue({
           intentValue,
           provider: materializerProvider,

--- a/src/redteam/providers/constants.ts
+++ b/src/redteam/providers/constants.ts
@@ -1,4 +1,4 @@
-import { getEnvFloat } from '../../envars';
+import { getEnvFloat, getEnvInt } from '../../envars';
 
 export const ATTACKER_MODEL = 'gpt-5.5-2026-04-23';
 
@@ -7,3 +7,16 @@ export const ATTACKER_MODEL_SMALL = 'gpt-5.4-mini-2026-03-17';
 export const TEMPERATURE = getEnvFloat('PROMPTFOO_JAILBREAK_TEMPERATURE')
   ? getEnvFloat('PROMPTFOO_JAILBREAK_TEMPERATURE')
   : 0.7;
+
+/**
+ * Bounded output cap for redteam attack/grading model calls.
+ *
+ * These calls produce short structured decisions/attack prompts (typically a few
+ * hundred tokens). Without an explicit cap they fall through to `OPENAI_MAX_TOKENS`
+ * (or the model's output ceiling), so an occasional degenerate / non-terminating
+ * generation can run all the way to tens of thousands of tokens — minutes of latency
+ * followed by an unparseable response. Cap it here, independently of the generic
+ * `OPENAI_MAX_TOKENS` knob (which is often raised for large *generation* outputs), so
+ * tuning generation can never silently uncap the attack/grading providers.
+ */
+export const REDTEAM_PROVIDER_MAX_TOKENS = getEnvInt('PROMPTFOO_REDTEAM_PROVIDER_MAX_TOKENS', 4096);

--- a/src/redteam/providers/constants.ts
+++ b/src/redteam/providers/constants.ts
@@ -19,4 +19,15 @@ export const TEMPERATURE = getEnvFloat('PROMPTFOO_JAILBREAK_TEMPERATURE')
  * `OPENAI_MAX_TOKENS` knob (which is often raised for large *generation* outputs), so
  * tuning generation can never silently uncap the attack/grading providers.
  */
-export const REDTEAM_PROVIDER_MAX_TOKENS = getEnvInt('PROMPTFOO_REDTEAM_PROVIDER_MAX_TOKENS', 4096);
+export const DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS = 4096;
+
+/**
+ * Read the cap at provider-construction time so values supplied through the CLI's
+ * `--env-file` flow are honored after startup imports have completed.
+ */
+export function getRedteamProviderMaxTokens(): number {
+  return Math.max(
+    1,
+    getEnvInt('PROMPTFOO_REDTEAM_PROVIDER_MAX_TOKENS', DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS),
+  );
+}

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -232,6 +232,7 @@ export class CrescendoProvider implements ApiProvider {
           provider: this.config.redteamProvider,
           preferSmallModel: false,
           jsonOnly: true,
+          purpose: 'attack',
         });
       }
     }

--- a/src/redteam/providers/custom/index.ts
+++ b/src/redteam/providers/custom/index.ts
@@ -232,6 +232,7 @@ export class CustomProvider implements ApiProvider {
           provider: this.config.redteamProvider,
           preferSmallModel: false,
           jsonOnly: true,
+          purpose: 'attack',
         });
       }
     }
@@ -251,6 +252,7 @@ export class CustomProvider implements ApiProvider {
         this.scoringProvider = await redteamProviderManager.getProvider({
           provider: this.config.redteamProvider,
           preferSmallModel: false,
+          purpose: 'attack',
         });
       }
     }

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -906,6 +906,7 @@ class RedteamIterativeProvider implements ApiProvider {
       redteamProvider: await redteamProviderManager.getProvider({
         provider: this.redteamProvider,
         jsonOnly: true,
+        purpose: 'attack',
       }),
       gradingProvider: await redteamProviderManager.getGradingProvider({
         provider: this.gradingProvider,

--- a/src/redteam/providers/iterativeImage.ts
+++ b/src/redteam/providers/iterativeImage.ts
@@ -633,6 +633,7 @@ class RedteamIterativeProvider implements ApiProvider {
         provider: this.redteamProvider,
         preferSmallModel: false,
         jsonOnly: true,
+        purpose: 'attack',
       }),
       targetProvider: context.originalProvider,
       injectVar,

--- a/src/redteam/providers/iterativeMeta.ts
+++ b/src/redteam/providers/iterativeMeta.ts
@@ -760,6 +760,7 @@ class RedteamIterativeMetaProvider implements ApiProvider {
       agentProvider: await redteamProviderManager.getProvider({
         provider: this.agentProvider,
         jsonOnly: true,
+        purpose: 'attack',
       }),
       gradingProvider: await redteamProviderManager.getGradingProvider({
         provider: this.gradingProvider,

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -1345,6 +1345,7 @@ class RedteamIterativeTreeProvider implements ApiProvider {
       redteamProvider = await redteamProviderManager.getProvider({
         provider: this.config.redteamProvider as RedteamFileConfig['provider'],
         jsonOnly: true,
+        purpose: 'attack',
       });
       gradingProvider = await redteamProviderManager.getGradingProvider({
         jsonOnly: true,

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -30,7 +30,12 @@ import { TokenUsageTracker } from '../../util/tokenUsage';
 import { TransformInputType, transform } from '../../util/transform';
 import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
-import { ATTACKER_MODEL, ATTACKER_MODEL_SMALL, TEMPERATURE } from './constants';
+import {
+  ATTACKER_MODEL,
+  ATTACKER_MODEL_SMALL,
+  REDTEAM_PROVIDER_MAX_TOKENS,
+  TEMPERATURE,
+} from './constants';
 
 import type { TraceContextData } from '../../tracing/traceContext';
 import type { ProviderOptions } from '../../types/providers';
@@ -108,6 +113,12 @@ async function loadRedteamProvider({
       config: {
         temperature: TEMPERATURE,
         response_format: jsonOnly ? { type: 'json_object' } : undefined,
+        // Bound the output so a degenerate/runaway generation can't run to the model's
+        // token ceiling (minutes of latency + an unparseable response). Set both forms
+        // so the cap applies whether the model takes `max_tokens` (e.g. gpt-4.1) or
+        // `max_completion_tokens` (reasoning / gpt-5 models). See REDTEAM_PROVIDER_MAX_TOKENS.
+        max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
+        max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
       },
     });
   }

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -234,7 +234,7 @@ async function loadRedteamProvider({
 }
 
 function getDefaultTestProvider(): RedteamFileConfig['provider'] | undefined {
-  if (typeof cliState.config?.defaultTest !== 'object') {
+  if (!cliState.config?.defaultTest || typeof cliState.config.defaultTest !== 'object') {
     return undefined;
   }
 

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -129,10 +129,19 @@ function getOpenAiOutputCapKind(provider: ApiProvider): OpenAiOutputCapKind | un
   return undefined;
 }
 
-function cloneProviderConfig(provider: ApiProvider): ApiProvider {
+async function cloneProviderConfig(provider: ApiProvider): Promise<ApiProvider> {
   const config = (provider as { config?: Record<string, unknown> }).config;
   if (!config || typeof config !== 'object') {
     return provider;
+  }
+
+  // Some providers (notably Azure) populate authentication state asynchronously on the
+  // original instance. Wait before cloning so the capped copy receives the initialized state
+  // rather than a promise whose continuation will mutate a different object.
+  const initializationPromise = (provider as { initializationPromise?: Promise<unknown> | null })
+    .initializationPromise;
+  if (initializationPromise) {
+    await initializationPromise;
   }
 
   const descriptors = Object.getOwnPropertyDescriptors(provider);
@@ -146,7 +155,7 @@ function cloneProviderConfig(provider: ApiProvider): ApiProvider {
   return Object.create(Object.getPrototypeOf(provider), descriptors) as ApiProvider;
 }
 
-function withDefaultOutputCap(provider: ApiProvider): ApiProvider {
+async function withDefaultOutputCap(provider: ApiProvider): Promise<ApiProvider> {
   const providerKind = getOpenAiOutputCapKind(provider);
   if (!providerKind) {
     return provider;
@@ -155,7 +164,7 @@ function withDefaultOutputCap(provider: ApiProvider): ApiProvider {
   // A caller may reuse an instantiated provider for normal batch generation. Clone the
   // provider's own state before changing its config so attack/grading limits do not leak into
   // those uncapped generation calls.
-  const cappedProvider = cloneProviderConfig(provider);
+  const cappedProvider = await cloneProviderConfig(provider);
   const config = (cappedProvider as { config?: Record<string, unknown> }).config;
   if (!config || typeof config !== 'object') {
     return cappedProvider;
@@ -219,7 +228,7 @@ async function loadRedteamProvider({
     });
   }
   if (shouldCapOutput) {
-    ret = withDefaultOutputCap(ret);
+    ret = await withDefaultOutputCap(ret);
   }
   return ret;
 }

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -92,31 +92,69 @@ export function resetRedteamProviderLoader(): void {
  * provider-specific: native providers use different request schemas, while the Responses API
  * uses `max_output_tokens` and chat/completions use different aliases.
  */
-function applyDefaultOutputCap(provider: ApiProvider): void {
+function isOpenAiOutputCapProvider(provider: ApiProvider): boolean {
+  const providerId = provider.id();
+  const constructorName = provider.constructor?.name ?? '';
+  return (
+    provider instanceof OpenAiChatCompletionProvider ||
+    providerId.includes(':responses:') ||
+    constructorName.includes('ResponsesProvider') ||
+    providerId.includes(':completion:') ||
+    constructorName === 'OpenAiCompletionProvider'
+  );
+}
+
+function cloneProviderConfig(provider: ApiProvider): ApiProvider {
   const config = (provider as { config?: Record<string, unknown> }).config;
   if (!config || typeof config !== 'object') {
-    return;
+    return provider;
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(provider);
+  const configDescriptor = Object.getOwnPropertyDescriptor(provider, 'config');
+  descriptors.config = {
+    configurable: configDescriptor?.configurable ?? true,
+    enumerable: configDescriptor?.enumerable ?? true,
+    value: { ...config },
+    writable: true,
+  };
+  return Object.create(Object.getPrototypeOf(provider), descriptors) as ApiProvider;
+}
+
+function withDefaultOutputCap(provider: ApiProvider): ApiProvider {
+  if (!isOpenAiOutputCapProvider(provider)) {
+    return provider;
+  }
+
+  // A caller may reuse an instantiated provider for normal batch generation. Clone the
+  // provider's own state before changing its config so attack/grading limits do not leak into
+  // those uncapped generation calls.
+  const cappedProvider = cloneProviderConfig(provider);
+  const config = (cappedProvider as { config?: Record<string, unknown> }).config;
+  if (!config || typeof config !== 'object') {
+    return cappedProvider;
   }
 
   const defaultCap = getRedteamProviderMaxTokens();
-  const providerId = provider.id();
-  const constructorName = provider.constructor?.name ?? '';
+  const providerId = cappedProvider.id();
+  const constructorName = cappedProvider.constructor?.name ?? '';
 
   if (providerId.includes(':responses:') || constructorName.includes('ResponsesProvider')) {
     config.max_output_tokens ??= defaultCap;
-    return;
+    return cappedProvider;
   }
 
-  if (provider instanceof OpenAiChatCompletionProvider) {
+  if (cappedProvider instanceof OpenAiChatCompletionProvider) {
     const configuredCap = config.max_completion_tokens ?? config.max_tokens ?? defaultCap;
     config.max_tokens ??= configuredCap;
     config.max_completion_tokens ??= configuredCap;
-    return;
+    return cappedProvider;
   }
 
   if (providerId.includes(':completion:') || constructorName === 'OpenAiCompletionProvider') {
     config.max_tokens ??= defaultCap;
   }
+  return cappedProvider;
 }
 
 async function loadRedteamProvider({
@@ -139,9 +177,6 @@ async function loadRedteamProvider({
   } else if (typeof redteamProvider === 'string' || isProviderOptions(redteamProvider)) {
     logger.debug(`Loading ${purpose} provider`, { provider: redteamProvider });
     ret = (await redteamProviderLoader([redteamProvider]))[0];
-    if (shouldCapOutput) {
-      applyDefaultOutputCap(ret);
-    }
   } else {
     const defaultModel = preferSmallModel ? ATTACKER_MODEL_SMALL : ATTACKER_MODEL;
     logger.debug(`Using default ${purpose} provider: ${defaultModel}`);
@@ -160,6 +195,9 @@ async function loadRedteamProvider({
       },
     });
   }
+  if (shouldCapOutput) {
+    ret = withDefaultOutputCap(ret);
+  }
   return ret;
 }
 
@@ -177,6 +215,9 @@ function getDefaultTestProvider(): RedteamFileConfig['provider'] | undefined {
 class RedteamProviderManager {
   private provider: ApiProvider | undefined;
   private jsonOnlyProvider: ApiProvider | undefined;
+  private attackProvider: ApiProvider | undefined;
+  private attackJsonOnlyProvider: ApiProvider | undefined;
+  private configuredProvider: RedteamFileConfig['provider'] | undefined;
   private multilingualProvider: ApiProvider | undefined;
   private gradingProvider: ApiProvider | undefined;
   private gradingJsonOnlyProvider: ApiProvider | undefined;
@@ -204,6 +245,9 @@ class RedteamProviderManager {
   clearProvider() {
     this.provider = undefined;
     this.jsonOnlyProvider = undefined;
+    this.attackProvider = undefined;
+    this.attackJsonOnlyProvider = undefined;
+    this.configuredProvider = undefined;
     this.multilingualProvider = undefined;
     this.gradingProvider = undefined;
     this.gradingJsonOnlyProvider = undefined;
@@ -212,6 +256,9 @@ class RedteamProviderManager {
   }
 
   async setProvider(provider: RedteamFileConfig['provider']) {
+    this.configuredProvider = provider;
+    this.attackProvider = undefined;
+    this.attackJsonOnlyProvider = undefined;
     this.provider = await loadRedteamProvider({ provider });
     this.jsonOnlyProvider = await loadRedteamProvider({ provider, jsonOnly: true });
   }
@@ -244,6 +291,29 @@ class RedteamProviderManager {
     if (purpose === 'generation' && this.provider && this.jsonOnlyProvider) {
       logger.debug(`[RedteamProviderManager] Using cached redteam provider: ${this.provider.id()}`);
       return this.wrapProvider(jsonOnly ? this.jsonOnlyProvider : this.provider);
+    }
+
+    if (purpose === 'attack' && this.configuredProvider !== undefined) {
+      const cachedAttackProvider = jsonOnly ? this.attackJsonOnlyProvider : this.attackProvider;
+      if (cachedAttackProvider) {
+        logger.debug(
+          `[RedteamProviderManager] Using cached attack provider: ${cachedAttackProvider.id()}`,
+        );
+        return this.wrapProvider(cachedAttackProvider);
+      }
+
+      const loadedAttackProvider = await loadRedteamProvider({
+        provider: this.configuredProvider,
+        jsonOnly,
+        preferSmallModel,
+        purpose: 'attack',
+      });
+      if (jsonOnly) {
+        this.attackJsonOnlyProvider = loadedAttackProvider;
+      } else {
+        this.attackProvider = loadedAttackProvider;
+      }
+      return this.wrapProvider(loadedAttackProvider);
     }
 
     // Check if we have an explicit provider argument or redteam.provider configured

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -92,16 +92,38 @@ export function resetRedteamProviderLoader(): void {
  * provider-specific: native providers use different request schemas, while the Responses API
  * uses `max_output_tokens` and chat/completions use different aliases.
  */
-function isOpenAiOutputCapProvider(provider: ApiProvider): boolean {
-  const providerId = provider.id();
+type OpenAiOutputCapKind = 'chat' | 'completion' | 'responses';
+
+function hasProviderPrototype(provider: ApiProvider, constructorName: string): boolean {
+  let prototype = Object.getPrototypeOf(provider);
+  while (prototype) {
+    if (prototype.constructor?.name === constructorName) {
+      return true;
+    }
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return false;
+}
+
+function getOpenAiOutputCapKind(provider: ApiProvider): OpenAiOutputCapKind | undefined {
   const constructorName = provider.constructor?.name ?? '';
-  return (
-    provider instanceof OpenAiChatCompletionProvider ||
-    providerId.includes(':responses:') ||
-    constructorName.includes('ResponsesProvider') ||
-    providerId.includes(':completion:') ||
-    constructorName === 'OpenAiCompletionProvider'
-  );
+  if (
+    hasProviderPrototype(provider, 'OpenAiResponsesProvider') ||
+    constructorName === 'AzureResponsesProvider' ||
+    constructorName === 'XAIResponsesProvider'
+  ) {
+    return 'responses';
+  }
+  if (provider instanceof OpenAiChatCompletionProvider) {
+    return 'chat';
+  }
+  if (
+    hasProviderPrototype(provider, 'OpenAiCompletionProvider') ||
+    constructorName === 'AzureCompletionProvider'
+  ) {
+    return 'completion';
+  }
+  return undefined;
 }
 
 function cloneProviderConfig(provider: ApiProvider): ApiProvider {
@@ -122,7 +144,8 @@ function cloneProviderConfig(provider: ApiProvider): ApiProvider {
 }
 
 function withDefaultOutputCap(provider: ApiProvider): ApiProvider {
-  if (!isOpenAiOutputCapProvider(provider)) {
+  const providerKind = getOpenAiOutputCapKind(provider);
+  if (!providerKind) {
     return provider;
   }
 
@@ -136,22 +159,19 @@ function withDefaultOutputCap(provider: ApiProvider): ApiProvider {
   }
 
   const defaultCap = getRedteamProviderMaxTokens();
-  const providerId = cappedProvider.id();
-  const constructorName = cappedProvider.constructor?.name ?? '';
-
-  if (providerId.includes(':responses:') || constructorName.includes('ResponsesProvider')) {
+  if (providerKind === 'responses') {
     config.max_output_tokens ??= defaultCap;
     return cappedProvider;
   }
 
-  if (cappedProvider instanceof OpenAiChatCompletionProvider) {
+  if (providerKind === 'chat') {
     const configuredCap = config.max_completion_tokens ?? config.max_tokens ?? defaultCap;
     config.max_tokens ??= configuredCap;
     config.max_completion_tokens ??= configuredCap;
     return cappedProvider;
   }
 
-  if (providerId.includes(':completion:') || constructorName === 'OpenAiCompletionProvider') {
+  if (providerKind === 'completion') {
     config.max_tokens ??= defaultCap;
   }
   return cappedProvider;

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -396,8 +396,12 @@ class RedteamProviderManager {
       return this.wrapProvider(loaded);
     }
 
-    // 4) Fallback to the configured redteam provider or the default local grader.
-    const loaded = await loadRedteamProvider({ jsonOnly, purpose: 'grading' });
+    // 4) Fallback to the manager-configured redteam provider or the default local grader.
+    const loaded = await loadRedteamProvider({
+      provider: this.configuredProvider,
+      jsonOnly,
+      purpose: 'grading',
+    });
     return this.wrapProvider(loaded);
   }
 

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -87,6 +87,26 @@ export function resetRedteamProviderLoader(): void {
   redteamProviderLoader = defaultRedteamProviderLoader;
 }
 
+/**
+ * Apply a bounded default output cap to a loaded redteam provider so a degenerate /
+ * non-terminating generation can't run all the way to the model's token ceiling (minutes of
+ * latency, then an unparseable response). Only a DEFAULT: if the provider config already
+ * specifies any output bound (`max_tokens` or `max_completion_tokens`) it is respected and
+ * left untouched. Otherwise both forms are set so the cap applies whether the model takes
+ * `max_tokens` (e.g. gpt-4.1) or `max_completion_tokens` (reasoning / gpt-5 models).
+ */
+function applyDefaultOutputCap(provider: ApiProvider): void {
+  const config = (provider as { config?: Record<string, unknown> }).config;
+  if (!config || typeof config !== 'object') {
+    return;
+  }
+  if (config.max_tokens !== undefined || config.max_completion_tokens !== undefined) {
+    return;
+  }
+  config.max_tokens = REDTEAM_PROVIDER_MAX_TOKENS;
+  config.max_completion_tokens = REDTEAM_PROVIDER_MAX_TOKENS;
+}
+
 async function loadRedteamProvider({
   provider,
   jsonOnly = false,
@@ -106,6 +126,11 @@ async function loadRedteamProvider({
   } else if (typeof redteamProvider === 'string' || isProviderOptions(redteamProvider)) {
     logger.debug(`Loading ${purpose} provider`, { provider: redteamProvider });
     ret = (await redteamProviderLoader([redteamProvider]))[0];
+    // A configured redteam provider (string id or ProviderOptions) would otherwise fall
+    // through to OPENAI_MAX_TOKENS / the model's output ceiling, so an occasional degenerate
+    // generation can run away. Apply a bounded default cap to the loaded provider unless it
+    // set one explicitly.
+    applyDefaultOutputCap(ret);
   } else {
     const defaultModel = preferSmallModel ? ATTACKER_MODEL_SMALL : ATTACKER_MODEL;
     logger.debug(`Using default ${purpose} provider: ${defaultModel}`);

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -114,7 +114,10 @@ function getOpenAiOutputCapKind(provider: ApiProvider): OpenAiOutputCapKind | un
   ) {
     return 'responses';
   }
-  if (provider instanceof OpenAiChatCompletionProvider) {
+  if (
+    provider instanceof OpenAiChatCompletionProvider ||
+    hasProviderPrototype(provider, 'AzureChatCompletionProvider')
+  ) {
     return 'chat';
   }
   if (

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -33,7 +33,7 @@ import { throwIfTargetPromptExceedsMaxChars } from '../shared/promptLength';
 import {
   ATTACKER_MODEL,
   ATTACKER_MODEL_SMALL,
-  REDTEAM_PROVIDER_MAX_TOKENS,
+  getRedteamProviderMaxTokens,
   TEMPERATURE,
 } from './constants';
 
@@ -88,37 +88,50 @@ export function resetRedteamProviderLoader(): void {
 }
 
 /**
- * Apply a bounded default output cap to a loaded redteam provider so a degenerate /
- * non-terminating generation can't run all the way to the model's token ceiling (minutes of
- * latency, then an unparseable response). Only a DEFAULT: if the provider config already
- * specifies any output bound (`max_tokens` or `max_completion_tokens`) it is respected and
- * left untouched. Otherwise both forms are set so the cap applies whether the model takes
- * `max_tokens` (e.g. gpt-4.1) or `max_completion_tokens` (reasoning / gpt-5 models).
+ * Apply a bounded default output cap to OpenAI-family attack/grading providers. Keep this
+ * provider-specific: native providers use different request schemas, while the Responses API
+ * uses `max_output_tokens` and chat/completions use different aliases.
  */
 function applyDefaultOutputCap(provider: ApiProvider): void {
   const config = (provider as { config?: Record<string, unknown> }).config;
   if (!config || typeof config !== 'object') {
     return;
   }
-  if (config.max_tokens !== undefined || config.max_completion_tokens !== undefined) {
+
+  const defaultCap = getRedteamProviderMaxTokens();
+  const providerId = provider.id();
+  const constructorName = provider.constructor?.name ?? '';
+
+  if (providerId.includes(':responses:') || constructorName.includes('ResponsesProvider')) {
+    config.max_output_tokens ??= defaultCap;
     return;
   }
-  config.max_tokens = REDTEAM_PROVIDER_MAX_TOKENS;
-  config.max_completion_tokens = REDTEAM_PROVIDER_MAX_TOKENS;
+
+  if (provider instanceof OpenAiChatCompletionProvider) {
+    const configuredCap = config.max_completion_tokens ?? config.max_tokens ?? defaultCap;
+    config.max_tokens ??= configuredCap;
+    config.max_completion_tokens ??= configuredCap;
+    return;
+  }
+
+  if (providerId.includes(':completion:') || constructorName === 'OpenAiCompletionProvider') {
+    config.max_tokens ??= defaultCap;
+  }
 }
 
 async function loadRedteamProvider({
   provider,
   jsonOnly = false,
   preferSmallModel = false,
-  purpose = 'redteam',
+  purpose = 'generation',
 }: {
   provider?: RedteamFileConfig['provider'];
   jsonOnly?: boolean;
   preferSmallModel?: boolean;
-  purpose?: 'redteam' | 'grading';
+  purpose?: 'attack' | 'generation' | 'grading';
 } = {}) {
   let ret;
+  const shouldCapOutput = purpose === 'attack' || purpose === 'grading';
   const redteamProvider = provider || cliState.config?.redteam?.provider;
   if (isApiProvider(redteamProvider)) {
     logger.debug(`Using ${purpose} provider: ${redteamProvider}`);
@@ -126,28 +139,39 @@ async function loadRedteamProvider({
   } else if (typeof redteamProvider === 'string' || isProviderOptions(redteamProvider)) {
     logger.debug(`Loading ${purpose} provider`, { provider: redteamProvider });
     ret = (await redteamProviderLoader([redteamProvider]))[0];
-    // A configured redteam provider (string id or ProviderOptions) would otherwise fall
-    // through to OPENAI_MAX_TOKENS / the model's output ceiling, so an occasional degenerate
-    // generation can run away. Apply a bounded default cap to the loaded provider unless it
-    // set one explicitly.
-    applyDefaultOutputCap(ret);
+    if (shouldCapOutput) {
+      applyDefaultOutputCap(ret);
+    }
   } else {
     const defaultModel = preferSmallModel ? ATTACKER_MODEL_SMALL : ATTACKER_MODEL;
     logger.debug(`Using default ${purpose} provider: ${defaultModel}`);
+    const maxTokens = shouldCapOutput ? getRedteamProviderMaxTokens() : undefined;
     ret = new OpenAiChatCompletionProvider(defaultModel, {
       config: {
         temperature: TEMPERATURE,
         response_format: jsonOnly ? { type: 'json_object' } : undefined,
-        // Bound the output so a degenerate/runaway generation can't run to the model's
-        // token ceiling (minutes of latency + an unparseable response). Set both forms
-        // so the cap applies whether the model takes `max_tokens` (e.g. gpt-4.1) or
-        // `max_completion_tokens` (reasoning / gpt-5 models). See REDTEAM_PROVIDER_MAX_TOKENS.
-        max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
-        max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
+        ...(maxTokens === undefined
+          ? {}
+          : {
+              // Set both aliases; OpenAI chat selects the valid field for the active model.
+              max_tokens: maxTokens,
+              max_completion_tokens: maxTokens,
+            }),
       },
     });
   }
   return ret;
+}
+
+function getDefaultTestProvider(): RedteamFileConfig['provider'] | undefined {
+  if (typeof cliState.config?.defaultTest !== 'object') {
+    return undefined;
+  }
+
+  const defaultTest = cliState.config.defaultTest as any;
+  return (
+    defaultTest.provider || defaultTest.options?.provider?.text || defaultTest.options?.provider
+  );
 }
 
 class RedteamProviderManager {
@@ -210,12 +234,14 @@ class RedteamProviderManager {
     provider,
     jsonOnly = false,
     preferSmallModel = false,
+    purpose = 'generation',
   }: {
     provider?: RedteamFileConfig['provider'];
     jsonOnly?: boolean;
     preferSmallModel?: boolean;
+    purpose?: 'attack' | 'generation';
   }): Promise<ApiProvider> {
-    if (this.provider && this.jsonOnlyProvider) {
+    if (purpose === 'generation' && this.provider && this.jsonOnlyProvider) {
       logger.debug(`[RedteamProviderManager] Using cached redteam provider: ${this.provider.id()}`);
       return this.wrapProvider(jsonOnly ? this.jsonOnlyProvider : this.provider);
     }
@@ -226,14 +252,7 @@ class RedteamProviderManager {
     // If no explicit redteam provider, try defaultTest config chain as fallback
     // This ensures users who configure defaultTest.options.provider get consistent behavior
     if (!hasExplicitProvider) {
-      const defaultTestProvider =
-        (typeof cliState.config?.defaultTest === 'object' &&
-          (cliState.config?.defaultTest as any)?.provider) ||
-        (typeof cliState.config?.defaultTest === 'object' &&
-          (cliState.config?.defaultTest as any)?.options?.provider?.text) ||
-        (typeof cliState.config?.defaultTest === 'object' &&
-          (cliState.config?.defaultTest as any)?.options?.provider) ||
-        undefined;
+      const defaultTestProvider = getDefaultTestProvider();
 
       if (defaultTestProvider) {
         logger.debug(
@@ -251,6 +270,7 @@ class RedteamProviderManager {
           provider: defaultTestProvider,
           jsonOnly,
           preferSmallModel,
+          purpose,
         });
         logger.debug(
           `[RedteamProviderManager] Using redteam provider from defaultTest: ${redteamProvider.id()}`,
@@ -264,7 +284,12 @@ class RedteamProviderManager {
       jsonOnly,
       preferSmallModel,
     });
-    const redteamProvider = await loadRedteamProvider({ provider, jsonOnly, preferSmallModel });
+    const redteamProvider = await loadRedteamProvider({
+      provider,
+      jsonOnly,
+      preferSmallModel,
+      purpose,
+    });
     logger.debug(`[RedteamProviderManager] Loaded redteam provider: ${redteamProvider.id()}`);
     return this.wrapProvider(redteamProvider);
   }
@@ -291,14 +316,7 @@ class RedteamProviderManager {
     }
 
     // 3) Try defaultTest config chain (grading-first)
-    const cfg =
-      (typeof cliState.config?.defaultTest === 'object' &&
-        (cliState.config?.defaultTest as any)?.provider) ||
-      (typeof cliState.config?.defaultTest === 'object' &&
-        (cliState.config?.defaultTest as any)?.options?.provider?.text) ||
-      (typeof cliState.config?.defaultTest === 'object' &&
-        (cliState.config?.defaultTest as any)?.options?.provider) ||
-      undefined;
+    const cfg = getDefaultTestProvider();
 
     if (cfg) {
       const loaded = await loadRedteamProvider({ provider: cfg, jsonOnly, purpose: 'grading' });
@@ -308,8 +326,9 @@ class RedteamProviderManager {
       return this.wrapProvider(loaded);
     }
 
-    // 4) Fallback to redteam provider (already wraps)
-    return this.getProvider({ jsonOnly });
+    // 4) Fallback to the configured redteam provider or the default local grader.
+    const loaded = await loadRedteamProvider({ jsonOnly, purpose: 'grading' });
+    return this.wrapProvider(loaded);
   }
 
   async getMultilingualProvider(): Promise<ApiProvider | undefined> {

--- a/src/redteam/providers/voiceCrescendo/index.ts
+++ b/src/redteam/providers/voiceCrescendo/index.ts
@@ -275,6 +275,7 @@ export class VoiceCrescendoProvider implements ApiProvider {
           provider: this.config.redteamProvider,
           preferSmallModel: false,
           jsonOnly: true,
+          purpose: 'attack',
         });
       }
     }

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -107,6 +107,7 @@ export async function encodeMathPrompt(text: string, concept: string): Promise<s
   const redteamProvider = await redteamProviderManager.getProvider({
     jsonOnly: true,
     preferSmallModel: true,
+    purpose: 'attack',
   });
   const examplePrompt = EXAMPLES[Math.floor(Math.random() * EXAMPLES.length)];
 

--- a/test/redteam/providers/attackProviderOutputCap.test.ts
+++ b/test/redteam/providers/attackProviderOutputCap.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { AzureChatCompletionProvider } from '../../../src/providers/azure/chat';
 import { OpenAiChatCompletionProvider } from '../../../src/providers/openai/chat';
 import { OpenAiResponsesProvider } from '../../../src/providers/openai/responses';
 import { DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS } from '../../../src/redteam/providers/constants';
@@ -45,6 +46,24 @@ describe('redteam attack provider output caps', () => {
       const { body } = await (loaded as OpenAiResponsesProvider).getOpenAiBody('hello');
 
       expect(body.max_output_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(body).not.toHaveProperty('max_tokens');
+    } finally {
+      restoreLoader();
+    }
+  });
+
+  it('caps the actual Azure reasoning-chat request body for attack calls', async () => {
+    const provider = new AzureChatCompletionProvider('gpt-5-deployment', { config: {} });
+    const restoreLoader = setRedteamProviderLoader(async () => [provider]);
+
+    try {
+      const loaded = await redteamProviderManager.getProvider({
+        provider: 'azure:chat:gpt-5-deployment',
+        purpose: 'attack',
+      });
+      const { body } = await (loaded as AzureChatCompletionProvider).getOpenAiBody('hello');
+
+      expect(body.max_completion_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
       expect(body).not.toHaveProperty('max_tokens');
     } finally {
       restoreLoader();

--- a/test/redteam/providers/attackProviderOutputCap.test.ts
+++ b/test/redteam/providers/attackProviderOutputCap.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { OpenAiChatCompletionProvider } from '../../../src/providers/openai/chat';
+import { OpenAiResponsesProvider } from '../../../src/providers/openai/responses';
+import { DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS } from '../../../src/redteam/providers/constants';
+import {
+  redteamProviderManager,
+  resetRedteamProviderLoader,
+  setRedteamProviderLoader,
+} from '../../../src/redteam/providers/shared';
+import { mockProcessEnv } from '../../util/utils';
+
+describe('redteam attack provider output caps', () => {
+  afterEach(() => {
+    redteamProviderManager.clearProvider();
+    resetRedteamProviderLoader();
+  });
+
+  it('caps the actual OpenAI chat request body for attack calls', async () => {
+    const provider = new OpenAiChatCompletionProvider('gpt-4.1', { config: {} });
+    const restoreLoader = setRedteamProviderLoader(async () => [provider]);
+
+    try {
+      const loaded = await redteamProviderManager.getProvider({
+        provider: 'openai:chat:gpt-4.1',
+        purpose: 'attack',
+      });
+      const { body } = await (loaded as OpenAiChatCompletionProvider).getOpenAiBody('hello');
+
+      expect(body.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(body).not.toHaveProperty('max_completion_tokens');
+    } finally {
+      restoreLoader();
+    }
+  });
+
+  it('caps the actual OpenAI Responses request body with max_output_tokens', async () => {
+    const provider = new OpenAiResponsesProvider('gpt-5.5', { config: {} });
+    const restoreLoader = setRedteamProviderLoader(async () => [provider]);
+
+    try {
+      const loaded = await redteamProviderManager.getProvider({
+        provider: 'openai:responses:gpt-5.5',
+        purpose: 'attack',
+      });
+      const { body } = await (loaded as OpenAiResponsesProvider).getOpenAiBody('hello');
+
+      expect(body.max_output_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(body).not.toHaveProperty('max_tokens');
+    } finally {
+      restoreLoader();
+    }
+  });
+
+  it('preserves a larger batch-generation budget from OPENAI_MAX_TOKENS', async () => {
+    const restoreEnv = mockProcessEnv({ OPENAI_MAX_TOKENS: '32768' });
+    const provider = new OpenAiChatCompletionProvider('gpt-4.1', { config: {} });
+    const restoreLoader = setRedteamProviderLoader(async () => [provider]);
+
+    try {
+      const loaded = await redteamProviderManager.getProvider({
+        provider: 'openai:chat:gpt-4.1',
+      });
+      const { body } = await (loaded as OpenAiChatCompletionProvider).getOpenAiBody('hello');
+
+      expect(body.max_tokens).toBe(32768);
+    } finally {
+      restoreLoader();
+      restoreEnv();
+    }
+  });
+});

--- a/test/redteam/providers/attackProviderOutputCap.test.ts
+++ b/test/redteam/providers/attackProviderOutputCap.test.ts
@@ -53,7 +53,9 @@ describe('redteam attack provider output caps', () => {
   });
 
   it('caps the actual Azure reasoning-chat request body for attack calls', async () => {
-    const provider = new AzureChatCompletionProvider('gpt-5-deployment', { config: {} });
+    const provider = new AzureChatCompletionProvider('gpt-5-deployment', {
+      config: { apiKey: 'test-key' },
+    });
     const restoreLoader = setRedteamProviderLoader(async () => [provider]);
 
     try {

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -268,6 +268,39 @@ describe('shared redteam provider utilities', () => {
       expect(mockedLoadApiProviders).toHaveBeenCalledWith([providerOptions]);
     });
 
+    it('applies a bounded default output cap to a configured provider with no output bound', async () => {
+      const loaded = {
+        id: () => 'openai:gpt-4.1',
+        callApi: vi.fn(),
+        config: {} as Record<string, unknown>,
+      };
+      mockedLoadApiProviders.mockResolvedValue([loaded]);
+      redteamProviderManager.clearProvider();
+
+      await redteamProviderManager.getProvider({ provider: 'openai:gpt-4.1' });
+
+      expect(loaded.config.max_tokens).toBe(REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(loaded.config.max_completion_tokens).toBe(REDTEAM_PROVIDER_MAX_TOKENS);
+    });
+
+    it('respects an explicit output bound on a configured provider (does not override)', async () => {
+      const loaded = {
+        id: () => 'openai:gpt-4.1',
+        callApi: vi.fn(),
+        config: { max_tokens: 9000 } as Record<string, unknown>,
+      };
+      mockedLoadApiProviders.mockResolvedValue([loaded]);
+      redteamProviderManager.clearProvider();
+
+      await redteamProviderManager.getProvider({
+        provider: { id: 'openai:gpt-4.1', config: { max_tokens: 9000 } },
+      });
+
+      expect(loaded.config.max_tokens).toBe(9000);
+      // We must not graft a mismatched completion cap on top of the caller's bound.
+      expect(loaded.config.max_completion_tokens).toBeUndefined();
+    });
+
     it('uses small model when preferSmallModel is true', async () => {
       const result = await redteamProviderManager.getProvider({ preferSmallModel: true });
 

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -302,7 +302,9 @@ describe('shared redteam provider utilities', () => {
     });
 
     it('applies the chat output cap to configured Azure chat attack providers', async () => {
-      const loaded = new AzureChatCompletionProvider('gpt-5-deployment', { config: {} });
+      const loaded = new AzureChatCompletionProvider('gpt-5-deployment', {
+        config: { apiKey: 'test-key' },
+      });
       mockedLoadApiProviders.mockResolvedValue([loaded]);
       redteamProviderManager.clearProvider();
 
@@ -318,7 +320,7 @@ describe('shared redteam provider utilities', () => {
         DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
       );
       expect(result).not.toBe(loaded);
-      expect(loaded.config).toEqual({});
+      expect(loaded.config).toEqual({ apiKey: 'test-key' });
     });
 
     it('waits for Azure authentication state before cloning a capped provider', async () => {

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import cliState from '../../../src/cliState';
+import { OllamaCompletionProvider } from '../../../src/providers/ollama';
 import { OpenAiCompletionProvider } from '../../../src/providers/openai/completion';
 import { OpenAiResponsesProvider } from '../../../src/providers/openai/responses';
 import {
@@ -360,6 +361,19 @@ describe('shared redteam provider utilities', () => {
         purpose: 'attack',
       });
 
+      expect(loaded.config).toEqual({});
+    });
+
+    it('does not mistake a native completion provider for OpenAI completions', async () => {
+      const loaded = new OllamaCompletionProvider('llama3.2', { config: {} });
+      mockedLoadApiProviders.mockResolvedValue([loaded]);
+
+      const result = await redteamProviderManager.getProvider({
+        provider: 'ollama:completion:llama3.2',
+        purpose: 'attack',
+      });
+
+      expect(result).toBe(loaded);
       expect(loaded.config).toEqual({});
     });
 

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import cliState from '../../../src/cliState';
+import { AzureChatCompletionProvider } from '../../../src/providers/azure/chat';
 import { OllamaCompletionProvider } from '../../../src/providers/ollama';
 import { OpenAiCompletionProvider } from '../../../src/providers/openai/completion';
 import { OpenAiResponsesProvider } from '../../../src/providers/openai/responses';
@@ -289,6 +290,26 @@ describe('shared redteam provider utilities', () => {
       expect(result).not.toBe(loaded);
       expect(loaded.config.max_tokens).toBeUndefined();
       expect(loaded.config.max_completion_tokens).toBeUndefined();
+    });
+
+    it('applies the chat output cap to configured Azure chat attack providers', async () => {
+      const loaded = new AzureChatCompletionProvider('gpt-5-deployment', { config: {} });
+      mockedLoadApiProviders.mockResolvedValue([loaded]);
+      redteamProviderManager.clearProvider();
+
+      const result = await redteamProviderManager.getProvider({
+        provider: 'azure:chat:gpt-5-deployment',
+        purpose: 'attack',
+      });
+
+      expect((result as AzureChatCompletionProvider).config.max_tokens).toBe(
+        DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+      );
+      expect((result as AzureChatCompletionProvider).config.max_completion_tokens).toBe(
+        DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+      );
+      expect(result).not.toBe(loaded);
+      expect(loaded.config).toEqual({});
     });
 
     it('does not cap a configured OpenAI provider used for batch generation', async () => {

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -3,6 +3,7 @@ import cliState from '../../../src/cliState';
 import {
   ATTACKER_MODEL,
   ATTACKER_MODEL_SMALL,
+  REDTEAM_PROVIDER_MAX_TOKENS,
   TEMPERATURE,
 } from '../../../src/redteam/providers/constants';
 import {
@@ -143,7 +144,23 @@ describe('shared redteam provider utilities', () => {
       expect(mockOpenAiInstances[0].config).toEqual({
         temperature: TEMPERATURE,
         response_format: undefined,
+        max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
+        max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
       });
+    });
+
+    it('bounds the default provider output so a runaway generation cannot reach the model ceiling', async () => {
+      // Regression: without an explicit cap the default redteam provider falls through to
+      // OPENAI_MAX_TOKENS (or the model's output ceiling), so a degenerate generation can
+      // run to tens of thousands of tokens. The cap must be set and modest, and applied in
+      // both `max_tokens` (e.g. gpt-4.1) and `max_completion_tokens` (reasoning/gpt-5) forms.
+      await redteamProviderManager.getProvider({});
+
+      const { config } = mockOpenAiInstances[0];
+      expect(config.max_tokens).toBe(REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(config.max_completion_tokens).toBe(REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(REDTEAM_PROVIDER_MAX_TOKENS).toBeLessThanOrEqual(8192);
+      expect(REDTEAM_PROVIDER_MAX_TOKENS).toBeGreaterThan(0);
     });
 
     it('clears cached providers', async () => {
@@ -260,6 +277,8 @@ describe('shared redteam provider utilities', () => {
       expect(mockOpenAiInstances[0].config).toEqual({
         temperature: TEMPERATURE,
         response_format: undefined,
+        max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
+        max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
       });
     });
 
@@ -272,6 +291,8 @@ describe('shared redteam provider utilities', () => {
       expect(mockOpenAiInstances[0].config).toEqual({
         temperature: TEMPERATURE,
         response_format: { type: 'json_object' },
+        max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
+        max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
       });
     });
 
@@ -501,6 +522,8 @@ describe('shared redteam provider utilities', () => {
         expect(mockOpenAiInstances[0].config).toEqual({
           temperature: TEMPERATURE,
           response_format: { type: 'json_object' },
+          max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
+          max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
         });
       });
     });

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -312,6 +312,35 @@ describe('shared redteam provider utilities', () => {
       expect(loaded.config).toEqual({});
     });
 
+    it('waits for Azure authentication state before cloning a capped provider', async () => {
+      let resolveAuth!: (headers: Record<string, string>) => void;
+      const authHeaders = new Promise<Record<string, string>>((resolve) => {
+        resolveAuth = resolve;
+      });
+      class DeferredAzureChatCompletionProvider extends AzureChatCompletionProvider {
+        override getAuthHeaders(): Promise<Record<string, string>> {
+          return authHeaders;
+        }
+      }
+      const configured = new DeferredAzureChatCompletionProvider('gpt-5-deployment', {
+        config: {},
+      });
+
+      const attackPromise = redteamProviderManager.getProvider({
+        provider: configured,
+        purpose: 'attack',
+      });
+      resolveAuth({ 'api-key': 'initialized-key' });
+      const attack = await attackPromise;
+
+      expect(attack).not.toBe(configured);
+      expect((attack as any).authHeaders).toEqual({ 'api-key': 'initialized-key' });
+      expect((attack as AzureChatCompletionProvider).config.max_completion_tokens).toBe(
+        DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+      );
+      expect(configured.config).toEqual({});
+    });
+
     it('does not cap a configured OpenAI provider used for batch generation', async () => {
       const loaded = new MockOpenAiChatCompletionProvider('gpt-4.1', { config: {} });
       mockedLoadApiProviders.mockResolvedValue([loaded]);

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -273,6 +273,15 @@ describe('shared redteam provider utilities', () => {
       expect(mockedLoadApiProviders).toHaveBeenCalledWith([providerOptions]);
     });
 
+    it('falls back cleanly when defaultTest is null', async () => {
+      setCliStateConfig({ defaultTest: null } as any);
+
+      const result = await redteamProviderManager.getProvider({ purpose: 'attack' });
+
+      expect(result.id()).toBe(`openai:${ATTACKER_MODEL}`);
+      expect(mockOpenAiInstances).toHaveLength(1);
+    });
+
     it('applies a bounded default output cap to a configured OpenAI chat attack provider', async () => {
       const loaded = new MockOpenAiChatCompletionProvider('gpt-4.1', { config: {} });
       mockedLoadApiProviders.mockResolvedValue([loaded]);

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -276,13 +276,18 @@ describe('shared redteam provider utilities', () => {
       mockedLoadApiProviders.mockResolvedValue([loaded]);
       redteamProviderManager.clearProvider();
 
-      await redteamProviderManager.getProvider({
+      const result = await redteamProviderManager.getProvider({
         provider: 'openai:gpt-4.1',
         purpose: 'attack',
       });
 
-      expect(loaded.config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
-      expect(loaded.config.max_completion_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect((result as any).config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect((result as any).config.max_completion_tokens).toBe(
+        DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+      );
+      expect(result).not.toBe(loaded);
+      expect(loaded.config.max_tokens).toBeUndefined();
+      expect(loaded.config.max_completion_tokens).toBeUndefined();
     });
 
     it('does not cap a configured OpenAI provider used for batch generation', async () => {
@@ -302,40 +307,47 @@ describe('shared redteam provider utilities', () => {
       mockedLoadApiProviders.mockResolvedValue([loaded]);
       redteamProviderManager.clearProvider();
 
-      await redteamProviderManager.getProvider({
+      const result = await redteamProviderManager.getProvider({
         provider: { id: 'openai:gpt-4.1', config: { max_tokens: 9000 } },
         purpose: 'attack',
       });
 
-      expect(loaded.config.max_tokens).toBe(9000);
-      expect(loaded.config.max_completion_tokens).toBe(9000);
+      expect((result as any).config.max_tokens).toBe(9000);
+      expect((result as any).config.max_completion_tokens).toBe(9000);
+      expect(loaded.config).toEqual({ max_tokens: 9000 });
     });
 
     it('uses max_output_tokens for configured OpenAI Responses attack providers', async () => {
       const loaded = new OpenAiResponsesProvider('gpt-5.5', { config: {} });
       mockedLoadApiProviders.mockResolvedValue([loaded]);
 
-      await redteamProviderManager.getProvider({
+      const result = await redteamProviderManager.getProvider({
         provider: 'openai:responses:gpt-5.5',
         purpose: 'attack',
       });
 
-      expect(loaded.config.max_output_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
-      expect(loaded.config.max_tokens).toBeUndefined();
-      expect(loaded.config.max_completion_tokens).toBeUndefined();
+      expect((result as OpenAiResponsesProvider).config.max_output_tokens).toBe(
+        DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+      );
+      expect((result as OpenAiResponsesProvider).config.max_tokens).toBeUndefined();
+      expect((result as OpenAiResponsesProvider).config.max_completion_tokens).toBeUndefined();
+      expect(loaded.config).toEqual({});
     });
 
     it('uses max_tokens for configured OpenAI completion attack providers', async () => {
       const loaded = new OpenAiCompletionProvider('davinci-002', { config: {} });
       mockedLoadApiProviders.mockResolvedValue([loaded]);
 
-      await redteamProviderManager.getProvider({
+      const result = await redteamProviderManager.getProvider({
         provider: 'openai:completion:davinci-002',
         purpose: 'attack',
       });
 
-      expect(loaded.config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
-      expect(loaded.config.max_completion_tokens).toBeUndefined();
+      expect((result as OpenAiCompletionProvider).config.max_tokens).toBe(
+        DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+      );
+      expect((result as OpenAiCompletionProvider).config.max_completion_tokens).toBeUndefined();
+      expect(loaded.config).toEqual({});
     });
 
     it('does not inject OpenAI-only fields into native providers', async () => {
@@ -431,6 +443,44 @@ describe('shared redteam provider utilities', () => {
       expect(mockedLoadApiProviders).toHaveBeenNthCalledWith(2, ['test-provider']);
     });
 
+    it('reuses a preconfigured provider for attack calls without capping generation', async () => {
+      const configured = new MockOpenAiChatCompletionProvider('gpt-4.1', { config: {} });
+      mockedLoadApiProviders.mockResolvedValue([configured]);
+
+      await redteamProviderManager.setProvider('openai:gpt-4.1');
+
+      const generation = await redteamProviderManager.getProvider({});
+      const attack = await redteamProviderManager.getProvider({ purpose: 'attack' });
+      const cachedAttack = await redteamProviderManager.getProvider({ purpose: 'attack' });
+
+      expect(generation).toBe(configured);
+      expect(generation.config.max_tokens).toBeUndefined();
+      expect(attack).not.toBe(configured);
+      expect((attack as any).config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect((attack as any).config.max_completion_tokens).toBe(
+        DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+      );
+      expect(cachedAttack).toBe(attack);
+      expect(mockedLoadApiProviders).toHaveBeenCalledTimes(3);
+      expect(mockedLoadApiProviders).toHaveBeenNthCalledWith(3, ['openai:gpt-4.1']);
+    });
+
+    it('caps an instantiated OpenAI attack provider without mutating the caller instance', async () => {
+      const configured = new MockOpenAiChatCompletionProvider('gpt-4.1', { config: {} });
+
+      const attack = await redteamProviderManager.getProvider({
+        provider: configured as any,
+        purpose: 'attack',
+      });
+
+      expect(attack).not.toBe(configured);
+      expect((attack as any).config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect((attack as any).config.max_completion_tokens).toBe(
+        DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+      );
+      expect(configured.config).toEqual({});
+    });
+
     describe('getGradingProvider', () => {
       it('returns cached grading provider set via setGradingProvider', async () => {
         redteamProviderManager.clearProvider();
@@ -470,9 +520,10 @@ describe('shared redteam provider utilities', () => {
 
         const got = await redteamProviderManager.getProvider({ purpose: 'attack' });
 
-        expect(got).toBe(loaded);
+        expect(got).not.toBe(loaded);
         expect(mockedLoadApiProviders).toHaveBeenCalledWith(['openai:gpt-4.1']);
-        expect(loaded.config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+        expect((got as any).config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+        expect(loaded.config.max_tokens).toBeUndefined();
       });
 
       it('falls back to redteam provider when grading not set', async () => {

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import cliState from '../../../src/cliState';
+import { OpenAiCompletionProvider } from '../../../src/providers/openai/completion';
+import { OpenAiResponsesProvider } from '../../../src/providers/openai/responses';
 import {
   ATTACKER_MODEL,
   ATTACKER_MODEL_SMALL,
-  REDTEAM_PROVIDER_MAX_TOKENS,
+  DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+  getRedteamProviderMaxTokens,
   TEMPERATURE,
 } from '../../../src/redteam/providers/constants';
 import {
@@ -144,23 +147,23 @@ describe('shared redteam provider utilities', () => {
       expect(mockOpenAiInstances[0].config).toEqual({
         temperature: TEMPERATURE,
         response_format: undefined,
-        max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
-        max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
       });
     });
 
-    it('bounds the default provider output so a runaway generation cannot reach the model ceiling', async () => {
+    it('bounds the default attack provider without capping batch generation', async () => {
       // Regression: without an explicit cap the default redteam provider falls through to
       // OPENAI_MAX_TOKENS (or the model's output ceiling), so a degenerate generation can
-      // run to tens of thousands of tokens. The cap must be set and modest, and applied in
-      // both `max_tokens` (e.g. gpt-4.1) and `max_completion_tokens` (reasoning/gpt-5) forms.
+      // run to tens of thousands of tokens. Apply the cap to short attack calls, but preserve
+      // the provider's normal output budget for batch test-case generation.
       await redteamProviderManager.getProvider({});
+      await redteamProviderManager.getProvider({ purpose: 'attack' });
 
-      const { config } = mockOpenAiInstances[0];
-      expect(config.max_tokens).toBe(REDTEAM_PROVIDER_MAX_TOKENS);
-      expect(config.max_completion_tokens).toBe(REDTEAM_PROVIDER_MAX_TOKENS);
-      expect(REDTEAM_PROVIDER_MAX_TOKENS).toBeLessThanOrEqual(8192);
-      expect(REDTEAM_PROVIDER_MAX_TOKENS).toBeGreaterThan(0);
+      expect(mockOpenAiInstances[0].config.max_tokens).toBeUndefined();
+      expect(mockOpenAiInstances[0].config.max_completion_tokens).toBeUndefined();
+      expect(mockOpenAiInstances[1].config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(mockOpenAiInstances[1].config.max_completion_tokens).toBe(
+        DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+      );
     });
 
     it('clears cached providers', async () => {
@@ -268,41 +271,104 @@ describe('shared redteam provider utilities', () => {
       expect(mockedLoadApiProviders).toHaveBeenCalledWith([providerOptions]);
     });
 
-    it('applies a bounded default output cap to a configured provider with no output bound', async () => {
-      const loaded = {
-        id: () => 'openai:gpt-4.1',
-        callApi: vi.fn(),
-        config: {} as Record<string, unknown>,
-      };
+    it('applies a bounded default output cap to a configured OpenAI chat attack provider', async () => {
+      const loaded = new MockOpenAiChatCompletionProvider('gpt-4.1', { config: {} });
       mockedLoadApiProviders.mockResolvedValue([loaded]);
       redteamProviderManager.clearProvider();
 
-      await redteamProviderManager.getProvider({ provider: 'openai:gpt-4.1' });
+      await redteamProviderManager.getProvider({
+        provider: 'openai:gpt-4.1',
+        purpose: 'attack',
+      });
 
-      expect(loaded.config.max_tokens).toBe(REDTEAM_PROVIDER_MAX_TOKENS);
-      expect(loaded.config.max_completion_tokens).toBe(REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(loaded.config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(loaded.config.max_completion_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
     });
 
-    it('respects an explicit output bound on a configured provider (does not override)', async () => {
-      const loaded = {
-        id: () => 'openai:gpt-4.1',
-        callApi: vi.fn(),
-        config: { max_tokens: 9000 } as Record<string, unknown>,
-      };
+    it('does not cap a configured OpenAI provider used for batch generation', async () => {
+      const loaded = new MockOpenAiChatCompletionProvider('gpt-4.1', { config: {} });
+      mockedLoadApiProviders.mockResolvedValue([loaded]);
+
+      await redteamProviderManager.getProvider({ provider: 'openai:gpt-4.1' });
+
+      expect(loaded.config.max_tokens).toBeUndefined();
+      expect(loaded.config.max_completion_tokens).toBeUndefined();
+    });
+
+    it('mirrors an explicit OpenAI chat output bound across model-specific aliases', async () => {
+      const loaded = new MockOpenAiChatCompletionProvider('gpt-4.1', {
+        config: { max_tokens: 9000 },
+      });
       mockedLoadApiProviders.mockResolvedValue([loaded]);
       redteamProviderManager.clearProvider();
 
       await redteamProviderManager.getProvider({
         provider: { id: 'openai:gpt-4.1', config: { max_tokens: 9000 } },
+        purpose: 'attack',
       });
 
       expect(loaded.config.max_tokens).toBe(9000);
-      // We must not graft a mismatched completion cap on top of the caller's bound.
+      expect(loaded.config.max_completion_tokens).toBe(9000);
+    });
+
+    it('uses max_output_tokens for configured OpenAI Responses attack providers', async () => {
+      const loaded = new OpenAiResponsesProvider('gpt-5.5', { config: {} });
+      mockedLoadApiProviders.mockResolvedValue([loaded]);
+
+      await redteamProviderManager.getProvider({
+        provider: 'openai:responses:gpt-5.5',
+        purpose: 'attack',
+      });
+
+      expect(loaded.config.max_output_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(loaded.config.max_tokens).toBeUndefined();
       expect(loaded.config.max_completion_tokens).toBeUndefined();
     });
 
+    it('uses max_tokens for configured OpenAI completion attack providers', async () => {
+      const loaded = new OpenAiCompletionProvider('davinci-002', { config: {} });
+      mockedLoadApiProviders.mockResolvedValue([loaded]);
+
+      await redteamProviderManager.getProvider({
+        provider: 'openai:completion:davinci-002',
+        purpose: 'attack',
+      });
+
+      expect(loaded.config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      expect(loaded.config.max_completion_tokens).toBeUndefined();
+    });
+
+    it('does not inject OpenAI-only fields into native providers', async () => {
+      const loaded = createMockProvider({ id: 'cohere:command-a-03-2025' });
+      loaded.config = {};
+      mockedLoadApiProviders.mockResolvedValue([loaded]);
+
+      await redteamProviderManager.getProvider({
+        provider: 'cohere:command-a-03-2025',
+        purpose: 'attack',
+      });
+
+      expect(loaded.config).toEqual({});
+    });
+
+    it('reads and clamps the attack cap when the provider is constructed', async () => {
+      const restoreEnv = mockProcessEnv({ PROMPTFOO_REDTEAM_PROVIDER_MAX_TOKENS: '8192' });
+      try {
+        await redteamProviderManager.getProvider({ purpose: 'attack' });
+        expect(mockOpenAiInstances[0].config.max_tokens).toBe(8192);
+
+        mockProcessEnv({ PROMPTFOO_REDTEAM_PROVIDER_MAX_TOKENS: '-5' });
+        expect(getRedteamProviderMaxTokens()).toBe(1);
+      } finally {
+        restoreEnv();
+      }
+    });
+
     it('uses small model when preferSmallModel is true', async () => {
-      const result = await redteamProviderManager.getProvider({ preferSmallModel: true });
+      const result = await redteamProviderManager.getProvider({
+        preferSmallModel: true,
+        purpose: 'attack',
+      });
 
       // Check that an instance was created with the small model
       expect(mockOpenAiInstances.length).toBe(1);
@@ -310,13 +376,16 @@ describe('shared redteam provider utilities', () => {
       expect(mockOpenAiInstances[0].config).toEqual({
         temperature: TEMPERATURE,
         response_format: undefined,
-        max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
-        max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
+        max_tokens: DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+        max_completion_tokens: DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
       });
     });
 
     it('sets response_format to json_object when jsonOnly is true', async () => {
-      const result = await redteamProviderManager.getProvider({ jsonOnly: true });
+      const result = await redteamProviderManager.getProvider({
+        jsonOnly: true,
+        purpose: 'attack',
+      });
 
       // Check that an instance was created with json_object response_format
       expect(mockOpenAiInstances.length).toBe(1);
@@ -324,8 +393,8 @@ describe('shared redteam provider utilities', () => {
       expect(mockOpenAiInstances[0].config).toEqual({
         temperature: TEMPERATURE,
         response_format: { type: 'json_object' },
-        max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
-        max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
+        max_tokens: DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+        max_completion_tokens: DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
       });
     });
 
@@ -390,6 +459,22 @@ describe('shared redteam provider utilities', () => {
         expect(mockedLoadApiProviders).toHaveBeenCalledWith(['from-defaultTest-provider']);
       });
 
+      it('uses the defaultTest chain for attack providers', async () => {
+        const loaded = new MockOpenAiChatCompletionProvider('gpt-4.1', { config: {} });
+        mockedLoadApiProviders.mockResolvedValue([loaded]);
+        setCliStateConfig({
+          defaultTest: {
+            provider: 'openai:gpt-4.1',
+          },
+        });
+
+        const got = await redteamProviderManager.getProvider({ purpose: 'attack' });
+
+        expect(got).toBe(loaded);
+        expect(mockedLoadApiProviders).toHaveBeenCalledWith(['openai:gpt-4.1']);
+        expect(loaded.config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+      });
+
       it('falls back to redteam provider when grading not set', async () => {
         redteamProviderManager.clearProvider();
         setCliStateConfig({}); // no defaultTest
@@ -397,6 +482,10 @@ describe('shared redteam provider utilities', () => {
         // Expect fallback to default OpenAI redteam provider
         const got = await redteamProviderManager.getGradingProvider({ jsonOnly: true });
         expect(got.id()).toContain('openai:');
+        expect(mockOpenAiInstances[0].config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+        expect(mockOpenAiInstances[0].config.max_completion_tokens).toBe(
+          DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+        );
       });
     });
 
@@ -555,8 +644,6 @@ describe('shared redteam provider utilities', () => {
         expect(mockOpenAiInstances[0].config).toEqual({
           temperature: TEMPERATURE,
           response_format: { type: 'json_object' },
-          max_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
-          max_completion_tokens: REDTEAM_PROVIDER_MAX_TOKENS,
         });
       });
     });

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -538,6 +538,26 @@ describe('shared redteam provider utilities', () => {
           DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
         );
       });
+
+      it('uses a manager-configured redteam provider for grading without capping generation', async () => {
+        const configured = new MockOpenAiChatCompletionProvider('gpt-4.1', { config: {} });
+        mockedLoadApiProviders.mockResolvedValue([configured]);
+
+        await redteamProviderManager.setProvider('openai:gpt-4.1');
+
+        const generation = await redteamProviderManager.getProvider({});
+        const grading = await redteamProviderManager.getGradingProvider();
+
+        expect(generation).toBe(configured);
+        expect(generation.config).toEqual({});
+        expect(grading).not.toBe(configured);
+        expect((grading as any).config.max_tokens).toBe(DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS);
+        expect((grading as any).config.max_completion_tokens).toBe(
+          DEFAULT_REDTEAM_PROVIDER_MAX_TOKENS,
+        );
+        expect(mockedLoadApiProviders).toHaveBeenCalledTimes(3);
+        expect(mockedLoadApiProviders).toHaveBeenNthCalledWith(3, ['openai:gpt-4.1']);
+      });
     });
 
     describe('getProvider with defaultTest fallback', () => {


### PR DESCRIPTION
## Summary

The red-team **attack/grading providers** — used by the iterative strategies (`jailbreak:meta`/meta-agent, `crescendo`, `hydra`, `goat`) via `redteamProviderManager` — were constructed in `loadRedteamProvider` with only `temperature` + `response_format` and **no `max_tokens`**. They therefore fall through to `OPENAI_MAX_TOKENS` (or the model's output ceiling).

When `OPENAI_MAX_TOKENS` is raised for large *test-case generation* outputs, these **short-decision/attack** calls inherit that budget. An occasional degenerate / non-terminating generation (repetition or runaway-JSON, more likely under JSON mode + non-zero temperature + complex agentic prompts) then runs all the way to the model's **32,768-token ceiling** — minutes of latency followed by an unparseable response, which surfaces as generation timeouts, parse failures (`"Failed to parse agent output"`), and instance saturation.

This was observed in production: agentic-decision calls (`meta-agent-decision`, `hydra-decision`, `agentic:memory-poisoning`, `goat`) returning `completionTokens = 32768` with 2–10 min latency, e.g. a single `meta-agent` call with a 1,901-token prompt producing 32,768 completion tokens in 235s → 500.

## What changed

- Add `REDTEAM_PROVIDER_MAX_TOKENS` (default **4096**, overridable via `PROMPTFOO_REDTEAM_PROVIDER_MAX_TOKENS`) in `src/redteam/providers/constants.ts`.
- Apply it to the default redteam provider in `loadRedteamProvider` (`shared.ts`), setting **both** `max_tokens` and `max_completion_tokens` so the cap applies whether the model takes `max_tokens` (e.g. gpt-4.1) or `max_completion_tokens` (reasoning / gpt-5 models).
- This is a **dedicated** cap, independent of the generic `OPENAI_MAX_TOKENS` knob, so tuning generation can never again silently uncap the attack/grading providers.

A short structured decision/attack needs a few hundred tokens; 4096 leaves generous headroom (≈16k chars — well above e.g. a 3,500-char Crescendo turn) while bounding a runaway to ~seconds instead of minutes.

## Testing

- New regression test in `test/redteam/providers/shared.test.ts` asserting the default provider sets a bounded `max_tokens`/`max_completion_tokens` (and that the cap is modest and > 0).
- Updated the existing default-provider config assertions to include the new fields.
- Full file green (62/62); `tsc`, Biome lint/format, and `architecture:check` clean.

### Deterministic repro (request body inspection, gpt-4.1)

| Scenario | request body `max_tokens` |
|---|---|
| `OPENAI_MAX_TOKENS=32768`, redteam default config (pre-fix) | **32768** |
| explicit `max_tokens=4096` (this fix) | 4096 |
| `OPENAI_MAX_TOKENS` unset (chat.ts default) | 1024 |

## Notes / scope

This is the **library-level** hardening so redteam providers are never uncapped by a high global `OPENAI_MAX_TOKENS`. The production incident also has two companion fixes outside this PR:
- **Immediate (ops):** lower `OPENAI_MAX_TOKENS` on the cloud server (it was set to `32768`, which is what made the cap the model ceiling).
- **promptfoo-cloud:** give the server-side `getModels()` attack/decision providers a dedicated cap (they currently read `OPENAI_MAX_TOKENS` directly).
