### PR TITLE
feat(providers): expand Google model support — Nano Banana 2 Lite, GA image aliases, gemini-pro-latest

### DIFF
--- a/examples/google-imagen/README.md
+++ b/examples/google-imagen/README.md
@@ -69,10 +69,12 @@ export GOOGLE_PROJECT_ID=your-project-id
 
 ### Imagen Models (use `google:image:` prefix)
 
-- `imagen-4.0-ultra-generate-preview-06-06` - Ultra quality ($0.06/image)
-- `imagen-4.0-generate-preview-06-06` - Standard quality ($0.04/image)
-- `imagen-4.0-fast-generate-preview-06-06` - Fast generation ($0.02/image)
+- `imagen-4.0-ultra-generate-001` - Ultra quality ($0.06/image)
+- `imagen-4.0-generate-001` - Standard quality ($0.04/image)
+- `imagen-4.0-fast-generate-001` - Fast generation ($0.02/image)
 - `imagen-3.0-generate-002` - Imagen 3.0 ($0.04/image)
+
+Google has deprecated the Imagen 4 models with an August 17, 2026 shutdown and recommends `gemini-3.1-flash-image` as the replacement. The older `imagen-4.0-*-preview-06-06` ids are already shut down.
 
 ### Gemini Native Image Generation
 
@@ -81,7 +83,7 @@ export GOOGLE_PROJECT_ID=your-project-id
 - `google:gemini-3-pro-image` - Gemini 3 Pro (Nano Banana Pro) with native image generation (~$0.134/image at 1K/2K)
 - `google:gemini-2.5-flash-image` - Gemini 2.5 Flash (Nano Banana) with image generation (~$0.039/image)
 
-`gemini-3.1-flash-image` and `gemini-3-pro-image` also accept their `-preview` aliases (e.g. `google:gemini-3.1-flash-image-preview`). Nano Banana 2 Lite has no `-preview` alias — use `gemini-3.1-flash-lite-image`.
+Use the GA ids above; Google shut down the `gemini-3.1-flash-image-preview` and `gemini-3-pro-image-preview` aliases on June 25, 2026. Nano Banana 2 Lite never had a `-preview` alias.
 
 ## Running the Example
 

--- a/examples/google-imagen/README.md
+++ b/examples/google-imagen/README.md
@@ -77,6 +77,7 @@ export GOOGLE_PROJECT_ID=your-project-id
 ### Gemini Native Image Generation
 
 - `google:gemini-3.1-flash-image-preview` - Gemini 3.1 Flash (Nano Banana 2) with native image generation (~$0.067/image at 1K)
+- `google:gemini-3.1-flash-lite-image-preview` - Gemini 3.1 Flash-Lite (Nano Banana 2 Lite) for fast, low-cost image generation (~$0.02/image, estimated)
 - `google:gemini-3-pro-image-preview` - Gemini 3 Pro with native image generation (~$0.05/image, estimated)
 - `google:gemini-2.5-flash-image` - Gemini 2.5 Flash with image generation (~$0.04/image)
 

--- a/examples/google-imagen/README.md
+++ b/examples/google-imagen/README.md
@@ -76,10 +76,12 @@ export GOOGLE_PROJECT_ID=your-project-id
 
 ### Gemini Native Image Generation
 
-- `google:gemini-3.1-flash-image-preview` - Gemini 3.1 Flash (Nano Banana 2) with native image generation (~$0.067/image at 1K)
-- `google:gemini-3.1-flash-lite-image-preview` - Gemini 3.1 Flash-Lite (Nano Banana 2 Lite) for fast, low-cost image generation (~$0.02/image, estimated)
-- `google:gemini-3-pro-image-preview` - Gemini 3 Pro with native image generation (~$0.05/image, estimated)
-- `google:gemini-2.5-flash-image` - Gemini 2.5 Flash with image generation (~$0.04/image)
+- `google:gemini-3.1-flash-lite-image` - Gemini 3.1 Flash-Lite (Nano Banana 2 Lite) for the fastest, lowest-cost image generation (~$0.034/image at 1K; 1K only)
+- `google:gemini-3.1-flash-image` - Gemini 3.1 Flash (Nano Banana 2) with native image generation (~$0.067/image at 1K)
+- `google:gemini-3-pro-image` - Gemini 3 Pro (Nano Banana Pro) with native image generation (~$0.134/image at 1K/2K)
+- `google:gemini-2.5-flash-image` - Gemini 2.5 Flash (Nano Banana) with image generation (~$0.039/image)
+
+Each Gemini 3.x image model also accepts its `-preview` alias (e.g. `google:gemini-3.1-flash-image-preview`), which resolves to the same model.
 
 ## Running the Example
 

--- a/examples/google-imagen/README.md
+++ b/examples/google-imagen/README.md
@@ -81,7 +81,7 @@ export GOOGLE_PROJECT_ID=your-project-id
 - `google:gemini-3-pro-image` - Gemini 3 Pro (Nano Banana Pro) with native image generation (~$0.134/image at 1K/2K)
 - `google:gemini-2.5-flash-image` - Gemini 2.5 Flash (Nano Banana) with image generation (~$0.039/image)
 
-Each Gemini 3.x image model also accepts its `-preview` alias (e.g. `google:gemini-3.1-flash-image-preview`), which resolves to the same model.
+`gemini-3.1-flash-image` and `gemini-3-pro-image` also accept their `-preview` aliases (e.g. `google:gemini-3.1-flash-image-preview`). Nano Banana 2 Lite has no `-preview` alias — use `gemini-3.1-flash-lite-image`.
 
 ## Running the Example
 

--- a/examples/google-imagen/promptfooconfig-advanced.yaml
+++ b/examples/google-imagen/promptfooconfig-advanced.yaml
@@ -6,7 +6,7 @@ prompts:
 
 providers:
   # Google AI Studio configuration (API key authentication)
-  - id: google:image:imagen-4.0-generate-preview-06-06
+  - id: google:image:imagen-4.0-generate-001
     label: Imagen 4.0 (Google AI Studio)
     config:
       aspectRatio: '16:9'
@@ -14,7 +14,7 @@ providers:
       # Note: seed and addWatermark are not supported in Google AI Studio
 
   # Vertex AI configuration (OAuth authentication)
-  - id: google:image:imagen-4.0-generate-preview-06-06
+  - id: google:image:imagen-4.0-generate-001
     label: Imagen 4.0 (Vertex AI)
     config:
       projectId: 'your-project-id' # Forces Vertex AI usage

--- a/examples/google-imagen/promptfooconfig-gemini.yaml
+++ b/examples/google-imagen/promptfooconfig-gemini.yaml
@@ -11,23 +11,23 @@ providers:
     config:
       imageAspectRatio: '16:9'
 
-  # Gemini 3.1 Flash Image Preview (Nano Banana 2)
+  # Gemini 3.1 Flash Image (Nano Banana 2) — the gemini-3.1-flash-image-preview alias also works
   # imageSize supports: 512px, 1K, 2K, 4K
-  - id: google:gemini-3.1-flash-image-preview
+  - id: google:gemini-3.1-flash-image
     config:
       imageAspectRatio: '16:9'
       imageSize: '2K'
 
-  # Gemini 3.1 Flash-Lite Image Preview (Nano Banana 2 Lite)
-  # Fastest, lowest-cost tier; imageSize supports: 512px, 1K, 2K, 4K
-  - id: google:gemini-3.1-flash-lite-image-preview
+  # Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite)
+  # Fastest, lowest-cost tier; 1K resolution only
+  - id: google:gemini-3.1-flash-lite-image
     config:
       imageAspectRatio: '16:9'
       imageSize: '1K'
 
-  # Gemini 3 Pro - Advanced image generation with reasoning (global endpoint only)
-  # imageSize is supported for Gemini 3 models (1K, 2K, 4K)
-  - id: google:gemini-3-pro-image-preview
+  # Gemini 3 Pro Image (Nano Banana Pro) — advanced generation, global endpoint only
+  # The gemini-3-pro-image-preview alias also works; imageSize supports 1K, 2K, 4K
+  - id: google:gemini-3-pro-image
     config:
       imageAspectRatio: '16:9'
       imageSize: '2K'

--- a/examples/google-imagen/promptfooconfig-gemini.yaml
+++ b/examples/google-imagen/promptfooconfig-gemini.yaml
@@ -11,8 +11,8 @@ providers:
     config:
       imageAspectRatio: '16:9'
 
-  # Gemini 3.1 Flash Image (Nano Banana 2) — the gemini-3.1-flash-image-preview alias also works
-  # imageSize supports: 512px, 1K, 2K, 4K
+  # Gemini 3.1 Flash Image (Nano Banana 2)
+  # imageSize supports: 512px, 1K, 2K, 4K (this model only; see per-model notes below)
   - id: google:gemini-3.1-flash-image
     config:
       imageAspectRatio: '16:9'
@@ -26,7 +26,7 @@ providers:
       imageSize: '1K'
 
   # Gemini 3 Pro Image (Nano Banana Pro) — advanced generation, global endpoint only
-  # The gemini-3-pro-image-preview alias also works; imageSize supports 1K, 2K, 4K
+  # imageSize supports: 1K, 2K, 4K
   - id: google:gemini-3-pro-image
     config:
       imageAspectRatio: '16:9'
@@ -34,9 +34,11 @@ providers:
 
 defaultTest:
   assert:
-    # Verify that an image was generated
-    - type: contains
-      value: '![Generated Image](data:image/'
+    # Verify that an image was generated (images land in the structured
+    # providerResponse.images field; output alone is text when the model
+    # also returns text parts)
+    - type: javascript
+      value: '(context.providerResponse?.images?.length ?? 0) > 0'
 
 tests:
   - vars:

--- a/examples/google-imagen/promptfooconfig-gemini.yaml
+++ b/examples/google-imagen/promptfooconfig-gemini.yaml
@@ -18,6 +18,13 @@ providers:
       imageAspectRatio: '16:9'
       imageSize: '2K'
 
+  # Gemini 3.1 Flash-Lite Image Preview (Nano Banana 2 Lite)
+  # Fastest, lowest-cost tier; imageSize supports: 512px, 1K, 2K, 4K
+  - id: google:gemini-3.1-flash-lite-image-preview
+    config:
+      imageAspectRatio: '16:9'
+      imageSize: '1K'
+
   # Gemini 3 Pro - Advanced image generation with reasoning (global endpoint only)
   # imageSize is supported for Gemini 3 models (1K, 2K, 4K)
   - id: google:gemini-3-pro-image-preview

