### PR TITLE
docs(site): fix stale source-code links and outdated references

### DIFF
--- a/site/docs/integrations/mcp-server.md
+++ b/site/docs/integrations/mcp-server.md
@@ -298,7 +298,6 @@ export ANTHROPIC_API_KEY=sk-ant-...
 
 # Configure promptfoo behavior
 export PROMPTFOO_CONFIG_DIR=/path/to/configs
-export PROMPTFOO_OUTPUT_DIR=/path/to/outputs
 
 # Start server with environment
 npx promptfoo@latest mcp --transport stdio

--- a/site/docs/providers/localai.md
+++ b/site/docs/providers/localai.md
@@ -23,7 +23,7 @@ The model name is typically the filename of the `.bin` file that you downloaded 
 
 ## Configuring parameters
 
-You can set parameters like `temperature` and `apiBaseUrl` ([full list here](https://github.com/promptfoo/promptfoo/blob/main/src/providers/localai.ts#L7)). For example, using [LocalAI's lunademo](https://localai.io/docs/getting-started/models/):
+You can set parameters like `temperature` and `apiBaseUrl` ([full list here](https://github.com/promptfoo/promptfoo/blob/main/src/providers/localai.ts#L16)). For example, using [LocalAI's lunademo](https://localai.io/docs/getting-started/models/):
 
 ```yaml title="promptfooconfig.yaml"
 providers:

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -54,7 +54,7 @@ providers:
         effort: minimal # GPT-5.5 uses none instead
 ```
 
-The OpenAI provider supports a handful of [configuration options](https://github.com/promptfoo/promptfoo/blob/main/src/providers/openai/types.ts#L112-L185), such as `temperature`, `max_tokens`, `max_completion_tokens`, `functions`, and `tools`, which can be used to customize model behavior like so:
+The OpenAI provider supports a handful of [configuration options](https://github.com/promptfoo/promptfoo/blob/main/src/providers/openai/types.ts#L128-L212), such as `temperature`, `max_tokens`, `max_completion_tokens`, `functions`, and `tools`, which can be used to customize model behavior like so:
 
 ```yaml title="promptfooconfig.yaml"
 providers:

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -54,7 +54,7 @@ providers:
         effort: minimal # GPT-5.5 uses none instead
 ```
 
-The OpenAI provider supports a handful of [configuration options](https://github.com/promptfoo/promptfoo/blob/main/src/providers/openai/types.ts#L128-L212), such as `temperature`, `max_tokens`, `max_completion_tokens`, `functions`, and `tools`, which can be used to customize model behavior like so:
+The OpenAI provider supports a handful of [configuration options](https://github.com/promptfoo/promptfoo/blob/main/src/providers/openai/types.ts#L131-L215), such as `temperature`, `max_tokens`, `max_completion_tokens`, `functions`, and `tools`, which can be used to customize model behavior like so:
 
 ```yaml title="promptfooconfig.yaml"
 providers:

--- a/site/docs/providers/replicate.md
+++ b/site/docs/providers/replicate.md
@@ -55,7 +55,7 @@ providers:
 
 ## Configuration
 
-The Replicate provider supports several [configuration options](https://github.com/promptfoo/promptfoo/blob/main/src/providers/replicate.ts#L9-L17) that can be used to customize the behavior of the models, like so:
+The Replicate provider supports several [configuration options](https://github.com/promptfoo/promptfoo/blob/main/src/providers/replicate.ts#L24) that can be used to customize the behavior of the models, like so:
 
 | Parameter            | Description                                                   |
 | -------------------- | ------------------------------------------------------------- |

--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -601,7 +601,7 @@ The severity levels affect:
 - Issue prioritization in vulnerability tables
 - Dashboard statistics and metrics
 
-See [source code](https://github.com/promptfoo/promptfoo/blob/main/src/redteam/constants.ts#L553) for a list of default severity levels.
+See [source code](https://github.com/promptfoo/promptfoo/blob/main/src/redteam/constants/metadata.ts#L504) for a list of default severity levels.
 
 ### Strategies
 

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -77,7 +77,7 @@ Most commands support the following common options:
 
 :::note
 
-For `promptfoo eval`, `-v` is the short form of `--vars`, so the `--verbose` flag is not available on that command. Set `LOG_LEVEL=debug` to enable debug logs during eval runs.
+For `promptfoo eval`, `-v` is the short form of `--vars`, not `--verbose`. Use the long form (`--verbose`) or set `LOG_LEVEL=debug` to enable debug logs during eval runs.
 
 :::
 

--- a/site/docs/usage/command-line.md
+++ b/site/docs/usage/command-line.md
@@ -77,7 +77,7 @@ Most commands support the following common options:
 
 :::note
 
-For `promptfoo eval`, `-v` is the short form of `--vars`, not `--verbose`. Use the long form (`--verbose`) or set `LOG_LEVEL=debug` to enable debug logs during eval runs.
+For `promptfoo eval`, `-v` is the short form of `--vars`, so the `--verbose` flag is not available on that command. Set `LOG_LEVEL=debug` to enable debug logs during eval runs.
 
 :::
 

--- a/src/providers/AGENTS.md
+++ b/src/providers/AGENTS.md
@@ -101,9 +101,9 @@ if (cachedResponse) {
 
 **Reference implementations:**
 
-- `bedrock/converse.ts:985` - Sets cached flag correctly
-- `pythonCompletion.ts:194` - Example with spread operator
-- `google/vertex.ts:268` - Multiple cache points handled correctly
+- `bedrock/converse.ts:1275` - Sets cached flag correctly
+- `pythonCompletion.ts:62` - Sets the flag on the parsed result
+- `google/vertex.ts:371` - Multiple cache points handled correctly
 
 ## Testing Requirements
 
@@ -123,7 +123,7 @@ The eligibility bar in `site/docs/contributing.md` ("Provider eligibility") appl
 **All seven items are required** before a provider is complete:
 
 1. Implement `ApiProvider` interface
-2. Add env vars to `src/types/env.ts` (`ProviderEnvOverridesSchema`)
+2. Add env vars to `ProviderEnvOverridesSchema` in `src/contracts/env.ts` (re-exported via `src/types/env.ts`)
 3. Add env vars to `src/envars.ts` (if documenting in CLI help)
 4. Add tests in `test/providers/`
 5. Add docs in `site/docs/providers/<provider>.md`
@@ -137,7 +137,7 @@ After updating env schema, regenerate JSON schema: `npm run jsonSchema:generate`
 ```bash
 # Check all pieces exist
 ls src/providers/myprovider.ts
-grep -q "MYPROVIDER_API_KEY" src/types/env.ts && echo "env.ts updated"
+grep -q "MYPROVIDER_API_KEY" src/contracts/env.ts && echo "env schema updated"
 ls test/providers/myprovider.test.ts
 ls site/docs/providers/myprovider.md
 grep -q "myprovider" site/docs/providers/index.md && echo "index.md updated"

--- a/src/providers/AGENTS.md
+++ b/src/providers/AGENTS.md
@@ -101,7 +101,7 @@ if (cachedResponse) {
 
 **Reference implementations:**
 
-- `bedrock/converse.ts:1275` - Sets cached flag correctly
+- `bedrock/converse.ts:1276` - Sets cached flag correctly
 - `pythonCompletion.ts:62` - Sets the flag on the parsed result
 - `google/vertex.ts:371` - Multiple cache points handled correctly
 


### PR DESCRIPTION
## Summary

- update GitHub source links to their current line ranges (localai, replicate, and openai config options; the red team default severity map now lives in `src/redteam/constants/metadata.ts`)
- correct the provider env-var registration path to `src/contracts/env.ts` and refresh the cached-flag reference line numbers in the provider AGENTS guide
- clarify that `promptfoo eval` has no `--verbose` flag (`-v` is `--vars`); use `LOG_LEVEL=debug` for debug logs
- remove the nonexistent `PROMPTFOO_OUTPUT_DIR` env var from the MCP server example

## Validation

- `npx prettier --check` on the changed docs
- `SKIP_OG_GENERATION=true npm --prefix site run build`