### PR TITLE
fix(providers): correct stale model pricing

### DIFF
--- a/src/providers/azure/defaults.ts
+++ b/src/providers/azure/defaults.ts
@@ -47,55 +47,71 @@ export const AZURE_SORA_COST_PER_SECOND = 0.1;
 export const AZURE_MODELS: AzureModelCost[] = [
   // =============================================================================
   // GPT-5 Series (Latest Flagship)
-  // Note: Pricing is provisional/estimated based on relative model capabilities
+  // Global Standard rates verified against the Azure Retail Prices API (prices.azure.com, eastus2)
   // =============================================================================
   {
     id: 'gpt-5',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5-2025-08-07',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5-pro',
-    cost: { input: 5 / 1000000, output: 20 / 1000000 },
+    cost: { input: 15 / 1000000, output: 120 / 1000000 },
   },
   {
     id: 'gpt-5-pro-2025-10-06',
-    cost: { input: 5 / 1000000, output: 20 / 1000000 },
+    cost: { input: 15 / 1000000, output: 120 / 1000000 },
   },
   {
     id: 'gpt-5.4',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: {
+      input: 2.5 / 1000000,
+      output: 15 / 1000000,
+      longContext: { threshold: 272_000, input: 5 / 1000000, output: 22.5 / 1000000 },
+    },
   },
   {
     id: 'gpt-5.4-2026-03-05',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: {
+      input: 2.5 / 1000000,
+      output: 15 / 1000000,
+      longContext: { threshold: 272_000, input: 5 / 1000000, output: 22.5 / 1000000 },
+    },
   },
   {
     id: 'gpt-5.4-pro',
-    cost: { input: 5 / 1000000, output: 20 / 1000000 },
+    cost: {
+      input: 30 / 1000000,
+      output: 180 / 1000000,
+      longContext: { threshold: 272_000, input: 60 / 1000000, output: 270 / 1000000 },
+    },
   },
   {
     id: 'gpt-5.4-pro-2026-03-05',
-    cost: { input: 5 / 1000000, output: 20 / 1000000 },
+    cost: {
+      input: 30 / 1000000,
+      output: 180 / 1000000,
+      longContext: { threshold: 272_000, input: 60 / 1000000, output: 270 / 1000000 },
+    },
   },
   {
     id: 'gpt-5.4-mini',
-    cost: { input: 0.4 / 1000000, output: 1.6 / 1000000 },
+    cost: { input: 0.75 / 1000000, output: 4.5 / 1000000 },
   },
   {
     id: 'gpt-5.4-mini-2026-03-17',
-    cost: { input: 0.4 / 1000000, output: 1.6 / 1000000 },
+    cost: { input: 0.75 / 1000000, output: 4.5 / 1000000 },
   },
   {
     id: 'gpt-5.4-nano',
-    cost: { input: 0.1 / 1000000, output: 0.4 / 1000000 },
+    cost: { input: 0.2 / 1000000, output: 1.25 / 1000000 },
   },
   {
     id: 'gpt-5.4-nano-2026-03-17',
-    cost: { input: 0.1 / 1000000, output: 0.4 / 1000000 },
+    cost: { input: 0.2 / 1000000, output: 1.25 / 1000000 },
   },
   // gpt-5.5 / gpt-5.2 / gpt-5.3 — Global Standard rates verified against the Azure Retail Prices
   // API (prices.azure.com, serviceFamily 'AI + Machine Learning'). gpt-5.5 uses the short-context
@@ -138,76 +154,76 @@ export const AZURE_MODELS: AzureModelCost[] = [
   },
   {
     id: 'gpt-5-mini',
-    cost: { input: 0.4 / 1000000, output: 1.6 / 1000000 },
+    cost: { input: 0.25 / 1000000, output: 2 / 1000000 },
   },
   {
     id: 'gpt-5-mini-2025-08-07',
-    cost: { input: 0.4 / 1000000, output: 1.6 / 1000000 },
+    cost: { input: 0.25 / 1000000, output: 2 / 1000000 },
   },
   {
     id: 'gpt-5-nano',
-    cost: { input: 0.1 / 1000000, output: 0.4 / 1000000 },
+    cost: { input: 0.05 / 1000000, output: 0.4 / 1000000 },
   },
   {
     id: 'gpt-5-nano-2025-08-07',
-    cost: { input: 0.1 / 1000000, output: 0.4 / 1000000 },
+    cost: { input: 0.05 / 1000000, output: 0.4 / 1000000 },
   },
   {
     id: 'gpt-5-chat',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5-chat-2025-08-07',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5-chat-2025-10-03',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5-codex',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5-codex-2025-09-15',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
 
   // =============================================================================
   // GPT-5.1 Series (Newest)
-  // Note: Pricing is provisional/estimated based on relative model capabilities
+  // Global Standard rates verified against the Azure Retail Prices API (prices.azure.com, eastus2)
   // =============================================================================
   {
     id: 'gpt-5.1',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5.1-2025-11-13',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5.1-chat',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5.1-chat-2025-11-13',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5.1-codex',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5.1-codex-2025-11-13',
-    cost: { input: 2.5 / 1000000, output: 10 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 10 / 1000000 },
   },
   {
     id: 'gpt-5.1-codex-mini',
-    cost: { input: 0.4 / 1000000, output: 1.6 / 1000000 },
+    cost: { input: 0.25 / 1000000, output: 2 / 1000000 },
   },
   {
     id: 'gpt-5.1-codex-mini-2025-11-13',
-    cost: { input: 0.4 / 1000000, output: 1.6 / 1000000 },
+    cost: { input: 0.25 / 1000000, output: 2 / 1000000 },
   },
 
   // =============================================================================
@@ -251,11 +267,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
   },
   {
     id: 'o3',
-    cost: { input: 10 / 1000000, output: 40 / 1000000 },
+    cost: { input: 2 / 1000000, output: 8 / 1000000 },
   },
   {
     id: 'o3-2025-04-16',
-    cost: { input: 10 / 1000000, output: 40 / 1000000 },
+    cost: { input: 2 / 1000000, output: 8 / 1000000 },
   },
   {
     id: 'o3-pro',
@@ -375,11 +391,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
   },
   {
     id: 'gpt-realtime',
-    cost: { input: 5 / 1000000, output: 20 / 1000000 },
+    cost: { input: 4 / 1000000, output: 16 / 1000000 },
   },
   {
     id: 'gpt-realtime-2025-08-28',
-    cost: { input: 5 / 1000000, output: 20 / 1000000 },
+    cost: { input: 4 / 1000000, output: 16 / 1000000 },
   },
   {
     id: 'gpt-realtime-mini',
@@ -399,11 +415,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
   },
   {
     id: 'gpt-audio-mini',
-    cost: { input: 0.15 / 1000000, output: 0.6 / 1000000 },
+    cost: { input: 0.6 / 1000000, output: 2.4 / 1000000 },
   },
   {
     id: 'gpt-audio-mini-2025-10-06',
-    cost: { input: 0.15 / 1000000, output: 0.6 / 1000000 },
+    cost: { input: 0.6 / 1000000, output: 2.4 / 1000000 },
   },
 
   // =============================================================================
@@ -419,11 +435,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
   },
   {
     id: 'gpt-4o-mini-transcribe',
-    cost: { input: 0.15 / 1000000, output: 0.6 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 5 / 1000000 },
   },
   {
     id: 'gpt-4o-mini-transcribe-2025-03-20',
-    cost: { input: 0.15 / 1000000, output: 0.6 / 1000000 },
+    cost: { input: 1.25 / 1000000, output: 5 / 1000000 },
   },
   {
     id: 'gpt-4o-transcribe-diarize',
@@ -435,11 +451,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
   },
   {
     id: 'gpt-4o-mini-tts',
-    cost: { input: 0.15 / 1000000, output: 0.6 / 1000000 },
+    cost: { input: 0.6 / 1000000, output: 12 / 1000000 },
   },
   {
     id: 'gpt-4o-mini-tts-2025-03-20',
-    cost: { input: 0.15 / 1000000, output: 0.6 / 1000000 },
+    cost: { input: 0.6 / 1000000, output: 12 / 1000000 },
   },
 
   // =============================================================================
