### PR TITLE
fix(mcp): contain HTTP transport to loopback with host/CSRF protection

### DIFF
--- a/architecture/edge-baseline.json
+++ b/architecture/edge-baseline.json
@@ -11,7 +11,7 @@
   "cli -> node": 124,
   "cli -> providers": 3,
   "cli -> redteam": 10,
-  "cli -> view-server": 6,
+  "cli -> view-server": 7,
   "core -> contracts": 1,
   "core -> legacy-contracts": 94,
   "core -> legacy-runtime": 47,

--- a/site/docs/integrations/mcp-server.md
+++ b/site/docs/integrations/mcp-server.md
@@ -1,13 +1,13 @@
 ---
 title: Promptfoo MCP Server
-description: Deploy promptfoo as Model Context Protocol server enabling external AI agents to access evaluation and red teaming capabilities
+description: Run promptfoo as a local Model Context Protocol server for evaluation and red teaming capabilities
 sidebar_label: MCP Server
 sidebar_position: 21
 ---
 
 # Promptfoo MCP Server
 
-Expose promptfoo's eval tools to AI agents via Model Context Protocol (MCP).
+Expose promptfoo's eval tools to local AI agents via Model Context Protocol (MCP).
 
 :::info Prerequisites
 
@@ -36,7 +36,7 @@ instead of `npx promptfoo@latest ...` so both packages resolve from the same pro
 # For Cursor, Claude Desktop (STDIO transport)
 npx promptfoo@latest mcp --transport stdio
 
