### PR TITLE
fix(assertions): default context-recall and context-relevance threshold to 0.5

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/context-recall.md
+++ b/site/docs/configuration/expected-outputs/model-graded/context-recall.md
@@ -32,7 +32,7 @@ assert:
 
 - `value` - Expected answer/ground truth
 - `context` - Retrieved text (in vars or via `contextTransform`)
-- `threshold` - Minimum score 0-1 (default: 0)
+- `threshold` - Minimum score 0-1 (default: 0.5)
 
 ### Full example
 

--- a/site/docs/configuration/expected-outputs/model-graded/context-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/context-relevance.md
@@ -35,7 +35,7 @@ assert:
 
 - `query` - User's question (in test vars)
 - `context` - Retrieved text (in vars or via `contextTransform`)
-- `threshold` - Minimum score 0-1 (default: 0)
+- `threshold` - Minimum score 0-1 (default: 0.5)
 
 ### Full example
 

--- a/src/assertions/contextRecall.ts
+++ b/src/assertions/contextRecall.ts
@@ -35,7 +35,7 @@ export const handleContextRecall = async ({
   const result = await matchesContextRecall(
     context, // context parameter (used as {{context}} in prompt)
     renderedValue, // ground truth parameter (used as {{groundTruth}} in prompt)
-    (assertion.threshold as number) ?? 0,
+    (assertion.threshold as number) ?? 0.5,
     test.options,
     test.vars,
     providerCallContext,

--- a/src/assertions/contextRelevance.ts
+++ b/src/assertions/contextRelevance.ts
@@ -40,7 +40,7 @@ export const handleContextRelevance = async ({
   const result = await matchesContextRelevance(
     test.vars.query,
     context,
-    (assertion.threshold as number) ?? 0,
+    (assertion.threshold as number) ?? 0.5,
     test.options,
     providerCallContext,
   );

--- a/test/assertions/contextRecall.test.ts
+++ b/test/assertions/contextRecall.test.ts
@@ -127,7 +127,7 @@ describe('handleContextRecall', () => {
     );
   });
 
-  it('should use default threshold of 0 when not provided', async () => {
+  it('should use default threshold of 0.5 when not provided', async () => {
     const mockResult = { pass: true, score: 1, reason: 'Perfect match' };
     mockMatchesContextRecall.mockResolvedValue(mockResult);
     vi.mocked(contextUtils.resolveContext).mockResolvedValue('test context');
@@ -162,7 +162,7 @@ describe('handleContextRecall', () => {
     expect(mockMatchesContextRecall).toHaveBeenCalledWith(
       'test context',
       'test value',
-      0,
+      0.5,
       {},
       { context: 'test context' },
       undefined,
@@ -212,7 +212,7 @@ describe('handleContextRecall', () => {
     expect(mockMatchesContextRecall).toHaveBeenCalledWith(
       'test prompt',
       'test output',
-      0,
+      0.5,
       {},
       {},
       undefined,
@@ -259,7 +259,7 @@ describe('handleContextRecall', () => {
       'prompt',
       {},
     );
-    expect(mockMatchesContextRecall).toHaveBeenCalledWith('ctx', 'val', 0, {}, {}, undefined);
+    expect(mockMatchesContextRecall).toHaveBeenCalledWith('ctx', 'val', 0.5, {}, {}, undefined);
   });
 
   it('should throw error when renderedValue is not a string', async () => {
@@ -317,6 +317,49 @@ describe('handleContextRecall', () => {
 
     await expect(handleContextRecall(params)).rejects.toThrow(
       'context-recall assertion requires a prompt',
+    );
+  });
+
+  it('should use a default threshold of 0.5 when none is specified', async () => {
+    const mockMatchesContextRecallInner = vi.spyOn(matchers, 'matchesContextRecall');
+    mockMatchesContextRecallInner.mockResolvedValue({
+      pass: true,
+      score: 0.7,
+      reason: 'Recall 0.70 is >= 0.5',
+    });
+    vi.mocked(contextUtils.resolveContext).mockResolvedValue('test context');
+    const mockProvider = createMockProvider({ response: {} });
+
+    const params: AssertionParams = {
+      assertion: { type: 'context-recall' },
+      renderedValue: 'Expected fact',
+      prompt: 'test prompt',
+      test: { vars: { context: 'test context' }, options: {} },
+      baseType: 'context-recall',
+      assertionValueContext: {
+        prompt: 'test prompt',
+        vars: { context: 'test context' },
+        test: { vars: { context: 'test context' }, options: {} },
+        logProbs: undefined,
+        provider: mockProvider,
+        providerResponse: undefined,
+      },
+      inverse: false,
+      output: 'test output',
+      outputString: 'test output',
+      provider: mockProvider,
+      providerResponse: {} as ProviderResponse,
+    };
+
+    await handleContextRecall(params);
+
+    expect(mockMatchesContextRecallInner).toHaveBeenCalledWith(
+      'test context',
+      'Expected fact',
+      0.5,
+      {},
+      { context: 'test context' },
+      undefined,
     );
   });
 });

--- a/test/assertions/contextRelevance.test.ts
+++ b/test/assertions/contextRelevance.test.ts
@@ -158,7 +158,7 @@ describe('handleContextRelevance', () => {
     );
   });
 
-  it('should use default threshold of 0 when not provided', async () => {
+  it('should use default threshold of 0.5 when not provided', async () => {
     const mockResult = { pass: true, score: 1, reason: 'Perfect relevance' };
     vi.mocked(matchesContextRelevance).mockResolvedValue(mockResult);
     vi.mocked(contextUtils.resolveContext).mockResolvedValue('test context');
@@ -193,7 +193,7 @@ describe('handleContextRelevance', () => {
     expect(matchesContextRelevance).toHaveBeenCalledWith(
       'test query',
       'test context',
-      0,
+      0.5,
       {},
       undefined,
     );
@@ -296,7 +296,7 @@ describe('handleContextRelevance', () => {
       undefined,
       { output: 'out', tokenUsage: {} },
     );
-    expect(matchesContextRelevance).toHaveBeenCalledWith('q', 'cx', 0, {}, undefined);
+    expect(matchesContextRelevance).toHaveBeenCalledWith('q', 'cx', 0.5, {}, undefined);
     expect(result.metadata).toEqual({
       context: 'cx',
     });


### PR DESCRIPTION
## Bug

Both `context-recall` and `context-relevance` assertion handlers pass
`(assertion.threshold as number) ?? 0` to their matcher:

```ts
// src/assertions/contextRecall.ts
const result = await matchesContextRecall(
  context,
  renderedValue,
  (assertion.threshold as number) ?? 0,   // ← always 0 when omitted
  ...
);

// src/assertions/contextRelevance.ts
const result = await matchesContextRelevance(
  test.vars.query,
  context,
  (assertion.threshold as number) ?? 0,   // ← always 0 when omitted
  ...
);
```

The matcher decides pass/fail with:

```ts
const pass = score >= threshold - Number.EPSILON;
```

With `threshold = 0`, `pass = score >= -EPSILON` is true for every score in `[0, 1]`. So:

```yaml
assert:
  - type: context-recall
    value: 'Expected fact'
  - type: context-relevance
```

**can never fail** when no `threshold` is given — they are no-op graders.

## Fix

Default both thresholds to **0.5**, consistent with the sibling fixes in #9849 (answer-relevance → 0.7) and #9907 (context-faithfulness → 0.7).

## Files changed

1. `src/assertions/contextRecall.ts` — `?? 0` → `?? 0.5`
2. `src/assertions/contextRelevance.ts` — `?? 0` → `?? 0.5`
3. `test/assertions/contextRecall.test.ts` — rename + update existing default-threshold tests; add new test verifying the 0.5 default
4. `test/assertions/contextRelevance.test.ts` — rename + update existing default-threshold tests
5. `site/docs/.../context-recall.md` — `(default: 0)` → `(default: 0.5)`
6. `site/docs/.../context-relevance.md` — `(default: 0)` → `(default: 0.5)`

## Verification

```
npx vitest run test/assertions/contextRecall.test.ts test/assertions/contextRelevance.test.ts
Test Files  2 passed (2)
Tests  14 passed (14)   ← was 13 before (new test added)
```

All 59 assertion tests pass.

Closes #9910