### PR TITLE
fix(providers): guard array access in Bedrock Titan and Cohere output handlers

### DIFF
--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -1779,7 +1779,7 @@ export const BEDROCK_MODEL = {
       );
       return { inputText: prompt, textGenerationConfig };
     },
-    output: (_config: BedrockOptions, responseJson: any) => responseJson?.results[0]?.outputText,
+    output: (_config: BedrockOptions, responseJson: any) => responseJson?.results?.[0]?.outputText,
     tokenUsage: getOpenAiCompatibleTokenUsage,
   },
   LLAMA2: getLlamaModelHandler(LlamaVersion.V2),
@@ -1820,7 +1820,7 @@ export const BEDROCK_MODEL = {
       addConfigParam(params, 'stop_sequences', stop, undefined, undefined);
       return params;
     },
-    output: (_config: BedrockOptions, responseJson: any) => responseJson?.generations[0]?.text,
+    output: (_config: BedrockOptions, responseJson: any) => responseJson?.generations?.[0]?.text,
     tokenUsage: (responseJson: any, _promptText: string): TokenUsage => {
       if (responseJson?.meta?.billed_units) {
         const inputTokens = coerceStrToNum(responseJson.meta.billed_units.input_tokens);

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -913,6 +913,34 @@ describe('AwsBedrockGenericProvider', () => {
     });
   });
 
+  describe('BEDROCK_MODEL TITAN_TEXT', () => {
+    const modelHandler = BEDROCK_MODEL.TITAN_TEXT;
+
+    it('should extract outputText from the first result', () => {
+      const mockResponse = { results: [{ outputText: 'This is a test response.' }] };
+      expect(modelHandler.output({}, mockResponse)).toBe('This is a test response.');
+    });
+
+    it('should return undefined when results are missing instead of throwing', () => {
+      expect(modelHandler.output({}, {})).toBeUndefined();
+      expect(modelHandler.output({}, { results: [] })).toBeUndefined();
+    });
+  });
+
+  describe('BEDROCK_MODEL COHERE_COMMAND', () => {
+    const modelHandler = BEDROCK_MODEL.COHERE_COMMAND;
+
+    it('should extract text from the first generation', () => {
+      const mockResponse = { generations: [{ text: 'This is a test response.' }] };
+      expect(modelHandler.output({}, mockResponse)).toBe('This is a test response.');
+    });
+
+    it('should return undefined when generations are missing instead of throwing', () => {
+      expect(modelHandler.output({}, {})).toBeUndefined();
+      expect(modelHandler.output({}, { generations: [] })).toBeUndefined();
+    });
+  });
+
   describe('getCredentials', () => {
     it('should return credentials if accessKeyId and secretAccessKey are provided', async () => {
       const provider = new (class extends AwsBedrockGenericProvider {


### PR DESCRIPTION
The Bedrock `TITAN_TEXT` and `COHERE_COMMAND` output handlers index an array immediately after an optional chain that only covers the top-level object:

```ts
// TITAN_TEXT
output: (_config, responseJson) => responseJson?.results[0]?.outputText,
// COHERE_COMMAND
output: (_config, responseJson) => responseJson?.generations[0]?.text,
```

`responseJson?.results[0]` guards `responseJson` but not `results`. When the response is present but the field is missing or `undefined` (an error body, an empty or truncated payload), `results`/`generations` is `undefined`, and `undefined[0]` throws:

```
TypeError: Cannot read properties of undefined (reading '0')
```

This is reachable in practice because `model.output(...)` runs on two paths. The fresh-request path is wrapped in a try/catch, but the cache-hit branch calls the handler before that try block, so a cached response missing the expected field surfaces as an uncaught crash rather than a handled empty result.

Every other handler in this file already uses the safe form (`responseJson.choices?.[0]?.message?.content`); these two were the outliers. The fix is the missing `?.`:

```ts
responseJson?.results?.[0]?.outputText
responseJson?.generations?.[0]?.text
```

There was no output-handler coverage for these two models, so I added some. The "missing field returns `undefined` instead of throwing" cases fail on `main` with the `TypeError` above and pass with the fix; valid responses still return the text. `test/providers/bedrock/index.test.ts` is green (329 passing).