-# For web tools (HTTP transport)
+# For local web tools (HTTP transport)
 npx promptfoo@latest mcp --transport http --port 3100
 ```
 
@@ -167,7 +167,13 @@ The AI will:
 Choose the appropriate transport based on your use case:
 
 - **STDIO (`--transport stdio`)**: For desktop AI tools (Cursor, Claude Desktop) that communicate via stdin/stdout
-- **HTTP (`--transport http`)**: For web applications, APIs, and remote integrations that need HTTP endpoints
+- **HTTP (`--transport http`)**: For local web applications, APIs, and integrations that need HTTP endpoints. HTTP binds to `127.0.0.1`.
+
+### HTTP Security
+
+The HTTP transport exposes tools that can run evals, read local promptfoo configs, and write generated outputs. It only listens on `127.0.0.1`, rejects non-local `Host` headers, and blocks cross-site browser POSTs.
+
+MCP tools that load config files accept YAML and JSON configs only. JavaScript and TypeScript configs are rejected because importing them executes code. Config globs and referenced files must also stay within the project directory where the MCP server started.
 
 ## Best Practices
 
@@ -298,6 +304,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 
 # Configure promptfoo behavior
 export PROMPTFOO_CONFIG_DIR=/path/to/configs
+export PROMPTFOO_OUTPUT_DIR=/path/to/outputs
 
 # Start server with environment
 npx promptfoo@latest mcp --transport stdio

--- a/src/commands/mcp/server.ts
+++ b/src/commands/mcp/server.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import express from 'express';
 import logger from '../../logger';
+import { csrfProtection } from '../../server/middleware/csrfProtection';
 import telemetry from '../../telemetry';
 import { isMissingPackageImportError } from '../../util/packageImportErrors';
 import { registerResources } from './resources';
@@ -18,6 +19,39 @@ import { registerRunEvaluationTool } from './tools/runEvaluation';
 import { registerShareEvaluationTool } from './tools/shareEvaluation';
 import { registerTestProviderTool } from './tools/testProvider';
 import { registerValidatePromptfooConfigTool } from './tools/validatePromptfooConfig';
+import type { NextFunction, Request, Response } from 'express';
+
+export const DEFAULT_MCP_HTTP_HOST = '127.0.0.1';
+const ALLOWED_MCP_HTTP_HOSTS = new Set(['127.0.0.1', 'localhost', '[::1]', '::1']);
+
+function getHostnameFromHostHeader(host: string): string | undefined {
+  const bracketedIpv6 = host.match(/^(\[[^\]]+\])(?::\d+)?$/);
+  if (bracketedIpv6) {
+    return bracketedIpv6[1].toLowerCase();
+  }
+
+  const hostnameWithOptionalPort = host.match(/^([^:@/]+)(?::\d+)?$/);
+  return hostnameWithOptionalPort?.[1].toLowerCase();
+}
+
+export function mcpHostProtection(req: Request, res: Response, next: NextFunction): void {
+  const hostname = req.headers.host ? getHostnameFromHostHeader(req.headers.host) : undefined;
+  if (hostname && ALLOWED_MCP_HTTP_HOSTS.has(hostname)) {
+    next();
+    return;
+  }
+
+  logger.warn('[MCP] Blocked request with non-local Host header', {
+    host: req.headers.host,
+    method: req.method,
+    path: req.path,
+  });
+  res.status(403).json({ error: 'MCP HTTP requests require a local Host header' });
+}
+
+function formatHttpHostForUrl(host: string): string {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
 
 function setMcpTransport(transport: 'http' | 'stdio'): void {
   Object.assign(process.env, { MCP_TRANSPORT: transport });
@@ -129,7 +163,9 @@ export async function startHttpMcpServer(port: number): Promise<void> {
   setMcpTransport('http');
 
   const app = express();
+  app.use(mcpHostProtection);
   app.use(express.json());
+  app.use(csrfProtection);
 
   const mcpServer = await createMcpServer();
 
@@ -159,14 +195,17 @@ export async function startHttpMcpServer(port: number): Promise<void> {
   // Return a Promise that only resolves when the server shuts down
   // This keeps long-running commands running until SIGINT/SIGTERM
   return new Promise<void>((resolve) => {
-    const httpServer = app.listen(port, () => {
-      logger.info(`Promptfoo MCP server running at http://localhost:${port}`);
-      logger.info(`MCP endpoint: http://localhost:${port}/mcp`);
-      logger.info(`SSE endpoint: http://localhost:${port}/mcp/sse`);
+    const host = DEFAULT_MCP_HTTP_HOST;
+    const urlHost = formatHttpHostForUrl(host);
+    const httpServer = app.listen(port, host, () => {
+      logger.info(`Promptfoo MCP server running at http://${urlHost}:${port}`);
+      logger.info(`MCP endpoint: http://${urlHost}:${port}/mcp`);
+      logger.info(`SSE endpoint: http://${urlHost}:${port}/mcp/sse`);
 
       // Track server start
       telemetry.record('feature_used', {
         feature: 'mcp_server_started',
+        host,
         transport: 'http',
         port,
       });
@@ -181,6 +220,8 @@ export async function startHttpMcpServer(port: number): Promise<void> {
         return;
       }
       isShuttingDown = true;
+      process.removeListener('SIGINT', shutdown);
+      process.removeListener('SIGTERM', shutdown);
 
       logger.info('Shutting down MCP server...');
       const SHUTDOWN_TIMEOUT_MS = 5000;
@@ -261,6 +302,9 @@ export async function startStdioMcpServer(): Promise<void> {
           return;
         }
         isShuttingDown = true;
+        process.removeListener('SIGINT', shutdown);
+        process.removeListener('SIGTERM', shutdown);
+        process.stdin.removeListener('end', shutdown);
 
         // Add timeout to prevent indefinite hangs, matching HTTP server pattern
         const SHUTDOWN_TIMEOUT_MS = 5000;

--- a/test/commands/mcp/server.test.ts
+++ b/test/commands/mcp/server.test.ts
@@ -9,30 +9,6 @@ vi.mock('node:crypto', () => ({
   randomUUID: mockRandomUUID,
 }));
 
-const expressMocks = vi.hoisted(() => {
-  const close = vi.fn((callback: (error?: Error) => void) => callback());
-  const listen = vi.fn((_port: number, callback: () => void) => {
-    callback();
-    return { close };
-  });
-  const app = {
-    use: vi.fn(),
-    post: vi.fn(),
-    get: vi.fn(),
-    listen,
-  };
-  const json = vi.fn();
-  const express = Object.assign(
-    vi.fn(() => app),
-    { json },
-  );
-  return { app, close, express, json, listen };
-});
-
-vi.mock('express', () => ({
-  default: expressMocks.express,
-}));
-
 // Mock dependencies before importing the module
 vi.mock('../../../src/logger', () => ({
   default: {
@@ -128,6 +104,41 @@ const mcpServerMocks = vi.hoisted(() => {
   return { mcpServerCalls, MockMcpServer, mockMcpServerImplementation };
 });
 
+const expressMocks = vi.hoisted(() => {
+  const postHandlers: Record<string, any> = {};
+  const getHandlers: Record<string, any> = {};
+  const httpServer = {
+    close: vi.fn((callback?: (error?: Error) => void) => callback?.()),
+  };
+  const app = {
+    get: vi.fn(),
+    listen: vi.fn(),
+    post: vi.fn(),
+    use: vi.fn(),
+  };
+  const expressFactory = Object.assign(
+    vi.fn(() => app),
+    {
+      json: vi.fn(() => 'json-middleware'),
+    },
+  );
+
+  return { app, expressFactory, getHandlers, httpServer, postHandlers };
+});
+
+const transportMocks = vi.hoisted(() => {
+  const instances: Array<{ handleRequest: ReturnType<typeof vi.fn> }> = [];
+  const StreamableHTTPServerTransport = vi.fn(function MockStreamableHTTPServerTransport(
+    this: { handleRequest: ReturnType<typeof vi.fn> },
+    _options?: { sessionIdGenerator?: () => string },
+  ) {
+    this.handleRequest = vi.fn().mockResolvedValue(undefined);
+    instances.push(this);
+  });
+
+  return { instances, StreamableHTTPServerTransport };
+});
+
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   McpServer: mcpServerMocks.MockMcpServer,
 }));
@@ -136,16 +147,12 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
   StdioServerTransport: vi.fn().mockImplementation(() => ({})),
 }));
 
