### PR TITLE
fix(redteam): stop presenting deprecated or invalid prompt-injection ids in tool guidance

### DIFF
--- a/src/commands/mcp/tools/redteamGenerate.ts
+++ b/src/commands/mcp/tools/redteamGenerate.ts
@@ -83,7 +83,7 @@ export function registerRedteamGenerateTool(server: McpServer) {
             
             Additional plugins: ${Array.from(REDTEAM_ADDITIONAL_PLUGINS).sort().join(', ')}
             
-            Example: ["harmful", "pii", "indirect-prompt-injection"]
+            Example: ["harmful", "pii", "hijacking"]
           `,
         ),
       strategies: z

--- a/src/commands/mcp/tools/redteamGenerate.ts
+++ b/src/commands/mcp/tools/redteamGenerate.ts
@@ -83,7 +83,7 @@ export function registerRedteamGenerateTool(server: McpServer) {
             
             Additional plugins: ${Array.from(REDTEAM_ADDITIONAL_PLUGINS).sort().join(', ')}
             
-            Example: ["harmful", "pii", "prompt-injection"]
+            Example: ["harmful", "pii", "indirect-prompt-injection"]
           `,
         ),
       strategies: z
@@ -97,7 +97,7 @@ export function registerRedteamGenerateTool(server: McpServer) {
             
             Additional strategies: ${Array.from(ADDITIONAL_STRATEGIES).sort().join(', ')}
             
-            Example: ["jailbreak", "prompt-injection"]
+            Example: ["jailbreak", "jailbreak-templates"]
           `,
         ),
       numTests: z

--- a/src/commands/mcp/tools/redteamRun.ts
+++ b/src/commands/mcp/tools/redteamRun.ts
@@ -276,7 +276,7 @@ export function registerRedteamRunTool(server: McpServer) {
               basic: dedent`
                 redteam:
                   purpose: "Test my chatbot for safety issues"
-                  plugins: ["harmful", "pii", "indirect-prompt-injection"]
+                  plugins: ["harmful", "pii", "hijacking"]
                 targets:
                   - id: "my-model"
                     config:

--- a/src/commands/mcp/tools/redteamRun.ts
+++ b/src/commands/mcp/tools/redteamRun.ts
@@ -276,7 +276,7 @@ export function registerRedteamRunTool(server: McpServer) {
               basic: dedent`
                 redteam:
                   purpose: "Test my chatbot for safety issues"
-                  plugins: ["harmful", "pii", "prompt-injection"]
+                  plugins: ["harmful", "pii", "indirect-prompt-injection"]
                 targets:
                   - id: "my-model"
                     config:

--- a/src/redteam/AGENTS.md
+++ b/src/redteam/AGENTS.md
@@ -8,13 +8,13 @@
 src/redteam/
 ├── plugins/      # Vulnerability-specific test generators
 │   ├── pii.ts             # PII leakage detection
-│   ├── harmful.ts         # Harmful content generation
-│   ├── sql-injection.ts   # SQL injection attempts
+│   ├── harmful/           # Harmful content generation
+│   ├── sqlInjection.ts    # SQL injection attempts
 │   └── ...
 ├── strategies/   # Attack transformation techniques
-│   ├── jailbreak.ts       # Guardrail bypass attempts
-│   ├── prompt-injection.ts
-│   ├── base64.ts         # Obfuscation strategies
+│   ├── iterative.ts       # Iterative jailbreak refinement
+│   ├── promptInjections/  # jailbreak-templates strategy
+│   ├── base64.ts          # Obfuscation strategies
 │   └── ...
 └── graders.ts    # Response evaluation logic
 ```

--- a/src/redteam/riskScoring.ts
+++ b/src/redteam/riskScoring.ts
@@ -58,6 +58,9 @@ export interface SystemRiskScore extends RiskScore {
 const STRATEGY_METADATA: Record<string, StrategyMetadata> = {
   layer: { humanExploitable: true, humanComplexity: 'medium' },
   basic: { humanExploitable: true, humanComplexity: 'low' },
+  // 'prompt-injection' is the deprecated alias of 'jailbreak-templates'; keep
+  // both keys so results recorded under either id score identically.
+  'jailbreak-templates': { humanExploitable: true, humanComplexity: 'low' },
   'prompt-injection': { humanExploitable: true, humanComplexity: 'low' },
   jailbreak: { humanExploitable: true, humanComplexity: 'medium' },
   'jailbreak:composite': { humanExploitable: true, humanComplexity: 'medium' },

--- a/test/redteam/riskScoring.test.ts
+++ b/test/redteam/riskScoring.test.ts
@@ -29,6 +29,14 @@ describe('Risk Scoring', () => {
       expect(unknownMeta.humanExploitable).toBe(true);
       expect(unknownMeta.humanComplexity).toBe('medium');
     });
+
+    it('should score jailbreak-templates identically to its deprecated prompt-injection alias', () => {
+      const canonicalMeta = getStrategyMetadata('jailbreak-templates');
+      expect(canonicalMeta.humanExploitable).toBe(true);
+      expect(canonicalMeta.humanComplexity).toBe('low');
+
+      expect(getStrategyMetadata('prompt-injection')).toEqual(canonicalMeta);
+    });
   });
 
   describe('calculatePluginRiskScore', () => {


### PR DESCRIPTION
## Summary

Follow-up to #9931 (docs sweep of the deprecated `prompt-injection` strategy alias), covering the `src/` stragglers found during that review:

- **MCP tool descriptions presented `prompt-injection` as a plugin id** in `redteam_generate`'s plugins example and `redteam_run`'s error-guidance example config. It was never a valid plugin, so an agent following the example gets a validation error. Examples now use `indirect-prompt-injection` (plugin) and `jailbreak-templates` (strategy).
- **`riskScoring.ts` only had the deprecated alias key**: results recorded under the canonical `jailbreak-templates` id fell back to the default `humanComplexity: 'medium'` instead of `'low'`. Added the canonical key alongside the alias so both score identically.
- Fixed stale file names in the `src/redteam/AGENTS.md` layout tree (`prompt-injection.ts` → `promptInjections/`, `jailbreak.ts` → `iterative.ts`, `sql-injection.ts` → `sqlInjection.ts`, `harmful.ts` → `harmful/`).

## Testing

- `npx vitest run test/redteam/riskScoring.test.ts test/commands/mcp/server.test.ts` — 27 pass
- `tsc` clean, Biome clean, Prettier clean