### PR TITLE
refactor(redteam): extract reusable generatePrompts() primitive

### DIFF
--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -35,6 +35,18 @@ import type {
 } from '../../types/index';
 import type { RedteamGradingContext } from '../grading/types';
 
+export type GeneratedPrompt = {
+  __prompt: string;
+  metadata?: Record<string, unknown>;
+};
+
+type ParsedGeneratedPrompt = { __prompt: string } | Record<string, string>;
+
+type PromptLengthValidationResult = {
+  acceptedPrompts: ParsedGeneratedPrompt[];
+  retryInstructions: string | undefined;
+};
+
 /**
  * Abstract base class for creating plugins that generate test cases.
  */
@@ -108,6 +120,20 @@ export abstract class RedteamPluginBase {
     delayMs: number = 0,
     templateGetter: () => Promise<string> = this.getTemplate.bind(this),
   ): Promise<TestCase[]> {
+    const prompts = await this.generatePrompts(n, delayMs, templateGetter);
+    return this.promptsToTestCases(prompts);
+  }
+
+  /**
+   * Generates raw prompt payloads without converting them into TestCase objects.
+   * Portfolio-style generators can reuse this primitive while applying their own
+   * planning and selection steps before materialization.
+   */
+  protected async generatePrompts(
+    n: number,
+    delayMs: number = 0,
+    templateGetter: () => Promise<string> = this.getTemplate.bind(this),
+  ): Promise<GeneratedPrompt[]> {
     logger.debug(`Generating ${n} test cases`);
     const batchSize = 20;
 
@@ -126,10 +152,9 @@ export abstract class RedteamPluginBase {
      * In multi-input mode, returns Record<string, string>[]
      */
     let retryInstructions: string | undefined;
-    // biome-ignore-start lint/complexity/noExcessiveCognitiveComplexity: Existing redteam generation flow handles batching, parsing, retries, and validation in one place.
     const generatePrompts = async (
-      currentPrompts: { __prompt: string }[] | Record<string, string>[],
-    ): Promise<{ __prompt: string }[] | Record<string, string>[]> => {
+      currentPrompts: ParsedGeneratedPrompt[],
+    ): Promise<ParsedGeneratedPrompt[]> => {
       const remainingCount = n - currentPrompts.length;
       const currentBatchSize = Math.min(remainingCount, batchSize);
 
@@ -169,68 +194,15 @@ export abstract class RedteamPluginBase {
         return [];
       }
 
-      // Handle inference refusals. Result is thrown rather than returning an empty array in order to
-      // catch and show a explanatory error message.
-      // Skip the refusal check if the output contains valid prompt markers (e.g., "Prompt:", "PromptBlock:", "<Prompt>"),
-      // since generated test prompts may contain refusal-like language (e.g., "as an AI") as part of their content.
-      const hasValidPromptMarkers =
-        /prompt\s*:/i.test(generatedPrompts) ||
-        generatedPrompts.includes('PromptBlock:') ||
-        /<Prompt>/i.test(generatedPrompts);
-      if (!hasValidPromptMarkers && isBasicRefusal(generatedPrompts)) {
-        let message = `${this.provider.id()} returned a refusal during inference for ${this.constructor.name} test case generation.`;
-        // We don't know exactly why the prompt was refused, but we can provide hints to the user based on the values which were
-        // included in the context window during inference.
-        const context: Record<string, string> = {};
-        if (this.purpose) {
-          context.purpose = this.purpose;
-        }
-        if (this.config.examples) {
-          context.examples = this.config.examples.join(', ');
-        }
-
-        if (context) {
-          message += ` User-configured values were included in inference and may have been deemed harmful: ${JSON.stringify(context)}. Check these and retry.`;
-        }
-
-        throw new Error(message);
-      }
+      this.assertNotRefusal(generatedPrompts);
 
       // Use formatter to parse output
       const formatter = getPromptOutputFormatter(this.config);
       const parsedPrompts = formatter.parse(generatedPrompts, this.config);
-      const acceptedPrompts: ({ __prompt: string } | Record<string, string>)[] = [];
-      const rejectedPromptLengths: number[] = [];
-      let rejectedPromptLimit: number | undefined;
-
-      for (const prompt of parsedPrompts) {
-        const promptText = '__prompt' in prompt ? prompt.__prompt : JSON.stringify(prompt);
-        // TODO(ian): In multi-input mode, validate the generated user-facing field values rather
-        // than the serialized JSON envelope stored in __prompt, which overcounts keys/braces.
-        const violation = getGeneratedPromptOverLimit(promptText, this.config.maxCharsPerMessage);
-        if (violation) {
-          rejectedPromptLengths.push(violation.length);
-          rejectedPromptLimit = violation.limit;
-        } else {
-          acceptedPrompts.push(prompt);
-        }
-      }
-
-      if (rejectedPromptLengths.length > 0) {
-        retryInstructions = dedent`
-          Your previous response included ${rejectedPromptLengths.length} generated prompt${
-            rejectedPromptLengths.length === 1 ? '' : 's'
-          } that exceeded the ${rejectedPromptLimit ?? 'configured'}-character limit.
-          The longest rejected prompt was ${Math.max(...rejectedPromptLengths)} characters.
-          Generate replacement prompts only, and keep every user message within the character limit.
-        `.trim();
-      } else {
-        retryInstructions = undefined;
-      }
-
-      return acceptedPrompts as { __prompt: string }[] | Record<string, string>[];
+      const validationResult = this.validatePromptLengths(parsedPrompts);
+      retryInstructions = validationResult.retryInstructions;
+      return validationResult.acceptedPrompts;
     };
-    // biome-ignore-end lint/complexity/noExcessiveCognitiveComplexity: Existing redteam generation flow handles batching, parsing, retries, and validation in one place.
 
     const allPrompts = await retryWithDeduplication(
       generatePrompts as (current: { __prompt: string }[]) => Promise<{ __prompt: string }[]>,
@@ -243,7 +215,78 @@ export abstract class RedteamPluginBase {
       logger.warn(`Expected ${n} prompts, got ${prompts.length} for ${this.constructor.name}`);
     }
 
-    return this.promptsToTestCases(prompts as { __prompt: string }[]);
+    return prompts as GeneratedPrompt[];
+  }
+
+  private assertNotRefusal(generatedPrompts: string): void {
+    // Handle inference refusals. Result is thrown rather than returning an empty array in order to
+    // catch and show a explanatory error message.
+    // Skip the refusal check if the output contains valid prompt markers (e.g., "Prompt:", "PromptBlock:", "<Prompt>"),
+    // since generated test prompts may contain refusal-like language (e.g., "as an AI") as part of their content.
+    const hasValidPromptMarkers =
+      /prompt\s*:/i.test(generatedPrompts) ||
+      generatedPrompts.includes('PromptBlock:') ||
+      /<Prompt>/i.test(generatedPrompts);
+    if (hasValidPromptMarkers || !isBasicRefusal(generatedPrompts)) {
+      return;
+    }
+
+    let message = `${this.provider.id()} returned a refusal during inference for ${this.constructor.name} test case generation.`;
+    // We don't know exactly why the prompt was refused, but we can provide hints to the user based on the values which were
+    // included in the context window during inference.
+    const context: Record<string, string> = {};
+    if (this.purpose) {
+      context.purpose = this.purpose;
+    }
+    if (this.config.examples) {
+      context.examples = this.config.examples.join(', ');
+    }
+
+    if (Object.keys(context).length > 0) {
+      message += ` User-configured values were included in inference and may have been deemed harmful: ${JSON.stringify(context)}. Check these and retry.`;
+    }
+
+    throw new Error(message);
+  }
+
+  private validatePromptLengths(
+    parsedPrompts: ParsedGeneratedPrompt[],
+  ): PromptLengthValidationResult {
+    const acceptedPrompts: ParsedGeneratedPrompt[] = [];
+    const rejectedPromptLengths: number[] = [];
+    let rejectedPromptLimit: number | undefined;
+
+    for (const prompt of parsedPrompts) {
+      const promptText = '__prompt' in prompt ? prompt.__prompt : JSON.stringify(prompt);
+      // TODO(ian): In multi-input mode, validate the generated user-facing field values rather
+      // than the serialized JSON envelope stored in __prompt, which overcounts keys/braces.
+      const violation = getGeneratedPromptOverLimit(promptText, this.config.maxCharsPerMessage);
+      if (!violation) {
+        acceptedPrompts.push(prompt);
+        continue;
+      }
+
+      rejectedPromptLengths.push(violation.length);
+      rejectedPromptLimit = violation.limit;
+    }
+
+    if (rejectedPromptLengths.length === 0) {
+      return {
+        acceptedPrompts,
+        retryInstructions: undefined,
+      };
+    }
+
+    return {
+      acceptedPrompts,
+      retryInstructions: dedent`
+        Your previous response included ${rejectedPromptLengths.length} generated prompt${
+          rejectedPromptLengths.length === 1 ? '' : 's'
+        } that exceeded the ${rejectedPromptLimit ?? 'configured'}-character limit.
+        The longest rejected prompt was ${Math.max(...rejectedPromptLengths)} characters.
+        Generate replacement prompts only, and keep every user message within the character limit.
+      `.trim(),
+    };
   }
 
   /**
@@ -254,7 +297,7 @@ export abstract class RedteamPluginBase {
    * @param prompts - An array of { __prompt: string } objects.
    * @returns An array of test cases.
    */
-  protected async promptsToTestCases(prompts: { __prompt: string }[]): Promise<TestCase[]> {
+  protected async promptsToTestCases(prompts: GeneratedPrompt[]): Promise<TestCase[]> {
     const hasMultipleInputs = this.config.inputs && Object.keys(this.config.inputs).length > 0;
 
     return Promise.all(
@@ -287,6 +330,7 @@ export abstract class RedteamPluginBase {
             metadata: {
               pluginId: getShortPluginId(this.id),
               pluginConfig: this.config,
+              ...(promptObj.metadata ?? {}),
               ...(materializedInputVars?.metadata
                 ? { inputMaterialization: materializedInputVars.metadata }
                 : {}),

--- a/test/redteam/plugins/base.test.ts
+++ b/test/redteam/plugins/base.test.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, Mock, MockInstance, vi } f
 import cliState from '../../../src/cliState';
 import { matchesLlmRubric } from '../../../src/matchers/llmGrading';
 import { MULTI_INPUT_VAR } from '../../../src/redteam/constants';
-import { RedteamGraderBase, RedteamPluginBase } from '../../../src/redteam/plugins/base';
+import {
+  type GeneratedPrompt,
+  RedteamGraderBase,
+  RedteamPluginBase,
+} from '../../../src/redteam/plugins/base';
 import {
   parseGeneratedInputs,
   parseGeneratedPrompts,
@@ -2184,6 +2188,40 @@ describe('RedteamGraderBase', () => {
 
       // All fields should flow through
       expect(tests[0]?.metadata?.pluginConfig).toEqual(fullConfig);
+    });
+
+    it('merges per-prompt metadata from generatePrompts into generated test cases', async () => {
+      // Exercises the generatePrompts() primitive: a subclass can attach
+      // per-prompt metadata to a GeneratedPrompt and generateTests() surfaces it
+      // through promptsToTestCases without disturbing the plugin metadata.
+      class MetadataPlugin extends RedteamPluginBase {
+        readonly id = 'metadata-plugin-id';
+
+        protected async getTemplate(): Promise<string> {
+          return 'template';
+        }
+
+        protected getAssertions(prompt: string): Assertion[] {
+          return [{ type: 'contains', value: prompt }];
+        }
+
+        protected async generatePrompts(): Promise<GeneratedPrompt[]> {
+          return [{ __prompt: 'seeded prompt', metadata: { seededBy: 'test', weight: 3 } }];
+        }
+      }
+
+      const plugin = new MetadataPlugin(testProvider, 'test purpose', 'testVar', {});
+      const tests = await plugin.generateTests(1);
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0]?.vars?.testVar).toBe('seeded prompt');
+      expect(tests[0]?.metadata).toEqual(
+        expect.objectContaining({
+          pluginId: 'metadata-plugin-id',
+          seededBy: 'test',
+          weight: 3,
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Behavior-preserving refactor of `RedteamPluginBase`, extracted from #9401
(semantic generation portfolios) as the compile-time prerequisite that the
portfolio core builds on. Landing it on its own de-risks and shrinks #9401
without changing what any plugin emits.

## What changed

- **`generatePrompts()` primitive.** `generateTests()` now delegates to a new
  reusable `protected generatePrompts()` that returns `GeneratedPrompt[]`, and
  `promptsToTestCases()` materializes those into `TestCase[]`. This lets
  portfolio-style generators reuse the batching/retry/parse primitive while
  applying their own planning and selection before materialization.
- **Helper extraction.** The inline inference-refusal check and prompt-length
  validation move into `assertNotRefusal()` and `validatePromptLengths()`. The
  closure is now simple enough that the previous
  `noExcessiveCognitiveComplexity` biome suppression is no longer needed and was
  removed.
- **`GeneratedPrompt` metadata.** `GeneratedPrompt` carries optional per-prompt
  `metadata`, which `promptsToTestCases()` merges into the generated test case's
  metadata (dormant until a producer sets it, e.g. the portfolio core).
- **Correctness fix.** The refusal-hint builder tested `if (context)` on a
  freshly-allocated object literal, which is always truthy, so the
  "user-configured values were included" hint was appended even when no
  `purpose`/`examples` were present. Now gated on
  `Object.keys(context).length > 0`.

## Scope

Only the `generatePrompts()` primitive, its helpers, the `GeneratedPrompt`
metadata plumbing, and the empty-context fix are included. The portfolio
generation extension point, selection wiring, and `src/redteam/generation/*`
code from #9401 are intentionally **not** part of this PR — this slice does not
import from `src/redteam/generation/*`.

## Testing

- `npx vitest run test/redteam/plugins/base.test.ts` — 121 passed (adds one
  focused test proving the `generatePrompts()` → `promptsToTestCases()`
  delegation surfaces per-prompt `metadata`).
- `npx vitest run test/redteam/plugins/` — 56 files / 881 tests passed, confirming
  the refactor does not change what plugins emit.
- `npm run tsc`, `npm run l`, `npm run f` — clean.

Refs #9401.