-const streamableHttpMocks = vi.hoisted(() => ({
-  constructor: vi.fn().mockImplementation(function MockStreamableHTTPServerTransport() {
-    return {
-      handleRequest: vi.fn(),
-    };
-  }),
+vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: transportMocks.StreamableHTTPServerTransport,
 }));
 
-vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
-  StreamableHTTPServerTransport: streamableHttpMocks.constructor,
+vi.mock('express', () => ({
+  default: expressMocks.expressFactory,
 }));
 
 const { mcpServerCalls } = mcpServerMocks;
@@ -160,9 +167,25 @@ describe('MCP Server', () => {
     mcpServerMocks.MockMcpServer.mockReset().mockImplementation(
       mcpServerMocks.mockMcpServerImplementation,
     );
-    streamableHttpMocks.constructor.mockClear();
     mockRandomUUID.mockClear();
     mcpServerCalls.length = 0;
+    transportMocks.instances.length = 0;
+    Object.keys(expressMocks.postHandlers).forEach((key) => delete expressMocks.postHandlers[key]);
+    Object.keys(expressMocks.getHandlers).forEach((key) => delete expressMocks.getHandlers[key]);
+    expressMocks.app.use.mockReset().mockReturnValue(expressMocks.app);
+    expressMocks.app.post.mockReset().mockImplementation((path, handler) => {
+      expressMocks.postHandlers[path] = handler;
+      return expressMocks.app;
+    });
+    expressMocks.app.get.mockReset().mockImplementation((path, handler) => {
+      expressMocks.getHandlers[path] = handler;
+      return expressMocks.app;
+    });
+    expressMocks.app.listen.mockReset().mockImplementation((_port, _host, callback) => {
+      callback?.();
+      return expressMocks.httpServer;
+    });
+    expressMocks.httpServer.close.mockReset().mockImplementation((callback) => callback?.());
   });
 
   describe('createMcpServer', () => {
@@ -284,7 +307,142 @@ describe('MCP Server', () => {
     });
   });
 
