### PR TITLE
fix(providers): correct Mistral alias pricing drift and refresh models/docs

### DIFF
--- a/examples/mistral/README.md
+++ b/examples/mistral/README.md
@@ -17,26 +17,26 @@ This example requires:
 
 ## What This Example Shows
 
-- **Mathematical Reasoning**: AIME2024 competition problems with Magistral models
+- **Mathematical Reasoning**: AIME2024 competition problems with Magistral Medium
 - **Model Comparison**: Compare Mistral's different model capabilities
-- **Reasoning Models**: Showcase Magistral Small and Medium for complex problems
+- **Reasoning Models**: Showcase Magistral Medium (native reasoning) vs. Mistral Small 4
 - **Chat Capabilities**: General conversation and task completion
 - **Mistral-powered Evaluation**: Use Mistral models for grading instead of OpenAI
 - **Mistral Embeddings**: Use Mistral's embedding model for similarity checks
 
 ## Models Demonstrated
 
-### Reasoning Models (Magistral)
+### Reasoning Models
 
-- **Magistral Medium** (`magistral-medium-latest`): Enterprise reasoning model ($2/$5 per M tokens)
-- **Magistral Small** (`magistral-small-latest`): Open-source reasoning model ($0.5/$1.5 per M tokens)
+- **Magistral Medium** (`magistral-medium-latest` → `magistral-medium-2509`): Native reasoning model ($2/$5 per 1M tokens, 128k context) — the reasoning showcase in these examples.
 
-### Traditional Chat Models
+> Mistral folded Magistral Small into **Mistral Small 4**: the `magistral-small-latest` alias now resolves to `mistral-small-2603` (a hybrid model, $0.15/$0.60 per 1M), so these examples use the canonical `mistral-small-latest` id. Enable Small 4's reasoning mode with `reasoning_effort: high`. The standalone `magistral-small-2509` snapshot is deprecated (retires 2026-07-31).
 
-- **Mistral Large** (`mistral-large-latest`): Top-tier model for complex tasks
-- **Mistral Medium** (`mistral-medium-latest`): Balanced multimodal model
-- **Mistral Small** (`mistral-small-latest`): Efficient general-purpose model
-- **Mistral Large 3** (`mistral-large-2512`): Current multimodal large model
+### Chat Models
+
+- **Mistral Medium 3.5** (`mistral-medium-latest` → `mistral-medium-2604`): Frontier agentic/coding multimodal model ($1.50/$7.50 per 1M, 256k context)
+- **Mistral Large 3** (`mistral-large-latest` → `mistral-large-2512`): General-purpose multimodal model ($0.50/$1.50 per 1M, 256k context)
+- **Mistral Small 4** (`mistral-small-latest` → `mistral-small-2603`): Hybrid instruct/reasoning/coding model ($0.15/$0.60 per 1M, 256k context)
 
 ### Evaluation Models
 

--- a/examples/mistral/promptfooconfig.aime2024.yaml
+++ b/examples/mistral/promptfooconfig.aime2024.yaml
@@ -17,8 +17,10 @@ providers:
       temperature: 0.7
       top_p: 0.95
       max_tokens: 40960
-  - id: mistral:magistral-small-latest
-    label: Magistral Small
+  # The `magistral-small-latest` alias now resolves to Mistral Small 4, so use the
+  # canonical id. It contrasts a general hybrid model against native-reasoning Magistral.
+  - id: mistral:mistral-small-latest
+    label: Mistral Small 4
     config:
       temperature: 0.7
       top_p: 0.95

--- a/examples/mistral/promptfooconfig.comparison.yaml
+++ b/examples/mistral/promptfooconfig.comparison.yaml
@@ -2,8 +2,9 @@
 description: 'Compare reasoning capabilities across Mistral models'
 
 providers:
+  # `magistral-small-latest` was dropped: it now resolves to the same model as
+  # `mistral-small-latest` (Mistral Small 4), so listing both would duplicate a model.
   - mistral:magistral-medium-latest
-  - mistral:magistral-small-latest
   - mistral:mistral-large-latest
   - mistral:mistral-small-latest
 
@@ -15,7 +16,7 @@ tests:
       problem: "A company has 100 employees. 60% work remotely, 25% work hybrid, and the rest work in office. If remote workers get a $200 stipend and hybrid workers get $100, what's the total monthly stipend cost?"
     assert:
       - type: llm-rubric
-        value: 'Shows clear mathematical reasoning and arrives at correct answer ($13,500)'
+        value: 'Shows clear mathematical reasoning and arrives at correct answer ($14,500)'
       - type: cost
         threshold: 0.10
 

--- a/examples/mistral/promptfooconfig.reasoning.yaml
+++ b/examples/mistral/promptfooconfig.reasoning.yaml
@@ -9,8 +9,10 @@ providers:
       top_p: 0.95
       max_tokens: 40960
 
-  - id: mistral:magistral-small-latest
-    label: magistral-small
+  # The `magistral-small-latest` alias now resolves to Mistral Small 4, so use the
+  # canonical id. Small 4 solves these with chain-of-thought when prompted to.
+  - id: mistral:mistral-small-latest
+    label: mistral-small-4
     config:
       temperature: 0.7
       top_p: 0.95
@@ -20,32 +22,23 @@ prompts:
   - 'Think through this problem step by step: {{problem}}'
 
 tests:
+  # Reasoning models keep their working in a separate (stripped) thinking chunk and format
+  # final answers with LaTeX, so correctness is graded with a model rubric rather than brittle
+  # substring matching.
   - vars:
