### PR TITLE
docs: replace LLMs.txt specification link

### DIFF
--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -127,7 +127,7 @@ These settings are not a network firewall. For strict offline or air-gapped use,
 
 ### Do you publish an LLMs.txt?
 
-Yes. The documentation website follows the [LLMs.txt specification](https://llmspec.ai/) so automated tools can easily index our content. You can access the files at:
+Yes. The documentation website follows the [LLMs.txt specification](https://llmstxt.org/) so automated tools can easily index our content. You can access the files at:
 
 - [llms.txt](https://www.promptfoo.dev/llms.txt) - Navigation and structure
 - [llms-full.txt](https://www.promptfoo.dev/llms-full.txt) - Complete documentation content


### PR DESCRIPTION
Updated the LLMs.txt specification link to the correct URL.

I think the fictional `llmspec.ai` is the result of hallucinations.