### PR TITLE
feat(config): add YAML source location to prompt reference errors

### DIFF
--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -455,13 +455,7 @@ export async function maybeReadConfig(configPath: string): Promise<UnifiedConfig
   }
 }
 
-async function readPromptReferenceSources(
-  configPaths?: string[],
-): Promise<PromptReferenceSource[]> {
-  if (!configPaths) {
-    return [];
-  }
-
+async function readPromptReferenceSources(configPaths: string[]): Promise<PromptReferenceSource[]> {
   const sources: PromptReferenceSource[] = [];
   for (const configPath of configPaths) {
     const resolvedPath = path.resolve(process.cwd(), configPath);

--- a/src/util/config/load.ts
+++ b/src/util/config/load.ts
@@ -45,7 +45,10 @@ import { filterProviderConfigs, getProviderIdAndLabel } from '../eval/filterProv
 import { filterTests } from '../eval/filterTests';
 import { promptfooCommand } from '../promptfooCommand';
 import { readTest, readTests } from '../testCaseReader';
-import { validateTestPromptReferences } from '../validateTestPromptReferences';
+import {
+  type PromptReferenceSource,
+  validateTestPromptReferences,
+} from '../validateTestPromptReferences';
 import { validateTestProviderReferences } from '../validateTestProviderReferences';
 import { DEFAULT_CONFIG_EXTENSIONS } from './extensions';
 
@@ -452,6 +455,36 @@ export async function maybeReadConfig(configPath: string): Promise<UnifiedConfig
   }
 }
 
+async function readPromptReferenceSources(
+  configPaths?: string[],
+): Promise<PromptReferenceSource[]> {
+  if (!configPaths) {
+    return [];
+  }
+
+  const sources: PromptReferenceSource[] = [];
+  for (const configPath of configPaths) {
+    const resolvedPath = path.resolve(process.cwd(), configPath);
+    const globPaths =
+      globSync(resolvedPath, {
+        windowsPathsNoEscape: true,
+      }) ?? [];
+
+    for (const globPath of globPaths) {
+      const ext = path.parse(globPath).ext;
+      if (ext !== '.yaml' && ext !== '.yml') {
+        continue;
+      }
+      sources.push({
+        path: globPath,
+        content: await fsPromises.readFile(globPath, 'utf-8'),
+      });
+    }
+  }
+
+  return sources;
+}
+
 /**
  * Build a dedupe key for a provider entry. Provider functions and instances
  * whose behavior is identity-sensitive use reference identity. Provider option
@@ -746,8 +779,10 @@ export async function resolveConfigs(
   let fileConfig: Partial<UnifiedConfig> = {};
   let defaultConfig = _defaultConfig;
   const configPaths = cmdObj.config;
+  let promptReferenceSources: PromptReferenceSource[] = [];
   if (configPaths) {
     fileConfig = await combineConfigs(configPaths);
+    promptReferenceSources = await readPromptReferenceSources(configPaths);
     // The user has provided a config file, so we do not want to use the default config.
     defaultConfig = {};
   }
@@ -1043,6 +1078,7 @@ export async function resolveConfigs(
     testSuite.tests || [],
     testSuite.prompts,
     typeof testSuite.defaultTest === 'object' ? testSuite.defaultTest : undefined,
+    { promptReferenceSources },
   );
 
   cliState.config = config;

--- a/src/util/validateTestPromptReferences.ts
+++ b/src/util/validateTestPromptReferences.ts
@@ -37,11 +37,21 @@ function unquote(value: string): string {
 
 type SectionItem = { description?: string; location?: string };
 
+function refLocation(
+  source: PromptReferenceSource,
+  line: string,
+  lineNumber: number,
+  ref: string,
+): string | undefined {
+  const column = line.indexOf(ref);
+  return column === -1 ? undefined : `${source.path}:${lineNumber}:${column + 1}`;
+}
+
 /**
  * Split a source's target section into list items, recording each item's
- * description and the first line containing `ref`. Nested prompt refs always
- * indent deeper than item markers, so item boundaries are list markers at the
- * section's first list indent.
+ * description and the first line within its `prompts:` block containing
+ * `ref`. Nested prompt refs always indent deeper than item markers, so item
+ * boundaries are list markers at the section's first list indent.
  */
 function collectSectionItems(
   source: PromptReferenceSource,
@@ -51,6 +61,7 @@ function collectSectionItems(
   const lines = source.content.split(/\r?\n/);
   let inSection = false;
   let itemIndent: number | undefined;
+  let promptsIndent: number | undefined;
   const items: SectionItem[] = [{}];
 
   for (let i = 0; i < lines.length; i++) {
@@ -65,10 +76,7 @@ function collectSectionItems(
     if (!inSection) {
       if (indent === 0 && isYamlKey(trimmed, section)) {
         inSection = true;
-        const column = line.indexOf(ref);
-        if (column !== -1) {
-          items[0].location = `${source.path}:${i + 1}:${column + 1}`;
-        }
+        items[0].location = refLocation(source, line, i + 1, ref);
       }
       continue;
     }
@@ -89,10 +97,15 @@ function collectSectionItems(
       item.description ??= unquote(stripped.slice('description:'.length).trim());
       continue;
     }
-    const column = line.indexOf(ref);
-    if (column !== -1) {
-      item.location ??= `${source.path}:${i + 1}:${column + 1}`;
+    // Only search inside the item's `prompts:` block so the same string in
+    // vars or assertions doesn't steal the location.
+    if (isYamlKey(stripped, 'prompts')) {
+      promptsIndent = indent + (trimmed.length - stripped.length);
+    } else if (promptsIndent === undefined || indent <= promptsIndent) {
+      promptsIndent = undefined;
+      continue;
     }
+    item.location ??= refLocation(source, line, i + 1, ref);
   }
 
   return items;

--- a/src/util/validateTestPromptReferences.ts
+++ b/src/util/validateTestPromptReferences.ts
@@ -37,6 +37,11 @@ function unquote(value: string): string {
 
 type SectionItem = { description?: string; location?: string };
 
+// While scanning we track an exact list-item match separately from a looser
+// substring match, so a valid prompt whose name *contains* the missing ref
+// (e.g. `- GhostBuster` when `Ghost` is missing) can't steal the location.
+type WorkingItem = SectionItem & { looseLocation?: string };
+
 function refLocation(
   source: PromptReferenceSource,
   line: string,
@@ -62,7 +67,7 @@ function collectSectionItems(
   let inSection = false;
   let itemIndent: number | undefined;
   let promptsIndent: number | undefined;
-  const items: SectionItem[] = [{}];
+  const items: WorkingItem[] = [{}];
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -105,10 +110,22 @@ function collectSectionItems(
       promptsIndent = undefined;
       continue;
     }
-    item.location ??= refLocation(source, line, i + 1, ref);
+    const location = refLocation(source, line, i + 1, ref);
+    if (location) {
+      // A block list item whose whole value is the ref is an exact match and
+      // wins; otherwise keep it only as a substring fallback.
+      if (isListItem && unquote(stripped) === ref) {
+        item.location ??= location;
+      } else {
+        item.looseLocation ??= location;
+      }
+    }
   }
 
-  return items;
+  return items.map((item) => ({
+    description: item.description,
+    location: item.location ?? item.looseLocation,
+  }));
 }
 
 /**

--- a/src/util/validateTestPromptReferences.ts
+++ b/src/util/validateTestPromptReferences.ts
@@ -2,6 +2,15 @@ import { doesPromptRefMatch } from './promptMatching';
 
 import type { Prompt, TestCase } from '../types/index';
 
+export type PromptReferenceSource = {
+  path: string;
+  content: string;
+};
+
+type ValidateTestPromptReferencesOptions = {
+  promptReferenceSources?: PromptReferenceSource[];
+};
+
 export class PromptReferenceValidationError extends Error {
   constructor(message: string) {
     super(message);
@@ -9,20 +18,114 @@ export class PromptReferenceValidationError extends Error {
   }
 }
 
+type PromptReferenceContext = {
+  section: 'tests' | 'defaultTest';
+  description?: string;
+};
+
+function isYamlKey(trimmedLine: string, key: string): boolean {
+  return trimmedLine === `${key}:` || trimmedLine.startsWith(`${key}: `);
+}
+
+function unquote(value: string): string {
+  const quote = value[0];
+  if ((quote === '"' || quote === "'") && value.length >= 2 && value.endsWith(quote)) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+type SectionItem = { description?: string; location?: string };
+
 /**
- * Get available prompt identifiers for error messages.
+ * Split a source's target section into list items, recording each item's
+ * description and the first line containing `ref`. Nested prompt refs always
+ * indent deeper than item markers, so item boundaries are list markers at the
+ * section's first list indent.
  */
-function getAvailablePromptIdentifiers(prompts: Prompt[]): string[] {
-  const identifiers = new Set<string>();
-  for (const p of prompts) {
-    if (p.label) {
-      identifiers.add(p.label);
+function collectSectionItems(
+  source: PromptReferenceSource,
+  ref: string,
+  section: PromptReferenceContext['section'],
+): SectionItem[] {
+  const lines = source.content.split(/\r?\n/);
+  let inSection = false;
+  let itemIndent: number | undefined;
+  const items: SectionItem[] = [{}];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
     }
-    if (p.id) {
-      identifiers.add(p.id);
+    const indent = line.search(/\S/);
+    const isListItem = trimmed === '-' || trimmed.startsWith('- ');
+
+    if (!inSection) {
+      if (indent === 0 && isYamlKey(trimmed, section)) {
+        inSection = true;
+        const column = line.indexOf(ref);
+        if (column !== -1) {
+          items[0].location = `${source.path}:${i + 1}:${column + 1}`;
+        }
+      }
+      continue;
+    }
+    if (indent === 0 && !isListItem) {
+      break;
+    }
+
+    if (isListItem) {
+      itemIndent ??= indent;
+      if (indent <= itemIndent) {
+        items.push({});
+      }
+    }
+
+    const item = items[items.length - 1];
+    const stripped = trimmed.replace(/^-\s*/, '');
+    if (isYamlKey(stripped, 'description')) {
+      item.description ??= unquote(stripped.slice('description:'.length).trim());
+      continue;
+    }
+    const column = line.indexOf(ref);
+    if (column !== -1) {
+      item.location ??= `${source.path}:${i + 1}:${column + 1}`;
     }
   }
-  return Array.from(identifiers).sort();
+
+  return items;
+}
+
+/**
+ * Best-effort `path:line:column` for a prompt ref, without a YAML parser.
+ * Prefers the item whose description matches the erroring test's description,
+ * falling back to the first occurrence in the right section.
+ */
+function findPromptReferenceLocation(
+  ref: string,
+  sources: PromptReferenceSource[] | undefined,
+  context: PromptReferenceContext,
+): string | undefined {
+  const targetDescription = context.section === 'tests' ? context.description : undefined;
+  let fallback: string | undefined;
+
+  for (const source of sources ?? []) {
+    const withRef = collectSectionItems(source, ref, context.section).filter(
+      (item) => item.location,
+    );
+    const match =
+      targetDescription === undefined
+        ? withRef[0]
+        : withRef.find((item) => item.description === targetDescription);
+    if (match) {
+      return match.location;
+    }
+    fallback ??= withRef[0]?.location;
+  }
+
+  return fallback;
 }
 
 /**
@@ -32,44 +135,40 @@ function getAvailablePromptIdentifiers(prompts: Prompt[]): string[] {
  * @param tests - Array of test cases to validate
  * @param prompts - Array of available prompts
  * @param defaultTest - Optional default test case to validate
+ * @param options - Optional source files for YAML location hints
  * @throws PromptReferenceValidationError if any prompt reference is invalid
  */
 export function validateTestPromptReferences(
   tests: TestCase[],
   prompts: Prompt[],
   defaultTest?: Partial<TestCase>,
+  options?: ValidateTestPromptReferencesOptions,
 ): void {
-  // Validate defaultTest.prompts first
-  if (defaultTest?.prompts && Array.isArray(defaultTest.prompts)) {
-    for (const ref of defaultTest.prompts) {
-      const matchFound = prompts.some((prompt) => doesPromptRefMatch(ref, prompt));
-      if (!matchFound) {
-        const available = getAvailablePromptIdentifiers(prompts);
-        throw new PromptReferenceValidationError(
-          `defaultTest references prompt "${ref}" which does not exist.\n` +
-            `Available prompts: [${available.join(', ')}]`,
-        );
+  const check = (refs: string[] | undefined, label: string, context: PromptReferenceContext) => {
+    if (!Array.isArray(refs)) {
+      return;
+    }
+    for (const ref of refs) {
+      if (prompts.some((prompt) => doesPromptRefMatch(ref, prompt))) {
+        continue;
       }
+      const available = [...new Set(prompts.flatMap((p) => [p.label, p.id]))]
+        .filter((id): id is string => !!id)
+        .sort();
+      const message =
+        `${label} references prompt "${ref}" which does not exist.\n` +
+        `Available prompts: [${available.join(', ')}]`;
+      const location = findPromptReferenceLocation(ref, options?.promptReferenceSources, context);
+      throw new PromptReferenceValidationError(location ? `${location}: ${message}` : message);
     }
-  }
+  };
 
-  // Validate each test case's prompts
-  for (let testIdx = 0; testIdx < tests.length; testIdx++) {
-    const test = tests[testIdx];
-    if (!test.prompts || !Array.isArray(test.prompts) || test.prompts.length === 0) {
-      continue;
-    }
-
-    for (const ref of test.prompts) {
-      const matchFound = prompts.some((prompt) => doesPromptRefMatch(ref, prompt));
-      if (!matchFound) {
-        const available = getAvailablePromptIdentifiers(prompts);
-        const testDesc = test.description ? ` ("${test.description}")` : '';
-        throw new PromptReferenceValidationError(
-          `Test #${testIdx + 1}${testDesc} references prompt "${ref}" which does not exist.\n` +
-            `Available prompts: [${available.join(', ')}]`,
-        );
-      }
-    }
-  }
+  check(defaultTest?.prompts, 'defaultTest', { section: 'defaultTest' });
+  tests.forEach((test, testIdx) => {
+    const testDesc = test.description ? ` ("${test.description}")` : '';
+    check(test.prompts, `Test #${testIdx + 1}${testDesc}`, {
+      section: 'tests',
+      description: test.description,
+    });
+  });
 }

--- a/test/test-prompts-filter.test.ts
+++ b/test/test-prompts-filter.test.ts
@@ -312,6 +312,34 @@ describe('validateTestPromptReferences', () => {
       );
     });
 
+    it('should not let a prompt whose name contains the missing ref steal the location', () => {
+      // `Ghost Extended` is a valid prompt referenced on line 7; the missing
+      // `Ghost` is on line 8. A raw substring match would wrongly report line 7.
+      const promptsWithGhost: Prompt[] = [{ raw: 'x', label: 'Ghost Extended' }];
+      const tests: TestCase[] = [{ description: 'substr', prompts: ['Ghost Extended', 'Ghost'] }];
+      expect(() =>
+        validateTestPromptReferences(tests, promptsWithGhost, undefined, {
+          promptReferenceSources: [
+            {
+              path: 'promptfooconfig.yaml',
+              content: [
+                'prompts:',
+                '  - raw: x',
+                '    label: Ghost Extended',
+                'tests:',
+                '  - description: substr',
+                '    prompts:',
+                '      - Ghost Extended',
+                '      - Ghost',
+              ].join('\n'),
+            },
+          ],
+        }),
+      ).toThrow(
+        /promptfooconfig\.yaml:8:9: Test #1 \("substr"\) references prompt "Ghost" which does not exist/,
+      );
+    });
+
     it('should point at the defaultTest prompt line when tests reference the same missing prompt', () => {
       const defaultTest: Partial<TestCase> = { prompts: ['Missing Prompt'] };
       const tests: TestCase[] = [

--- a/test/test-prompts-filter.test.ts
+++ b/test/test-prompts-filter.test.ts
@@ -232,6 +232,41 @@ describe('validateTestPromptReferences', () => {
       );
     });
 
+    it('should point at the prompts entry when the ref string also appears in vars', () => {
+      const tests: TestCase[] = [
+        {
+          description: 'Missing prompt',
+          vars: { question: 'Missing Prompt' },
+          prompts: ['Missing Prompt'],
+        },
+      ];
+      expect(() =>
+        validateTestPromptReferences(tests, prompts, undefined, {
+          promptReferenceSources: [
+            {
+              path: 'promptfooconfig.yaml',
+              content: [
+                'prompts:',
+                '  - id: prompt-a',
+                '    label: Factual Assistant',
+                'tests:',
+                '  - description: Missing prompt',
+                '    vars:',
+                '      question: Missing Prompt',
+                '    assert:',
+                '      - type: contains',
+                '        value: Missing Prompt',
+                '    prompts:',
+                '      - Missing Prompt',
+              ].join('\n'),
+            },
+          ],
+        }),
+      ).toThrow(
+        /promptfooconfig\.yaml:12:9: Test #1 \("Missing prompt"\) references prompt "Missing Prompt" which does not exist/,
+      );
+    });
+
     it('should include YAML location when source is provided for defaultTest prompt references', () => {
       const defaultTest: Partial<TestCase> = { prompts: ['Missing Default'] };
       expect(() =>

--- a/test/test-prompts-filter.test.ts
+++ b/test/test-prompts-filter.test.ts
@@ -206,6 +206,107 @@ describe('validateTestPromptReferences', () => {
       expect(() => validateTestPromptReferences(tests, prompts)).toThrow(/Available prompts:/);
     });
 
+    it('should include YAML location when source is provided for test prompt references', () => {
+      const tests: TestCase[] = [{ description: 'Missing prompt', prompts: ['Missing Prompt'] }];
+      expect(() =>
+        validateTestPromptReferences(tests, prompts, undefined, {
+          promptReferenceSources: [
+            {
+              path: 'promptfooconfig.yaml',
+              content: [
+                'providers:',
+                '  - openai:gpt-4.1-mini',
+                'prompts:',
+                '  - id: prompt-a',
+                '    label: Factual Assistant',
+                'tests:',
+                '  - description: Missing prompt',
+                '    prompts:',
+                '      - Missing Prompt',
+              ].join('\n'),
+            },
+          ],
+        }),
+      ).toThrow(
+        /promptfooconfig\.yaml:9:9: Test #1 \("Missing prompt"\) references prompt "Missing Prompt" which does not exist/,
+      );
+    });
+
+    it('should include YAML location when source is provided for defaultTest prompt references', () => {
+      const defaultTest: Partial<TestCase> = { prompts: ['Missing Default'] };
+      expect(() =>
+        validateTestPromptReferences([], prompts, defaultTest, {
+          promptReferenceSources: [
+            {
+              path: 'promptfooconfig.yaml',
+              content: ['defaultTest:', '  prompts:', '    - Missing Default'].join('\n'),
+            },
+          ],
+        }),
+      ).toThrow(
+        /promptfooconfig\.yaml:3:7: defaultTest references prompt "Missing Default" which does not exist/,
+      );
+    });
+
+    it('should point at the target duplicate when prompts appear before description', () => {
+      // Simulates filtered tests: only the second YAML item is validated, but the
+      // first item references the same missing prompt with `prompts` before `description`.
+      const tests: TestCase[] = [{ description: 'Target duplicate', prompts: ['Missing Prompt'] }];
+      expect(() =>
+        validateTestPromptReferences(tests, prompts, undefined, {
+          promptReferenceSources: [
+            {
+              path: 'promptfooconfig.yaml',
+              content: [
+                'prompts:',
+                '  - id: prompt-a',
+                '    label: Factual Assistant',
+                'tests:',
+                '  - prompts:',
+                '      - Missing Prompt',
+                '    description: First duplicate',
+                '  - prompts:',
+                '      - Missing Prompt',
+                '    description: Target duplicate',
+              ].join('\n'),
+            },
+          ],
+        }),
+      ).toThrow(
+        /promptfooconfig\.yaml:9:9: Test #1 \("Target duplicate"\) references prompt "Missing Prompt" which does not exist/,
+      );
+    });
+
+    it('should point at the defaultTest prompt line when tests reference the same missing prompt', () => {
+      const defaultTest: Partial<TestCase> = { prompts: ['Missing Prompt'] };
+      const tests: TestCase[] = [
+        { description: 'Uses missing prompt', prompts: ['Missing Prompt'] },
+      ];
+      expect(() =>
+        validateTestPromptReferences(tests, prompts, defaultTest, {
+          promptReferenceSources: [
+            {
+              path: 'promptfooconfig.yaml',
+              content: [
+                'prompts:',
+                '  - id: prompt-a',
+                '    label: Factual Assistant',
+                'tests:',
+                '  - description: Uses missing prompt',
+                '    prompts:',
+                '      - Missing Prompt',
+                'defaultTest:',
+                '  prompts:',
+                '    - Missing Prompt',
+              ].join('\n'),
+            },
+          ],
+        }),
+      ).toThrow(
+        /promptfooconfig\.yaml:10:7: defaultTest references prompt "Missing Prompt" which does not exist/,
+      );
+    });
+
     it('should throw error when wildcard matches nothing', () => {
       const tests: TestCase[] = [{ prompts: ['Science:*'] }];
       expect(() => validateTestPromptReferences(tests, prompts)).toThrow(

--- a/test/util/config/load.test.ts
+++ b/test/util/config/load.test.ts
@@ -1562,6 +1562,32 @@ describe('resolveConfigs', () => {
     expect(cliState.basePath).toBe(path.dirname('config.json'));
   });
 
+  it('should include YAML location when an inline test references a missing prompt', async () => {
+    const configText = [
+      'providers:',
+      '  - echo',
+      'prompts:',
+      '  - raw: Hello',
+      '    label: Existing Prompt',
+      'tests:',
+      '  - description: Missing prompt',
+      '    prompts:',
+      '      - Missing Prompt',
+    ].join('\n');
+
+    vi.mocked(fs.readFileSync).mockReturnValue(configText);
+    vi.mocked(globSync).mockReturnValue(['config.yaml']);
+    vi.mocked(readPrompts).mockResolvedValue([{ raw: 'Hello', label: 'Existing Prompt' }]);
+    vi.mocked(loadApiProviders).mockResolvedValue([createMockProvider({ id: 'echo' })]);
+    vi.mocked(readTests).mockImplementation(async (tests) =>
+      Array.isArray(tests) ? (tests as TestCase[]) : [],
+    );
+
+    await expect(resolveConfigs({ config: ['config.yaml'] }, {})).rejects.toThrow(
+      /config\.yaml:9:9: Test #1 \("Missing prompt"\) references prompt "Missing Prompt" which does not exist/,
+    );
+  });
+
   it('should return the provider configs selected by a target filter', async () => {
     const providers = [
       { id: 'promptfoo://provider/excluded-target', config: { label: 'excluded' } },


### PR DESCRIPTION
## Summary

Prompt reference validation errors now point at the offending line in the configuration file.

**Before**

```text
> Test #1 ("Missing prompt") references prompt "Missing Prompt" which does not exist.

(Use `node --trace-warnings ...` to show where the warning was created)

file://text-to-sql-ts/node_modules/promptfoo/dist/src/main.js:1761
                        throw new PromptReferenceValidationError(
                              `Test #${testIdx + 1}${testDesc} references prompt "${ref}" which does not exist.\nAvailable prompts: [${available.join(", ")}]`
                        );
                              ^

PromptReferenceValidationError: Test #1 ("CoT prompt includes thinking tag") references prompt "Chain of Thought & Few-Shot Examples" which does not exist.
Available prompts: [Basic]
```

**After**

```text
> promptfooconfig.yaml:9:9: Test #1 ("Missing prompt") references prompt "Missing Prompt" which does not exist.

$ promptfoo eval -c promptfooconfig.yaml --output data/results.csv

(node:62047) ExperimentalWarning: DecompressInterceptor is experimental and subject to change
(Use `node --trace-warnings ...` to show where the warning was created)

file:///promptfoo_promptfoo/src/util/validateTestPromptReferences.ts:162
      throw new PromptReferenceValidationError(location ? `${location}: ${message}` : message);
            ^

PromptReferenceValidationError: text-to-sql-ts/promptfooconfig.yaml:35:9: Test #1 ("CoT prompt includes thinking tag") references prompt "Chain of Thought & Few-Shot Examples" which does not exist.
Available prompts: [Basic]
```