### PR TITLE
fix(init): promptfoo init will print undefined when initializing and selecting redteam as action

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -341,7 +341,18 @@ async function askForPermissionToOverwrite({
   return hasPermissionToWrite;
 }
 
-export async function createDummyFiles(directory: string | null, interactive: boolean = true) {
+interface InitProjectResult {
+  numPrompts: number;
+  providerPrefixes: string[];
+  action: string;
+  language: string;
+  outDirectory: string;
+}
+
+export async function createDummyFiles(
+  directory: string | null,
+  interactive: boolean = true,
+): Promise<InitProjectResult> {
   const outDirectory = directory || '.';
   const outDirAbsolute = path.join(process.cwd(), outDirectory);
 
@@ -436,6 +447,7 @@ export async function createDummyFiles(directory: string | null, interactive: bo
         providerPrefixes: [],
         action: 'redteam',
         language: 'not_applicable',
+        outDirectory,
       };
     }
 

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -308,15 +308,18 @@ describe('initializeProject', () => {
 
     const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
 
-    await initializeProject(null, true);
+    try {
+      await initializeProject(null, true);
 
-    const messages = infoSpy.mock.calls.map((call) => String(call[0]));
+      const messages = infoSpy.mock.calls.map((call) => String(call[0]));
 
-    // Regression: the redteam branch dropped `outDirectory`, so the "Next steps"
-    // output interpolated `undefined` into the path and `cd` command.
-    expect(messages.some((msg) => msg.includes('undefined'))).toBe(false);
-    expect(messages.some((msg) => msg.includes('cd undefined'))).toBe(false);
-
-    infoSpy.mockRestore();
+      // Regression: the redteam branch dropped `outDirectory`, so the "Next steps"
+      // output interpolated `undefined` into the path and `cd` command.
+      expect(messages.some((msg) => msg.includes('undefined'))).toBe(false);
+      expect(messages.some((msg) => msg.includes('cd undefined'))).toBe(false);
+    } finally {
+      // Restore in `finally` so a failing assertion can't leak the spy into other tests.
+      infoSpy.mockRestore();
+    }
   });
 });

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -3,6 +3,7 @@ import { rm } from 'fs/promises';
 import { AbortPromptError, ExitPromptError } from '@inquirer/core';
 import yaml from 'js-yaml';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import logger from '../src/logger';
 import {
   createDummyFiles,
   initializeProject,
@@ -299,5 +300,23 @@ describe('initializeProject', () => {
     await expect(initializeProject(null, true)).resolves.toBeUndefined();
 
     expect(process.exitCode).toBe(130);
+  });
+
+  it('should not print an "undefined" directory in next steps for the redteam path', async () => {
+    // `promptfoo init` with no directory arg, choosing "Run a red team evaluation".
+    mockSelect.mockResolvedValueOnce('redteam');
+
+    const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
+
+    await initializeProject(null, true);
+
+    const messages = infoSpy.mock.calls.map((call) => String(call[0]));
+
+    // Regression: the redteam branch dropped `outDirectory`, so the "Next steps"
+    // output interpolated `undefined` into the path and `cd` command.
+    expect(messages.some((msg) => msg.includes('undefined'))).toBe(false);
+    expect(messages.some((msg) => msg.includes('cd undefined'))).toBe(false);
+
+    infoSpy.mockRestore();
   });
 });

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -283,6 +283,7 @@ describe('initializeProject', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     process.exitCode = originalExitCode;
   });
 
@@ -302,24 +303,25 @@ describe('initializeProject', () => {
     expect(process.exitCode).toBe(130);
   });
 
-  it('should not print an "undefined" directory in next steps for the redteam path', async () => {
+  it('should print current-directory next steps for the redteam path', async () => {
     // `promptfoo init` with no directory arg, choosing "Run a red team evaluation".
     mockSelect.mockResolvedValueOnce('redteam');
 
     const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => logger);
 
-    try {
-      await initializeProject(null, true);
+    await initializeProject(null, true);
 
-      const messages = infoSpy.mock.calls.map((call) => String(call[0]));
+    const messages = infoSpy.mock.calls.map((call) => String(call[0]));
 
-      // Regression: the redteam branch dropped `outDirectory`, so the "Next steps"
-      // output interpolated `undefined` into the path and `cd` command.
-      expect(messages.some((msg) => msg.includes('undefined'))).toBe(false);
-      expect(messages.some((msg) => msg.includes('cd undefined'))).toBe(false);
-    } finally {
-      // Restore in `finally` so a failing assertion can't leak the spy into other tests.
-      infoSpy.mockRestore();
-    }
+    // Regression: the redteam branch dropped `outDirectory`, so the "Next steps"
+    // output interpolated `undefined` instead of using the current-directory flow.
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Setup complete! Next steps:'),
+        expect.stringContaining('to evaluate your prompts'),
+        expect.stringContaining('to view results in your browser'),
+      ]),
+    );
+    expect(messages.some((msg) => msg.includes('undefined'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Running `promptfoo init` and selecting "Run a red team evaluation" prints broken next
steps that reference a directory literally named `undefined`:

```
✅ Wrote promptfooconfig.yaml to ./undefined

  1. Run cd undefined
  ...
```

There is no `undefined` directory, and the suggested `cd undefined` fails.

## Cause

`initializeProject` decides which next-steps message to print based on the
`outDirectory` value returned by `createDummyFiles`. The redteam branch was the only
return path that forgot to include `outDirectory`, so it came back as `undefined`. That
skipped the normal "current directory" message and fell through to the branch that
interpolates the directory name into the path and `cd` command.

## Impact

Exisitng message implied to me something may be broken, so i went digging. It
does not seem to have any impact on subsequent `promptfoo redteam run` commands,
but the message is confusing for users and can be easily fixed.

## Fix

Include the already-computed `outDirectory` in the redteam branch's return value, like
every other path does. For a plain `promptfoo init` it resolves to `'.'`, so the flow
now prints the correct "Setup complete!" next steps instead of `./undefined`. The bug
was purely a dropped field, so restoring it is the whole fix.

To prevent the same class of bug, `createDummyFiles` now has an explicit
`InitProjectResult` return type with `outDirectory` required. Previously the function's
return type was inferred as a union of its two branches, so a branch missing
`outDirectory` simply widened the consumer's value to `string | undefined` — which is
valid in the template-literal output and the `=== '.'` check, so strict typechecking
never flagged it. With the annotation, any return path that omits `outDirectory` now
fails to compile (`TS2741: Property 'outDirectory' is missing ... but required`).

## Tests

Added a regression test that runs the redteam init path and asserts no next-steps
message contains `undefined`. It fails before the change and passes after. `tsc` and the
full `test/onboarding.test.ts` suite pass; confirmed the new return type makes the
missing-field case a compile error.

## Repro (before fix)

```
promptfoo init

Created red teaming configuration file at promptfooconfig.yaml


To generate test cases and run your red team, use the command:

    promptfoo redteam run

✅ Wrote promptfooconfig.yaml to ./undefined

  1. Run cd undefined
  2. Run promptfoo eval to evaluate your prompts
  3. Run promptfoo view to view results in your browser

  Docs: https://promptfoo.dev/docs/configuration/guide
```

## After fix

```
promptfoo init

Created red teaming configuration file at promptfooconfig.yaml


To generate test cases and run your red team, use the command:

    promptfoo redteam run

✅ Setup complete! Next steps:

  1. Run promptfoo eval to evaluate your prompts
  2. Run promptfoo view to view results in your browser
```