--- a/examples/google-imagen/promptfooconfig-gemini.yaml
+++ b/examples/google-imagen/promptfooconfig-gemini.yaml
@@ -19,7 +19,7 @@ providers:
       imageSize: '2K'
 
   # Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite)
-  # Fastest, lowest-cost tier; 1K resolution only
+  # Fastest, lowest-cost tier; 1K resolution only; no Google Search grounding
   - id: google:gemini-3.1-flash-lite-image
     config:
       imageAspectRatio: '16:9'

--- a/examples/google-imagen/promptfooconfig.yaml
+++ b/examples/google-imagen/promptfooconfig.yaml
@@ -6,7 +6,7 @@ prompts:
 
 providers:
   # Ultra quality - highest detail and quality
-  - id: google:image:imagen-4.0-ultra-generate-preview-06-06
+  - id: google:image:imagen-4.0-ultra-generate-001
     config:
       # projectId: 'your-project-id'  # Optional: Can be set here or via GOOGLE_PROJECT_ID env var
       aspectRatio: '16:9'
@@ -15,7 +15,7 @@ providers:
       # addWatermark: false  # Note: addWatermark is only supported in Vertex AI
 
   # Standard quality - balanced quality and speed
-  - id: google:image:imagen-4.0-generate-preview-06-06
+  - id: google:image:imagen-4.0-generate-001
     config:
       aspectRatio: '16:9'
       # seed: 42  # Note: seed is only supported in Vertex AI
@@ -23,7 +23,7 @@ providers:
       # addWatermark: false  # Note: addWatermark is only supported in Vertex AI
 
   # Fast generation - optimized for speed