-      problem: 'A farmer has chickens and rabbits in a pen. There are 30 heads and 74 legs total. How many chickens and how many rabbits are there?'
+      problem: 'A farmer has chickens and rabbits in a pen. There are 30 heads and 88 legs total. How many chickens and how many rabbits are there?'
     assert:
-      - type: contains
-        value: 'step'
       - type: llm-rubric
         value: 'Correctly identifies that there are 16 chickens and 14 rabbits through systematic reasoning'
-      - type: contains-any
-        value: ['16 chickens', '14 rabbits', 'chickens: 16', 'rabbits: 14']
 
   - vars:
       problem: 'Three friends split a restaurant bill. Alice pays twice as much as Bob, and Charlie pays $15 more than Bob. If the total bill is $105, how much does each person pay?'
     assert:
-      - type: contains
-        value: 'equation'
       - type: llm-rubric
         value: 'Shows the algebraic setup and correctly calculates Bob: $22.50, Alice: $45, Charlie: $37.50'
-      - type: contains-any
-        value: ['22.50', '$22.50', '45', '$45', '37.50', '$37.50']
 
   - vars:
       problem: 'A water tank is being filled by two pipes and drained by one pipe. Pipe A fills at 10 gallons/minute, Pipe B fills at 15 gallons/minute, and the drain empties at 8 gallons/minute. If all pipes operate simultaneously and the tank starts empty, how long will it take to fill a 340-gallon tank?'
     assert:
-      - type: contains
-        value: 'rate'
       - type: llm-rubric
         value: 'Correctly calculates the net fill rate (17 gallons/minute) and determines it takes 20 minutes'
-      - type: contains-any
-        value: ['20 minutes', '20 min', '17 gallons/minute', '17 gal/min']

--- a/examples/mistral/promptfooconfig.yaml
+++ b/examples/mistral/promptfooconfig.yaml
@@ -13,13 +13,6 @@ providers:
       top_p: 0.95
       max_tokens: 40960
 
-  - id: mistral:magistral-small-latest
-    label: magistral-small
-    config:
-      temperature: 0.7
-      top_p: 0.95
-      max_tokens: 40960
-
   # Traditional chat models
   - id: mistral:mistral-large-latest
     label: large

--- a/site/docs/providers/mistral.md
+++ b/site/docs/providers/mistral.md
@@ -187,41 +187,61 @@ You can specify which Mistral model to use in your configuration. The following 
 
 #### Current Models
 
-| Model                     | Context | Input Price | Output Price | Best For (resolves to)                                    |
-| ------------------------- | ------- | ----------- | ------------ | --------------------------------------------------------- |
-| `mistral-medium-latest`   | 256k    | $1.50/1M    | $7.50/1M     | Agentic and coding-heavy workloads (Medium 3.5, `-2604`)  |
-| `mistral-large-latest`    | 256k    | $0.50/1M    | $1.50/1M     | General-purpose multimodal tasks (Large 3, `-2512`)       |
-| `mistral-small-latest`    | 256k    | $0.15/1M    | $0.60/1M     | Hybrid instruct, reasoning, and coding (Small 4, `-2603`) |
-| `magistral-medium-latest` | 128k    | $2.00/1M    | $5.00/1M     | Native reasoning (Magistral Medium, `-2509`)              |
-| `codestral-latest`        | 256k    | $0.30/1M    | $0.90/1M     | Code generation and FIM (`codestral-2508`)                |
-| `devstral-medium-latest`  | 256k    | $0.40/1M    | $2.00/1M     | Software-engineering agents (Devstral 2, `devstral-2512`) |
-| `ministral-14b-latest`    | 256k    | $0.20/1M    | $0.20/1M     | Compact multimodal deployments                            |
-| `ministral-8b-latest`     | 256k    | $0.15/1M    | $0.15/1M     | Efficient on-prem/edge deployments                        |
-| `ministral-3b-latest`     | 128k    | $0.10/1M    | $0.10/1M     | Smallest multimodal deployments                           |
-| `open-mistral-nemo`       | 128k    | $0.15/1M    | $0.15/1M     | Multilingual and research workloads                       |
+| Model                     | Context | Input Price | Output Price | Capabilities             | Best For                                 |
+| ------------------------- | ------- | ----------- | ------------ | ------------------------ | ---------------------------------------- |
+| `mistral-medium-latest`   | 256k    | $1.50/1M    | $7.50/1M     | Text, vision, reasoning¹ | Agentic and coding-heavy workloads       |
+| `mistral-large-latest`    | 256k    | $0.50/1M    | $1.50/1M     | Text, vision             | General-purpose multimodal tasks         |
+| `mistral-small-latest`    | 256k    | $0.15/1M    | $0.60/1M     | Text, vision, reasoning¹ | Hybrid instruct, reasoning, and coding   |
+| `magistral-medium-latest` | 128k    | $2.00/1M    | $5.00/1M     | Native reasoning, vision | Step-by-step reasoning                   |
+| `codestral-latest`        | 256k    | $0.30/1M    | $0.90/1M     | Code, FIM                | Code generation and completion           |
+| `devstral-medium-latest`  | 256k    | $0.40/1M    | $2.00/1M     | Code agents              | Software-engineering agents (Devstral 2) |
+| `ministral-14b-latest`    | 256k    | $0.20/1M    | $0.20/1M     | Text, vision             | Compact multimodal deployments           |
+| `ministral-8b-latest`     | 256k    | $0.15/1M    | $0.15/1M     | Text, vision             | Efficient on-prem/edge deployments       |
+| `ministral-3b-latest`     | 128k    | $0.10/1M    | $0.10/1M     | Text, vision             | Smallest multimodal deployments          |
+| `open-mistral-nemo`       | 128k    | $0.15/1M    | $0.15/1M     | Text                     | Multilingual and research workloads      |
 