@@ -773,7 +789,7 @@ export const AZURE_MODELS: AzureModelCost[] = [
   },
   {
     id: 'grok-code-fast-1',
-    cost: { input: 0.15 / 1000000, output: 0.6 / 1000000 },
+    cost: { input: 0.2 / 1000000, output: 1.5 / 1000000 },
   },
   // Newer Grok on Azure — Global Standard from the Azure Retail Prices API (prices.azure.com).
   // (grok-4-20 is intentionally omitted: its catalog id maps ambiguously to either the "Grok 4.2"

--- a/src/providers/azure/defaults.ts
+++ b/src/providers/azure/defaults.ts
@@ -44,6 +44,13 @@ export const AZURE_VIDEO_DURATIONS = [5, 10, 15, 20] as const;
  */
 export const AZURE_SORA_COST_PER_SECOND = 0.1;
 
+/**
+ * Prompt-token count above which GPT-5.x models switch to their long-context
+ * pricing tier. Matches OpenAI's own threshold (see `GPT_5_LONG_CONTEXT_THRESHOLD`
+ * in `src/providers/openai/util.ts`).
+ */
+const GPT_5_LONG_CONTEXT_THRESHOLD = 272_000;
+
 export const AZURE_MODELS: AzureModelCost[] = [
   // =============================================================================
   // GPT-5 Series (Latest Flagship)
@@ -70,7 +77,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
     cost: {
       input: 2.5 / 1000000,
       output: 15 / 1000000,
-      longContext: { threshold: 272_000, input: 5 / 1000000, output: 22.5 / 1000000 },
+      longContext: {
+        threshold: GPT_5_LONG_CONTEXT_THRESHOLD,
+        input: 5 / 1000000,
+        output: 22.5 / 1000000,
+      },
     },
   },
   {
@@ -78,7 +89,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
     cost: {
       input: 2.5 / 1000000,
       output: 15 / 1000000,
-      longContext: { threshold: 272_000, input: 5 / 1000000, output: 22.5 / 1000000 },
+      longContext: {
+        threshold: GPT_5_LONG_CONTEXT_THRESHOLD,
+        input: 5 / 1000000,
+        output: 22.5 / 1000000,
+      },
     },
   },
   {
@@ -86,7 +101,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
     cost: {
       input: 30 / 1000000,
       output: 180 / 1000000,
-      longContext: { threshold: 272_000, input: 60 / 1000000, output: 270 / 1000000 },
+      longContext: {
+        threshold: GPT_5_LONG_CONTEXT_THRESHOLD,
+        input: 60 / 1000000,
+        output: 270 / 1000000,
+      },
     },
   },
   {
@@ -94,7 +113,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
     cost: {
       input: 30 / 1000000,
       output: 180 / 1000000,
-      longContext: { threshold: 272_000, input: 60 / 1000000, output: 270 / 1000000 },
+      longContext: {
+        threshold: GPT_5_LONG_CONTEXT_THRESHOLD,
+        input: 60 / 1000000,
+        output: 270 / 1000000,
+      },
     },
   },
   {
@@ -114,15 +137,31 @@ export const AZURE_MODELS: AzureModelCost[] = [
     cost: { input: 0.2 / 1000000, output: 1.25 / 1000000 },
   },
   // gpt-5.5 / gpt-5.2 / gpt-5.3 — Global Standard rates verified against the Azure Retail Prices
-  // API (prices.azure.com, serviceFamily 'AI + Machine Learning'). gpt-5.5 uses the short-context
-  // Global Standard tier (long-context is 10/45). gpt-5.2/5.3 chat and codex share 1.75/14.
+  // API (prices.azure.com, serviceFamily 'AI + Machine Learning'). gpt-5.5 long-context is 10/45
+  // above the threshold. gpt-5.2/5.3 chat and codex share 1.75/14.
   {
     id: 'gpt-5.5',
-    cost: { input: 5 / 1000000, output: 30 / 1000000 },
+    cost: {
+      input: 5 / 1000000,
+      output: 30 / 1000000,
+      longContext: {
+        threshold: GPT_5_LONG_CONTEXT_THRESHOLD,
+        input: 10 / 1000000,
+        output: 45 / 1000000,
+      },
+    },
   },
   {
     id: 'gpt-5.5-2026-04-23',
-    cost: { input: 5 / 1000000, output: 30 / 1000000 },
+    cost: {
+      input: 5 / 1000000,
+      output: 30 / 1000000,
+      longContext: {
+        threshold: GPT_5_LONG_CONTEXT_THRESHOLD,
+        input: 10 / 1000000,
+        output: 45 / 1000000,
+      },
+    },
   },
   {
     id: 'gpt-5.2',

--- a/src/providers/azure/types.ts
+++ b/src/providers/azure/types.ts
@@ -121,6 +121,11 @@ export interface AzureModelCost {
   cost: {
     input: number;
     output: number;
+    longContext?: {
+      threshold: number;
+      input: number;
+      output: number;
+    };
   };
 }
 

--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -21,6 +21,23 @@ type MiniMaxConfig = OpenAiCompletionOptions & {
   cacheReadCost?: number;
 };
 
+type MiniMaxModelCost = {
+  input: number;
+  output: number;
+  cache_read: number;
+  longContext?: {
+    threshold: number;
+    input: number;
+    output: number;
+    cache_read: number;
+  };
+};
+
+type MiniMaxModel = {
+  id: string;
+  cost: MiniMaxModelCost;
+};
+
 type MiniMaxProviderOptions = Omit<ProviderOptions, 'config'> & {
   config?: {
     config?: MiniMaxConfig;
@@ -37,13 +54,19 @@ function getProviderEnvString(env: EnvOverrides | undefined, key: EnvVarKey): st
   return undefined;
 }
 
-export const MINIMAX_CHAT_MODELS = [
+export const MINIMAX_CHAT_MODELS: MiniMaxModel[] = [
   {
     id: 'MiniMax-M3',
     cost: {
-      input: 0.6 / 1e6,
-      output: 2.4 / 1e6,
-      cache_read: 0.12 / 1e6,
+      input: 0.3 / 1e6,
+      output: 1.2 / 1e6,
+      cache_read: 0.06 / 1e6,
+      longContext: {
+        threshold: 512_000,
+        input: 0.6 / 1e6,
+        output: 2.4 / 1e6,
+        cache_read: 0.12 / 1e6,
+      },
     },
   },
   {
@@ -87,9 +110,13 @@ export function calculateMiniMaxCost(
     ? Math.min(Math.max(cachedTokens!, 0), promptTokens!)
     : 0;
   const uncachedPromptTokens = promptTokens! - billableCachedTokens;
-  const inputCost = config.inputCost ?? config.cost ?? model.cost.input;
-  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
-  const cacheReadCost = config.cacheReadCost ?? model.cost.cache_read;
+  const modelCost =
+    model.cost.longContext && promptTokens! > model.cost.longContext.threshold
+      ? model.cost.longContext
+      : model.cost;
+  const inputCost = config.inputCost ?? config.cost ?? modelCost.input;
+  const outputCost = config.outputCost ?? config.cost ?? modelCost.output;
+  const cacheReadCost = config.cacheReadCost ?? modelCost.cache_read;
 
   const inputCostTotal = inputCost * uncachedPromptTokens;
   const cacheReadCostTotal = cacheReadCost * billableCachedTokens;

--- a/src/providers/openai/billing.ts
+++ b/src/providers/openai/billing.ts
@@ -62,6 +62,7 @@ const STANDARD_CACHED_INPUT_RATES = buildRateTable<number>([
   { models: ['gpt-5.6-sol'], rates: perMillion(0.5) },
   { models: ['gpt-5.6-terra'], rates: perMillion(0.25) },
   { models: ['gpt-5.6-luna'], rates: perMillion(0.1) },
+  { models: ['chat-latest'], rates: perMillion(0.5) },
   { models: ['gpt-5.5', 'gpt-5.5-2026-04-23'], rates: perMillion(0.5) },
   { models: ['gpt-5.4', 'gpt-5.4-2026-03-05'], rates: perMillion(0.25) },
   { models: ['gpt-5.4-mini', 'gpt-5.4-mini-2026-03-17'], rates: perMillion(0.075) },

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -69,6 +69,15 @@ export const OPENAI_CHAT_MODELS: OpenAIModelInfo[] = [
       output: 15 / 1e6,
     },
   })),
+  // `chat-latest` is the bare alias for the latest Instant model used in ChatGPT
+  // (the pricing page's "Specialized models › ChatGPT" row).
+  ...['chat-latest'].map((model) => ({
+    id: model,
+    cost: {
+      input: 5 / 1e6,
+      output: 30 / 1e6,
+    },
+  })),
   ...['gpt-4.1', 'gpt-4.1-2025-04-14'].map((model) => ({
     id: model,
     cost: {
@@ -383,24 +392,15 @@ export const OPENAI_CHAT_MODELS: OpenAIModelInfo[] = [
     },
   })),
   // gpt-audio models
-  ...['gpt-audio', 'gpt-audio-2025-08-28'].map((model) => ({
+  ...['gpt-audio', 'gpt-audio-2025-08-28', 'gpt-audio-1.5'].map((model) => ({
     id: model,
-    cost: {
-      input: 2.5 / 1e6,
-      output: 10 / 1e6,
-      audioInput: 40 / 1e6,
-      audioOutput: 80 / 1e6,
-    },
-  })),
-  {
-    id: 'gpt-audio-1.5',
     cost: {
       input: 2.5 / 1e6,
       output: 10 / 1e6,
       audioInput: 32 / 1e6,
       audioOutput: 64 / 1e6,
     },
-  },
+  })),
   ...['gpt-audio-mini', 'gpt-audio-mini-2025-12-15', 'gpt-audio-mini-2025-10-06'].map((model) => ({
     id: model,
     cost: {

--- a/src/providers/xai/chat.ts
+++ b/src/providers/xai/chat.ts
@@ -95,6 +95,12 @@ type XAIModelCost = {
   };
 };
 
+type XAIModel = {
+  id: string;
+  cost: XAIModelCost;
+  aliases?: string[];
+};
+
 type XAIConfig = {
   region?: string;
   reasoning_effort?: 'none' | 'low' | 'medium' | 'high';
@@ -113,7 +119,7 @@ type XAIProviderOptions = Omit<ProviderOptions, 'config'> & {
 // Pricing here is sourced from xAI's `/v1/language-models/<id>` endpoint, which
 // reports per-token prices in "ticks" (1 tick = $1e-10). The same scale is used
 // by `usage.cost_in_usd_ticks` on chat/responses results.
-export const XAI_CHAT_MODELS = [
+export const XAI_CHAT_MODELS: XAIModel[] = [
   // Grok 4.20 Models
   {
     id: 'grok-4.20-0309-reasoning',
@@ -526,8 +532,10 @@ export function calculateXAICost(
   }
 
   const inputCostOverride = config.inputCost ?? config.cost;
+  // xAI charges the higher tier for requests that "exceed" the threshold, so the
+  // switch is exclusive (>), matching the minimax/azure/google tiered-cost paths.
   const modelCost: XAIModelCost =
-    model.cost.longContext && promptTokens >= model.cost.longContext.threshold
+    model.cost.longContext && promptTokens > model.cost.longContext.threshold
       ? model.cost.longContext
       : model.cost;
   const inputCost = inputCostOverride ?? modelCost.input;

--- a/src/providers/xai/chat.ts
+++ b/src/providers/xai/chat.ts
@@ -83,6 +83,18 @@ export interface XAICostConfig {
   cacheReadCost?: number;
 }
 
+type XAIModelCost = {
+  input: number;
+  output: number;
+  cache_read?: number;
+  longContext?: {
+    threshold: number;
+    input: number;
+    output: number;
+    cache_read?: number;
+  };
+};
+
 type XAIConfig = {
   region?: string;
   reasoning_effort?: 'none' | 'low' | 'medium' | 'high';
@@ -191,23 +203,21 @@ export const XAI_CHAT_MODELS = [
     },
     aliases: ['grok-4-1-fast-non-reasoning-latest'],
   },
-  // Grok Code Fast Models
+  // Grok Build Models
   {
-    id: 'grok-code-fast-1',
+    id: 'grok-build-0.1',
     cost: {
-      input: 0.2 / 1e6,
-      output: 1.5 / 1e6,
-      cache_read: 0.02 / 1e6,
+      input: 1.0 / 1e6,
+      output: 2.0 / 1e6,
+      cache_read: 0.2 / 1e6,
+      longContext: {
+        threshold: 200_000,
+        input: 2.0 / 1e6,
+        output: 4.0 / 1e6,
+        cache_read: 0.4 / 1e6,
+      },
     },
-    aliases: ['grok-code-fast'],
-  },
-  {
-    id: 'grok-code-fast-1-0825',
-    cost: {
-      input: 0.2 / 1e6,
-      output: 1.5 / 1e6,
-      cache_read: 0.02 / 1e6,
-    },
+    aliases: ['grok-code-fast-1', 'grok-code-fast', 'grok-code-fast-1-0825'],
   },
   // Grok-4 Fast Models (2M context window)
   {
@@ -336,10 +346,8 @@ const GROK_43_REDIRECTED_CHAT_MODELS = new Set([
   'grok-4-0709',
   'grok-4',
   'grok-4-latest',
-  // grok-code-fast-1 family — xAI's catalog also exposes a dated slug.
-  'grok-code-fast-1',
-  'grok-code-fast',
-  'grok-code-fast-1-0825',
+  // NOTE: the grok-code-fast family is NOT redirected here — xAI's current docs
+  // list those slugs as aliases of grok-build-0.1, which has its own pricing.
   // grok-3 family — xAI's catalog collapses every -beta/-fast variant into
   // the same id, so they all share the post-retirement billing target.
   'grok-3',
@@ -405,7 +413,7 @@ export const GROK_REASONING_MODELS = [
   'grok-4-1-fast',
   'grok-4-1-fast-latest',
   'grok-4-1-fast-reasoning-latest',
-  // Grok Code Fast
+  'grok-build-0.1',
   'grok-code-fast-1',
   'grok-code-fast',
   'grok-code-fast-1-0825',
@@ -518,10 +526,14 @@ export function calculateXAICost(
   }
 
   const inputCostOverride = config.inputCost ?? config.cost;
-  const inputCost = inputCostOverride ?? model.cost.input;
-  const outputCost = config.outputCost ?? config.cost ?? model.cost.output;
+  const modelCost: XAIModelCost =
+    model.cost.longContext && promptTokens >= model.cost.longContext.threshold
+      ? model.cost.longContext
+      : model.cost;
+  const inputCost = inputCostOverride ?? modelCost.input;
+  const outputCost = config.outputCost ?? config.cost ?? modelCost.output;
   const cacheReadCost =
-    config.cacheReadCost ?? inputCostOverride ?? model.cost.cache_read ?? inputCost;
+    config.cacheReadCost ?? inputCostOverride ?? modelCost.cache_read ?? inputCost;
 
   const billableCachedTokens = Number.isFinite(cachedTokens)
     ? Math.min(Math.max(cachedTokens!, 0), promptTokens)

--- a/test/providers/azure/util.test.ts
+++ b/test/providers/azure/util.test.ts
@@ -35,6 +35,24 @@ describe('calculateAzureCost', () => {
     expect(typeof cost).toBe('number');
   });
 
+  it('uses long-context pricing for GPT-5.4 above the 272k threshold', () => {
+    expect(calculateAzureCost('gpt-5.4', {}, 272_000, 1_000)).toBeCloseTo(
+      (272_000 * 2.5 + 1_000 * 15) / 1e6,
+      12,
+    );
+    expect(calculateAzureCost('gpt-5.4', {}, 272_001, 1_000)).toBeCloseTo(
+      (272_001 * 5 + 1_000 * 22.5) / 1e6,
+      12,
+    );
+  });
+
+  it('uses long-context pricing for GPT-5.4 pro above the 272k threshold', () => {
+    expect(calculateAzureCost('gpt-5.4-pro', {}, 272_001, 1_000)).toBeCloseTo(
+      (272_001 * 60 + 1_000 * 270) / 1e6,
+      12,
+    );
+  });
+
   it('calculates cost for Claude Fable 5', () => {
     expect(calculateAzureCost('claude-fable-5', {}, 1000, 500)).toBeCloseTo(0.035, 6);
   });
@@ -108,7 +126,7 @@ describe('AZURE_MODELS cost coverage', () => {
       id: 'gpt-5.4',
       inputTokens: 1000,
       outputTokens: 1000,
-      expectedCost: 0.0125,
+      expectedCost: 0.0175, // $2.50/1M input + $15/1M output
       family: 'GPT-5.x',
     },
     { id: 'gpt-4.1', inputTokens: 1000, outputTokens: 1000, expectedCost: 0.01, family: 'GPT-4.1' },
@@ -117,7 +135,7 @@ describe('AZURE_MODELS cost coverage', () => {
       id: 'o3',
       inputTokens: 1000,
       outputTokens: 1000,
-      expectedCost: 0.05,
+      expectedCost: 0.01, // $2/1M input + $8/1M output (June 2025 price cut)
       family: 'o-series reasoning',
     },
     {
@@ -248,6 +266,25 @@ describe('AZURE_MODELS cost coverage', () => {
     ['gpt-5.5', 5, 30],
     ['gpt-5.2', 1.75, 14],
     ['gpt-5.1-codex-max', 1.25, 10],
+    ['gpt-5', 1.25, 10],
+    ['gpt-5-pro', 15, 120],
+    ['gpt-5-mini', 0.25, 2],
+    ['gpt-5-nano', 0.05, 0.4],
+    ['gpt-5-chat', 1.25, 10],
+    ['gpt-5-codex', 1.25, 10],
+    ['gpt-5.1', 1.25, 10],
+    ['gpt-5.1-chat', 1.25, 10],
+    ['gpt-5.1-codex', 1.25, 10],
+    ['gpt-5.1-codex-mini', 0.25, 2],
+    ['gpt-5.4-pro', 60, 180],
+    ['gpt-5.4-mini', 0.75, 4.5],
+    ['gpt-5.4-nano', 0.2, 1.25],
+    ['o3', 2, 8],
+    ['gpt-realtime', 4, 16],
+    ['gpt-audio-mini', 0.6, 2.4],
+    ['gpt-4o-mini-transcribe', 1.25, 5],
+    ['gpt-4o-mini-tts', 0.6, 12],
+    ['grok-code-fast-1', 0.2, 1.5],
     ['grok-4.3', 1.25, 2.5],
     ['grok-4-1-fast-reasoning', 0.2, 0.5],
     ['Kimi-K2-Thinking', 0.6, 2.5],

--- a/test/providers/azure/util.test.ts
+++ b/test/providers/azure/util.test.ts
@@ -47,8 +47,23 @@ describe('calculateAzureCost', () => {
   });
 
   it('uses long-context pricing for GPT-5.4 pro above the 272k threshold', () => {
+    expect(calculateAzureCost('gpt-5.4-pro', {}, 272_000, 1_000)).toBeCloseTo(
+      (272_000 * 30 + 1_000 * 180) / 1e6,
+      12,
+    );
     expect(calculateAzureCost('gpt-5.4-pro', {}, 272_001, 1_000)).toBeCloseTo(
       (272_001 * 60 + 1_000 * 270) / 1e6,
+      12,
+    );
+  });
+
+  it('uses long-context pricing for GPT-5.5 above the 272k threshold', () => {
+    expect(calculateAzureCost('gpt-5.5', {}, 272_000, 1_000)).toBeCloseTo(
+      (272_000 * 5 + 1_000 * 30) / 1e6,
+      12,
+    );
+    expect(calculateAzureCost('gpt-5.5', {}, 272_001, 1_000)).toBeCloseTo(
+      (272_001 * 10 + 1_000 * 45) / 1e6,
       12,
     );
   });
@@ -260,8 +275,11 @@ describe('AZURE_MODELS cost coverage', () => {
     expect(calculateAzureCost(id, {}, 1000, 1000)).toBeGreaterThan(0);
   });
 
-  // Exact per-1M input/output rates for entries added/corrected from the Azure Retail Prices API.
-  // Probing input and output separately catches a swapped input/output or a transcription typo.
+  // Exact standard-tier per-1M input/output rates for entries added/corrected from the Azure
+  // Retail Prices API. Probing input and output separately catches a swapped input/output or a
+  // transcription typo. Input is probed at 100k tokens — below every long-context threshold —
+  // so tiered models (gpt-5.4-pro, gpt-5.5) assert their standard input rate here, while the
+  // long-context tiers are pinned by the dedicated boundary tests above.
   it.each([
     ['gpt-5.5', 5, 30],
     ['gpt-5.2', 1.75, 14],
@@ -276,7 +294,7 @@ describe('AZURE_MODELS cost coverage', () => {
     ['gpt-5.1-chat', 1.25, 10],
     ['gpt-5.1-codex', 1.25, 10],
     ['gpt-5.1-codex-mini', 0.25, 2],
-    ['gpt-5.4-pro', 60, 180],
+    ['gpt-5.4-pro', 30, 180],
     ['gpt-5.4-mini', 0.75, 4.5],
     ['gpt-5.4-nano', 0.2, 1.25],
     ['o3', 2, 8],
@@ -294,7 +312,7 @@ describe('AZURE_MODELS cost coverage', () => {
     ['gpt-oss-120b', 0.15, 0.6],
     ['Phi-3-medium-4k-instruct', 0.17, 0.68],
   ])('prices %s at exactly %d in / %d out per 1M', (id, inputPerM, outputPerM) => {
-    expect(calculateAzureCost(id, {}, 1_000_000, 0)).toBeCloseTo(inputPerM as number, 9);
+    expect(calculateAzureCost(id, {}, 100_000, 0)).toBeCloseTo((inputPerM as number) / 10, 9);
     expect(calculateAzureCost(id, {}, 0, 1_000_000)).toBeCloseTo(outputPerM as number, 9);
   });
 });

--- a/test/providers/minimax.test.ts
+++ b/test/providers/minimax.test.ts
@@ -24,11 +24,16 @@ vi.mock('../../src/logger', () => ({
 
 describe('calculateMiniMaxCost', () => {
   it('should calculate cost without cache for MiniMax-M3', () => {
-    const cost = calculateMiniMaxCost('MiniMax-M3', {}, 1000000, 1000000);
-    expect(cost).toBeCloseTo(3.0); // (0.6 + 2.4)
+    const cost = calculateMiniMaxCost('MiniMax-M3', {}, 500000, 1000000);
+    expect(cost).toBeCloseTo(1.35); // (0.3 * 0.5 + 1.2) — standard <=512k tier
   });
 
   it('should calculate cost with cache hits for MiniMax-M3', () => {
+    const cost = calculateMiniMaxCost('MiniMax-M3', {}, 500000, 1000000, 250000);
+    expect(cost).toBeCloseTo(1.29); // (0.3 * 0.25 + 0.06 * 0.25 + 1.2)
+  });
+
+  it('should calculate long-context cost for MiniMax-M3 above 512k prompt tokens', () => {
     const cost = calculateMiniMaxCost('MiniMax-M3', {}, 1000000, 1000000, 500000);
     expect(cost).toBeCloseTo(2.76); // (0.6 * 0.5 + 0.12 * 0.5 + 2.4)
   });
@@ -104,9 +109,15 @@ describe('MINIMAX_CHAT_MODELS', () => {
   it('should have correct pricing for MiniMax-M3', () => {
     const model = MINIMAX_CHAT_MODELS.find((m) => m.id === 'MiniMax-M3');
     expect(model).toBeDefined();
-    expect(model?.cost.input).toBeCloseTo(0.6 / 1e6);
-    expect(model?.cost.output).toBeCloseTo(2.4 / 1e6);
-    expect(model?.cost.cache_read).toBeCloseTo(0.12 / 1e6);
+    expect(model?.cost.input).toBeCloseTo(0.3 / 1e6);
+    expect(model?.cost.output).toBeCloseTo(1.2 / 1e6);
+    expect(model?.cost.cache_read).toBeCloseTo(0.06 / 1e6);
+    expect(model?.cost.longContext).toEqual({
+      threshold: 512_000,
+      input: 0.6 / 1e6,
+      output: 2.4 / 1e6,
+      cache_read: 0.12 / 1e6,
+    });
   });
 
   it('should have correct pricing for MiniMax-M2.7', () => {

--- a/test/providers/minimax.test.ts
+++ b/test/providers/minimax.test.ts
@@ -38,6 +38,19 @@ describe('calculateMiniMaxCost', () => {
     expect(cost).toBeCloseTo(2.76); // (0.6 * 0.5 + 0.12 * 0.5 + 2.4)
   });
 
+  it('should switch MiniMax-M3 to long-context pricing only above the 512k threshold', () => {
+    // Exactly at the threshold stays on the standard tier (exclusive >).
+    expect(calculateMiniMaxCost('MiniMax-M3', {}, 512_000, 1_000_000)).toBeCloseTo(
+      (0.3 * 512_000 + 1.2 * 1_000_000) / 1e6,
+      10,
+    );
+    // One token over switches the whole request to the long-context tier.
+    expect(calculateMiniMaxCost('MiniMax-M3', {}, 512_001, 1_000_000)).toBeCloseTo(
+      (0.6 * 512_001 + 2.4 * 1_000_000) / 1e6,
+      10,
+    );
+  });
+
   it('should calculate cost without cache for MiniMax-M2.7', () => {
     const cost = calculateMiniMaxCost('MiniMax-M2.7', {}, 1000000, 1000000);
     expect(cost).toBeCloseTo(1.5); // (0.3 + 1.2)

--- a/test/providers/openai/billing.test.ts
+++ b/test/providers/openai/billing.test.ts
@@ -137,6 +137,20 @@ describe('OpenAI billing helpers', () => {
     );
   });
 
+  it('prices chat-latest cached input at the published discount', () => {
+    expect(
+      calculateOpenAIUsageCost(
+        'chat-latest',
+        {},
+        {
+          prompt_tokens: 2_000,
+          completion_tokens: 1_000,
+          prompt_tokens_details: { cached_tokens: 500 },
+        },
+      ),
+    ).toBeCloseTo((1_500 * 5 + 500 * 0.5 + 1_000 * 30) / 1e6, 10);
+  });
+
   it('uses returned service tiers when pricing flex and priority work', () => {
     const usage = {
       input_tokens: 1_000,

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -221,6 +221,16 @@ describe('calculateOpenAICost', () => {
     expect(cost).toBeCloseTo((1000 * 2.5 + 500 * 10 + 200 * 32 + 100 * 64) / 1e6, 6);
   });
 
+  it('should calculate cost correctly with audio tokens for gpt-audio (repriced to $32/$64)', () => {
+    const cost = calculateOpenAICost('gpt-audio', {}, 1000, 500, 200, 100);
+    expect(cost).toBeCloseTo((1000 * 2.5 + 500 * 10 + 200 * 32 + 100 * 64) / 1e6, 6);
+  });
+
+  it('should calculate cost correctly for the chat-latest alias', () => {
+    const cost = calculateOpenAICost('chat-latest', {}, 1000, 500);
+    expect(cost).toBeCloseTo((1000 * 5 + 500 * 30) / 1e6, 6);
+  });
+
   it('should calculate cost correctly for gpt-audio-mini-2025-12-15', () => {
     const cost = calculateOpenAICost('gpt-audio-mini-2025-12-15', {}, 1000, 500, 200, 100);
     expect(cost).toBeCloseTo((1000 * 0.6 + 500 * 2.4 + 200 * 10 + 100 * 20) / 1e6, 6);

--- a/test/providers/xai/chat.test.ts
+++ b/test/providers/xai/chat.test.ts
@@ -707,27 +707,29 @@ describe('xAI Chat Provider', () => {
       }
     });
 
-    it('uses higher-context pricing for grok-build-0.1 and its aliases at 200k tokens', () => {
+    it('switches grok-build-0.1 and its aliases to higher-context pricing above 200k tokens', () => {
       for (const modelName of [
         'grok-build-0.1',
         'grok-code-fast-1',
         'grok-code-fast',
         'grok-code-fast-1-0825',
       ]) {
-        expect(calculateXAICost(modelName, {}, 199_999, 1_000)).toBeCloseTo(
-          (199_999 * 1 + 1_000 * 2) / 1e6,
+        // Exactly at the threshold stays on the standard tier (exclusive >).
+        expect(calculateXAICost(modelName, {}, 200_000, 1_000)).toBeCloseTo(
+          (200_000 * 1 + 1_000 * 2) / 1e6,
           10,
         );
-        expect(calculateXAICost(modelName, {}, 200_000, 1_000)).toBeCloseTo(
-          (200_000 * 2 + 1_000 * 4) / 1e6,
+        // One token over switches the whole request to the higher tier.
+        expect(calculateXAICost(modelName, {}, 200_001, 1_000)).toBeCloseTo(
+          (200_001 * 2 + 1_000 * 4) / 1e6,
           10,
         );
       }
     });
 
     it('uses higher-context cache-read pricing for grok-build-0.1 cached prompt tokens', () => {
-      expect(calculateXAICost('grok-build-0.1', {}, 200_000, 1_000, 0, 100_000)).toBeCloseTo(
-        (100_000 * 2 + 100_000 * 0.4 + 1_000 * 4) / 1e6,
+      expect(calculateXAICost('grok-build-0.1', {}, 200_001, 1_000, 0, 100_000)).toBeCloseTo(
+        (100_001 * 2 + 100_000 * 0.4 + 1_000 * 4) / 1e6,
         10,
       );
     });

--- a/test/providers/xai/chat.test.ts
+++ b/test/providers/xai/chat.test.ts
@@ -269,7 +269,8 @@ describe('xAI Chat Provider', () => {
       expect(GROK_3_MINI_MODELS).not.toContain('grok-2-1212');
     });
 
-    it('identifies Grok Code Fast as reasoning models', () => {
+    it('identifies Grok Build and its Grok Code Fast aliases as reasoning models', () => {
+      expect(GROK_REASONING_MODELS).toContain('grok-build-0.1');
       expect(GROK_REASONING_MODELS).toContain('grok-code-fast-1');
       expect(GROK_REASONING_MODELS).toContain('grok-code-fast');
       expect(GROK_REASONING_MODELS).toContain('grok-code-fast-1-0825');
@@ -680,10 +681,6 @@ describe('xAI Chat Provider', () => {
         'grok-4-1-fast-reasoning',
         'grok-4-fast-non-reasoning',
         'grok-4',
-        'grok-code-fast',
-        // xAI exposes a dated grok-code-fast-1 alias on /v1/language-models;
-        // it shares the post-retirement billing target with the undated slug.
-        'grok-code-fast-1-0825',
         'grok-3',
         // The grok-3 family collapses every -beta and -fast variant into the
         // same id on xAI's catalog, so all of them must redirect together.
@@ -694,6 +691,45 @@ describe('xAI Chat Provider', () => {
       ]) {
         expect(calculateXAICost(modelName, {}, 1_000_000, 1_000_000)).toBeCloseTo(3.75, 10);
       }
+    });
+
+    it('bills grok-build-0.1 and its grok-code-fast aliases at its own pricing', () => {
+      // xAI's docs list grok-code-fast-1 / grok-code-fast / grok-code-fast-1-0825 as
+      // aliases of grok-build-0.1 ($1.00 input / $2.00 output per 1M tokens), so they
+      // must NOT redirect to grok-4.3 pricing.
+      for (const modelName of [
+        'grok-build-0.1',
+        'grok-code-fast-1',
+        'grok-code-fast',
+        'grok-code-fast-1-0825',
+      ]) {
+        expect(calculateXAICost(modelName, {}, 100_000, 1_000_000)).toBeCloseTo(2.1, 10);
+      }
+    });
+
+    it('uses higher-context pricing for grok-build-0.1 and its aliases at 200k tokens', () => {
+      for (const modelName of [
+        'grok-build-0.1',
+        'grok-code-fast-1',
+        'grok-code-fast',
+        'grok-code-fast-1-0825',
+      ]) {
+        expect(calculateXAICost(modelName, {}, 199_999, 1_000)).toBeCloseTo(
+          (199_999 * 1 + 1_000 * 2) / 1e6,
+          10,
+        );
+        expect(calculateXAICost(modelName, {}, 200_000, 1_000)).toBeCloseTo(
+          (200_000 * 2 + 1_000 * 4) / 1e6,
+          10,
+        );
+      }
+    });
+
+    it('uses higher-context cache-read pricing for grok-build-0.1 cached prompt tokens', () => {
+      expect(calculateXAICost('grok-build-0.1', {}, 200_000, 1_000, 0, 100_000)).toBeCloseTo(
+        (100_000 * 2 + 100_000 * 0.4 + 1_000 * 4) / 1e6,
+        10,
+      );
     });
 
     it('returns undefined for invalid inputs', () => {


### PR DESCRIPTION
## Summary
- OpenAI: reprice `gpt-audio` audio tokens to $32/$64, add the `chat-latest` alias ($5/$30), and bill `chat-latest` cached input at the published $0.50/M rate
- xAI: bill `grok-code-fast-1`/`grok-code-fast`/`grok-code-fast-1-0825` as aliases of `grok-build-0.1`, keep `grok-build-0.1` out of the retired-model `grok-4.3` redirect set, and add the official higher-context tier above 200k prompt tokens ($2/M input, $0.40/M cached input, $4/M output)
- MiniMax: reprice `MiniMax-M3` to its current standard-tier rate and add configured `longContext` pricing above 512k prompt tokens
- Azure: sync OpenAI-family entries against the Azure Retail Prices API and add GPT-5.4/GPT-5.4 Pro long-context pricing above 272k prompt tokens; also fixes Azure's `grok-code-fast-1` meter to $0.20/$1.50, matching `prices.azure.com`

All pricing numbers were fact-checked against each provider's live docs/pricing API before landing. A related fix for Anthropic's stale >200K Sonnet 4.5/4.6 long-context tier is in a separate PR from `fix/claude-long-context-pricing`.

## Test plan
- [x] `npx vitest run test/providers/azure/util.test.ts test/providers/minimax.test.ts test/providers/openai/util.test.ts test/providers/openai/billing.test.ts test/providers/xai/chat.test.ts` — 343 passed
- [x] `npm run tsc`
- [x] `npm run l` — exits 0; reports existing complexity warnings outside the touched pricing files
- [x] `npm run f` — exits 0; reports the same existing complexity warnings
