### PR TITLE
fix(site): declare js-yaml dependency so Cloudflare Pages build resolves v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45217,6 +45217,7 @@
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "dompurify": "^3.4.8",
+        "js-yaml": "^5.0.0",
         "react-countup": "^6.5.3",
         "swiper": "^12.1.2"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -90,6 +90,7 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "dompurify": "^3.4.8",
+    "js-yaml": "^5.0.0",
     "react-countup": "^6.5.3",
     "swiper": "^12.1.2"
   }


### PR DESCRIPTION
## Problem

Every **Cloudflare Pages** deploy has failed since #9919 (js-yaml v5), while the in-repo **Build Docs** CI job stays green. The docs site preview hasn't deployed for any commit on `main` since 2026-07-02.

## Root cause

#9919 rewrote `site/src/utils/yaml.ts` to use js-yaml **v5-only** named exports (`defineMappingTag`, `legacyMapTag`, `setTag`, `mergeTag`, `binaryTag`, `timestampTag`, `omapTag`, `pairsTag`, `CORE_SCHEMA.withTags`) — but **`site/package.json` never declared `js-yaml`**. The site relied on the dependency being hoisted from the root workspace.

- **Build Docs (CI)** runs `docusaurus build` with `working-directory: site` **inside the root workspace**, so `yaml.ts` resolves the root-hoisted `js-yaml@5` → passes.
- **Cloudflare Pages** builds `site/` **in isolation** (its build root is `site/`). A standalone `npm install` there resolves `js-yaml@4.x` from docusaurus's transitive tree, which lacks the v5 exports.

## Reproduction (isolated `site/` build, mirroring Cloudflare)

```
BROKEN (transitive js-yaml 4.3.0):
  export 'defineMappingTag' (imported as 'yaml') was not found in 'js-yaml'
    in ./src/utils/yaml.ts   → build exit 1
FIXED (js-yaml declared → 5.2.1):
  [SUCCESS] Generated static files in "build".   → build exit 0
```

## Fix

Declare `js-yaml: ^5.0.0` as a direct `site` dependency (matches the root). js-yaml v5 already sits at the top level of the workspace, so the lockfile change is a single line and no new tree entries are added. v5 ships its own types, so no `@types/js-yaml` is required. Safe whether Cloudflare builds from `site/` or the repo root.

## Test plan
- [x] Isolated `site/` `npm install` + `docusaurus build` fails against transitive v4, succeeds with the declared v5 (reproduction above)
- [x] Bisected the failure to #9919; Build Docs CI green on the same commits
- [x] `prettier --check site/package.json` clean; lockfile diff is 1 line (no audit drift)