### PR TITLE
fix(providers): correct Codex SDK provider config handling

### DIFF
--- a/src/providers/openai/codex-sdk.ts
+++ b/src/providers/openai/codex-sdk.ts
@@ -2003,6 +2003,10 @@ export class OpenAICodexSDKProvider implements ApiProvider {
       ...this.config,
       ...context?.prompt?.config,
     };
+    // Promptfoo may attach the live target provider object to prompt config for
+    // generic provider workflows. Codex accepts this key for loader compatibility,
+    // but runtime variable rendering must not recurse into provider methods.
+    delete mergedConfig.provider;
     const config = renderVarsInObject(mergedConfig, context?.vars) as OpenAICodexSDKConfig;
 
     const requestedModel =

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -2516,6 +2516,35 @@ describe('OpenAICodexSDKProvider', () => {
         );
       });
 
+      it('should ignore attached live provider objects before rendering prompt config vars', async () => {
+        mockRun.mockResolvedValue(createMockResponse('Response'));
+
+        const attachedProvider: Record<string, unknown> = {
+          id: () => 'attached-provider',
+        };
+        attachedProvider.self = attachedProvider;
+
+        const provider = new OpenAICodexSDKProvider({
+          env: { OPENAI_API_KEY: 'test-api-key' },
+        });
+
+        await expect(
+          provider.callApi('Test prompt', {
+            prompt: {
+              config: {
+                model: '{{ model }}',
+                provider: attachedProvider,
+              } as any,
+            },
+            vars: { model: 'gpt-5.2' },
+          } as any),
+        ).resolves.toMatchObject({
+          output: 'Response',
+        });
+
+        expect(mockRun).toHaveBeenCalledWith('Test prompt', {});
+      });
+
       it('should use CODEX_API_KEY from env if available', async () => {
         mockRun.mockResolvedValue(createMockResponse('Response'));
 


### PR DESCRIPTION
## Summary

Fixes a config-handling bug in the OpenAI Codex SDK provider where a live target provider object attached to prompt config was passed through Nunjucks variable rendering.

Promptfoo attaches the live target `provider` object onto `prompt.config` for generic provider workflows. `OpenAICodexSDKProvider.callApi` merges `prompt.config` into its own config and then passes the merged object straight to `renderVarsInObject`. `renderVarsInObject` recurses into nested objects **and invokes any function-valued property** it encounters. Because a provider object exposes methods (`id()`, `callApi()`, ...) and can hold circular references, this caused variable rendering to:

- **call provider methods** during config rendering (unintended side effects), and
- for self-referential provider objects, **recurse until `RangeError: Maximum call stack size exceeded`**.

## Fix

Delete the injected `provider` key from the merged config before rendering:

```ts
delete mergedConfig.provider;
const config = renderVarsInObject(mergedConfig, context?.vars) as OpenAICodexSDKConfig;
```

The config type (`provider?: unknown`) and Zod schema (`provider: z.unknown().optional()`) already accept this key for loader compatibility — this change only prevents runtime var rendering from recursing into it.

## Test

Adds a regression test that attaches a self-referential provider object (with a function-valued `id()` method and a circular `self` reference) to `prompt.config` and asserts `callApi` resolves normally and forwards only the templated config to the SDK. Verified load-bearing: without the `delete`, the new test fails with `RangeError: Maximum call stack size exceeded`; with it, all 157 tests in the file pass.

## Provenance

Extracted from #8871 (agentic runtime redteam plugins/docs/examples) as an independent, low-risk provider fix that can land ahead of that PR's larger plugin work. This PR contains **only** the `codex-sdk.ts` config-handling hunk and its matching test — none of the agentic-runtime plugin/parser/docs code.

Refs #8871.
