### PR TITLE
test(util): cover backslash escapes in convertSlashCommentsToHash

### DIFF
--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -190,8 +190,19 @@ export function convertSlashCommentsToHash(str: string): string {
 
           case 'doubleQuote':
             result += char;
-            if (char === '"' && prevChar !== '\\') {
-              state = 'normal';
+            if (char === '"') {
+              // Count consecutive backslashes immediately before this quote.
+              // An even count (0, 2, 4, …) means the quote is not escaped and
+              // closes the string; an odd count means the quote is escaped.
+              let numBackslashes = 0;
+              let k = i - 1;
+              while (k >= 0 && line[k] === '\\') {
+                numBackslashes++;
+                k--;
+              }
+              if (numBackslashes % 2 === 0) {
+                state = 'normal';
+              }
             }
             break;
         }

--- a/test/util/json.test.ts
+++ b/test/util/json.test.ts
@@ -453,6 +453,29 @@ describe('json utilities', () => {
         const expected = 'url: http://example.com/path # trailing comment';
         expect(convertSlashCommentsToHash(input)).toBe(expected);
       });
+
+      it('should convert // after a string ending with an escaped backslash', () => {
+        // "C:\\" in raw text: the value ends with one backslash (even-count \\).
+        // The closing " is NOT escaped, so the subsequent // IS a comment.
+        const input = '{ "path": "C:\\\\" } // Windows path comment';
+        const expected = '{ "path": "C:\\\\" } # Windows path comment';
+        expect(convertSlashCommentsToHash(input)).toBe(expected);
+      });
+
+      it('should keep // inside a string whose value ends with an escaped backslash', () => {
+        // Value is "C:\\Users\\" — ends with \\, closing " is not escaped.
+        const input = '"C:\\\\Users\\\\" // comment';
+        const expected = '"C:\\\\Users\\\\" # comment';
+        expect(convertSlashCommentsToHash(input)).toBe(expected);
+      });
+
+      it('should not close string on triple-backslash-quote (odd count = escaped)', () => {
+        // "\\\\" is three backslashes + closing quote: two escaped backslashes,
+        // then an escaped quote -> string not closed at that quote.
+        const input = '"text\\\\\\" still inside" // comment';
+        const expected = '"text\\\\\\" still inside" # comment';
+        expect(convertSlashCommentsToHash(input)).toBe(expected);
+      });
     });
 
     it('should skip non-object YAML values', () => {


### PR DESCRIPTION
## Bug

`convertSlashCommentsToHash` (used by `extractJsonObjects` to strip `//` comments before YAML/JSON parsing) uses a single-character look-behind — `prevChar !== '\\'` — to determine whether a `"` closes a double-quoted string. This is incorrect when the `"` is preceded by an **even** number of backslashes.

**Example (Windows path with trailing backslash):**
```
{ "path": "C:\\" } // comment
```
Raw characters inside the JSON value are `C:\\` (two backslashes). The closing `"` after `\\` is **not** escaped, but `prevChar === '\\'` caused the function to stay inside the doubleQuote state — so the `//` was never converted to `#` and reached `js-yaml` verbatim.

## Root cause

```ts
// before
case 'doubleQuote':
  result += char;
  if (char === '"' && prevChar !== '\\') { // ← single-char look-behind, wrong for \\"
    state = 'normal';
  }
  break;
```

## Fix

Count the consecutive backslashes immediately before the `"`. An **even** count (0, 2, 4, …) means the quote is unescaped and closes the string; an **odd** count means it is escaped and the string continues.

```ts
// after
case 'doubleQuote':
  result += char;
  if (char === '"') {
    let numBackslashes = 0;
    let k = i - 1;
    while (k >= 0 && line[k] === '\\') { numBackslashes++; k--; }
    if (numBackslashes % 2 === 0) { state = 'normal'; }
  }
  break;
```

## Verification

```
npx vitest run test/util/json.test.ts
Tests  79 passed (79)
```

Three new regression tests were added (two for the even-backslash bug, one confirming existing odd-backslash behaviour is preserved). All 79 tests in `test/util/json.test.ts` pass; no existing test was modified.

> AI-assisted contribution.

Closes #9895

---

**Updated after merging `main` (scope changed):** the `src/util/json.ts` change described above landed
independently on main in #10030 (`fd607d1f00`), and #10080 (`01694e786e`) extended the same even/odd
backslash count to single-quoted strings and factored it into an `isEscapedQuote()` helper. The
production fix is therefore no longer part of this diff — the "Root cause" and "Fix" snippets above
describe the pre-merge state, not the current one. Issue #9895 is already closed.

What remains is **23 lines of test-only regression coverage** in `test/util/json.test.ts`:

- `should convert // after a string ending with an escaped backslash` — duplicates the case main
  already covers in #10030 (`{ "path": "C:\\" } // comment`).
- `should keep // inside a string whose value ends with an escaped backslash` — new: a double-quoted
  value with two even-backslash runs (`"C:\\Users\\" // comment`).
- `should not close string on triple-backslash-quote (odd count = escaped)` — new: an odd-count
  (escaped) quote inside a **double**-quoted string. Main only covers the odd-count case for
  single-quoted strings.

All three pass against main's `isEscapedQuote()` implementation (`test/util/json.test.ts`: 82 passed,
up from the 79 quoted above). Title updated `fix(util)` -> `test(util)` to match the test-only diff.