-:::note
+¹ Enable adjustable reasoning with `reasoning_effort: high`.
 
-`*-latest` and bare aliases follow whatever snapshot Mistral currently points them at, so
-their price tracks the resolved model. Both `mistral-medium-latest` and bare `mistral-medium`
-now resolve to Mistral Medium 3.5, and `magistral-small-latest` was folded into Mistral Small 4.
-Pin a dated snapshot (e.g. `mistral-medium-2604`) for stable pricing and behavior.
+:::note Aliases move — pin a snapshot for stability
+
+`*-latest` and bare aliases follow whatever snapshot Mistral currently points them at, so their
+price and behavior track the resolved model. Pin a dated snapshot (e.g. `mistral-medium-2604`)
+when you need stable pricing and behavior.
 
 :::
 
-#### Legacy Models (Deprecated)
+#### Model aliases and snapshots
 
-1. `open-mistral-7b`, `mistral-tiny`, `mistral-tiny-2312`
-2. `mistral-tiny-2407`, `mistral-tiny-latest`
-3. `mistral-small-2402`
-4. `mistral-medium-2312` (bare `mistral-medium` now resolves to Mistral Medium 3.5)
-5. `mistral-large-2402`
-6. `mistral-large-2407`
-7. `codestral-2405`
-8. `codestral-mamba-2407`, `open-codestral-mamba`, `codestral-mamba-latest`
-9. `open-mixtral-8x7b`, `mistral-small`, `mistral-small-2312`
-10. `open-mixtral-8x22b`, `open-mixtral-8x22b-2404`
-11. `magistral-small-2506`, `magistral-small-2507`, `magistral-small-2509` - reasoning snapshots deprecated after April 30, 2026 (`magistral-small-latest` now resolves to Mistral Small 4)
+| Alias                                                                                                     | Resolves to                                |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `mistral-medium-latest`, `mistral-medium`, `mistral-medium-3`, `mistral-medium-3-5`, `mistral-medium-3.5` | `mistral-medium-2604` (Mistral Medium 3.5) |
+| `mistral-large-latest`                                                                                    | `mistral-large-2512` (Mistral Large 3)     |
+| `mistral-small-latest`, `magistral-small-latest`                                                          | `mistral-small-2603` (Mistral Small 4)     |
+| `magistral-medium-latest`                                                                                 | `magistral-medium-2509` (Magistral Medium) |
+| `codestral-latest`, `mistral-code-latest`, `mistral-code-fim-latest`                                      | `codestral-2508` (Codestral)               |
+| `devstral-latest`, `devstral-medium-latest`, `mistral-code-agent-latest`                                  | `devstral-2512` (Devstral 2)               |
+| `open-mistral-nemo`, `mistral-tiny-latest`, `mistral-tiny-2407`                                           | `open-mistral-nemo-2407` (Mistral NeMo)    |
+
+The `magistral-small-latest` alias now resolves to Mistral Small 4 (a hybrid model), not the
+standalone Magistral Small reasoning snapshot. Enable Small 4's reasoning with
+`reasoning_effort: high`.
+
+#### Legacy Models (Deprecated or Retired)
+
+promptfoo keeps these IDs so it can cost-score cached results. **Retired** IDs return an error if you call them today; **deprecated** IDs still work until their retirement date.
+
+1. `open-mistral-7b`, `mistral-tiny`, `mistral-tiny-2312` (retired)
+2. `mistral-small-2402` (retired)
+3. `mistral-medium-2312` (retired; bare `mistral-medium` now resolves to Mistral Medium 3.5)
+4. `mistral-medium-2505`, `mistral-medium-2508` (Mistral Medium 3 / 3.1, deprecated — succeeded by Mistral Medium 3.5)
+5. `mistral-small-2506` (Mistral Small 3.2, deprecated — succeeded by Mistral Small 4)
+6. `mistral-large-2402`, `mistral-large-2407` (retired)
+7. `codestral-2405`, `codestral-mamba-2407`, `open-codestral-mamba`, `codestral-mamba-latest` (retired)
+8. `open-mixtral-8x7b`, `open-mixtral-8x22b`, `open-mixtral-8x22b-2404`, `mistral-small`, `mistral-small-2312` (retired)
+9. `pixtral-12b` (retired — use a current vision model such as `mistral-large-latest`)
+10. `magistral-small-2506`, `magistral-small-2507` (retired); `magistral-small-2509` — standalone reasoning snapshot, deprecated 2026-04-30, retiring 2026-07-31 (`magistral-small-latest` now resolves to Mistral Small 4)
+
+> `mistral-tiny-2407` / `mistral-tiny-latest` are **not** legacy — they are current aliases of `open-mistral-nemo` (see the aliases table above).
 
 ### Embedding Models
 
@@ -250,8 +270,9 @@ providers:
 
 Mistral's **Magistral** models are specialized native reasoning models. `magistral-medium-latest`
 currently points to the 2509 generation, which uses tokenized thinking chunks and a 128k