-  - id: google:image:imagen-4.0-fast-generate-preview-06-06
+  - id: google:image:imagen-4.0-fast-generate-001
     config:
       aspectRatio: '16:9'
       # seed: 42  # Note: seed is only supported in Vertex AI

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -365,6 +365,7 @@ See the [Google Imagen example](https://github.com/promptfoo/promptfoo/tree/main
 Gemini models can generate images natively using the `generateContent` API. Models with `-image` in the name automatically enable image generation:
 
 - `google:gemini-3.1-flash-image-preview` - Gemini 3.1 Flash (Nano Banana 2) with native image generation (~$0.067/image at 1K)
+- `google:gemini-3.1-flash-lite-image-preview` - Gemini 3.1 Flash-Lite (Nano Banana 2 Lite) for fast, low-cost image generation (~$0.02/image, estimated)
 - `google:gemini-3-pro-image-preview` - Gemini 3 Pro with advanced image generation (~$0.05/image, estimated)
 - `google:gemini-2.5-flash-image` - Gemini 2.5 Flash with image generation (~$0.04/image)
 

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -364,16 +364,18 @@ See the [Google Imagen example](https://github.com/promptfoo/promptfoo/tree/main
 
 Gemini models can generate images natively using the `generateContent` API. Models with `-image` in the name automatically enable image generation:
 
-- `google:gemini-3.1-flash-image-preview` - Gemini 3.1 Flash (Nano Banana 2) with native image generation (~$0.067/image at 1K)
-- `google:gemini-3.1-flash-lite-image-preview` - Gemini 3.1 Flash-Lite (Nano Banana 2 Lite) for fast, low-cost image generation (~$0.02/image, estimated)
-- `google:gemini-3-pro-image-preview` - Gemini 3 Pro with advanced image generation (~$0.05/image, estimated)
-- `google:gemini-2.5-flash-image` - Gemini 2.5 Flash with image generation (~$0.04/image)
+- `google:gemini-3.1-flash-lite-image` - Gemini 3.1 Flash-Lite (Nano Banana 2 Lite) for the fastest, lowest-cost image generation (~$0.034/image at 1K; 1K only)
+- `google:gemini-3.1-flash-image` - Gemini 3.1 Flash (Nano Banana 2) with native image generation (~$0.067/image at 1K)
+- `google:gemini-3-pro-image` - Gemini 3 Pro (Nano Banana Pro) for advanced image generation (~$0.134/image at 1K/2K)
+- `google:gemini-2.5-flash-image` - Gemini 2.5 Flash (Nano Banana) with image generation (~$0.039/image)
+
+Each Gemini 3.x image model also accepts its `-preview` alias (for example `google:gemini-3.1-flash-image-preview` or `google:gemini-3-pro-image-preview`), which resolves to the same model.
 
 Configuration options:
 
 ```yaml
 providers:
-  - id: google:gemini-3.1-flash-image-preview
+  - id: google:gemini-3.1-flash-image
     config:
       imageAspectRatio: '16:9' # 1:1, 1:4, 1:8, 2:3, 3:2, 3:4, 4:1, 4:3, 4:5, 5:4, 8:1, 9:16, 16:9, 21:9
       imageSize: '2K' # 512px (3.1 only), 1K, 2K, 4K
@@ -393,7 +395,7 @@ Google Search grounding lets the model use real-time search results to inform im
 
 ```yaml
 providers:
-  - id: google:gemini-3.1-flash-image-preview
+  - id: google:gemini-3.1-flash-image
     config:
       imageAspectRatio: '16:9'
       tools:

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -364,12 +364,12 @@ See the [Google Imagen example](https://github.com/promptfoo/promptfoo/tree/main
 
 Gemini models can generate images natively using the `generateContent` API. Models with `-image` in the name automatically enable image generation:
 
-- `google:gemini-3.1-flash-lite-image` - Gemini 3.1 Flash-Lite (Nano Banana 2 Lite) for the fastest, lowest-cost image generation (~$0.034/image at 1K; 1K only)
-- `google:gemini-3.1-flash-image` - Gemini 3.1 Flash (Nano Banana 2) with native image generation (~$0.067/image at 1K)
-- `google:gemini-3-pro-image` - Gemini 3 Pro (Nano Banana Pro) for advanced image generation (~$0.134/image at 1K/2K)
+- `google:gemini-3.1-flash-lite-image` - Gemini 3.1 Flash-Lite (Nano Banana 2 Lite) for the fastest, lowest-cost image generation (~$0.034/image at 1K; 1K only; no Google Search grounding)
+- `google:gemini-3.1-flash-image` - Gemini 3.1 Flash (Nano Banana 2) with native image generation (~$0.067/image at 1K, more at higher resolutions)
+- `google:gemini-3-pro-image` - Gemini 3 Pro (Nano Banana Pro) for advanced image generation (~$0.134/image at 1K/2K, ~$0.24 at 4K)
 - `google:gemini-2.5-flash-image` - Gemini 2.5 Flash (Nano Banana) with image generation (~$0.039/image)
 
-Each Gemini 3.x image model also accepts its `-preview` alias (for example `google:gemini-3.1-flash-image-preview` or `google:gemini-3-pro-image-preview`), which resolves to the same model.
+`gemini-3.1-flash-image` and `gemini-3-pro-image` also accept their `-preview` aliases (`gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview`), which resolve to the same models. Nano Banana 2 Lite has no `-preview` alias — use `gemini-3.1-flash-lite-image`.
 
 Configuration options:
 
@@ -389,9 +389,9 @@ Key differences from Imagen:
 - Resolution control via `imageSize` (`512px`, `1K`, `2K`, `4K`) - `512px` is Gemini 3.1 only
 - Can return both text and images in the same response
 - Uses same authentication as Gemini chat models
-- Supports Google Search grounding via `tools`
+- Supports Google Search grounding via `tools` (on `gemini-3.1-flash-image` and `gemini-3-pro-image`; **not** `gemini-3.1-flash-lite-image`)
 
-Google Search grounding lets the model use real-time search results to inform image generation:
+Google Search grounding lets the model use real-time search results to inform image generation. It is supported by `gemini-3.1-flash-image` and `gemini-3-pro-image`, but not by Nano Banana 2 Lite (`gemini-3.1-flash-lite-image`):
 
 ```yaml
 providers:

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -285,8 +285,9 @@ See the [Vertex AI provider documentation](/docs/providers/vertex) for detailed 
 - `google:gemini-2.5-pro` - Gemini 2.5 Pro model with enhanced reasoning, coding, and multimodal understanding
 - `google:gemini-2.5-flash` - Gemini 2.5 Flash model with enhanced reasoning and thinking capabilities
 - `google:gemini-2.5-flash-lite` - Cost-efficient Gemini 2.5 model optimized for high-volume, latency-sensitive tasks
-- `google:gemini-flash-latest` - Google-maintained alias for the latest Gemini Flash release
-- `google:gemini-flash-lite-latest` - Google-maintained alias for the latest Gemini Flash-Lite release
+- `google:gemini-pro-latest` - Google-maintained alias for the latest Gemini Pro release (currently resolves to `gemini-3.1-pro-preview`, same pricing)
+- `google:gemini-flash-latest` - Google-maintained alias for the latest Gemini Flash release (currently resolves to `gemini-3.5-flash`, same pricing)
+- `google:gemini-flash-lite-latest` - Google-maintained alias for the latest Gemini Flash-Lite release (currently resolves to `gemini-3.1-flash-lite`, same pricing)
 
 ### Embedding Models
 
@@ -294,6 +295,7 @@ Use the `google:embedding:` prefix (or the plural `google:embeddings:` alias) to
 
 - `google:embedding:gemini-embedding-001` - Recommended default. Multilingual plus code, up to 3,072 dimensions, 2,048 input-token limit
 - `google:embedding:gemini-embedding-2` - Latest Gemini embedding model for text input through promptfoo
+- `google:embedding:gemini-embedding-2-preview` - Preview alias for Gemini Embedding 2 ($0.20/1M input tokens)
 
 Optional config keys (forwarded as documented in Google's [embedContent reference](https://ai.google.dev/api/embeddings#EmbedContentRequest)):
 
@@ -309,9 +311,13 @@ Imagen models are available through both **Google AI Studio** and **Vertex AI**.
 
 #### Imagen 4 Models (Available in both Google AI Studio and Vertex AI)
 
-- `google:image:imagen-4.0-ultra-generate-preview-06-06` - Ultra quality ($0.06/image)
-- `google:image:imagen-4.0-generate-preview-06-06` - Standard quality ($0.04/image)
-- `google:image:imagen-4.0-fast-generate-preview-06-06` - Fast generation ($0.02/image)
+- `google:image:imagen-4.0-ultra-generate-001` - Ultra quality ($0.06/image)
+- `google:image:imagen-4.0-generate-001` - Standard quality ($0.04/image)
+- `google:image:imagen-4.0-fast-generate-001` - Fast generation ($0.02/image)
+
+:::warning
+Google has deprecated the Imagen 4 models with an August 17, 2026 shutdown and recommends [`gemini-3.1-flash-image`](#gemini-native-image-generation-models) as the replacement. The earlier `imagen-4.0-*-preview-06-06` ids are already shut down.
+:::
 
 #### Imagen 3 Models (Vertex AI only)
 
@@ -369,7 +375,7 @@ Gemini models can generate images natively using the `generateContent` API. Mode
 - `google:gemini-3-pro-image` - Gemini 3 Pro (Nano Banana Pro) for advanced image generation (~$0.134/image at 1K/2K, ~$0.24 at 4K)
 - `google:gemini-2.5-flash-image` - Gemini 2.5 Flash (Nano Banana) with image generation (~$0.039/image)
 
-`gemini-3.1-flash-image` and `gemini-3-pro-image` also accept their `-preview` aliases (`gemini-3.1-flash-image-preview`, `gemini-3-pro-image-preview`), which resolve to the same models. Nano Banana 2 Lite has no `-preview` alias — use `gemini-3.1-flash-lite-image`.
+Use the GA ids above; Google shut down the `gemini-3.1-flash-image-preview` and `gemini-3-pro-image-preview` aliases on June 25, 2026. Nano Banana 2 Lite never had a `-preview` alias.
 
 Configuration options:
 
@@ -378,7 +384,7 @@ providers:
   - id: google:gemini-3.1-flash-image
     config:
       imageAspectRatio: '16:9' # 1:1, 1:4, 1:8, 2:3, 3:2, 3:4, 4:1, 4:3, 4:5, 5:4, 8:1, 9:16, 16:9, 21:9
-      imageSize: '2K' # 512px (3.1 only), 1K, 2K, 4K
+      imageSize: '2K' # 512px, 1K, 2K, 4K on this model; flash-lite is 1K only, pro is 1K/2K/4K
       temperature: 0.7
 ```
 
@@ -386,7 +392,7 @@ Key differences from Imagen:
 
 - Uses same namespace as Gemini chat (`google:model-name`)
 - More aspect ratio options (includes 1:4, 1:8, 2:3, 3:2, 4:1, 4:5, 5:4, 8:1, 21:9)
-- Resolution control via `imageSize` (`512px`, `1K`, `2K`, `4K`) - `512px` is Gemini 3.1 only
+- Resolution control via `imageSize`: `512px`/`1K`/`2K`/`4K` on `gemini-3.1-flash-image`, `1K`/`2K`/`4K` on `gemini-3-pro-image`; `gemini-3.1-flash-lite-image` is `1K` only
 - Can return both text and images in the same response
 - Uses same authentication as Gemini chat models
 - Supports Google Search grounding via `tools` (on `gemini-3.1-flash-image` and `gemini-3-pro-image`; **not** `gemini-3.1-flash-lite-image`)

--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -2359,6 +2359,10 @@ describe('isImageProvider helper function', () => {
     expect(isImageProvider('google:gemini-2.5-flash-image')).toBe(true);
   });
 
+  it('should return true for Gemini 3.1 Flash-Lite image provider (Nano Banana 2 Lite)', () => {
+    expect(isImageProvider('google:gemini-3.1-flash-lite-image-preview')).toBe(true);
+  });
+
   it('should return false for text completion providers', () => {
     expect(isImageProvider('openai:gpt-4')).toBe(false);
   });

--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -2360,7 +2360,7 @@ describe('isImageProvider helper function', () => {
   });
 
   it('should return true for Gemini 3.1 Flash-Lite image provider (Nano Banana 2 Lite)', () => {
-    expect(isImageProvider('google:gemini-3.1-flash-lite-image-preview')).toBe(true);
+    expect(isImageProvider('google:gemini-3.1-flash-lite-image')).toBe(true);
   });
 
   it('should return false for text completion providers', () => {

--- a/src/providers/families/google.ts
+++ b/src/providers/families/google.ts
@@ -71,7 +71,7 @@ export const googleProviderFactories: ProviderFactory[] = [
 
       // Check if this is a Gemini native image generation model
       // These models have 'image' in their name (e.g., gemini-2.5-flash-image,
-      // gemini-3.1-flash-image-preview, gemini-3.1-flash-lite-image-preview)
+      // gemini-3.1-flash-image, gemini-3.1-flash-lite-image, gemini-3-pro-image)
       if (modelName.includes('-image')) {
         const { GeminiImageProvider } = await import('../google/gemini-image');
         return new GeminiImageProvider(modelName, providerOptions);

--- a/src/providers/families/google.ts
+++ b/src/providers/families/google.ts
@@ -70,7 +70,8 @@ export const googleProviderFactories: ProviderFactory[] = [
       const modelName = splits[1];
 
       // Check if this is a Gemini native image generation model
-      // These models have 'image' in their name (e.g., gemini-2.5-flash-image, gemini-3.1-flash-image-preview)
+      // These models have 'image' in their name (e.g., gemini-2.5-flash-image,
+      // gemini-3.1-flash-image-preview, gemini-3.1-flash-lite-image-preview)
       if (modelName.includes('-image')) {
         const { GeminiImageProvider } = await import('../google/gemini-image');
         return new GeminiImageProvider(modelName, providerOptions);

--- a/src/providers/families/google.ts
+++ b/src/providers/families/google.ts
@@ -69,9 +69,9 @@ export const googleProviderFactories: ProviderFactory[] = [
       // Default to regular Google API
       const modelName = splits[1];
 
-      // Check if this is a Gemini native image generation model
-      // These models have 'image' in their name (e.g., gemini-2.5-flash-image,
-      // gemini-3.1-flash-image, gemini-3.1-flash-lite-image, gemini-3-pro-image)
+      // Check if this is a Gemini native image generation model. Dispatch is on
+      // the '-image' substring (e.g., gemini-2.5-flash-image, gemini-3.1-flash-image,
+      // gemini-3.1-flash-lite-image, gemini-3-pro-image).
       if (modelName.includes('-image')) {
         const { GeminiImageProvider } = await import('../google/gemini-image');
         return new GeminiImageProvider(modelName, providerOptions);

--- a/src/providers/google/ai.studio.ts
+++ b/src/providers/google/ai.studio.ts
@@ -598,6 +598,10 @@ export class AIStudioEmbeddingProvider
         ? { cached: promptTokens ?? 0, total: promptTokens ?? 0, numRequests: 0 }
         : { total: promptTokens ?? 0, numRequests: 1 },
       cached,
+      cost:
+        cached || promptTokens === undefined
+          ? undefined
+          : calculateGoogleCost(this.modelName, this.config, promptTokens, 0),
     };
   }
 }

--- a/src/providers/google/gemini-image.ts
+++ b/src/providers/google/gemini-image.ts
@@ -40,6 +40,7 @@ interface GeminiImageOptions {
  * - gemini-2.5-flash-image
  * - gemini-3-pro-image-preview (Nano Banana Pro)
  * - gemini-3.1-flash-image-preview (Nano Banana 2)
+ * - gemini-3.1-flash-lite-image-preview (Nano Banana 2 Lite)
  */
 export class GeminiImageProvider implements ApiProvider {
   modelName: string;
@@ -400,11 +401,14 @@ export class GeminiImageProvider implements ApiProvider {
     // Pricing for Gemini native image generation
     // Gemini 2.5 Flash Image: $0.039/image (1290 output tokens * $30/1M tokens)
     // Gemini 3.1 Flash Image Preview: $0.067/image at 1K resolution
+    // Gemini 3.1 Flash-Lite Image Preview (Nano Banana 2 Lite): cheaper Flash-Lite tier, estimate
     // Gemini 3 Pro Image: Pricing TBD, using estimate
     const costMap: Record<string, number> = {
       'gemini-2.5-flash-image': 0.039,
       'gemini-2.5-flash-preview-image-generation': 0.039, // Deprecated alias
       'gemini-3.1-flash-image-preview': 0.067,
+      'gemini-3.1-flash-lite-image-preview': 0.02, // Nano Banana 2 Lite, estimated
+      'gemini-3.1-flash-lite-image': 0.02, // GA alias for Nano Banana 2 Lite, estimated
       'gemini-3-pro-image-preview': 0.05, // Estimated
     };
 

--- a/src/providers/google/gemini-image.ts
+++ b/src/providers/google/gemini-image.ts
@@ -39,6 +39,8 @@ interface GeminiImageOptions {
  * and '4K'; the resolution comes from the request's `imageSize` (default 1K).
  */
 // A model and its `-preview` alias share the same resolution-tiered prices.
+// The -preview aliases were shut down by Google on June 25, 2026; entries are
+// retained so historical results and stragglers still price correctly.
 const FLASH_IMAGE_PRICING = { '0.5K': 0.045, '1K': 0.067, '2K': 0.101, '4K': 0.151 }; // Nano Banana 2
 const PRO_IMAGE_PRICING = { '1K': 0.134, '2K': 0.134, '4K': 0.24 }; // Nano Banana Pro
 
@@ -54,16 +56,45 @@ const GEMINI_IMAGE_PRICING: Record<string, Record<string, number>> = {
 const DEFAULT_IMAGE_COST = 0.04;
 
 /**
+ * Token rates (USD per token) billed in addition to the per-image price.
+ * The per-image prices above cover only image-output tokens; Google bills
+ * prompt tokens and, on Gemini 3.x image models, text/thinking output tokens
+ * separately. Source: https://ai.google.dev/gemini-api/docs/pricing
+ * (gemini-2.5-flash-image lists no separate text-output rate.)
+ */
+const GEMINI_IMAGE_TOKEN_RATES: Record<string, { input: number; textOutput: number }> = {
+  'gemini-2.5-flash-image': { input: 0.3 / 1e6, textOutput: 0 },
+  'gemini-2.5-flash-preview-image-generation': { input: 0.3 / 1e6, textOutput: 0 },
+  'gemini-3.1-flash-lite-image': { input: 0.25 / 1e6, textOutput: 1.5 / 1e6 },
+  'gemini-3.1-flash-image': { input: 0.5 / 1e6, textOutput: 3 / 1e6 },
+  'gemini-3.1-flash-image-preview': { input: 0.5 / 1e6, textOutput: 3 / 1e6 },
+  'gemini-3-pro-image': { input: 2 / 1e6, textOutput: 12 / 1e6 },
+  'gemini-3-pro-image-preview': { input: 2 / 1e6, textOutput: 12 / 1e6 },
+};
+
+/**
+ * Image sizes accepted per model; models absent from this map accept every
+ * size Google documents for the family. gemini-3.1-flash-lite-image renders
+ * 1K only (2K/4K unsupported, and 512px is gemini-3.1-flash-image only).
+ */
+const MODEL_IMAGE_SIZES: Record<string, string[]> = {
+  'gemini-3.1-flash-lite-image': ['1K'],
+};
+
+/**
  * Gemini native image generation provider.
  *
  * Uses the Gemini generateContent API with responseModalities set to include images.
  * This is different from Imagen models which use the :predict endpoint.
  *
- * Supported models (GA and -preview aliases both resolve here):
+ * Supported models:
  * - gemini-2.5-flash-image (Nano Banana)
  * - gemini-3.1-flash-lite-image (Nano Banana 2 Lite)
- * - gemini-3.1-flash-image / gemini-3.1-flash-image-preview (Nano Banana 2)
- * - gemini-3-pro-image / gemini-3-pro-image-preview (Nano Banana Pro)
+ * - gemini-3.1-flash-image (Nano Banana 2)
+ * - gemini-3-pro-image (Nano Banana Pro)
+ *
+ * The -preview aliases of the 3.x models were shut down by Google on
+ * June 25, 2026; they still route here so existing configs price correctly.
  */
 export class GeminiImageProvider implements ApiProvider {
   modelName: string;
@@ -116,6 +147,11 @@ export class GeminiImageProvider implements ApiProvider {
       return {
         error: 'Prompt is required for image generation',
       };
+    }
+
+    const sizeError = this.validateImageSize();
+    if (sizeError) {
+      return { error: sizeError };
     }
 
     // Check if we should use Vertex AI (when projectId is provided)
@@ -274,14 +310,17 @@ export class GeminiImageProvider implements ApiProvider {
       },
     };
 
-    // Add image-specific configuration if provided.
-    // imageSize is supported on Gemini 3.x image models.
+    // Add image-specific configuration if provided. Top-level knobs override
+    // matching fields in a pass-through generationConfig.imageConfig without
+    // dropping its other fields. imageSize is supported on Gemini 3.x models.
     const supportsImageSize = this.supportsImageSize();
-    if (this.config.imageAspectRatio || (this.config.imageSize && supportsImageSize)) {
-      body.generationConfig.imageConfig = {
-        ...(this.config.imageAspectRatio && { aspectRatio: this.config.imageAspectRatio }),
-        ...(this.config.imageSize && supportsImageSize && { imageSize: this.config.imageSize }),
-      };
+    const imageConfig: Record<string, any> = {
+      ...(this.config.generationConfig?.imageConfig ?? {}),
+      ...(this.config.imageAspectRatio && { aspectRatio: this.config.imageAspectRatio }),
+      ...(this.config.imageSize && supportsImageSize && { imageSize: this.config.imageSize }),
+    };
+    if (Object.keys(imageConfig).length > 0) {
+      body.generationConfig.imageConfig = imageConfig;
     }
 
     // Add safety settings if provided
@@ -365,6 +404,11 @@ export class GeminiImageProvider implements ApiProvider {
     let totalCost = 0;
 
     for (const part of candidate.content.parts) {
+      // Skip interim thinking output (returned when thoughts are requested):
+      // thought images are billed as thinking tokens, not as final images.
+      if (part.thought) {
+        continue;
+      }
       if (part.text) {
         textParts.push(part.text);
       } else if (part.inlineData) {
@@ -374,6 +418,7 @@ export class GeminiImageProvider implements ApiProvider {
         totalCost += this.getCostPerImage();
       }
     }
+    totalCost += this.getTokenCost(data.usageMetadata);
 
     if (imageParts.length === 0 && textParts.length === 0) {
       return {
@@ -414,10 +459,39 @@ export class GeminiImageProvider implements ApiProvider {
       images,
       cached,
       latencyMs,
-      cost: totalCost > 0 ? totalCost : undefined,
+      // Cached responses were already paid for on the original request.
+      cost: cached || totalCost === 0 ? undefined : totalCost,
       tokenUsage,
       raw: data,
     };
+  }
+
+  /**
+   * The image size the request actually asks for: the top-level `imageSize`
+   * option wins, otherwise a pass-through `generationConfig.imageConfig`
+   * value applies. Mirrors the precedence used by buildRequestBody.
+   */
+  private getEffectiveImageSize(): string | undefined {
+    const topLevel = this.supportsImageSize() ? this.config.imageSize : undefined;
+    return topLevel ?? this.config.generationConfig?.imageConfig?.imageSize;
+  }
+
+  /** Normalize Google's '512px' label to its 0.5K pricing tier. */
+  private normalizeImageSize(size: string): string {
+    const raw = size.toUpperCase();
+    return raw === '512PX' ? '0.5K' : raw;
+  }
+
+  private validateImageSize(): string | undefined {
+    const allowedSizes = MODEL_IMAGE_SIZES[this.modelName];
+    const requested = this.getEffectiveImageSize();
+    if (!allowedSizes || requested === undefined) {
+      return undefined;
+    }
+    if (!allowedSizes.includes(this.normalizeImageSize(requested))) {
+      return `Model ${this.modelName} only supports imageSize ${allowedSizes.join(', ')}; got '${requested}'`;
+    }
+    return undefined;
   }
 
   private getCostPerImage(): number {
@@ -430,9 +504,28 @@ export class GeminiImageProvider implements ApiProvider {
       return pricing.default;
     }
     // Resolution-tiered models: bill by the requested imageSize (default 1K).
-    // '512px' is Google's label for the 0.5K tier.
-    const raw = (this.config.imageSize ?? '1K').toUpperCase();
-    const resolution = raw === '512PX' ? '0.5K' : raw;
+    const resolution = this.normalizeImageSize(this.getEffectiveImageSize() ?? '1K');
     return pricing[resolution] ?? pricing['1K'] ?? DEFAULT_IMAGE_COST;
+  }
+
+  /**
+   * Token charges billed on top of the per-image price: prompt tokens, plus
+   * text and thinking output tokens on models with a text-output rate. Image
+   * output tokens are covered by the per-image price and excluded here via
+   * the candidatesTokensDetails modality breakdown.
+   */
+  private getTokenCost(usageMetadata: any): number {
+    const rates = GEMINI_IMAGE_TOKEN_RATES[this.modelName];
+    if (!rates || !usageMetadata) {
+      return 0;
+    }
+    const promptTokens = usageMetadata.promptTokenCount ?? 0;
+    const textTokens = Array.isArray(usageMetadata.candidatesTokensDetails)
+      ? usageMetadata.candidatesTokensDetails
+          .filter((detail: any) => detail?.modality === 'TEXT')
+          .reduce((sum: number, detail: any) => sum + (detail.tokenCount ?? 0), 0)
+      : 0;
+    const thinkingTokens = usageMetadata.thoughtsTokenCount ?? 0;
+    return promptTokens * rates.input + (textTokens + thinkingTokens) * rates.textOutput;
   }
 }

--- a/src/providers/google/gemini-image.ts
+++ b/src/providers/google/gemini-image.ts
@@ -31,6 +31,25 @@ interface GeminiImageOptions {
 }
 
 /**
+ * Per-image price (USD) by model id and output resolution, standard tier.
+ * Source: https://ai.google.dev/gemini-api/docs/pricing
+ *
+ * Models billed at a single flat per-image rate use the `default` key. Models
+ * with resolution-tiered pricing key on '0.5K' (Google's `512px`), '1K', '2K',
+ * and '4K'; the resolution comes from the request's `imageSize` (default 1K).
+ */
+const GEMINI_IMAGE_PRICING: Record<string, Record<string, number>> = {
+  'gemini-2.5-flash-image': { default: 0.039 }, // Nano Banana
+  'gemini-2.5-flash-preview-image-generation': { default: 0.039 }, // Deprecated alias
+  'gemini-3.1-flash-lite-image': { default: 0.0336 }, // Nano Banana 2 Lite (1K only)
+  'gemini-3.1-flash-image': { '0.5K': 0.045, '1K': 0.067, '2K': 0.101, '4K': 0.151 }, // Nano Banana 2
+  'gemini-3.1-flash-image-preview': { '0.5K': 0.045, '1K': 0.067, '2K': 0.101, '4K': 0.151 },
+  'gemini-3-pro-image': { '1K': 0.134, '2K': 0.134, '4K': 0.24 }, // Nano Banana Pro
+  'gemini-3-pro-image-preview': { '1K': 0.134, '2K': 0.134, '4K': 0.24 },
+};
+const DEFAULT_IMAGE_COST = 0.04;
+
+/**
  * Gemini native image generation provider.
  *
  * Uses the Gemini generateContent API with responseModalities set to include images.
@@ -398,22 +417,18 @@ export class GeminiImageProvider implements ApiProvider {
   }
 
   private getCostPerImage(): number {
-    // Per-image pricing for Gemini native image generation (standard tier, 1K
-    // resolution). Prices from https://ai.google.dev/gemini-api/docs/pricing
-    // - Gemini 2.5 Flash Image (Nano Banana):        $0.039/image
-    // - Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite): $0.0336/image at 1K
-    // - Gemini 3.1 Flash Image (Nano Banana 2):      $0.067/image at 1K
-    // - Gemini 3 Pro Image (Nano Banana Pro):        $0.134/image at 1K/2K
-    const costMap: Record<string, number> = {
-      'gemini-2.5-flash-image': 0.039,
-      'gemini-2.5-flash-preview-image-generation': 0.039, // Deprecated alias
-      'gemini-3.1-flash-lite-image': 0.0336,
-      'gemini-3.1-flash-image': 0.067,
-      'gemini-3.1-flash-image-preview': 0.067, // Preview alias
-      'gemini-3-pro-image': 0.134,
-      'gemini-3-pro-image-preview': 0.134, // Preview alias
-    };
-
-    return costMap[this.modelName] || 0.04; // Default cost
+    const pricing = GEMINI_IMAGE_PRICING[this.modelName];
+    if (!pricing) {
+      return DEFAULT_IMAGE_COST;
+    }
+    // Flat-rate models (no resolution tiers).
+    if (pricing.default !== undefined) {
+      return pricing.default;
+    }
+    // Resolution-tiered models: bill by the requested imageSize (default 1K).
+    // '512px' is Google's label for the 0.5K tier.
+    const raw = (this.config.imageSize ?? '1K').toUpperCase();
+    const resolution = raw === '512PX' || raw === '0.5K' ? '0.5K' : raw;
+    return pricing[resolution] ?? pricing['1K'] ?? DEFAULT_IMAGE_COST;
   }
 }

--- a/src/providers/google/gemini-image.ts
+++ b/src/providers/google/gemini-image.ts
@@ -38,14 +38,18 @@ interface GeminiImageOptions {
  * with resolution-tiered pricing key on '0.5K' (Google's `512px`), '1K', '2K',
  * and '4K'; the resolution comes from the request's `imageSize` (default 1K).
  */
+// A model and its `-preview` alias share the same resolution-tiered prices.
+const FLASH_IMAGE_PRICING = { '0.5K': 0.045, '1K': 0.067, '2K': 0.101, '4K': 0.151 }; // Nano Banana 2
+const PRO_IMAGE_PRICING = { '1K': 0.134, '2K': 0.134, '4K': 0.24 }; // Nano Banana Pro
+
 const GEMINI_IMAGE_PRICING: Record<string, Record<string, number>> = {
   'gemini-2.5-flash-image': { default: 0.039 }, // Nano Banana
   'gemini-2.5-flash-preview-image-generation': { default: 0.039 }, // Deprecated alias
   'gemini-3.1-flash-lite-image': { default: 0.0336 }, // Nano Banana 2 Lite (1K only)
-  'gemini-3.1-flash-image': { '0.5K': 0.045, '1K': 0.067, '2K': 0.101, '4K': 0.151 }, // Nano Banana 2
-  'gemini-3.1-flash-image-preview': { '0.5K': 0.045, '1K': 0.067, '2K': 0.101, '4K': 0.151 },
-  'gemini-3-pro-image': { '1K': 0.134, '2K': 0.134, '4K': 0.24 }, // Nano Banana Pro
-  'gemini-3-pro-image-preview': { '1K': 0.134, '2K': 0.134, '4K': 0.24 },
+  'gemini-3.1-flash-image': FLASH_IMAGE_PRICING,
+  'gemini-3.1-flash-image-preview': FLASH_IMAGE_PRICING,
+  'gemini-3-pro-image': PRO_IMAGE_PRICING,
+  'gemini-3-pro-image-preview': PRO_IMAGE_PRICING,
 };
 const DEFAULT_IMAGE_COST = 0.04;
 
@@ -428,7 +432,7 @@ export class GeminiImageProvider implements ApiProvider {
     // Resolution-tiered models: bill by the requested imageSize (default 1K).
     // '512px' is Google's label for the 0.5K tier.
     const raw = (this.config.imageSize ?? '1K').toUpperCase();
-    const resolution = raw === '512PX' || raw === '0.5K' ? '0.5K' : raw;
+    const resolution = raw === '512PX' ? '0.5K' : raw;
     return pricing[resolution] ?? pricing['1K'] ?? DEFAULT_IMAGE_COST;
   }
 }

--- a/src/providers/google/gemini-image.ts
+++ b/src/providers/google/gemini-image.ts
@@ -36,11 +36,11 @@ interface GeminiImageOptions {
  * Uses the Gemini generateContent API with responseModalities set to include images.
  * This is different from Imagen models which use the :predict endpoint.
  *
- * Supported models:
- * - gemini-2.5-flash-image
- * - gemini-3-pro-image-preview (Nano Banana Pro)
- * - gemini-3.1-flash-image-preview (Nano Banana 2)
- * - gemini-3.1-flash-lite-image-preview (Nano Banana 2 Lite)
+ * Supported models (GA and -preview aliases both resolve here):
+ * - gemini-2.5-flash-image (Nano Banana)
+ * - gemini-3.1-flash-lite-image (Nano Banana 2 Lite)
+ * - gemini-3.1-flash-image / gemini-3.1-flash-image-preview (Nano Banana 2)
+ * - gemini-3-pro-image / gemini-3-pro-image-preview (Nano Banana Pro)
  */
 export class GeminiImageProvider implements ApiProvider {
   modelName: string;
@@ -398,18 +398,20 @@ export class GeminiImageProvider implements ApiProvider {
   }
 
   private getCostPerImage(): number {
-    // Pricing for Gemini native image generation
-    // Gemini 2.5 Flash Image: $0.039/image (1290 output tokens * $30/1M tokens)
-    // Gemini 3.1 Flash Image Preview: $0.067/image at 1K resolution
-    // Gemini 3.1 Flash-Lite Image Preview (Nano Banana 2 Lite): cheaper Flash-Lite tier, estimate
-    // Gemini 3 Pro Image: Pricing TBD, using estimate
+    // Per-image pricing for Gemini native image generation (standard tier, 1K
+    // resolution). Prices from https://ai.google.dev/gemini-api/docs/pricing
+    // - Gemini 2.5 Flash Image (Nano Banana):        $0.039/image
+    // - Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite): $0.0336/image at 1K
+    // - Gemini 3.1 Flash Image (Nano Banana 2):      $0.067/image at 1K
+    // - Gemini 3 Pro Image (Nano Banana Pro):        $0.134/image at 1K/2K
     const costMap: Record<string, number> = {
       'gemini-2.5-flash-image': 0.039,
       'gemini-2.5-flash-preview-image-generation': 0.039, // Deprecated alias
-      'gemini-3.1-flash-image-preview': 0.067,
-      'gemini-3.1-flash-lite-image-preview': 0.02, // Nano Banana 2 Lite, estimated
-      'gemini-3.1-flash-lite-image': 0.02, // GA alias for Nano Banana 2 Lite, estimated
-      'gemini-3-pro-image-preview': 0.05, // Estimated
+      'gemini-3.1-flash-lite-image': 0.0336,
+      'gemini-3.1-flash-image': 0.067,
+      'gemini-3.1-flash-image-preview': 0.067, // Preview alias
+      'gemini-3-pro-image': 0.134,
+      'gemini-3-pro-image-preview': 0.134, // Preview alias
     };
 
     return costMap[this.modelName] || 0.04; // Default cost

--- a/src/providers/google/image.ts
+++ b/src/providers/google/image.ts
@@ -330,7 +330,8 @@ export class GoogleImageProvider implements ApiProvider {
       images: imageOutputs,
       cached,
       latencyMs,
-      cost: totalCost,
+      // Cached responses were already paid for on the original request.
+      cost: cached ? undefined : totalCost,
     };
   }
 

--- a/src/providers/google/image.ts
+++ b/src/providers/google/image.ts
@@ -354,6 +354,11 @@ export class GoogleImageProvider implements ApiProvider {
   private getCost(): number {
     // Cost per image based on model
     const costMap: Record<string, number> = {
+      // Imagen 4 GA (generally available) names
+      'imagen-4.0-ultra-generate-001': 0.06,
+      'imagen-4.0-generate-001': 0.04,
+      'imagen-4.0-fast-generate-001': 0.02,
+      // Imagen 4 preview aliases
       'imagen-4.0-ultra-generate-preview-06-06': 0.06,
       'imagen-4.0-generate-preview-06-06': 0.04,
       'imagen-4.0-fast-generate-preview-06-06': 0.02,

--- a/src/providers/google/image.ts
+++ b/src/providers/google/image.ts
@@ -55,6 +55,21 @@ interface ImageGenerationResponse {
   };
 }
 
+/** Per-image cost (USD) by normalized Imagen model path. */
+const IMAGEN_COSTS: Record<string, number> = {
+  // Imagen 4 GA (generally available) names
+  'imagen-4.0-ultra-generate-001': 0.06,
+  'imagen-4.0-generate-001': 0.04,
+  'imagen-4.0-fast-generate-001': 0.02,
+  // Imagen 4 preview aliases
+  'imagen-4.0-ultra-generate-preview-06-06': 0.06,
+  'imagen-4.0-generate-preview-06-06': 0.04,
+  'imagen-4.0-fast-generate-preview-06-06': 0.02,
+  'imagen-3.0-generate-002': 0.04,
+  'imagen-3.0-generate-001': 0.04,
+  'imagen-3.0-fast-generate-001': 0.02,
+};
+
 export class GoogleImageProvider implements ApiProvider {
   modelName: string;
   config: CompletionOptions;
@@ -352,23 +367,9 @@ export class GoogleImageProvider implements ApiProvider {
   }
 
   private getCost(): number {
-    // Cost per image based on model
-    const costMap: Record<string, number> = {
-      // Imagen 4 GA (generally available) names
-      'imagen-4.0-ultra-generate-001': 0.06,
-      'imagen-4.0-generate-001': 0.04,
-      'imagen-4.0-fast-generate-001': 0.02,
-      // Imagen 4 preview aliases
-      'imagen-4.0-ultra-generate-preview-06-06': 0.06,
-      'imagen-4.0-generate-preview-06-06': 0.04,
-      'imagen-4.0-fast-generate-preview-06-06': 0.02,
-      'imagen-3.0-generate-002': 0.04,
-      'imagen-3.0-generate-001': 0.04,
-      'imagen-3.0-fast-generate-001': 0.02,
-    };
     // Use the normalized model path for cost lookup
     const modelPath = this.getModelPath();
-    return costMap[modelPath] || 0.04; // Default cost
+    return IMAGEN_COSTS[modelPath] || 0.04; // Default cost
   }
 
   private async withRetry<T>(operation: () => Promise<T>, operationName: string): Promise<T> {

--- a/src/providers/google/shared.ts
+++ b/src/providers/google/shared.ts
@@ -39,11 +39,12 @@ const GEMINI_2_5_PRO_TIERED_COST = {
  * Note: Vertex AI may have different pricing for some models.
  */
 export const GOOGLE_MODELS: GoogleModel[] = [
-  // Gemini 3.5 models
-  {
-    id: 'gemini-3.5-flash',
+  // Gemini 3.5 models. gemini-flash-latest is a Google-maintained alias that currently
+  // resolves server-side to gemini-3.5-flash (verified via response modelVersion).
+  ...['gemini-3.5-flash', 'gemini-flash-latest'].map((id) => ({
+    id,
     cost: { input: 1.5 / 1e6, output: 9.0 / 1e6 },
-  },
+  })),
 
   // Gemini 3.1 models. gemini-pro-latest is a Google-maintained alias that currently
   // resolves server-side to gemini-3.1-pro-preview, so it tracks the Gemini 3 Pro tier.
@@ -55,10 +56,14 @@ export const GOOGLE_MODELS: GoogleModel[] = [
     }),
   ),
   // gemini-3.1-flash-lite (GA) and its preview alias share Flash-Lite pricing.
-  ...['gemini-3.1-flash-lite', 'gemini-3.1-flash-lite-preview'].map((id) => ({
-    id,
-    cost: { input: 0.25 / 1e6, output: 1.5 / 1e6 },
-  })),
+  // gemini-flash-lite-latest currently resolves server-side to gemini-3.1-flash-lite
+  // (verified via response modelVersion).
+  ...['gemini-3.1-flash-lite', 'gemini-3.1-flash-lite-preview', 'gemini-flash-lite-latest'].map(
+    (id) => ({
+      id,
+      cost: { input: 0.25 / 1e6, output: 1.5 / 1e6 },
+    }),
+  ),
 
   // Gemini 3.0 models (Preview)
   {
@@ -77,16 +82,14 @@ export const GOOGLE_MODELS: GoogleModel[] = [
     cost: GEMINI_2_5_PRO_COST,
     tieredCost: GEMINI_2_5_PRO_TIERED_COST,
   })),
-  // gemini-flash-latest is a Google-maintained alias that resolves server-side to the
-  // current Flash snapshot. Pricing tracks the Flash tier ($0.30/$2.50 per 1M tokens).
-  ...['gemini-2.5-flash', 'gemini-2.5-flash-preview-04-17', 'gemini-flash-latest'].map((id) => ({
+  ...['gemini-2.5-flash', 'gemini-2.5-flash-preview-04-17'].map((id) => ({
     id,
     cost: { input: 0.3 / 1e6, output: 2.5 / 1e6 },
   })),
-  ...['gemini-2.5-flash-lite', 'gemini-flash-lite-latest'].map((id) => ({
-    id,
+  {
+    id: 'gemini-2.5-flash-lite',
     cost: { input: 0.1 / 1e6, output: 0.4 / 1e6 },
-  })),
+  },
 
   // Gemini 2.0 models
   ...['gemini-2.0-flash', 'gemini-2.0-flash-001'].map((id) => ({

--- a/src/providers/google/shared.ts
+++ b/src/providers/google/shared.ts
@@ -45,20 +45,15 @@ export const GOOGLE_MODELS: GoogleModel[] = [
     cost: { input: 1.5 / 1e6, output: 9.0 / 1e6 },
   },
 
-  // Gemini 3.1 models
-  ...['gemini-3.1-pro-preview', 'gemini-3.1-pro-preview-customtools'].map((id) => ({
-    id,
-    cost: GEMINI_3_PRO_COST,
-    tieredCost: GEMINI_3_PRO_TIERED_COST,
-  })),
-  // gemini-pro-latest is a Google-maintained alias that resolves server-side to the
-  // current Gemini Pro snapshot (currently gemini-3.1-pro-preview). Pricing tracks the
-  // Gemini 3 Pro tier.
-  {
-    id: 'gemini-pro-latest',
-    cost: GEMINI_3_PRO_COST,
-    tieredCost: GEMINI_3_PRO_TIERED_COST,
-  },
+  // Gemini 3.1 models. gemini-pro-latest is a Google-maintained alias that currently
+  // resolves server-side to gemini-3.1-pro-preview, so it tracks the Gemini 3 Pro tier.
+  ...['gemini-3.1-pro-preview', 'gemini-3.1-pro-preview-customtools', 'gemini-pro-latest'].map(
+    (id) => ({
+      id,
+      cost: GEMINI_3_PRO_COST,
+      tieredCost: GEMINI_3_PRO_TIERED_COST,
+    }),
+  ),
   // gemini-3.1-flash-lite (GA) and its preview alias share Flash-Lite pricing.
   ...['gemini-3.1-flash-lite', 'gemini-3.1-flash-lite-preview'].map((id) => ({
     id,

--- a/src/providers/google/shared.ts
+++ b/src/providers/google/shared.ts
@@ -51,6 +51,14 @@ export const GOOGLE_MODELS: GoogleModel[] = [
     cost: GEMINI_3_PRO_COST,
     tieredCost: GEMINI_3_PRO_TIERED_COST,
   })),
+  // gemini-pro-latest is a Google-maintained alias that resolves server-side to the
+  // current Gemini Pro snapshot (currently gemini-3.1-pro-preview). Pricing tracks the
+  // Gemini 3 Pro tier.
+  {
+    id: 'gemini-pro-latest',
+    cost: GEMINI_3_PRO_COST,
+    tieredCost: GEMINI_3_PRO_TIERED_COST,
+  },
   // gemini-3.1-flash-lite (GA) and its preview alias share Flash-Lite pricing.
   ...['gemini-3.1-flash-lite', 'gemini-3.1-flash-lite-preview'].map((id) => ({
     id,
@@ -165,17 +173,18 @@ export const GOOGLE_MODELS: GoogleModel[] = [
     cost: { input: 0.5 / 1e6, output: 1.5 / 1e6 },
   },
 
-  // Gemini Robotics
+  // Gemini Robotics (1.5-preview is intentionally excluded as a shutdown model;
+  // see the shutdown-models test in test/providers/google/util.test.ts)
   {
     id: 'gemini-robotics-er-1.6-preview',
     cost: { input: 1.0 / 1e6, output: 5.0 / 1e6 },
   },
 
   // Gemini Embedding
-  {
-    id: 'gemini-embedding-2',
+  ...['gemini-embedding-2', 'gemini-embedding-2-preview'].map((id) => ({
+    id,
     cost: { input: 0.2 / 1e6, output: 0 },
-  },
+  })),
   {
     id: 'gemini-embedding-001',
     cost: { input: 0.15 / 1e6, output: 0 },

--- a/src/providers/google/types.ts
+++ b/src/providers/google/types.ts
@@ -45,6 +45,10 @@ interface FileData {
 
 export interface Part {
   text?: string;
+  // True for interim thinking output (text or images) when thoughts are
+  // requested; thought parts are not final content and are billed as
+  // thinking tokens rather than per-image output.
+  thought?: boolean;
   inlineData?: Blob;
   functionCall?: FunctionCall;
   functionResponse?: FunctionResponse;
@@ -233,6 +237,13 @@ export interface CompletionOptions {
     thinkingConfig?: {
       thinkingBudget?: number;
       thinkingLevel?: 'MINIMAL' | 'LOW' | 'MEDIUM' | 'HIGH';
+    };
+
+    // Image configuration for Gemini image models; the top-level
+    // imageAspectRatio/imageSize options override matching fields here.
+    imageConfig?: {
+      aspectRatio?: string;
+      imageSize?: string;
     };
   };
 

--- a/test/providers/google/ai.studio.test.ts
+++ b/test/providers/google/ai.studio.test.ts
@@ -2500,6 +2500,41 @@ describe('AIStudioEmbeddingProvider', () => {
     expect(response.tokenUsage).toEqual({ total: 7, numRequests: 1 });
   });
 
+  it('reports cost for priced embedding models', async () => {
+    vi.mocked(cache.fetchWithCache).mockResolvedValue(embeddingResponse([0.1, 0.2], 10_000) as any);
+
+    const provider = new AIStudioEmbeddingProvider('gemini-embedding-2-preview');
+    const response = await provider.callEmbeddingApi('hello world');
+
+    // $0.20 per 1M input tokens
+    expect(response.cost).toBeCloseTo(0.002, 10);
+  });
+
+  it('omits cost for cached embedding responses', async () => {
+    vi.mocked(cache.fetchWithCache).mockResolvedValue({
+      data: {
+        embedding: { values: [0.1, 0.2] },
+        usageMetadata: { promptTokenCount: 10_000 },
+      },
+      cached: true,
+    } as any);
+
+    const provider = new AIStudioEmbeddingProvider('gemini-embedding-2-preview');
+    const response = await provider.callEmbeddingApi('hello world');
+
+    expect(response.cached).toBe(true);
+    expect(response.cost).toBeUndefined();
+  });
+
+  it('omits cost when the response has no usage metadata', async () => {
+    vi.mocked(cache.fetchWithCache).mockResolvedValue(embeddingResponse([0.1, 0.2]) as any);
+
+    const provider = new AIStudioEmbeddingProvider('gemini-embedding-2-preview');
+    const response = await provider.callEmbeddingApi('hello world');
+
+    expect(response.cost).toBeUndefined();
+  });
+
   it('forwards taskType, outputDimensionality, and title from config', async () => {
     vi.mocked(cache.fetchWithCache).mockResolvedValue(embeddingResponse([0.1], 1) as any);
 

--- a/test/providers/google/gemini-image.test.ts
+++ b/test/providers/google/gemini-image.test.ts
@@ -300,6 +300,51 @@ describe('GeminiImageProvider', () => {
         }),
       );
     });
+
+    it('should use global endpoint with v1 for gemini-3.1-flash-lite-image-preview', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image-preview', {
+        config: {
+          projectId: 'test-project',
+          region: 'us-central1',
+        },
+      });
+
+      const mockClient = {
+        request: vi.fn().mockResolvedValue({
+          data: {
+            candidates: [
+              {
+                content: {
+                  parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+                },
+                finishReason: 'STOP',
+              },
+            ],
+          },
+        }),
+      };
+
+      mockGetGoogleClient.mockResolvedValue({
+        client: mockClient as any,
+        projectId: 'test-project',
+      });
+
+      await provider.callApi('Test prompt');
+
+      // Nano Banana 2 Lite is a Gemini 3.x model and uses the global endpoint
+      expect(mockClient.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining('https://aiplatform.googleapis.com/v1/'),
+        }),
+      );
+      expect(mockClient.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining(
+            '/publishers/google/models/gemini-3.1-flash-lite-image-preview:generateContent',
+          ),
+        }),
+      );
+    });
   });
 
   describe('Image configuration', () => {
@@ -392,6 +437,47 @@ describe('GeminiImageProvider', () => {
       expect(body.generationConfig.imageConfig).toEqual({
         aspectRatio: '1:1',
         imageSize: '512px',
+      });
+    });
+
+    it('should pass imageSize config for gemini-3.1-flash-lite-image-preview', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image-preview', {
+        config: {
+          imageAspectRatio: '16:9',
+          imageSize: '1K',
+        },
+      });
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      mimeType: 'image/png',
+                      data: 'base64data',
+                    },
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      await provider.callApi('Test prompt');
+
+      const callArgs = mockFetchWithCache.mock.calls[0];
+      const body = JSON.parse(callArgs[1]!.body as string);
+      expect(body.generationConfig.imageConfig).toEqual({
+        aspectRatio: '16:9',
+        imageSize: '1K',
       });
     });
 
@@ -728,6 +814,37 @@ describe('GeminiImageProvider', () => {
       const result = await provider.callApi('Test prompt');
 
       expect(result.cost).toBe(0.067);
+    });
+
+    it('should return correct cost for gemini-3.1-flash-lite-image-preview', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image-preview');
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      mimeType: 'image/png',
+                      data: 'base64data',
+                    },
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.cost).toBe(0.02);
     });
   });
 

--- a/test/providers/google/gemini-image.test.ts
+++ b/test/providers/google/gemini-image.test.ts
@@ -894,6 +894,65 @@ describe('GeminiImageProvider', () => {
 
       expect(result.cost).toBe(0.134);
     });
+
+    it.each([
+      { model: 'gemini-3.1-flash-image', imageSize: '512px', expected: 0.045 },
+      { model: 'gemini-3.1-flash-image', imageSize: '1K', expected: 0.067 },
+      { model: 'gemini-3.1-flash-image', imageSize: '2K', expected: 0.101 },
+      { model: 'gemini-3.1-flash-image', imageSize: '4K', expected: 0.151 },
+      { model: 'gemini-3-pro-image', imageSize: '2K', expected: 0.134 },
+      { model: 'gemini-3-pro-image', imageSize: '4K', expected: 0.24 },
+    ] as const)('should scale per-image cost by imageSize ($model @ $imageSize)', async ({
+      model,
+      imageSize,
+      expected,
+    }) => {
+      const provider = new GeminiImageProvider(model, { config: { imageSize } });
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.cost).toBe(expected);
+    });
+
+    it('should default resolution-tiered cost to the 1K price when imageSize is unset', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-image');
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.cost).toBe(0.067);
+    });
   });
 
   describe('API key handling', () => {

--- a/test/providers/google/gemini-image.test.ts
+++ b/test/providers/google/gemini-image.test.ts
@@ -399,6 +399,43 @@ describe('GeminiImageProvider', () => {
       });
     });
 
+    it('should merge top-level options with a pass-through generationConfig.imageConfig', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-image', {
+        config: {
+          imageAspectRatio: '16:9',
+          generationConfig: { imageConfig: { imageSize: '2K' } },
+        },
+      });
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      const callArgs = mockFetchWithCache.mock.calls[0];
+      const body = JSON.parse(callArgs[1]!.body as string);
+      // The nested imageSize must survive the top-level aspectRatio override
+      // and be billed at its tier.
+      expect(body.generationConfig.imageConfig).toEqual({
+        aspectRatio: '16:9',
+        imageSize: '2K',
+      });
+      expect(result.cost).toBe(0.101);
+    });
+
     it('should pass imageSize config for gemini-3.1-flash-image-preview', async () => {
       const provider = new GeminiImageProvider('gemini-3.1-flash-image-preview', {
         config: {
@@ -952,6 +989,176 @@ describe('GeminiImageProvider', () => {
       const result = await provider.callApi('Test prompt');
 
       expect(result.cost).toBe(0.067);
+    });
+
+    it('should not report cost for cached responses', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-image');
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+          usageMetadata: { totalTokenCount: 1200 },
+        },
+        cached: true,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.cached).toBe(true);
+      expect(result.cost).toBeUndefined();
+    });
+
+    it('should bill prompt and text/thinking tokens on top of the per-image price', async () => {
+      const provider = new GeminiImageProvider('gemini-3-pro-image');
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { text: 'Here is your image.' },
+                  { inlineData: { mimeType: 'image/png', data: 'base64data' } },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+          usageMetadata: {
+            promptTokenCount: 1000,
+            candidatesTokenCount: 1130,
+            totalTokenCount: 2630,
+            thoughtsTokenCount: 500,
+            candidatesTokensDetails: [
+              { modality: 'IMAGE', tokenCount: 1120 },
+              { modality: 'TEXT', tokenCount: 10 },
+            ],
+          },
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      // $0.134 per image + 1000 input tokens * $2/1M + (10 text + 500 thinking) * $12/1M
+      expect(result.cost).toBeCloseTo(0.134 + 0.002 + 0.00612, 10);
+    });
+
+    it('should price by generationConfig.imageConfig.imageSize when the top-level option is unset', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-image', {
+        config: { generationConfig: { imageConfig: { imageSize: '4K' } } },
+      });
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.cost).toBe(0.151);
+    });
+
+    it('should not bill thought images as final images', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-image');
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  { thought: true, inlineData: { mimeType: 'image/png', data: 'draftimage' } },
+                  { inlineData: { mimeType: 'image/png', data: 'finalimage' } },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.images).toHaveLength(1);
+      expect(result.images![0].data).toBe('data:image/png;base64,finalimage');
+      expect(result.cost).toBe(0.067);
+    });
+  });
+
+  describe('Image size validation', () => {
+    it('should reject unsupported image sizes for gemini-3.1-flash-lite-image', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image', {
+        config: { imageSize: '4K' },
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.error).toContain('only supports imageSize 1K');
+      expect(mockFetchWithCache).not.toHaveBeenCalled();
+    });
+
+    it('should reject unsupported nested imageConfig sizes for gemini-3.1-flash-lite-image', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image', {
+        config: { generationConfig: { imageConfig: { imageSize: '2K' } } },
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.error).toContain('only supports imageSize 1K');
+      expect(mockFetchWithCache).not.toHaveBeenCalled();
+    });
+
+    it('should accept 1K for gemini-3.1-flash-lite-image', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image', {
+        config: { imageSize: '1K' },
+      });
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.error).toBeUndefined();
+      expect(result.cost).toBe(0.0336);
     });
   });
 

