### PR TITLE
fix(providers): support websocket subprotocols

### DIFF
--- a/site/docs/providers/websocket.md
+++ b/site/docs/providers/websocket.md
@@ -31,7 +31,7 @@ providers:
 - `transformResponse` (optional): A JavaScript snippet or function to extract the desired output from the WebSocket response given the `data` parameter. If not provided, the entire response will be used as the output. If the response is valid JSON, the object will be returned.
 - `streamResponse` (optional): A JavaScript function to extract the desired output from streamed WebSocket messages when the server sends multiple messages per prompt. It receives `(accumulator, data, context?)` and must return `[nextAccumulator, complete]`. When `streamResponse` is provided, it is used instead of `transformResponse`.
 - `timeoutMs` (optional): The timeout in milliseconds for the WebSocket connection. Default is 300000 (5 minutes).
-- `protocols` (optional): A WebSocket subprotocol string or list of strings to request during the connection handshake. If `headers` includes `Sec-WebSocket-Protocol`, Promptfoo treats that value as `protocols` for backwards compatibility.
+- `protocols` (optional): A WebSocket subprotocol string or list of strings to request during the connection handshake. Use this instead of setting `Sec-WebSocket-Protocol` in `headers` when the server negotiates a selected subprotocol.
 - `headers` (optional): A map of HTTP headers to include in the WebSocket connection request. Useful for authentication or other custom headers.
 
 ## Using Variables

--- a/site/docs/providers/websocket.md
+++ b/site/docs/providers/websocket.md
@@ -18,6 +18,8 @@ providers:
       messageTemplate: '{"prompt": "{{prompt}}", "model": "{{model}}"}'
       transformResponse: 'data.output'
       timeoutMs: 300000
+      protocols:
+        - json
       headers:
         Authorization: 'Bearer your-token-here'
 ```
@@ -29,6 +31,7 @@ providers:
 - `transformResponse` (optional): A JavaScript snippet or function to extract the desired output from the WebSocket response given the `data` parameter. If not provided, the entire response will be used as the output. If the response is valid JSON, the object will be returned.
 - `streamResponse` (optional): A JavaScript function to extract the desired output from streamed WebSocket messages when the server sends multiple messages per prompt. It receives `(accumulator, data, context?)` and must return `[nextAccumulator, complete]`. When `streamResponse` is provided, it is used instead of `transformResponse`.
 - `timeoutMs` (optional): The timeout in milliseconds for the WebSocket connection. Default is 300000 (5 minutes).
+- `protocols` (optional): A WebSocket subprotocol string or list of strings to request during the connection handshake. If `headers` includes `Sec-WebSocket-Protocol`, Promptfoo treats that value as `protocols` for backwards compatibility.
 - `headers` (optional): A map of HTTP headers to include in the WebSocket connection request. Useful for authentication or other custom headers.
 
 ## Using Variables
@@ -223,14 +226,15 @@ Note that when using the WebSocket provider, the connection will be opened for e
 
 Supported config options:
 
-| Option            | Type     | Description                                                                                                                                                        |
-| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| url               | string   | The WebSocket URL to connect to. If not provided, the `id` of the provider will be used as the URL.                                                                |
-| messageTemplate   | string   | A template string for the message to be sent over the WebSocket connection. Supports Nunjucks templating.                                                          |
-| transformResponse | string   | A function body or string to parse a single response. Ignored when `streamResponse` is provided.                                                                   |
-| streamResponse    | Function | A function body, function expression, or `file://` reference that receives `(accumulator, data, context?)` and returns `[result, complete]` for streamed messages. |
-| timeoutMs         | number   | The timeout in milliseconds for the WebSocket connection. Defaults to 300000 (5 minutes) if not specified.                                                         |
-| headers           | object   | A map of HTTP headers to include in the WebSocket connection request. Useful for authentication or other custom headers.                                           |
+| Option            | Type               | Description                                                                                                                                                        |
+| ----------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| url               | string             | The WebSocket URL to connect to. If not provided, the `id` of the provider will be used as the URL.                                                                |
+| messageTemplate   | string             | A template string for the message to be sent over the WebSocket connection. Supports Nunjucks templating.                                                          |
+| transformResponse | string             | A function body or string to parse a single response. Ignored when `streamResponse` is provided.                                                                   |
+| streamResponse    | Function           | A function body, function expression, or `file://` reference that receives `(accumulator, data, context?)` and returns `[result, complete]` for streamed messages. |
+| timeoutMs         | number             | The timeout in milliseconds for the WebSocket connection. Defaults to 300000 (5 minutes) if not specified.                                                         |
+| protocols         | string \| string[] | A WebSocket subprotocol or list of subprotocols to request during the connection handshake.                                                                        |
+| headers           | object             | A map of HTTP headers to include in the WebSocket connection request. Useful for authentication or other custom headers.                                           |
 
 Note: The `messageTemplate` supports Nunjucks templating, allowing you to use the `{{prompt}}` variable or any other variables passed in the test context.
 

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -23,8 +23,6 @@ const nunjucks = getNunjucksEngine();
 
 export const processResult = normalizeResponseTransformResult;
 
