### PR TITLE
test: isolate hoisted mock state in 7 exposed suites

### DIFF
--- a/test/commands/mcp/server.test.ts
+++ b/test/commands/mcp/server.test.ts
@@ -160,7 +160,13 @@ describe('MCP Server', () => {
     mcpServerMocks.MockMcpServer.mockReset().mockImplementation(
       mcpServerMocks.mockMcpServerImplementation,
     );
-    streamableHttpMocks.constructor.mockClear();
+    streamableHttpMocks.constructor
+      .mockReset()
+      .mockImplementation(function MockStreamableHTTPServerTransport() {
+        return {
+          handleRequest: vi.fn(),
+        };
+      });
     mockRandomUUID.mockClear();
     mcpServerCalls.length = 0;
   });

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -134,6 +134,11 @@ describe('logger', () => {
     mockGetEnvBool.mockImplementation((_, defaultValue) => defaultValue);
     mockGetConfigDirectoryPath.mockReset();
     mockGetConfigDirectoryPath.mockReturnValue('/mock/config');
+    winstonMock.transports.File.mockReset().mockImplementation(function (this: {
+      write: ReturnType<typeof vi.fn>;
+    }) {
+      this.write = vi.fn();
+    });
     for (const fn of Object.values(fsMock)) {
       (fn as Mock).mockReset();
     }

--- a/test/providers/mcp/client.test.ts
+++ b/test/providers/mcp/client.test.ts
@@ -85,7 +85,7 @@ const mcpMocks = vi.hoisted(() => {
   };
 });
 
-const { mockClient, mockStdioTransport, mockStreamableHTTPTransport } = mcpMocks;
+const { mockClient, mockSSETransport, mockStdioTransport, mockStreamableHTTPTransport } = mcpMocks;
 
 // Mock the modules before importing them
 vi.mock('@modelcontextprotocol/sdk/client/index.js', async (importOriginal) => {
@@ -146,6 +146,27 @@ describe('MCPClient', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockClient.registerCapabilities.mockReset();
+    mockClient.assertCapability.mockReset();
+    mockClient.connect.mockReset();
+    mockClient.ping.mockReset().mockResolvedValue({});
+    mockClient.listTools.mockReset().mockResolvedValue({
+      tools: [{ name: 'tool1', description: 'desc1', inputSchema: {} }],
+    });
+    mockClient.callTool.mockReset();
+    mockClient.close.mockReset().mockResolvedValue(undefined);
+    mockStdioTransport.close.mockReset().mockResolvedValue(undefined);
+    mockStdioTransport.connect.mockReset();
+    mockStdioTransport.start.mockReset();
+    mockStdioTransport.send.mockReset();
+    mockStreamableHTTPTransport.close.mockReset().mockResolvedValue(undefined);
+    mockStreamableHTTPTransport.connect.mockReset();
+    mockStreamableHTTPTransport.start.mockReset();
+    mockStreamableHTTPTransport.send.mockReset();
+    mockSSETransport.close.mockReset().mockResolvedValue(undefined);
+    mockSSETransport.connect.mockReset();
+    mockSSETransport.start.mockReset();
+    mockSSETransport.send.mockReset();
     mockGetEnvInt.mockReset();
     mockGetEnvInt.mockReturnValue(undefined);
     // Reset the OAuth token mock to return a valid token by default

--- a/test/providers/mcp/provider.test.ts
+++ b/test/providers/mcp/provider.test.ts
@@ -25,10 +25,10 @@ function createContext(payload: Record<string, unknown>) {
 describe('MCPProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mcpClientMock.initialize.mockResolvedValue(undefined);
-    mcpClientMock.getAllTools.mockReturnValue([]);
+    mcpClientMock.initialize.mockReset().mockResolvedValue(undefined);
+    mcpClientMock.getAllTools.mockReset().mockReturnValue([]);
     mcpClientMock.callTool.mockReset();
-    mcpClientMock.cleanup.mockResolvedValue(undefined);
+    mcpClientMock.cleanup.mockReset().mockResolvedValue(undefined);
   });
 
   it('should preserve existing output behavior without a response transform', async () => {

--- a/test/providers/pythonCompletion.cliState.test.ts
+++ b/test/providers/pythonCompletion.cliState.test.ts
@@ -104,6 +104,8 @@ describe('PythonProvider cliState.maxConcurrency', () => {
     workerPoolMocks.PythonWorkerPoolMock.mockClear();
     mockPoolInstance.initialize.mockReset().mockResolvedValue(undefined);
     mockPoolInstance.execute.mockReset().mockResolvedValue({ output: 'test' });
+    mockPoolInstance.getWorkerCount.mockReset().mockReturnValue(1);
+    mockPoolInstance.shutdown.mockReset().mockResolvedValue(undefined);
 
     // Reset cliState
     cliState.maxConcurrency = undefined;

--- a/test/redteam/providers/crescendo/index.test.ts
+++ b/test/redteam/providers/crescendo/index.test.ts
@@ -85,6 +85,11 @@ vi.mock('../../../../src/evaluatorHelpers', async () => ({
 
 beforeEach(() => {
   vi.mocked(shouldGenerateRemote).mockReturnValue(false);
+  mockApplyRuntimeTransforms.mockReset().mockImplementation(async ({ prompt }) => ({
+    transformedPrompt: prompt,
+    audio: undefined,
+    image: undefined,
+  }));
 });
 
 describe('MemorySystem', () => {

--- a/test/redteam/providers/hydra/index.test.ts
+++ b/test/redteam/providers/hydra/index.test.ts
@@ -115,6 +115,11 @@ describe('HydraProvider', () => {
     vi.clearAllMocks();
     // Reset the hoisted mock to ensure clean state
     mockGetGraderById.mockReset();
+    mockApplyRuntimeTransforms.mockReset().mockImplementation(async ({ prompt }) => ({
+      transformedPrompt: prompt,
+      audio: undefined,
+      image: undefined,
+    }));
     mockGetSessionId.mockReset().mockImplementation((response, context) => {
       return response?.sessionId ?? context?.vars?.sessionId;
     });


### PR DESCRIPTION
## Summary

This is the **additive mock-reset hardening** slice extracted from the monolith test-hygiene PR #9798, landable on its own.

Each of these 7 suites shares hoisted mock defaults (defined once via `vi.hoisted(...)`) across tests. Because `vi.clearAllMocks()` only clears call history — it does **not** restore a mock's implementation or return value — a test that reassigns a hoisted mock (e.g. `mockResolvedValueOnce`, or replacing an implementation) can leak that state into later tests, making them order-dependent. This change makes each suite's `beforeEach` explicitly `.mockReset()` and re-apply the intended default implementation/return value for the shared hoisted bindings it depends on, restoring per-test isolation.

## Changes

Pure `beforeEach` hardening in 7 exposed test files — no production code, no new test infrastructure:

- `test/commands/mcp/server.test.ts` — reset + re-implement the StreamableHTTP transport constructor mock
- `test/logger.test.ts` — reset + re-implement the winston `transports.File` mock
- `test/providers/mcp/client.test.ts` — reset the hoisted MCP client/transport mocks (including the previously-unreferenced SSE transport binding) and re-apply their defaults
- `test/providers/mcp/provider.test.ts` — `.mockReset()` before re-applying `initialize`/`getAllTools`/`cleanup` defaults
- `test/providers/pythonCompletion.cliState.test.ts` — reset `getWorkerCount`/`shutdown` on the shared pool instance
- `test/redteam/providers/crescendo/index.test.ts` — reset + re-implement `applyRuntimeTransforms`
- `test/redteam/providers/hydra/index.test.ts` — reset + re-implement `applyRuntimeTransforms`

## Why split it out

This carries no production-code changes and no open review threads, so it can land independently of #9798's deferred reset-interpreter work. Merging it now shrinks the blast radius of #9798.

## Verification

- `npx vitest run` across all 7 suites: **7 files passed, 267 tests passed**
- `npm run tsc`: clean
- `npm run l` / `npm run f`: no fixes applied

Extracted from #9798.