--- a/test/providers/google/gemini-image.test.ts
+++ b/test/providers/google/gemini-image.test.ts
@@ -301,8 +301,8 @@ describe('GeminiImageProvider', () => {
       );
     });
 
-    it('should use global endpoint with v1 for gemini-3.1-flash-lite-image-preview', async () => {
-      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image-preview', {
+    it('should use global endpoint with v1 for gemini-3.1-flash-lite-image', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image', {
         config: {
           projectId: 'test-project',
           region: 'us-central1',
@@ -340,7 +340,7 @@ describe('GeminiImageProvider', () => {
       expect(mockClient.request).toHaveBeenCalledWith(
         expect.objectContaining({
           url: expect.stringContaining(
-            '/publishers/google/models/gemini-3.1-flash-lite-image-preview:generateContent',
+            '/publishers/google/models/gemini-3.1-flash-lite-image:generateContent',
           ),
         }),
       );
@@ -440,8 +440,8 @@ describe('GeminiImageProvider', () => {
       });
     });
 
-    it('should pass imageSize config for gemini-3.1-flash-lite-image-preview', async () => {
-      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image-preview', {
+    it('should pass imageSize config for gemini-3.1-flash-lite-image', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image', {
         config: {
           imageAspectRatio: '16:9',
           imageSize: '1K',
@@ -751,7 +751,7 @@ describe('GeminiImageProvider', () => {
 
       const result = await provider.callApi('Test prompt');
 
-      expect(result.cost).toBe(0.05);
+      expect(result.cost).toBe(0.134);
     });
 
     it('should return correct cost for gemini-2.5-flash-image', async () => {
@@ -816,8 +816,8 @@ describe('GeminiImageProvider', () => {
       expect(result.cost).toBe(0.067);
     });
 
-    it('should return correct cost for gemini-3.1-flash-lite-image-preview', async () => {
-      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image-preview');
+    it('should return correct cost for gemini-3.1-flash-lite-image (Nano Banana 2 Lite)', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-lite-image');
 
       mockFetchWithCache.mockResolvedValueOnce({
         status: 200,
@@ -844,7 +844,55 @@ describe('GeminiImageProvider', () => {
 
       const result = await provider.callApi('Test prompt');
 
-      expect(result.cost).toBe(0.02);
+      expect(result.cost).toBe(0.0336);
+    });
+
+    it('should return correct cost for gemini-3.1-flash-image (GA Nano Banana 2)', async () => {
+      const provider = new GeminiImageProvider('gemini-3.1-flash-image');
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.cost).toBe(0.067);
+    });
+
+    it('should return correct cost for gemini-3-pro-image (GA Nano Banana Pro)', async () => {
+      const provider = new GeminiImageProvider('gemini-3-pro-image');
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: 'image/png', data: 'base64data' } }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        cached: false,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.cost).toBe(0.134);
     });
   });
 

--- a/test/providers/google/image.test.ts
+++ b/test/providers/google/image.test.ts
@@ -257,6 +257,22 @@ describe('GoogleImageProvider', async () => {
     }
   });
 
+  it('should not report cost for cached responses', async () => {
+    const provider = new GoogleImageProvider('imagen-4.0-fast-generate-001');
+    mockFetchWithCache.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        predictions: [{ bytesBase64Encoded: 'base64data', mimeType: 'image/png' }],
+      },
+      cached: true,
+    });
+
+    const result = await provider.callApi('Test prompt');
+
+    expect(result.cached).toBe(true);
+    expect(result.cost).toBeUndefined();
+  });
+
   describe('Google AI Studio', () => {
     beforeEach(() => {
       mockProcessEnv({ GOOGLE_PROJECT_ID: undefined });

--- a/test/providers/google/image.test.ts
+++ b/test/providers/google/image.test.ts
@@ -230,6 +230,11 @@ describe('GoogleImageProvider', async () => {
   it('should return correct cost for different models', async () => {
     // Test costs through actual API responses
     const testCases = [
+      // Imagen 4 GA names
+      { model: 'imagen-4.0-ultra-generate-001', expectedCost: 0.06 },
+      { model: 'imagen-4.0-generate-001', expectedCost: 0.04 },
+      { model: 'imagen-4.0-fast-generate-001', expectedCost: 0.02 },
+      // Imagen 4 preview aliases
       { model: 'imagen-4.0-ultra-generate-preview-06-06', expectedCost: 0.06 },
       { model: 'imagen-4.0-generate-preview-06-06', expectedCost: 0.04 },
       { model: 'imagen-4.0-fast-generate-preview-06-06', expectedCost: 0.02 },

--- a/test/providers/google/util.test.ts
+++ b/test/providers/google/util.test.ts
@@ -2677,6 +2677,25 @@ describe('util', () => {
       expect(cost).toBeCloseTo(0.002, 10);
     });
 
+    it('should calculate cost for gemini-embedding-2-preview (tracks gemini-embedding-2)', () => {
+      // gemini-embedding-2-preview: input=0.2/1M, output=0
+      const cost = calculateGoogleCost('gemini-embedding-2-preview', {}, 10000, 0);
+      expect(cost).toBeCloseTo(0.002, 10);
+    });
+
+    it('should apply Gemini 3 Pro tiered pricing for the gemini-pro-latest alias', () => {
+      // gemini-pro-latest resolves to the current Gemini Pro snapshot
+      // (gemini-3.1-pro-preview): base input=2.0/1M, output=12.0/1M;
+      // tiered (>200k): input=4.0/1M, output=18.0/1M.
+      const costBelowThreshold = calculateGoogleCost('gemini-pro-latest', {}, 100000, 50000);
+      // Expected (below 200k): (100000 * 2.0 + 50000 * 12.0) / 1M = 0.8
+      expect(costBelowThreshold).toBeCloseTo(0.8, 10);
+
+      const costAboveThreshold = calculateGoogleCost('gemini-pro-latest', {}, 250000, 50000);
+      // Expected (above 200k): (250000 * 4.0 + 50000 * 18.0) / 1M = 1.9
+      expect(costAboveThreshold).toBeCloseTo(1.9, 10);
+    });
+
     it('should apply tiered pricing for gemini-2.5-pro when above threshold', () => {
       // gemini-2.5-pro: base input=1.25/1M, output=10.0/1M
       // tiered (>200k): input=2.5/1M, output=15.0/1M

--- a/test/providers/google/util.test.ts
+++ b/test/providers/google/util.test.ts
@@ -2757,16 +2757,16 @@ describe('util', () => {
       expect(cost).toBeCloseTo(0.0035, 10);
     });
 
-    it('should calculate cost for gemini-flash-latest using flash pricing', () => {
-      // gemini-flash-latest aliases the current Flash snapshot: input=0.3/1M, output=2.5/1M
+    it('should calculate cost for gemini-flash-latest using the tier it currently resolves to', () => {
+      // gemini-flash-latest resolves server-side to gemini-3.5-flash: input=1.5/1M, output=9/1M
       const cost = calculateGoogleCost('gemini-flash-latest', {}, 1000, 500);
-      expect(cost).toBeCloseTo(0.00155, 10);
+      expect(cost).toBeCloseTo(0.006, 10);
     });
 
-    it('should calculate cost for gemini-flash-lite-latest using flash-lite alias pricing', () => {
-      // gemini-flash-lite-latest tracks the current Flash-Lite tier: input=0.1/1M, output=0.4/1M
+    it('should calculate cost for gemini-flash-lite-latest using the tier it currently resolves to', () => {
+      // gemini-flash-lite-latest resolves server-side to gemini-3.1-flash-lite: input=0.25/1M, output=1.5/1M
       const cost = calculateGoogleCost('gemini-flash-lite-latest', {}, 1000, 500);
-      expect(cost).toBeCloseTo(0.0003, 10);
+      expect(cost).toBeCloseTo(0.001, 10);
     });
 
     it('should return undefined for shutdown models', () => {

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -1209,9 +1209,13 @@ describe('Provider Registry', () => {
         'google:gemini-2.5-flash-image',
         async () => (await import('../../src/providers/google/gemini-image')).GeminiImageProvider,
       ],
-      // Nano Banana 2 Lite: bare google:<model> route dispatches on the '-image' substring.
+      // Nano Banana 2 Lite / Pro GA: bare google:<model> routes dispatch on the '-image' substring.
       [
-        'google:gemini-3.1-flash-lite-image-preview',
+        'google:gemini-3.1-flash-lite-image',
+        async () => (await import('../../src/providers/google/gemini-image')).GeminiImageProvider,
+      ],
+      [
+        'google:gemini-3-pro-image',
         async () => (await import('../../src/providers/google/gemini-image')).GeminiImageProvider,
       ],
       // Bare google:<model> default chat route (no service-type segment).

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -1209,9 +1209,13 @@ describe('Provider Registry', () => {
         'google:gemini-2.5-flash-image',
         async () => (await import('../../src/providers/google/gemini-image')).GeminiImageProvider,
       ],
-      // Nano Banana 2 Lite / Pro GA: bare google:<model> routes dispatch on the '-image' substring.
+      // Nano Banana 2 / 2 Lite / Pro GA: bare google:<model> routes dispatch on the '-image' substring.
       [
         'google:gemini-3.1-flash-lite-image',
+        async () => (await import('../../src/providers/google/gemini-image')).GeminiImageProvider,
+      ],
+      [
+        'google:gemini-3.1-flash-image',
         async () => (await import('../../src/providers/google/gemini-image')).GeminiImageProvider,
       ],
       [

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -1209,6 +1209,11 @@ describe('Provider Registry', () => {
         'google:gemini-2.5-flash-image',
         async () => (await import('../../src/providers/google/gemini-image')).GeminiImageProvider,
       ],
+      // Nano Banana 2 Lite: bare google:<model> route dispatches on the '-image' substring.
+      [
+        'google:gemini-3.1-flash-lite-image-preview',
+        async () => (await import('../../src/providers/google/gemini-image')).GeminiImageProvider,
+      ],
       // Bare google:<model> default chat route (no service-type segment).
       [
         'google:gemini-2.5-flash',


### PR DESCRIPTION
## Summary

Expands promptfoo's Google provider coverage across image and text models, grounded in the official docs and **verified against the live Gemini API + gcloud/Vertex**.

Highlights:
- **Nano Banana 2 Lite** (`google:gemini-3.1-flash-lite-image`) — the fastest, lowest-cost Gemini image tier.
- **GA aliases** for the current Gemini image models, with correct per-image + resolution-aware pricing.
- **Imagen 4 GA** model names.
- **`gemini-pro-latest`** and **`gemini-embedding-2-preview`** text/embedding aliases.

## Image models (Gemini native + Imagen)

| Model id | Marketing name | Pricing | Change |
|---|---|---|---|
| `gemini-3.1-flash-lite-image` | Nano Banana 2 Lite | $0.0336/img (1K only) | **new** |
| `gemini-3.1-flash-image` (+`-preview`) | Nano Banana 2 | $0.045/$0.067/$0.101/$0.151 at 0.5K/1K/2K/4K | **new GA** + resolution-aware |
| `gemini-3-pro-image` (+`-preview`) | Nano Banana Pro | $0.134 (1K/2K), $0.24 (4K) | **new GA**; corrected `-preview` from est. $0.05 |
| `gemini-2.5-flash-image` | Nano Banana | $0.039/img | unchanged |
| `imagen-4.0-{fast,,ultra}-generate-001` | Imagen 4 GA | $0.02/$0.04/$0.06 | **new** (were defaulting to $0.04) |

`getCostPerImage` now bills by the requested `imageSize` (default 1K); flat-rate models are unaffected. Per-image prices from the [official pricing page](https://ai.google.dev/gemini-api/docs/pricing), cross-checked against live billing.

## Text / embedding aliases

| Model id | Pricing | Notes |
|---|---|---|
| `gemini-pro-latest` | Gemini 3 Pro tier ($2/$12 per 1M, tiered $4/$18 >200k) | Resolves server-side to `gemini-3.1-pro-preview` (confirmed via response `modelVersion`); tracks the Pro tier like `gemini-flash-latest` tracks Flash. Live-verified (cost `$0.001284` for a real call). |
| `gemini-embedding-2-preview` | $0.20/1M input | Preview of `gemini-embedding-2`; confirmed callable via `embedContent` (HTTP 200). |

**Not added:** `gemini-robotics-er-1.5-preview` — the repo's shutdown-models test deliberately treats it as deprecated and requires it to stay out of `GOOGLE_MODELS`, so I respected that invariant.

## Verification

- **gcloud/Vertex existence audit:** every image id confirmed to exist via `:countTokens` (Gemini) and publisher-model `GET` (Imagen), each validated against a known-fake id that returned 404. Text aliases confirmed present in the live AI Studio catalog (AI Studio only; not on Vertex).
- **Live API:** all image ids generate real images with correct costs (`0.0336 / 0.067 / 0.134`, resolution-scaled); `gemini-pro-latest` returns and is billed at the Gemini 3 Pro tier.
- **Tests:** backend Google suite 650 pass; frontend `EvalOutputCell` 130 pass; lint/format/`tsc` clean; `promptfoo validate` passes on the example.
- **Reviews:** Copilot + Codex feedback addressed (resolution-aware pricing, docs accuracy, Flash-Lite grounding caveat, router comment, hoisted cost tables).

## Coverage note

Our text/chat coverage is otherwise already complete for the current lineup (2.0→3.5 tiers, `*-latest` aliases, computer-use, gemma-4, embeddings, robotics-1.6). Remaining catalog entries (Veo 3.1, TTS/audio, Lyria, deep-research) are owned by other providers or specialized families, out of scope here.