-context window. Mistral's public model card marks `magistral-small-2509` for deprecation
-after April 30, 2026.
+context window. Mistral's public model card deprecated the standalone `magistral-small-2509`
+snapshot on 2026-04-30 (retiring 2026-07-31); the `magistral-small-latest` alias now resolves to
+Mistral Small 4, whose reasoning mode you enable with `reasoning_effort: high`.
 
 ### Key Features of Magistral Models
 
@@ -262,7 +283,8 @@ after April 30, 2026.
 
 ### Magistral Model Variants
 
-- **Magistral Medium** (`magistral-medium-latest` / `magistral-medium-2509`)
+- **Magistral Medium** (`magistral-medium-latest` / `magistral-medium-2509`) — native reasoning
+- **Mistral Small 4** (`mistral-small-latest` / `magistral-small-latest`) — hybrid model; enable reasoning with `reasoning_effort: high`
 
 ### Usage Recommendations
 
@@ -540,7 +562,7 @@ export MISTRAL_API_HOST="api.mistral.ai"
 providers:
   - id: mistral:magistral-medium-latest
     config:
-      max_tokens: 8000 # Leave room for 32k input context
+      max_tokens: 8000 # Leave room for 128k input context
       temperature: 0.7
 ```
 
@@ -610,7 +632,7 @@ Error: Context length exceeded
 
 ```yaml
 providers:
-  - id: mistral:mistral-medium-latest # 128k context
+  - id: mistral:mistral-medium-latest # 256k context
     config:
       max_tokens: 4000 # Leave room for input
 ```
@@ -626,7 +648,7 @@ Error: Model not found
 ```yaml
 providers:
   - mistral:mistral-large-latest # ✅ Use latest
-  # - mistral:mistral-large-2402  # ❌ Deprecated
+  # - mistral:mistral-large-2402  # ❌ Retired
 ```
 
 ### Debugging Tips
@@ -680,7 +702,7 @@ npx promptfoo@latest init --example mistral
 - **[JSON Mode](https://github.com/promptfoo/promptfoo/blob/main/examples/mistral/promptfooconfig.json-mode.yaml)** - Structured output generation
 - **[Code Generation](https://github.com/promptfoo/promptfoo/blob/main/examples/mistral/promptfooconfig.code-generation.yaml)** - Multi-language code generation with Codestral
 - **[Reasoning Tasks](https://github.com/promptfoo/promptfoo/blob/main/examples/mistral/promptfooconfig.reasoning.yaml)** - Advanced step-by-step problem solving
-- **[Multimodal](https://github.com/promptfoo/promptfoo/blob/main/examples/mistral/promptfooconfig.multimodal.yaml)** - Vision capabilities with Pixtral
+- **[Multimodal](https://github.com/promptfoo/promptfoo/blob/main/examples/mistral/promptfooconfig.multimodal.yaml)** - Vision capabilities with a current multimodal model (`mistral-large-2512`)
 
 ### Quick Start
 

--- a/site/docs/providers/mistral.md
+++ b/site/docs/providers/mistral.md
@@ -69,6 +69,7 @@ providers:
       n: 1 # Number of completions
       reasoning_effort: high # high | none on adjustable reasoning models
       prompt_mode: reasoning # reasoning | null on native reasoning models
+      prompt_cache_key: shared-prefix # Reuse Mistral's server-side prompt cache across requests
 ```
 
 `safe_prompt` is still accepted for compatibility, but Mistral now recommends inline
@@ -186,35 +187,54 @@ You can specify which Mistral model to use in your configuration. The following 
 
 #### Current Models
 
-| Model                     | Context | Input Price | Output Price | Best For                               |
-| ------------------------- | ------- | ----------- | ------------ | -------------------------------------- |
-| `mistral-medium-3.5`      | 256k    | $1.50/1M    | $7.50/1M     | Agentic and coding-heavy workloads     |
-| `mistral-large-latest`    | 256k    | $0.50/1M    | $1.50/1M     | General-purpose multimodal tasks       |
-| `mistral-medium-latest`   | 128k    | $0.40/1M    | $2.00/1M     | Balanced multimodal workloads          |
-| `mistral-small-latest`    | 128k    | $0.10/1M    | $0.30/1M     | Cost-sensitive general tasks           |
-| `mistral-small-2603`      | 256k    | $0.15/1M    | $0.60/1M     | Hybrid instruct, reasoning, and coding |
-| `codestral-latest`        | 128k    | $0.30/1M    | $0.90/1M     | Code generation and FIM                |
-| `magistral-medium-latest` | 128k    | $2.00/1M    | $5.00/1M     | Native reasoning                       |
-| `open-mistral-nemo-2407`  | 128k    | $0.15/1M    | $0.15/1M     | Multilingual and research workloads    |
-| `ministral-14b-latest`    | 256k    | $0.20/1M    | $0.20/1M     | Compact multimodal deployments         |
+| Model                     | Context | Input Price | Output Price | Best For (resolves to)                                    |
+| ------------------------- | ------- | ----------- | ------------ | --------------------------------------------------------- |
+| `mistral-medium-latest`   | 256k    | $1.50/1M    | $7.50/1M     | Agentic and coding-heavy workloads (Medium 3.5, `-2604`)  |
+| `mistral-large-latest`    | 256k    | $0.50/1M    | $1.50/1M     | General-purpose multimodal tasks (Large 3, `-2512`)       |
+| `mistral-small-latest`    | 256k    | $0.15/1M    | $0.60/1M     | Hybrid instruct, reasoning, and coding (Small 4, `-2603`) |
+| `magistral-medium-latest` | 128k    | $2.00/1M    | $5.00/1M     | Native reasoning (Magistral Medium, `-2509`)              |
+| `codestral-latest`        | 256k    | $0.30/1M    | $0.90/1M     | Code generation and FIM (`codestral-2508`)                |
+| `devstral-medium-latest`  | 256k    | $0.40/1M    | $2.00/1M     | Software-engineering agents (Devstral 2, `devstral-2512`) |
+| `ministral-14b-latest`    | 256k    | $0.20/1M    | $0.20/1M     | Compact multimodal deployments                            |
+| `ministral-8b-latest`     | 256k    | $0.15/1M    | $0.15/1M     | Efficient on-prem/edge deployments                        |
+| `ministral-3b-latest`     | 128k    | $0.10/1M    | $0.10/1M     | Smallest multimodal deployments                           |
+| `open-mistral-nemo`       | 128k    | $0.15/1M    | $0.15/1M     | Multilingual and research workloads                       |
+
+:::note
+
+`*-latest` and bare aliases follow whatever snapshot Mistral currently points them at, so
+their price tracks the resolved model. Both `mistral-medium-latest` and bare `mistral-medium`
+now resolve to Mistral Medium 3.5, and `magistral-small-latest` was folded into Mistral Small 4.
+Pin a dated snapshot (e.g. `mistral-medium-2604`) for stable pricing and behavior.
+
+:::
 
 #### Legacy Models (Deprecated)
 
 1. `open-mistral-7b`, `mistral-tiny`, `mistral-tiny-2312`
 2. `mistral-tiny-2407`, `mistral-tiny-latest`
 3. `mistral-small-2402`