+  describe('mcpHostProtection', () => {
+    const buildContext = (host?: string) => {
+      const req = { headers: host === undefined ? {} : { host }, method: 'POST', path: '/mcp' };
+      const res = { json: vi.fn(), status: vi.fn().mockReturnThis() };
+      const next = vi.fn();
+      return { req, res, next };
+    };
+
+    it.each([
+      '127.0.0.1',
+      '127.0.0.1:3100',
+      'localhost',
+      'localhost:3100',
+      'LOCALHOST:3100',
+      '[::1]',
+      '[::1]:3100',
+    ])('allows loopback Host header %s', async (host) => {
+      const { mcpHostProtection } = await import('../../../src/commands/mcp/server');
+      const { req, res, next } = buildContext(host);
+
+      mcpHostProtection(req as any, res as any, next as any);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'attacker.example',
+      'attacker.example:3100',
+      '127.0.0.1.attacker.example',
+      '169.254.169.254',
+      'evil.localhost.attacker.example',
+      undefined,
+    ])('rejects non-local Host header %s', async (host) => {
+      const { mcpHostProtection } = await import('../../../src/commands/mcp/server');
+      const { req, res, next } = buildContext(host);
+
+      mcpHostProtection(req as any, res as any, next as any);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'MCP HTTP requests require a local Host header',
+      });
+    });
+  });
+
   describe('startHttpMcpServer', () => {
+    it('should bind HTTP transport to loopback by default', async () => {
+      const { DEFAULT_MCP_HTTP_HOST, startHttpMcpServer } = await import(
+        '../../../src/commands/mcp/server'
+      );
+
+      const serverPromise = startHttpMcpServer(3100);
+      await new Promise((resolve) => setImmediate(resolve));
+      process.emit('SIGINT');
+      await serverPromise;
+
+      expect(expressMocks.app.listen).toHaveBeenCalledWith(
+        3100,
+        DEFAULT_MCP_HTTP_HOST,
+        expect.any(Function),
+      );
+    });
+
+    it('should install browser origin protection on HTTP transport', async () => {
+      const { startHttpMcpServer } = await import('../../../src/commands/mcp/server');
+
+      const serverPromise = startHttpMcpServer(3100);
+      await new Promise((resolve) => setImmediate(resolve));
+      process.emit('SIGINT');
+      await serverPromise;
+
+      expect(expressMocks.app.use).toHaveBeenNthCalledWith(1, expect.any(Function));
+      expect(expressMocks.app.use).toHaveBeenNthCalledWith(2, 'json-middleware');
+      expect(expressMocks.app.use).toHaveBeenNthCalledWith(3, expect.any(Function));
+    });
+
+    it('should reject DNS-rebinding Host headers', async () => {
+      const { startHttpMcpServer } = await import('../../../src/commands/mcp/server');
+
+      const serverPromise = startHttpMcpServer(3100);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const hostProtection = expressMocks.app.use.mock.calls[0][0];
+      const request = {
+        headers: { host: 'attacker.example:3100' },
+        method: 'POST',
+        path: '/mcp',
+      };
+      const response = {
+        json: vi.fn(),
+        status: vi.fn().mockReturnThis(),
+      };
+      const next = vi.fn();
+
+      hostProtection(request, response, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(response.status).toHaveBeenCalledWith(403);
+      expect(response.json).toHaveBeenCalledWith({
+        error: 'MCP HTTP requests require a local Host header',
+      });
+
+      process.emit('SIGINT');
+      await serverPromise;
+    });
+
+    it('should handle MCP requests on loopback transport', async () => {
+      const { startHttpMcpServer } = await import('../../../src/commands/mcp/server');
+
+      const serverPromise = startHttpMcpServer(3100);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const mcpHandler = expressMocks.postHandlers['/mcp'];
+      const request = {
+        body: { jsonrpc: '2.0' },
+        get: vi.fn(),
+      };
+      const response = {
+        json: vi.fn(),
+        status: vi.fn().mockReturnThis(),
+      };
+
+      await mcpHandler(request, response);
+
+      expect(transportMocks.instances[0].handleRequest).toHaveBeenCalledWith(
+        request,
+        response,
+        request.body,
+      );
+
+      process.emit('SIGINT');
+      await serverPromise;
+    });
+
     it('creates cryptographically random session identifiers', async () => {
       const restoreEnv = mockProcessEnv({ MCP_TRANSPORT: undefined });
       let shutdown: (() => void) | undefined;
@@ -301,10 +459,10 @@ describe('MCP Server', () => {
         serverPromise = startHttpMcpServer(3100);
 
         await vi.waitFor(() => {
-          expect(streamableHttpMocks.constructor).toHaveBeenCalledOnce();
+          expect(transportMocks.StreamableHTTPServerTransport).toHaveBeenCalledOnce();
         });
 
-        const transportOptions = streamableHttpMocks.constructor.mock.calls[0][0] as {
+        const transportOptions = transportMocks.StreamableHTTPServerTransport.mock.calls[0][0] as {
           sessionIdGenerator: () => string;
         };
         expect(transportOptions.sessionIdGenerator()).toBe('secure-mcp-session-id');


### PR DESCRIPTION
## Summary

This extracts the **network-containment** slice from #8760 (MCP HTTP transport hardening) into a small, independently reviewable PR. It contains only the network boundary — nothing that touches per-tool workspace validation.

The MCP HTTP transport currently binds to all interfaces and accepts requests with any `Host`/`Origin`. That leaves it exposed to other machines on the network and to DNS-rebinding / CSRF attacks where a malicious web page drives a victim's local MCP server. This change contains the transport to the local machine:

- **Loopback binding** — the HTTP server now listens on `127.0.0.1` (`DEFAULT_MCP_HTTP_HOST`) instead of all interfaces, so it is not reachable from other hosts.
- **Host-header guard** (`mcpHostProtection`) — rejects any request whose `Host` header is not a loopback name (`127.0.0.1`, `localhost`, `[::1]`), returning `403`. This blocks DNS-rebinding attacks that target the server through an attacker-controlled hostname.
- **CSRF / cross-origin guard** — wires in the existing `src/server/middleware/csrfProtection` middleware so cross-site browser `POST`s are blocked.
- **Docs** — `site/docs/integrations/mcp-server.md` now documents that the HTTP transport is local-only (binds `127.0.0.1`, rejects non-local `Host`, blocks cross-site POSTs).

## Scope

This deliberately leaves behind #8760's **workspace-containment** part (the per-tool path/arg validators in `src/commands/mcp/lib/security.ts` and their per-tool wiring), which carries that PR's 21 open review threads and is being iterated on separately. None of those validators or tool changes are included here, so this slice can land independently.

## Architecture

`csrfProtection` already lives in `src/server/middleware/` (view-server layer) on `main`; no new middleware file is added. Importing it from the MCP command adds one `cli -> view-server` edge (an already-allowed dependency per `architecture/layers.json`), so `architecture/edge-baseline.json` is bumped `6 -> 7` for that single edge and nothing else. `npm run architecture:check` passes.

## Testing

- `test/commands/mcp/server.test.ts` — loopback binding, middleware ordering, transport handling, and a parameterized `mcpHostProtection` suite covering the allow-path (loopback `Host` variants incl. `[::1]`) and the reject-path (foreign hosts, DNS-rebinding suffixes like `127.0.0.1.attacker.example`, the `169.254.169.254` metadata address, and missing `Host`).
- `npm run tsc`, `npm run l`, `npm run f`, and `npm run architecture:check` all clean.

Refs #8760.