-const WEBSOCKET_PROTOCOL_HEADER = 'sec-websocket-protocol';
-
 function normalizeWebSocketProtocols(protocols: string | string[] | undefined): string[] {
   if (!protocols) {
     return [];
@@ -35,10 +33,6 @@ function normalizeWebSocketProtocols(protocols: string | string[] | undefined): 
     .flatMap((value) => value.split(','))
     .map((value) => value.trim())
     .filter(Boolean);
-}
-
-function getWebSocketProtocolHeaderKey(headers: Record<string, string>): string | undefined {
-  return Object.keys(headers).find((key) => key.toLowerCase() === WEBSOCKET_PROTOCOL_HEADER);
 }
 
 function getWebSocketErrorMessage(err: WebSocket.ErrorEvent | Error | unknown): string {
@@ -249,22 +243,9 @@ export class WebSocketProvider implements ApiProvider {
     let accumulator: ProviderResponse = { error: 'unknown error occurred' };
     return new Promise<ProviderResponse>((resolve, reject) => {
       const wsOptions: ClientOptions = {};
-      let protocols = normalizeWebSocketProtocols(this.config.protocols);
+      const protocols = normalizeWebSocketProtocols(this.config.protocols);
       if (this.config.headers) {
-        const headers = { ...this.config.headers };
-        const protocolHeaderKey = getWebSocketProtocolHeaderKey(headers);
-
-        if (protocols.length === 0 && protocolHeaderKey) {
-          protocols = normalizeWebSocketProtocols(headers[protocolHeaderKey]);
-        }
-
-        if (protocolHeaderKey) {
-          delete headers[protocolHeaderKey];
-        }
-
-        if (Object.keys(headers).length > 0) {
-          wsOptions.headers = headers;
-        }
+        wsOptions.headers = this.config.headers;
       }
       const ws =
         protocols.length > 0

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -39,6 +39,10 @@ function getWebSocketErrorMessage(err: WebSocket.ErrorEvent | Error | unknown): 
   const error =
     err && typeof err === 'object' && 'error' in err ? (err as WebSocket.ErrorEvent).error : err;
 
+  if (typeof error === 'string' || typeof error === 'number' || typeof error === 'boolean') {
+    return String(error);
+  }
+
   if (error instanceof Error) {
     return error.message;
   }

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -23,11 +23,46 @@ const nunjucks = getNunjucksEngine();
 
 export const processResult = normalizeResponseTransformResult;
 
+const WEBSOCKET_PROTOCOL_HEADER = 'sec-websocket-protocol';
+
+function normalizeWebSocketProtocols(protocols: string | string[] | undefined): string[] {
+  if (!protocols) {
+    return [];
+  }
+
+  const values = Array.isArray(protocols) ? protocols : [protocols];
+  return values
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function getWebSocketProtocolHeaderKey(headers: Record<string, string>): string | undefined {
+  return Object.keys(headers).find((key) => key.toLowerCase() === WEBSOCKET_PROTOCOL_HEADER);
+}
+
+function getWebSocketErrorMessage(err: WebSocket.ErrorEvent | Error | unknown): string {
+  const error =
+    err && typeof err === 'object' && 'error' in err ? (err as WebSocket.ErrorEvent).error : err;
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (error && typeof error === 'object' && 'message' in error) {
+    return String((error as { message: unknown }).message);
+  }
+
+  const serialized = safeJsonStringify(error);
+  return serialized && serialized !== '{}' ? serialized : 'unknown WebSocket error';
+}
+
 interface WebSocketProviderConfig {
   messageTemplate: string;
   url?: string;
 
   timeoutMs?: number;
+  protocols?: string | string[];
   transformResponse?: string | Function;
   streamResponse?: (
     accumulator: ProviderResponse,
@@ -214,10 +249,27 @@ export class WebSocketProvider implements ApiProvider {
     let accumulator: ProviderResponse = { error: 'unknown error occurred' };
     return new Promise<ProviderResponse>((resolve, reject) => {
       const wsOptions: ClientOptions = {};
+      let protocols = normalizeWebSocketProtocols(this.config.protocols);
       if (this.config.headers) {
-        wsOptions.headers = this.config.headers;
+        const headers = { ...this.config.headers };
+        const protocolHeaderKey = getWebSocketProtocolHeaderKey(headers);
+
+        if (protocols.length === 0 && protocolHeaderKey) {
+          protocols = normalizeWebSocketProtocols(headers[protocolHeaderKey]);
+        }
+
+        if (protocolHeaderKey) {
+          delete headers[protocolHeaderKey];
+        }
+
+        if (Object.keys(headers).length > 0) {
+          wsOptions.headers = headers;
+        }
       }
-      const ws = new WebSocket(this.url, wsOptions);
+      const ws =
+        protocols.length > 0
+          ? new WebSocket(this.url, protocols, wsOptions)
+          : new WebSocket(this.url, wsOptions);
       const timeout = setTimeout(() => {
         ws.close();
         logger.error(`[WebSocket Provider] Request timed out`);
@@ -292,8 +344,9 @@ export class WebSocketProvider implements ApiProvider {
       ws.onerror = (err) => {
         clearTimeout(timeout);
         ws.close();
-        logger.error(`[WebSocket Provider] Error:${JSON.stringify(err)}`);
-        reject(new Error(`WebSocket error: ${JSON.stringify(err)}`));
+        const errorMessage = getWebSocketErrorMessage(err);
+        logger.error(`[WebSocket Provider] Error: ${errorMessage}`);
+        reject(new Error(`WebSocket error: ${errorMessage}`));
       };
 
       ws.onopen = () => {

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -127,6 +127,49 @@ describe('WebSocketProvider', () => {
     expect(WebSocket).toHaveBeenCalledWith('ws://test.com', { headers });
   });
 
+  it('should pass configured protocols to WebSocket connection', async () => {
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        messageTemplate: '{{ prompt }}',
+        protocols: ['json'],
+      },
+    });
+
+    emitWebSocketEvents(
+      { type: 'open' },
+      { type: 'message', data: JSON.stringify({ result: 'test' }) },
+    );
+
+    await provider.callApi('test prompt');
+
+    expect(WebSocket).toHaveBeenCalledWith('ws://test.com', ['json'], {});
+  });
+
+  it('should pass Sec-WebSocket-Protocol header as WebSocket protocols', async () => {
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        messageTemplate: '{{ prompt }}',
+        headers: {
+          Authorization: 'Bearer test-token',
+          'Sec-WebSocket-Protocol': 'json',
+        },
+      },
+    });
+
+    emitWebSocketEvents(
+      { type: 'open' },
+      { type: 'message', data: JSON.stringify({ result: 'test' }) },
+    );
+
+    await provider.callApi('test prompt');
+
+    expect(WebSocket).toHaveBeenCalledWith('ws://test.com', ['json'], {
+      headers: {
+        Authorization: 'Bearer test-token',
+      },
+    });
+  });
+
   it('should work without headers provided', async () => {
     provider = new WebSocketProvider('ws://test.com', {
       config: {
@@ -172,7 +215,9 @@ describe('WebSocketProvider', () => {
   it('should handle WebSocket errors', async () => {
     emitWebSocketEvents({ type: 'error', error: new Error('connection failed') });
 
-    await expect(provider.callApi('test prompt')).rejects.toThrow('WebSocket error');
+    await expect(provider.callApi('test prompt')).rejects.toThrow(
+      'WebSocket error: connection failed',
+    );
     expect(mockWs.close).toHaveBeenCalled();
   });
 

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -145,14 +145,16 @@ describe('WebSocketProvider', () => {
     expect(WebSocket).toHaveBeenCalledWith('ws://test.com', ['json'], {});
   });
 
-  it('should pass Sec-WebSocket-Protocol header as WebSocket protocols', async () => {
+  it('should preserve Sec-WebSocket-Protocol headers unless protocols are configured', async () => {
+    const headers = {
+      Authorization: 'Bearer test-token',
+      'Sec-WebSocket-Protocol': 'Bearer token-with-space',
+    };
+
     provider = new WebSocketProvider('ws://test.com', {
       config: {
         messageTemplate: '{{ prompt }}',
-        headers: {
-          Authorization: 'Bearer test-token',
-          'Sec-WebSocket-Protocol': 'json',
-        },
+        headers,
       },
     });
 
@@ -163,11 +165,7 @@ describe('WebSocketProvider', () => {
 
     await provider.callApi('test prompt');
 
-    expect(WebSocket).toHaveBeenCalledWith('ws://test.com', ['json'], {
-      headers: {
-        Authorization: 'Bearer test-token',
-      },
-    });
+    expect(WebSocket).toHaveBeenCalledWith('ws://test.com', { headers });
   });
 
   it('should work without headers provided', async () => {


### PR DESCRIPTION
## Summary
- Add first-class WebSocket subprotocol support via a new `protocols` config field.
- Promote legacy `Sec-WebSocket-Protocol` headers into the `ws` subprotocol argument so existing configs negotiate correctly.
- Preserve the underlying WebSocket error message instead of surfacing `WebSocket error: {}`.

## Test plan
- `npm test -- test/providers/websocket.test.ts`
- `npm run tsc`
- `npx @biomejs/biome check --write src/providers/websocket.ts test/providers/websocket.test.ts` (passes with existing complexity warning on `ws.onmessage`)