-4. `mistral-medium-2312`, `mistral-medium`
+4. `mistral-medium-2312` (bare `mistral-medium` now resolves to Mistral Medium 3.5)
 5. `mistral-large-2402`
 6. `mistral-large-2407`
 7. `codestral-2405`
 8. `codestral-mamba-2407`, `open-codestral-mamba`, `codestral-mamba-latest`
 9. `open-mixtral-8x7b`, `mistral-small`, `mistral-small-2312`
 10. `open-mixtral-8x22b`, `open-mixtral-8x22b-2404`
-11. `magistral-small-latest`, `magistral-small-2509` - deprecated after April 30, 2026
+11. `magistral-small-2506`, `magistral-small-2507`, `magistral-small-2509` - reasoning snapshots deprecated after April 30, 2026 (`magistral-small-latest` now resolves to Mistral Small 4)
 
-### Embedding Model
+### Embedding Models
 
 - `mistral-embed` - $0.10/1M tokens - 8k context
+- `codestral-embed` (`codestral-embed-2505`) - $0.15/1M tokens - code-optimized embeddings
+
+Select an embedding model with the `mistral:embedding:` prefix:
+
+```yaml
+providers:
+  - mistral:embedding:mistral-embed
+  - mistral:embedding:codestral-embed
+```
 
 Here's an example config that compares different Mistral models:
 

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -77,17 +77,22 @@ const MISTRAL_CHAT_MODELS = [
       output: 2 / 1000000,
     },
   })),
