### PR TITLE
fix(ci): re-pin code-scan Node to 24.15.0 to stop install timeout

### DIFF
--- a/.github/workflows/promptfoo-code-scan.yml
+++ b/.github/workflows/promptfoo-code-scan.yml
@@ -33,11 +33,14 @@ jobs:
       # Pin to 24.15.0 (not .nvmrc): Node 24.16.0 adds ~10s to every HTTPS
       # request on Linux runners, dragging the scanner's uncached
       # `npm install -g promptfoo` (~860 packages) into a 14-minute crawl that
-      # trips the job timeout. Revisit when a newer Node resolves it.
+      # trips the job timeout. 24.17.0 still has the regression (PR #9859
+      # re-bumped it and every scan started timing out), so renovate.json
+      # disables Node updates for this file. Revisit — and re-enable that
+      # rule — when a newer Node resolves it.
       - name: Use Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '24.17.0'
+          node-version: '24.15.0'
 
       - name: Run Promptfoo Code Scan
         uses: promptfoo/code-scan-action@c4839dcb8623ca031ee6d271c7850dc71d994dd3 # v0

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,13 @@
       "enabled": false
     },
     {
+      "description": "Pin the code-scan workflow's Node to 24.15.0: Node >=24.16.0 has a Linux HTTPS slowdown (~10s/request) that drags the scanner's `npm install -g promptfoo` past the job's 15-minute timeout (see the comment in .github/workflows/promptfoo-code-scan.yml; first fixed in PR #9374, regressed by the blanket bump in PR #9859). Renovate must not re-bump this pin. Re-enable when a newer Node resolves the regression.",
+      "matchManagers": ["github-actions"],
+      "matchFileNames": [".github/workflows/promptfoo-code-scan.yml"],
+      "matchPackageNames": ["node"],
+      "enabled": false
+    },
+    {
       "description": "Group example directory updates as a fallback so package-specific groups still win",
       "matchFileNames": ["examples/**/package.json"],
       "groupName": "Example dependencies",


### PR DESCRIPTION
## Summary

The **Promptfoo Code Scan** (`security-scan`) job has been timing out at its 15-minute limit on **every PR and on `main`** since ~2026-06-24 00:41 UTC. Before that it completed in ~2 minutes.

### Root cause

PR #9859 (`chore(deps): update node.js`) was a blanket Node version bump. Among legitimate bumps (`.nvmrc`, `Dockerfile`) it also flipped the code-scan workflow's Node pin from `24.15.0` → `24.17.0`:

```diff
-          node-version: '24.15.0'
+          node-version: '24.17.0'
```

That pin was **not** a normal "track latest Node" value. PR #9374 deliberately set it to `24.15.0` because **Node ≥24.16.0 adds ~10s to every HTTPS request on Linux runners**, which drags the scanner's uncached `npm install -g promptfoo` (~860 packages) into a 14-minute crawl that trips the job timeout. The workflow comment documented this — but the comment said `24.15.0` while the value had drifted to `24.17.0`, which still has the regression.

Nothing in `renovate.json` protected the pin, so Renovate's `github-actions` manager treated the literal `node-version` as a `node` dependency and re-bumped it.

### Evidence

- The code-scan-action SHA is pinned and unchanged; the installed promptfoo CLI is pinned to pre-2026-04-11 via `NPM_CONFIG_BEFORE` (always `0.121.4`). The **only** variable that changed between the last green run (00:31 UTC) and the wall of timeouts is the Node bump in #9859.
- Last success: run `28066670157` (2m27s, 2026-06-24 00:31 UTC). Every run since the bump is `cancelled` at 15m, including `workflow_dispatch` runs on `main`.

### Fix

1. Restore `node-version: '24.15.0'` in `.github/workflows/promptfoo-code-scan.yml` (the last known-good value; 24.17.0 demonstrably still regresses).
2. Add a Renovate package rule that disables Node updates **for this one workflow file**, so the pin can't silently regress again. Scoped by `matchFileNames` + `matchManagers: github-actions` + `matchPackageNames: node`, so it does not affect `.nvmrc`, `Dockerfile`, or the code-scan-action's own workflow.

### Scope note

This is **not** a fix to PR #9869 (the csv-stringify lockfile bump that surfaced this) — that PR's diff is clean and correct. This restores CI for all open PRs and `main`.