### PR TITLE
docs(site): document Portkey MCP Gateway with the mcp provider

### DIFF
--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -61,3 +61,34 @@ providers:
     portkeyProvider: xxx
     portkeyApiBaseUrl: xxx
 ```
+
+## Portkey MCP Gateway
+
+To test MCP servers exposed through [Portkey's MCP Gateway](https://portkey.ai/docs/product/mcp-gateway/), use promptfoo's [`mcp` provider](/docs/providers/mcp/), **not** the `portkey:` provider. The `portkey:` provider and the `PORTKEY_API_BASE_URL` environment variable only apply to Portkey's OpenAI-compatible LLM gateway — they send chat-completions requests and cannot speak the MCP protocol. Pointing `PORTKEY_API_BASE_URL` at `https://mcp.portkey.ai` will not work.
+
+The MCP Gateway exposes each registered server (including your own internal servers) at `https://mcp.portkey.ai/<server-slug>/mcp`, where `<server-slug>` is the slug you gave the server in the Portkey MCP Registry. Authenticate with a workspace API key that has the **MCP Invoke** permission, sent as the `x-portkey-api-key` header. Header auth is non-interactive, so it works in CI; if no API key is sent, the gateway falls back to an interactive OAuth flow that cannot complete in an automated run.
+
+```yaml title="promptfooconfig.yaml"
+providers:
+  - id: mcp
+    config:
+      enabled: true
+      server:
+        name: portkey-gateway
+        url: https://mcp.portkey.ai/<your-server-slug>/mcp
+        headers:
+          x-portkey-api-key: '{{env.PORTKEY_API_KEY}}'
+
+tests:
+  # Each test calls one tool. The prompt is a JSON tool-call payload.
+  - vars:
+      prompt: '{"tool": "your_tool_name", "args": {"param1": "value1"}}'
+    assert:
+      - type: is-json
+```
+
+To give an LLM tool-calling access to the gateway instead of calling tools directly, use the same `server` block under a provider's [`mcp` config](/docs/integrations/mcp/). To red team a gateway-fronted server, use the same `mcp` target with the [`mcp` red team plugin](/docs/red-team/plugins/mcp/).
+
+:::note
+If a server's upstream auth in Portkey is per-user OAuth 2.1, use a user API key rather than a service key. Servers with no upstream auth, static headers, or client-credentials auth work with a service key.
+:::


### PR DESCRIPTION
## Summary

Adds a **Portkey MCP Gateway** section to the Portkey integration docs, explaining how to test MCP servers exposed through [Portkey's MCP Gateway](https://portkey.ai/docs/product/mcp-gateway/) with promptfoo.

This closes a documentation gap surfaced by a user question (Informa security team): they tried to reach the gateway by setting `PORTKEY_API_BASE_URL=https://mcp.portkey.ai` on the `portkey:` provider, which cannot work — that provider only speaks OpenAI chat-completions. There was no doc or example showing the correct approach.

## What the new section covers

- **Use the `mcp` provider, not `portkey:`** — and why `PORTKEY_API_BASE_URL` at `mcp.portkey.ai` fails.
- Gateway URL format `https://mcp.portkey.ai/<server-slug>/mcp` and the `x-portkey-api-key` header (workspace key with the **MCP Invoke** permission; header auth is headless-safe, OAuth fallback is not).
- A copy-pasteable `promptfooconfig.yaml` example (validated against the local build).
- Pointers to attaching MCP tools to an LLM provider and to the `mcp` red team plugin.
- A note on per-user OAuth upstream servers needing a user key vs. a service key.

All facts were verified against Portkey's official docs and the promptfoo source (`src/providers/mcp/*`).

## Testing

- `SKIP_OG_GENERATION=true npm run build` in `site/` — succeeds, no broken-links or MDX errors.
- Prettier: clean.
- The example config validates with `promptfoo validate`.