-  // Mistral Medium 3.5 — `mistral-medium-latest` and bare `mistral-medium` now resolve
-  // to `mistral-medium-2604`
-  ...['mistral-medium-2604', 'mistral-medium-3.5', 'mistral-medium-latest', 'mistral-medium'].map(
-    (id) => ({
-      id,
-      cost: {
-        input: 1.5 / 1000000,
-        output: 7.5 / 1000000,
-      },
-    }),
-  ),
+  // Mistral Medium 3.5 — `mistral-medium-latest`, bare `mistral-medium`, and the
+  // `mistral-medium-3` / `mistral-medium-3-5` aliases all resolve to `mistral-medium-2604`
+  ...[
+    'mistral-medium-2604',
+    'mistral-medium-3.5',
+    'mistral-medium-3-5',
+    'mistral-medium-3',
+    'mistral-medium-latest',
+    'mistral-medium',
+  ].map((id) => ({
+    id,
+    cost: {
+      input: 1.5 / 1000000,
+      output: 7.5 / 1000000,
+    },
+  })),
   {
     id: 'mistral-large-2402',
     cost: {
@@ -116,13 +121,16 @@ const MISTRAL_CHAT_MODELS = [
       output: 3 / 1000000,
     },
   },
-  ...['codestral-2508', 'codestral-latest'].map((id) => ({
-    id,
-    cost: {
-      input: 0.3 / 1000000,
-      output: 0.9 / 1000000,
-    },
-  })),
+  // Codestral — also aliased by the Mistral Code product ids
+  ...['codestral-2508', 'codestral-latest', 'mistral-code-latest', 'mistral-code-fim-latest'].map(
+    (id) => ({
+      id,
+      cost: {
+        input: 0.3 / 1000000,
+        output: 0.9 / 1000000,
+      },
+    }),
+  ),
   ...['codestral-mamba-2407', 'open-codestral-mamba', 'codestral-mamba-latest'].map((id) => ({
     id,
     cost: {
@@ -186,7 +194,13 @@ const MISTRAL_CHAT_MODELS = [
       output: 0.2 / 1000000,
     },
   })),
-  ...['devstral-2512', 'devstral-latest', 'devstral-medium-latest'].map((id) => ({
+  // Devstral 2 — `mistral-code-agent-latest` is the Mistral Code agent alias
+  ...[
+    'devstral-2512',
+    'devstral-latest',
+    'devstral-medium-latest',
+    'mistral-code-agent-latest',
+  ].map((id) => ({
     id,
     cost: {
       input: 0.4 / 1000000,

--- a/src/providers/mistral.ts
+++ b/src/providers/mistral.ts
@@ -44,41 +44,50 @@ const MISTRAL_CHAT_MODELS = [
       output: 3 / 1000000,
     },
   },
-  ...['mistral-small-2506', 'mistral-small-latest'].map((id) => ({
-    id,
+  // Mistral Small 3.2 (deprecated 2026-07-30) — historical pricing for cached results
+  {
+    id: 'mistral-small-2506',
     cost: {
       input: 0.1 / 1000000,
       output: 0.3 / 1000000,
     },
-  })),
-  {
-    id: 'mistral-small-2603',
+  },
+  // Mistral Small 4 — `mistral-small-latest` and `magistral-small-latest` (Magistral Small
+  // was folded into Mistral Small 4) both resolve to `mistral-small-2603`
+  ...['mistral-small-2603', 'mistral-small-latest', 'magistral-small-latest'].map((id) => ({
+    id,
     cost: {
       input: 0.15 / 1000000,
       output: 0.6 / 1000000,
     },
-  },
-  ...['mistral-medium-2312', 'mistral-medium'].map((id) => ({
-    id,
+  })),
+  // Mistral Medium 1 (retired) — historical pricing for cached results
+  {
+    id: 'mistral-medium-2312',
     cost: {
       input: 2.7 / 1000000,
       output: 8.1 / 1000000,
     },
-  })),
-  ...['mistral-medium-2505', 'mistral-medium-2508', 'mistral-medium-latest'].map((id) => ({
+  },
+  // Mistral Medium 3 / 3.1 (deprecated) — historical pricing for cached results
+  ...['mistral-medium-2505', 'mistral-medium-2508'].map((id) => ({
     id,
     cost: {
       input: 0.4 / 1000000,
       output: 2 / 1000000,
     },
   })),
-  {
-    id: 'mistral-medium-3.5',
-    cost: {
-      input: 1.5 / 1000000,
-      output: 7.5 / 1000000,
-    },
-  },
+  // Mistral Medium 3.5 — `mistral-medium-latest` and bare `mistral-medium` now resolve
+  // to `mistral-medium-2604`
+  ...['mistral-medium-2604', 'mistral-medium-3.5', 'mistral-medium-latest', 'mistral-medium'].map(
+    (id) => ({
+      id,
+      cost: {
+        input: 1.5 / 1000000,
+        output: 7.5 / 1000000,
+      },
+    }),
+  ),
   {
     id: 'mistral-large-2402',
     cost: {
@@ -135,12 +144,9 @@ const MISTRAL_CHAT_MODELS = [
       output: 6 / 1000000,
     },
   })),
-  ...[
-    'magistral-small-2506',
-    'magistral-small-2507',
-    'magistral-small-2509',
-    'magistral-small-latest',
-  ].map((id) => ({
+  // Magistral Small standalone reasoning snapshots. `magistral-small-latest` was
+  // repointed to Mistral Small 4 (priced above); 2506/2507 retired, 2509 deprecated.
+  ...['magistral-small-2506', 'magistral-small-2507', 'magistral-small-2509'].map((id) => ({
     id,
     cost: {
       input: 0.5 / 1000000,
@@ -180,7 +186,7 @@ const MISTRAL_CHAT_MODELS = [
       output: 0.2 / 1000000,
     },
   })),
-  ...['devstral-2512', 'devstral-latest'].map((id) => ({
+  ...['devstral-2512', 'devstral-latest', 'devstral-medium-latest'].map((id) => ({
     id,
     cost: {
       input: 0.4 / 1000000,
@@ -198,13 +204,20 @@ const MISTRAL_CHAT_MODELS = [
 ];
 
 const MISTRAL_EMBEDDING_MODELS = [
-  {
-    id: 'mistral-embed',
+  ...['mistral-embed', 'mistral-embed-2312'].map((id) => ({
+    id,
     cost: {
       input: 0.1 / 1000000,
       output: 0.1 / 1000000,
     },
-  },
+  })),
+  ...['codestral-embed', 'codestral-embed-2505'].map((id) => ({
+    id,
+    cost: {
+      input: 0.15 / 1000000,
+      output: 0.15 / 1000000,
+    },
+  })),
 ];
 
 interface MistralChatCompletionOptions {
@@ -241,6 +254,7 @@ interface MistralChatCompletionOptions {
       };
   prompt_mode?: 'reasoning' | null;
   reasoning_effort?: 'high' | 'none';
+  prompt_cache_key?: string;
   prediction?: Record<string, unknown> | null;
   metadata?: Record<string, unknown> | null;
   guardrails?: Array<Record<string, unknown>> | null;
@@ -411,6 +425,7 @@ function buildMistralChatParams(
     random_seed: config.random_seed ?? null,
     ...('prompt_mode' in config ? { prompt_mode: config.prompt_mode } : {}),
     ...(config.reasoning_effort === undefined ? {} : { reasoning_effort: config.reasoning_effort }),
+    ...(config.prompt_cache_key === undefined ? {} : { prompt_cache_key: config.prompt_cache_key }),
     ...('prediction' in config ? { prediction: config.prediction } : {}),
     ...('metadata' in config ? { metadata: config.metadata } : {}),
     ...('guardrails' in config ? { guardrails: config.guardrails } : {}),
@@ -720,11 +735,21 @@ export class MistralEmbeddingProvider implements ApiProvider {
   config: MistralChatCompletionOptions;
   env?: EnvOverrides;
 
+  static MISTRAL_EMBEDDING_MODELS_NAMES = MISTRAL_EMBEDDING_MODELS.map((model) => model.id);
+
   constructor(
-    options: { config?: MistralChatCompletionOptions; id?: string; env?: EnvOverrides } = {},
+    options: {
+      modelName?: string;
+      config?: MistralChatCompletionOptions;
+      id?: string;
+      env?: EnvOverrides;
+    } = {},
   ) {
-    const { config, env } = options;
-    this.modelName = 'mistral-embed';
+    const { modelName, config, env } = options;
+    this.modelName = modelName || 'mistral-embed';
+    if (!MistralEmbeddingProvider.MISTRAL_EMBEDDING_MODELS_NAMES.includes(this.modelName)) {
+      logger.warn(`Using unknown Mistral embedding model: ${this.modelName}`);
+    }
     this.config = config || {};
     this.env = env;
   }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -786,7 +786,10 @@ export const providerMap: ProviderFactory[] = [
       const modelType = splits[1];
       const modelName = splits.slice(2).join(':');
       if (modelType === 'embedding' || modelType === 'embeddings') {
-        return new MistralEmbeddingProvider(providerOptions);
+        return new MistralEmbeddingProvider({
+          ...providerOptions,
+          modelName: modelName || undefined,
+        });
       }
       return new MistralChatCompletionProvider(modelName || modelType, providerOptions);
     },

--- a/test/providers/mistral.test.ts
+++ b/test/providers/mistral.test.ts
@@ -353,6 +353,60 @@ describe('Mistral', () => {
       expect(result.cost).toBeCloseTo(0.0011, 6);
     });
 
+    // Regression coverage: Mistral silently repoints `*-latest`/bare aliases to newer
+    // models. These lock the hardcoded pricing to whatever the alias resolves to today.
+    it.each([
+      // [model, input price/M, output price/M, expected cost for 400 in / 600 out]
+      // mistral-small-latest -> Mistral Small 4 (mistral-small-2603): $0.15/$0.60
+      ['mistral-small-latest', 0.00042],
+      // magistral-small-latest folded into Mistral Small 4: $0.15/$0.60
+      ['magistral-small-latest', 0.00042],
+      // mistral-medium-latest + bare mistral-medium -> Mistral Medium 3.5: $1.50/$7.50
+      ['mistral-medium-latest', 0.0051],
+      ['mistral-medium', 0.0051],
+      // mistral-medium-2604 is the canonical dated ID for Mistral Medium 3.5
+      ['mistral-medium-2604', 0.0051],
+    ])('tracks current pricing for %s', async (model, expectedCost) => {
+      const provider = new MistralChatCompletionProvider(model);
+      vi.spyOn(provider, 'getApiKey').mockReturnValue('fake-api-key');
+
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: {
+          choices: [{ message: { content: 'ok' } }],
+          usage: { total_tokens: 1000, prompt_tokens: 400, completion_tokens: 600 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test alias pricing');
+      expect(result.cost).toBeCloseTo(expectedCost, 6);
+    });
+
+    it('forwards prompt_cache_key in the request body', async () => {
+      const provider = new MistralChatCompletionProvider('mistral-large-latest', {
+        config: { prompt_cache_key: 'shared-prefix-1' },
+      });
+      vi.spyOn(provider, 'getApiKey').mockReturnValue('fake-api-key');
+
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: {
+          choices: [{ message: { content: 'ok' } }],
+          usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      await provider.callApi('Test prompt cache key');
+
+      const requestInit = vi.mocked(fetchWithCache).mock.calls[0]?.[1];
+      const body = JSON.parse(requestInit?.body as string);
+      expect(body.prompt_cache_key).toBe('shared-prefix-1');
+    });
+
     it('should use cache when enabled', async () => {
       vi.mocked(isCacheEnabled).mockReturnValue(true);
       vi.mocked(getCache).mockReturnValue({
@@ -923,6 +977,41 @@ describe('Mistral', () => {
     it('should create a provider with default options', () => {
       expect(provider.modelName).toBe('mistral-embed');
       expect(provider.config).toEqual({});
+    });
+
+    it('should support non-default embedding models such as codestral-embed', async () => {
+      const codestralProvider = new MistralEmbeddingProvider({ modelName: 'codestral-embed' });
+      vi.spyOn(codestralProvider, 'getApiKey').mockReturnValue('fake-api-key');
+      expect(codestralProvider.modelName).toBe('codestral-embed');
+      expect(codestralProvider.id()).toBe('mistral:embedding:codestral-embed');
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: {
+          model: 'codestral-embed',
+          data: [{ embedding: [0.1, 0.2, 0.3] }],
+          usage: { total_tokens: 1000, prompt_tokens: 1000 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await codestralProvider.callEmbeddingApi('Test code');
+
+      // Request sends the codestral-embed model
+      const requestInit = vi.mocked(fetchWithCache).mock.calls[0]?.[1];
+      const body = JSON.parse(requestInit?.body as string);
+      expect(body.model).toBe('codestral-embed');
+      // Codestral Embed input pricing is $0.15/1M: 1000 tokens => 0.00015
+      expect(result.cost).toBeCloseTo(0.00015, 6);
+    });
+
+    it('should warn on an unknown embedding model', () => {
+      const unknownProvider = new MistralEmbeddingProvider({ modelName: 'not-a-real-embed' });
+      expect(unknownProvider.modelName).toBe('not-a-real-embed');
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        expect.stringContaining('Using unknown Mistral embedding model'),
+      );
     });
 
     it('should call Mistral Embedding API and return embedding with correct structure', async () => {

--- a/test/providers/mistral.test.ts
+++ b/test/providers/mistral.test.ts
@@ -366,6 +366,12 @@ describe('Mistral', () => {
       ['mistral-medium', 0.0051],
       // mistral-medium-2604 is the canonical dated ID for Mistral Medium 3.5
       ['mistral-medium-2604', 0.0051],
+      // version aliases that also resolve to Mistral Medium 3.5
+      ['mistral-medium-3-5', 0.0051],
+      // Mistral Code product aliases resolve to Codestral: $0.30/$0.90
+      ['mistral-code-latest', 0.00066],
+      // Devstral 2 agent alias: $0.40/$2.00
+      ['mistral-code-agent-latest', 0.00136],
     ])('tracks current pricing for %s', async (model, expectedCost) => {
       const provider = new MistralChatCompletionProvider(model);
       vi.spyOn(provider, 'getApiKey').mockReturnValue('fake-api-key');

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -719,6 +719,33 @@ describe('Provider Registry', () => {
       }
     });
 
+    it.each([
+      [
+        'mistral:mistral-large-latest',
+        'MistralChatCompletionProvider',
+        'mistral:mistral-large-latest',
+      ],
+      ['mistral:embedding', 'MistralEmbeddingProvider', 'mistral:embedding:mistral-embed'],
+      [
+        'mistral:embeddings:mistral-embed',
+        'MistralEmbeddingProvider',
+        'mistral:embedding:mistral-embed',
+      ],
+      [
+        'mistral:embedding:codestral-embed',
+        'MistralEmbeddingProvider',
+        'mistral:embedding:codestral-embed',
+      ],
+    ])('should route %s correctly', async (path, expectedProviderName, expectedId) => {
+      const factories = await getProviderFactories(path);
+      const factory = factories.find((f) => f.test(path));
+      expect(factory).toBeDefined();
+
+      const provider = await factory!.create(path, { config: {} }, mockContext);
+      expect(provider.constructor.name).toBe(expectedProviderName);
+      expect(provider.id()).toBe(expectedId);
+    });
+
     it('should handle bedrock Luma Ray video provider with model version', async () => {
       const factories = await getProviderFactories('bedrock:luma.ray-v2:0');
       const factory = factories.find((f) => f.test('bedrock:luma.ray-v2:0'));


### PR DESCRIPTION
## Summary

Mistral silently repoints `*-latest` / bare aliases to newer models, so the provider's hardcoded per-model costs had drifted. This corrects the cost calculation, refreshes the model catalog, and audits the docs and examples against the **live** `/v1/models` catalog and pricing page.

### Cost-calculation fixes (verified live)

| Alias | Resolves to today | Was billed | Correct |
| --- | --- | --- | --- |
| `mistral-small-latest` | Mistral Small 4 (`mistral-small-2603`) | $0.10 / $0.30 | **$0.15 / $0.60** |
| `mistral-medium-latest` + bare `mistral-medium` | Mistral Medium 3.5 (`mistral-medium-2604`) | $0.40/$2.00 & $2.70/$8.10 | **$1.50 / $7.50** |
| `magistral-small-latest` | folded into Mistral Small 4 | $0.50 / $1.50 | **$0.15 / $0.60** |

Dated snapshots kept their historical prices (for cost-scoring cached results).

### Catalog / API additions

- New model IDs: `mistral-medium-2604` (canonical Medium 3.5), `mistral-medium-3` / `-3-5` aliases, `codestral-embed` / `codestral-embed-2505`, `mistral-embed-2312`, `devstral-medium-latest`, and the Mistral Code aliases (`mistral-code-latest` / `-fim-latest` / `-agent-latest`).
- `mistral:embedding:<model>` now selects the embedding model (was hardcoded to `mistral-embed`); e.g. `mistral:embedding:codestral-embed`.
- Added the `prompt_cache_key` request param (verified accepted by the live API).
- Confirmed `reasoning_effort` accepts only `none` | `high` (others 400) — type left as-is.

### Docs audit (`site/docs/providers/mistral.md`)

- New **Capabilities** column and a **Model aliases & snapshots** reference table.
- Fixed stale context windows (Medium is 256k, not 128k; Magistral is 128k, not 32k).
- Corrected Magistral Small status/dates; split the legacy list into deprecated vs. retired; removed the retired Pixtral reference.

### Examples audit (`examples/mistral/*`)

- Use the canonical `mistral-small-latest` id (the `magistral-small-latest` alias now points there); dropped duplicate entries.
- Fixed two wrong expected answers (stipend `$13,500 → $14,500`; farmer legs `74 → 88`) and made the reasoning assertions robust to LaTeX-formatted output.

## Test plan

- [x] `npx vitest run test/providers/mistral.test.ts test/providers/registry.test.ts` — 135 pass (added alias-pricing regression + embedding-routing tests)
- [x] `tsc --noEmit` — 0 errors
- [x] Live eval against `api.mistral.ai`: alias resolution + cost calc match the corrected rates to 6 decimals
- [x] `comparison` and `reasoning` example configs pass 100% against the live API