### PR TITLE
test: simplify js-yaml mocks and dedupe json assertion fixtures

### DIFF
--- a/test/assertions/json.test.ts
+++ b/test/assertions/json.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { handleContainsJson, handleIsJson } from '../../src/assertions/json';
 import { createMockProvider, createProviderResponse } from '../factories/provider';
+import { createAtomicTestCase } from '../factories/testSuite';
 
-import type { AssertionParams, AssertionValue, AtomicTestCase } from '../../src/types/index';
+import type { AssertionParams, AssertionValue } from '../../src/types/index';
 
 const mockProvider = createMockProvider({
   id: 'mock',
@@ -14,7 +15,7 @@ const makeParams = (overrides: Partial<AssertionParams>): AssertionParams =>
     baseType: 'is-json' as const,
     assertionValueContext: {
       vars: {},
-      test: {} as AtomicTestCase,
+      test: createAtomicTestCase(),
       prompt: 'test prompt',
       logProbs: undefined,
       provider: mockProvider,
@@ -22,10 +23,19 @@ const makeParams = (overrides: Partial<AssertionParams>): AssertionParams =>
     },
     output: '{}',
     providerResponse: { output: '{}' },
-    test: {} as AtomicTestCase,
+    test: createAtomicTestCase(),
     inverse: false,
     ...overrides,
   }) as AssertionParams;
+
+const NAME_SCHEMA_YAML = [
+  'type: object',
+  'required:',
+  '  - name',
+  'properties:',
+  '  name:',
+  '    type: string',
+].join('\n');
 
 describe('handleIsJson', () => {
   it('passes for valid JSON with no schema', () => {
@@ -39,18 +49,10 @@ describe('handleIsJson', () => {
   });
 
   it('validates against a YAML string schema', () => {
-    const schema = [
-      'type: object',
-      'required:',
-      '  - name',
-      'properties:',
-      '  name:',
-      '    type: string',
-    ].join('\n');
     const pass = handleIsJson(
       makeParams({
-        assertion: { type: 'is-json', value: schema },
-        renderedValue: schema as AssertionValue,
+        assertion: { type: 'is-json', value: NAME_SCHEMA_YAML },
+        renderedValue: NAME_SCHEMA_YAML as AssertionValue,
         outputString: '{"name": "promptfoo"}',
       }),
     );
@@ -58,8 +60,8 @@ describe('handleIsJson', () => {
 
     const fail = handleIsJson(
       makeParams({
-        assertion: { type: 'is-json', value: schema },
-        renderedValue: schema as AssertionValue,
+        assertion: { type: 'is-json', value: NAME_SCHEMA_YAML },
+        renderedValue: NAME_SCHEMA_YAML as AssertionValue,
         outputString: '{"other": 1}',
       }),
     );
@@ -121,18 +123,10 @@ describe('handleContainsJson', () => {
   });
 
   it('validates contained JSON against a YAML string schema', () => {
-    const schema = [
-      'type: object',
-      'required:',
-      '  - name',
-      'properties:',
-      '  name:',
-      '    type: string',
-    ].join('\n');
     const pass = handleContainsJson(
       makeParams({
-        assertion: { type: 'contains-json', value: schema },
-        renderedValue: schema as AssertionValue,
+        assertion: { type: 'contains-json', value: NAME_SCHEMA_YAML },
+        renderedValue: NAME_SCHEMA_YAML as AssertionValue,
         outputString: 'result: {"name": "promptfoo"}',
       }),
     );
@@ -140,8 +134,8 @@ describe('handleContainsJson', () => {
 
     const fail = handleContainsJson(
       makeParams({
-        assertion: { type: 'contains-json', value: schema },
-        renderedValue: schema as AssertionValue,
+        assertion: { type: 'contains-json', value: NAME_SCHEMA_YAML },
+        renderedValue: NAME_SCHEMA_YAML as AssertionValue,
         outputString: 'result: {"other": 1}',
       }),
     );

--- a/test/redteam/shared.test.ts
+++ b/test/redteam/shared.test.ts
@@ -108,8 +108,12 @@ vi.mock('../../src/util/config/manage', async (importOriginal) => {
 });
 vi.mock('fs');
 vi.mock('fs/promises');
-vi.mock('js-yaml');
-vi.mock('../../src/util/yamlLoad');
+// js-yaml v5 is native ESM with a sealed namespace, so vi.spyOn cannot patch it.
+// Wrap dump in a spy-able mock that keeps the real implementation.
+vi.mock('js-yaml', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('js-yaml')>();
+  return { ...actual, dump: vi.fn(actual.dump) };
+});
 vi.mock('os');
 
 describe('doRedteamRun', () => {

--- a/test/util/config/main.test.ts
+++ b/test/util/config/main.test.ts
@@ -44,8 +44,12 @@ vi.mock('node:fs', () => ({
 }));
 
 vi.mock('os');
-vi.mock('js-yaml');
-vi.mock('../../../src/util/yamlLoad');
+// js-yaml v5 is native ESM with a sealed namespace, so vi.spyOn cannot patch it.
+// Wrap dump in a spy-able mock that keeps the real implementation.
+vi.mock('js-yaml', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('js-yaml')>();
+  return { ...actual, dump: vi.fn(actual.dump) };
+});
 vi.mock('../../../src/logger', () => ({
   default: {
     debug: vi.fn(),
@@ -196,6 +200,7 @@ describe('writePromptfooConfig', () => {
   });
 
   it('handles empty config', () => {
+    vi.mocked(yaml.dump).mockReturnValueOnce('');
     const mockConfig: Partial<UnifiedConfig> = {};
 
     writePromptfooConfig(mockConfig, mockOutputPath);


### PR DESCRIPTION
## Summary

Follow-up test cleanups from #9919 (found in a post-merge simplification review):

- Replace whole-library `vi.mock('js-yaml')` automocks — plus the `yamlLoad` automocks that existed only to guard against them — with the surgical `importOriginal` dump wrapper already used elsewhere in the suite, in `test/util/config/main.test.ts` and `test/redteam/shared.test.ts` (both suites exercise only `yaml.dump`). The empty-config test now stubs `dump` explicitly instead of relying on automock returning `undefined`.
- Hoist the duplicated YAML schema fixture in `test/assertions/json.test.ts` to a single module-level constant and use the existing `createAtomicTestCase` factory instead of `{} as AtomicTestCase` casts.

No production code changes.

## Verification

- `npx vitest run test/util/config/main.test.ts test/redteam/shared.test.ts test/assertions/json.test.ts test/util/yamlLoad.test.ts` — 63/63 pass against current `main` (js-yaml 5.1.0), including under random shuffle.
- `npm run tsc`, `npm run l` clean.