### PR TITLE
docs(site): fix Portkey MCP Gateway setup guidance

### DIFF
--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -64,11 +64,14 @@ providers:
 
 ## Portkey MCP Gateway
 
-To test MCP servers exposed through [Portkey's MCP Gateway](https://portkey.ai/docs/product/mcp-gateway/), use promptfoo's [`mcp` provider](/docs/providers/mcp/), **not** the `portkey:` provider. The `portkey:` provider and the `PORTKEY_API_BASE_URL` environment variable only apply to Portkey's OpenAI-compatible LLM gateway — they send chat-completions requests and cannot speak the MCP protocol. Pointing `PORTKEY_API_BASE_URL` at `https://mcp.portkey.ai` will not work.
+To test an MCP server exposed through [Portkey's MCP Gateway](https://portkey.ai/docs/product/mcp-gateway/) directly, use promptfoo's [`mcp` provider](/docs/providers/mcp/) and put the gateway URL in `server.url`. Do not set `PORTKEY_API_BASE_URL` to `https://mcp.portkey.ai`: that setting configures the OpenAI-compatible chat-completions endpoint used by the `portkey:` provider, not an MCP endpoint.
 
-The MCP Gateway exposes each registered server (including your own internal servers) at `https://mcp.portkey.ai/<server-slug>/mcp`, where `<server-slug>` is the slug you gave the server in the Portkey MCP Registry. Authenticate with a workspace API key that has the **MCP Invoke** permission, sent as the `x-portkey-api-key` header. Header auth is non-interactive, so it works in CI; if no API key is sent, the gateway falls back to an interactive OAuth flow that cannot complete in an automated run.
+The MCP Gateway exposes each registered server (including internal servers) at `https://mcp.portkey.ai/<server-slug>/mcp`, where `<server-slug>` is the slug configured in Portkey's MCP Registry. For non-interactive CLI and CI runs, use a workspace user API key with the `mcp invoke` permission in the `x-portkey-api-key` header. Portkey also supports an interactive OAuth flow when no API key is provided. See [Portkey's MCP Gateway authentication guide](https://portkey.ai/docs/product/mcp-gateway/authentication).
 
 ```yaml title="promptfooconfig.yaml"
+prompts:
+  - '{{prompt}}'
+
 providers:
   - id: mcp
     config:
@@ -84,11 +87,8 @@ tests:
   - vars:
       prompt: '{"tool": "your_tool_name", "args": {"param1": "value1"}}'
     assert:
-      - type: is-json
+      - type: contains
+        value: 'expected result'
 ```
 
-To give an LLM tool-calling access to the gateway instead of calling tools directly, use the same `server` block under a provider's [`mcp` config](/docs/integrations/mcp/). To red team a gateway-fronted server, use the same `mcp` target with the [`mcp` red team plugin](/docs/red-team/plugins/mcp/).
-
-:::note
-If a server's upstream auth in Portkey is per-user OAuth 2.1, use a user API key rather than a service key. Servers with no upstream auth, static headers, or client-credentials auth work with a service key.
-:::
+Each direct test supplies a JSON tool call in the form `{"tool": "tool_name", "args": {...}}`. To test an LLM application's prompt-to-tool behavior, put the same `server` block under the LLM provider's [`mcp` config](/docs/integrations/mcp/). That LLM or application target is also the appropriate shape for the [`mcp` red team plugin](/docs/red-team/plugins/mcp/); direct `id: mcp` tests are deterministic tool-level evals without an LLM.

--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -64,9 +64,11 @@ providers:
 
 ## Portkey MCP Gateway
 
-To test an MCP server exposed through [Portkey's MCP Gateway](https://portkey.ai/docs/product/mcp-gateway/) directly, use promptfoo's [`mcp` provider](/docs/providers/mcp/) and put the gateway URL in `server.url`. Do not set `PORTKEY_API_BASE_URL` to `https://mcp.portkey.ai`: that setting configures the OpenAI-compatible chat-completions endpoint used by the `portkey:` provider, not an MCP endpoint.
+Promptfoo can connect to [Portkey's MCP Gateway](https://portkey.ai/docs/product/mcp-gateway/) in two ways. Use the [`mcp` provider](/docs/providers/mcp/) to test or red team the MCP server directly. To test an LLM application that uses the server, add the same server block to the model provider's [`mcp` config](/docs/integrations/mcp/).
 
-The MCP Gateway exposes each registered server (including internal servers) at `https://mcp.portkey.ai/<server-slug>/mcp`, where `<server-slug>` is the slug configured in Portkey's MCP Registry. For non-interactive CLI and CI runs, use a workspace user API key with the `mcp invoke` permission in the `x-portkey-api-key` header. Portkey also supports an interactive OAuth flow when no API key is provided. See [Portkey's MCP Gateway authentication guide](https://portkey.ai/docs/product/mcp-gateway/authentication).
+`PORTKEY_API_BASE_URL` does not configure the MCP connection. It sets the OpenAI-compatible chat-completions endpoint used by the `portkey:` provider and defaults to `https://api.portkey.ai/v1`. Put the MCP Gateway URL in `server.url` instead.
+
+The gateway exposes each registered server at `https://mcp.portkey.ai/<server-slug>/mcp`, where `<server-slug>` is the slug from Portkey's MCP Registry. For non-interactive CLI and CI runs, send a workspace user API key with `mcp invoke` permission in the `x-portkey-api-key` header. Without an API key, Portkey starts an interactive OAuth flow intended for browser-based clients. See [Portkey's authentication guide](https://portkey.ai/docs/product/mcp-gateway/authentication).
 
 ```yaml title="promptfooconfig.yaml"
 prompts:
@@ -91,4 +93,4 @@ tests:
         value: 'expected result'
 ```
 
-Each direct functional test supplies a JSON tool call in the form `{"tool": "tool_name", "args": {...}}`. You can also red team the same `id: mcp` target with the [`mcp` red team plugin](/docs/red-team/plugins/mcp/); promptfoo materializes generated attacks into calls to the server's tools. To test an LLM application's prompt-to-tool behavior instead, put the same `server` block under the model provider's [`mcp` config](/docs/integrations/mcp/).
+Each functional test sends one JSON tool call in the form `{"tool": "tool_name", "args": {...}}`. For a red-team run, use the same `id: mcp` target with the [`mcp` plugin](/docs/red-team/plugins/mcp/); Promptfoo converts generated attacks into valid calls to the server's tools.

--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -91,4 +91,4 @@ tests:
         value: 'expected result'
 ```
 
-Each direct test supplies a JSON tool call in the form `{"tool": "tool_name", "args": {...}}`. To test an LLM application's prompt-to-tool behavior, put the same `server` block under the LLM provider's [`mcp` config](/docs/integrations/mcp/). That LLM or application target is also the appropriate shape for the [`mcp` red team plugin](/docs/red-team/plugins/mcp/); direct `id: mcp` tests are deterministic tool-level evals without an LLM.
+Each direct functional test supplies a JSON tool call in the form `{"tool": "tool_name", "args": {...}}`. You can also red team the same `id: mcp` target with the [`mcp` red team plugin](/docs/red-team/plugins/mcp/); promptfoo materializes generated attacks into calls to the server's tools. To test an LLM application's prompt-to-tool behavior instead, put the same `server` block under the model provider's [`mcp` config](/docs/integrations/mcp/).


### PR DESCRIPTION
## Summary

This fixes and simplifies the Portkey MCP Gateway guidance added in #9954.

- use `id: mcp` for direct server tests and direct MCP red teaming
- use a model provider's `config.mcp` when testing an LLM application that calls MCP tools
- keep `PORTKEY_API_BASE_URL` on Portkey's chat-completions API and put the MCP endpoint in `server.url`
- document the workspace user API key and `mcp invoke` permission required for headless runs
- make the example complete and use an assertion that works with text tool responses

## Why

The original copy made the `portkey:` and `mcp` provider roles sound mutually exclusive and suggested service keys could work for some gateway configurations. The actual boundary is simpler: the model request uses the Portkey chat-completions endpoint, while every MCP connection uses its own `server.url`. Portkey's current quickstart specifies a workspace user API key with `mcp invoke` permission for programmatic access.

Reference: https://portkey.ai/docs/product/mcp-gateway/quickstart

## Validation

- `npm run l`
- `npx prettier --check site/docs/integrations/portkey.md`
- parsed the fenced YAML example and validated it against `TestSuiteConfigSchema`
- verified that `PortkeyChatCompletionProvider` retains inherited MCP configuration
- `cd site && SKIP_OG_GENERATION=true npm run build`
