### PR TITLE
feat(app): surface websocket subprotocols

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
@@ -182,7 +182,8 @@ function ProviderConfigEditor({
     } else if (
       field in updatedTarget.config ||
       field === 'streamResponse' ||
-      field === 'transformResponse'
+      field === 'transformResponse' ||
+      field === 'protocols'
     ) {
       (updatedTarget.config as Record<string, unknown>)[field] = value;
     } else if (field === 'label') {

--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
@@ -71,6 +71,50 @@ describe('WebSocketEndpointConfiguration', () => {
     expect(update).toHaveBeenCalledWith('messageTemplate', 'Hey {{name}}');
   });
 
+  it('updates WebSocket subprotocols as a string array', async () => {
+    const user = userEvent.setup();
+    const update = vi.fn();
+
+    renderWithProviders(
+      <WebSocketEndpointConfiguration
+        selectedTarget={baseProvider}
+        updateWebSocketTarget={update}
+        urlError={null}
+      />,
+    );
+
+    const protocolsField = screen.getByLabelText('WebSocket Subprotocols');
+    await user.click(protocolsField);
+    await user.paste('json, graphql-transport-ws');
+
+    expect(update).toHaveBeenCalledWith('protocols', ['json', 'graphql-transport-ws']);
+  });
+
+  it('preserves raw Sec-WebSocket-Protocol headers and shows migration guidance', () => {
+    const update = vi.fn();
+    const providerWithHeader: ProviderOptions = {
+      ...baseProvider,
+      config: {
+        ...baseProvider.config,
+        headers: {
+          'Sec-WebSocket-Protocol': 'Bearer token-with-space',
+        },
+      },
+    };
+
+    renderWithProviders(
+      <WebSocketEndpointConfiguration
+        selectedTarget={providerWithHeader}
+        updateWebSocketTarget={update}
+        urlError={null}
+      />,
+    );
+
+    expect(screen.getByText(/move it here/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('WebSocket Subprotocols')).toHaveValue('');
+    expect(update).not.toHaveBeenCalledWith('headers', expect.anything());
+  });
+
   it('calls updateWebSocketTarget on Response Transform change', async () => {
     const user = userEvent.setup();
     const update = vi.fn();

--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.tsx
@@ -24,6 +24,30 @@ interface WebSocketEndpointConfigurationProps {
   urlError: string | null;
 }
 
+const formatProtocols = (protocols: unknown): string => {
+  if (Array.isArray(protocols)) {
+    return protocols.join(', ');
+  }
+  return typeof protocols === 'string' ? protocols : '';
+};
+
+const parseProtocols = (value: string): string[] | undefined => {
+  const protocols = value
+    .split(',')
+    .map((protocol) => protocol.trim())
+    .filter(Boolean);
+
+  return protocols.length > 0 ? protocols : undefined;
+};
+
+const hasRawWebSocketProtocolHeader = (headers: unknown): boolean => {
+  return (
+    headers != null &&
+    typeof headers === 'object' &&
+    Object.keys(headers).some((key) => key.toLowerCase() === 'sec-websocket-protocol')
+  );
+};
+
 const highlightJS = (code: string): string => {
   try {
     const grammar = Prism?.languages?.javascript;
@@ -67,6 +91,25 @@ const WebSocketEndpointConfiguration = ({
             onChange={(e) => updateWebSocketTarget('messageTemplate', e.target.value)}
             rows={3}
           />
+        </div>
+
+        <div className="mt-4 space-y-2">
+          <Label htmlFor="websocket-protocols">WebSocket Subprotocols</Label>
+          <Input
+            id="websocket-protocols"
+            value={formatProtocols(selectedTarget.config.protocols)}
+            onChange={(e) => updateWebSocketTarget('protocols', parseProtocols(e.target.value))}
+            placeholder="json, graphql-transport-ws"
+          />
+          <p className="text-sm text-muted-foreground">
+            Optional comma-separated subprotocols to request during the WebSocket handshake.
+          </p>
+          {hasRawWebSocketProtocolHeader(selectedTarget.config.headers) && (
+            <p className="text-sm text-muted-foreground">
+              If your <code>Sec-WebSocket-Protocol</code> header is a negotiated subprotocol, move
+              it here. Leave it in headers only when your endpoint expects a raw header.
+            </p>
+          )}
         </div>
 
         <div className="mt-4">

--- a/src/app/src/pages/redteam/setup/types.ts
+++ b/src/app/src/pages/redteam/setup/types.ts
@@ -101,6 +101,7 @@ export interface ProviderOptions {
     headers?: Record<string, string>;
     body?: string | object;
     messageTemplate?: string;
+    protocols?: string[];
     // Browser specific options
     steps?: BrowserStep[];
     headless?: boolean;


### PR DESCRIPTION
## Summary
- adds a WebSocket Subprotocols field to the redteam target setup UI
- stores negotiated subprotocols in config.protocols instead of overloading headers
- preserves raw Sec-WebSocket-Protocol headers and shows migration guidance when they are present

## Testing
- npm run test:app -- WebSocketEndpointConfiguration.test.tsx

Depends on the runtime support merged in #9944.