### PR TITLE
feat(tracing): persist OTEL span events

### DIFF
--- a/drizzle/0025_cheerful_changeling.sql
+++ b/drizzle/0025_cheerful_changeling.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `spans` ADD `events` text;

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1503 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4136d184-3c35-4960-a5c8-7098f21496c0",
+  "prevId": "00fa2978-039b-4dbd-8e05-d962a981755f",
+  "tables": {
+    "blob_assets": {
+      "name": "blob_assets",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "blob_assets_provider_idx": {
+          "name": "blob_assets_provider_idx",
+          "columns": [
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "blob_assets_created_at_idx": {
+          "name": "blob_assets_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "blob_assets_mime_type_idx": {
+          "name": "blob_assets_mime_type_idx",
+          "columns": [
+            "mime_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blob_references": {
+      "name": "blob_references",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blob_hash": {
+          "name": "blob_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_idx": {
+          "name": "test_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_idx": {
+          "name": "prompt_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "blob_references_blob_idx": {
+          "name": "blob_references_blob_idx",
+          "columns": [
+            "blob_hash"
+          ],
+          "isUnique": false
+        },
+        "blob_references_eval_idx": {
+          "name": "blob_references_eval_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "blob_references_blob_created_at_idx": {
+          "name": "blob_references_blob_created_at_idx",
+          "columns": [
+            "blob_hash",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blob_references_blob_hash_blob_assets_hash_fk": {
+          "name": "blob_references_blob_hash_blob_assets_hash_fk",
+          "tableFrom": "blob_references",
+          "tableTo": "blob_assets",
+          "columnsFrom": [
+            "blob_hash"
+          ],
+          "columnsTo": [
+            "hash"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blob_references_eval_id_evals_id_fk": {
+          "name": "blob_references_eval_id_evals_id_fk",
+          "tableFrom": "blob_references",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "configs": {
+      "name": "configs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "configs_created_at_idx": {
+          "name": "configs_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "configs_type_idx": {
+          "name": "configs_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "datasets": {
+      "name": "datasets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tests": {
+          "name": "tests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "datasets_created_at_idx": {
+          "name": "datasets_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_results": {
+      "name": "eval_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_idx": {
+          "name": "prompt_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_idx": {
+          "name": "test_idx",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case": {
+          "name": "test_case",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "success": {
+          "name": "success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grading_result": {
+          "name": "grading_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "named_scores": {
+          "name": "named_scores",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "eval_result_eval_id_idx": {
+          "name": "eval_result_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "eval_result_test_idx": {
+          "name": "eval_result_test_idx",
+          "columns": [
+            "test_idx"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_test_idx": {
+          "name": "eval_result_eval_test_idx",
+          "columns": [
+            "eval_id",
+            "test_idx"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_success_idx": {
+          "name": "eval_result_eval_success_idx",
+          "columns": [
+            "eval_id",
+            "success"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_failure_idx": {
+          "name": "eval_result_eval_failure_idx",
+          "columns": [
+            "eval_id",
+            "failure_reason"
+          ],
+          "isUnique": false
+        },
+        "eval_result_eval_test_success_idx": {
+          "name": "eval_result_eval_test_success_idx",
+          "columns": [
+            "eval_id",
+            "test_idx",
+            "success"
+          ],
+          "isUnique": false
+        },
+        "eval_result_response_idx": {
+          "name": "eval_result_response_idx",
+          "columns": [
+            "response"
+          ],
+          "isUnique": false
+        },
+        "eval_result_grading_result_reason_idx": {
+          "name": "eval_result_grading_result_reason_idx",
+          "columns": [
+            "json_extract(\"grading_result\", '$.reason')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_grading_result_comment_idx": {
+          "name": "eval_result_grading_result_comment_idx",
+          "columns": [
+            "json_extract(\"grading_result\", '$.comment')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_test_case_vars_idx": {
+          "name": "eval_result_test_case_vars_idx",
+          "columns": [
+            "json_extract(\"test_case\", '$.vars')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_test_case_metadata_idx": {
+          "name": "eval_result_test_case_metadata_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_named_scores_idx": {
+          "name": "eval_result_named_scores_idx",
+          "columns": [
+            "json_extract(\"named_scores\", '$')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_metadata_idx": {
+          "name": "eval_result_metadata_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_metadata_plugin_id_idx": {
+          "name": "eval_result_metadata_plugin_id_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$.pluginId')"
+          ],
+          "isUnique": false
+        },
+        "eval_result_metadata_strategy_id_idx": {
+          "name": "eval_result_metadata_strategy_id_idx",
+          "columns": [
+            "json_extract(\"metadata\", '$.strategyId')"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "eval_results_eval_id_evals_id_fk": {
+          "name": "eval_results_eval_id_evals_id_fk",
+          "tableFrom": "eval_results",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "eval_results_prompt_id_prompts_id_fk": {
+          "name": "eval_results_prompt_id_prompts_id_fk",
+          "tableFrom": "eval_results",
+          "tableTo": "prompts",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals": {
+      "name": "evals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results": {
+          "name": "results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompts": {
+          "name": "prompts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vars": {
+          "name": "vars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_options": {
+          "name": "runtime_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_redteam": {
+          "name": "is_redteam",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "evals_created_at_idx": {
+          "name": "evals_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "evals_author_idx": {
+          "name": "evals_author_idx",
+          "columns": [
+            "author"
+          ],
+          "isUnique": false
+        },
+        "evals_is_redteam_idx": {
+          "name": "evals_is_redteam_idx",
+          "columns": [
+            "is_redteam"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_datasets": {
+      "name": "evals_to_datasets",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_datasets_eval_id_idx": {
+          "name": "evals_to_datasets_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_datasets_dataset_id_idx": {
+          "name": "evals_to_datasets_dataset_id_idx",
+          "columns": [
+            "dataset_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_datasets_eval_id_evals_id_fk": {
+          "name": "evals_to_datasets_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_datasets",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evals_to_datasets_dataset_id_datasets_id_fk": {
+          "name": "evals_to_datasets_dataset_id_datasets_id_fk",
+          "tableFrom": "evals_to_datasets",
+          "tableTo": "datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_datasets_eval_id_dataset_id_pk": {
+          "columns": [
+            "eval_id",
+            "dataset_id"
+          ],
+          "name": "evals_to_datasets_eval_id_dataset_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_prompts": {
+      "name": "evals_to_prompts",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_id": {
+          "name": "prompt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_prompts_eval_id_idx": {
+          "name": "evals_to_prompts_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_prompts_prompt_id_idx": {
+          "name": "evals_to_prompts_prompt_id_idx",
+          "columns": [
+            "prompt_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_prompts_eval_id_evals_id_fk": {
+          "name": "evals_to_prompts_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_prompts",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "evals_to_prompts_prompt_id_prompts_id_fk": {
+          "name": "evals_to_prompts_prompt_id_prompts_id_fk",
+          "tableFrom": "evals_to_prompts",
+          "tableTo": "prompts",
+          "columnsFrom": [
+            "prompt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_prompts_eval_id_prompt_id_pk": {
+          "columns": [
+            "eval_id",
+            "prompt_id"
+          ],
+          "name": "evals_to_prompts_eval_id_prompt_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evals_to_tags": {
+      "name": "evals_to_tags",
+      "columns": {
+        "eval_id": {
+          "name": "eval_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "evals_to_tags_eval_id_idx": {
+          "name": "evals_to_tags_eval_id_idx",
+          "columns": [
+            "eval_id"
+          ],
+          "isUnique": false
+        },
+        "evals_to_tags_tag_id_idx": {
+          "name": "evals_to_tags_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "evals_to_tags_eval_id_evals_id_fk": {
+          "name": "evals_to_tags_eval_id_evals_id_fk",
+          "tableFrom": "evals_to_tags",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "eval_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evals_to_tags_tag_id_tags_id_fk": {
+          "name": "evals_to_tags_tag_id_tags_id_fk",
+          "tableFrom": "evals_to_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "evals_to_tags_eval_id_tag_id_pk": {
+          "columns": [
+            "eval_id",
+            "tag_id"
+          ],
+          "name": "evals_to_tags_eval_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_audits": {
+      "name": "model_audits",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_path": {
+          "name": "model_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_type": {
+          "name": "model_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "results": {
+          "name": "results",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checks": {
+          "name": "checks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "issues": {
+          "name": "issues",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_errors": {
+          "name": "has_errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_checks": {
+          "name": "total_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "passed_checks": {
+          "name": "passed_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_checks": {
+          "name": "failed_checks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revision_sha": {
+          "name": "revision_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_source": {
+          "name": "model_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_last_modified": {
+          "name": "source_last_modified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scanner_version": {
+          "name": "scanner_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_audits_created_at_idx": {
+          "name": "model_audits_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_path_idx": {
+          "name": "model_audits_model_path_idx",
+          "columns": [
+            "model_path"
+          ],
+          "isUnique": false
+        },
+        "model_audits_has_errors_idx": {
+          "name": "model_audits_has_errors_idx",
+          "columns": [
+            "has_errors"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_type_idx": {
+          "name": "model_audits_model_type_idx",
+          "columns": [
+            "model_type"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_id_idx": {
+          "name": "model_audits_model_id_idx",
+          "columns": [
+            "model_id"
+          ],
+          "isUnique": false
+        },
+        "model_audits_revision_sha_idx": {
+          "name": "model_audits_revision_sha_idx",
+          "columns": [
+            "revision_sha"
+          ],
+          "isUnique": false
+        },
+        "model_audits_content_hash_idx": {
+          "name": "model_audits_content_hash_idx",
+          "columns": [
+            "content_hash"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_revision_idx": {
+          "name": "model_audits_model_revision_idx",
+          "columns": [
+            "model_id",
+            "revision_sha"
+          ],
+          "isUnique": false
+        },
+        "model_audits_model_content_idx": {
+          "name": "model_audits_model_content_idx",
+          "columns": [
+            "model_id",
+            "content_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompts": {
+      "name": "prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompts_created_at_idx": {
+          "name": "prompts_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spans": {
+      "name": "spans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_id": {
+          "name": "span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_span_id": {
+          "name": "parent_span_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "spans_trace_id_idx": {
+          "name": "spans_trace_id_idx",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": false
+        },
+        "spans_span_id_idx": {
+          "name": "spans_span_id_idx",
+          "columns": [
+            "span_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "spans_trace_id_traces_trace_id_fk": {
+          "name": "spans_trace_id_traces_trace_id_fk",
+          "tableFrom": "spans",
+          "tableTo": "traces",
+          "columnsFrom": [
+            "trace_id"
+          ],
+          "columnsTo": [
+            "trace_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "tags_name_value_unique": {
+          "name": "tags_name_value_unique",
+          "columns": [
+            "name",
+            "value"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "traces": {
+      "name": "traces",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evaluation_id": {
+          "name": "evaluation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "traces_trace_id_unique": {
+          "name": "traces_trace_id_unique",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": true
+        },
+        "traces_evaluation_idx": {
+          "name": "traces_evaluation_idx",
+          "columns": [
+            "evaluation_id"
+          ],
+          "isUnique": false
+        },
+        "traces_trace_id_idx": {
+          "name": "traces_trace_id_idx",
+          "columns": [
+            "trace_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "traces_evaluation_id_evals_id_fk": {
+          "name": "traces_evaluation_id_evals_id_fk",
+          "tableFrom": "traces",
+          "tableTo": "evals",
+          "columnsFrom": [
+            "evaluation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "eval_result_grading_result_reason_idx": {
+        "columns": {
+          "json_extract(\"grading_result\", '$.reason')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_grading_result_comment_idx": {
+        "columns": {
+          "json_extract(\"grading_result\", '$.comment')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_test_case_vars_idx": {
+        "columns": {
+          "json_extract(\"test_case\", '$.vars')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_test_case_metadata_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_named_scores_idx": {
+        "columns": {
+          "json_extract(\"named_scores\", '$')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_metadata_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_metadata_plugin_id_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$.pluginId')": {
+            "isExpression": true
+          }
+        }
+      },
+      "eval_result_metadata_strategy_id_idx": {
+        "columns": {
+          "json_extract(\"metadata\", '$.strategyId')": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1779816393227,
       "tag": "0024_repair_eval_redteam_flags",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1783140414012,
+      "tag": "0025_cheerful_changeling",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -18,6 +18,7 @@ import {
   type ProviderOptions,
   type ProviderResponse,
   ResultFailureReason,
+  type TraceSpanEvent,
   type UnifiedConfig,
 } from '../types/index';
 import type { Attributes } from '@opentelemetry/api';
@@ -467,6 +468,7 @@ export const spansTable = sqliteTable(
     startTime: integer('start_time').notNull(),
     endTime: integer('end_time'),
     attributes: text('attributes', { mode: 'json' }).$type<Attributes>(),
+    events: text('events', { mode: 'json' }).$type<TraceSpanEvent[]>(),
     statusCode: integer('status_code'),
     statusMessage: text('status_message'),
   },

--- a/src/tracing/localSpanExporter.ts
+++ b/src/tracing/localSpanExporter.ts
@@ -138,6 +138,11 @@ export class LocalSpanExporter implements SpanExporter {
       startTime: startTimeMs,
       endTime: endTimeMs,
       attributes: this.convertAttributes(span.attributes),
+      events: span.events.map((event) => ({
+        name: event.name,
+        timestamp: event.time[0] * 1e3 + event.time[1] / 1e6,
+        attributes: this.convertAttributes(event.attributes ?? {}),
+      })),
       statusCode: span.status.code,
       statusMessage: span.status.message,
     };

--- a/src/tracing/otlpReceiver.ts
+++ b/src/tracing/otlpReceiver.ts
@@ -10,6 +10,7 @@ import {
   type DecodedScopeSpans,
   type DecodedSpan,
   decodeExportTraceServiceRequest,
+  longToNumber,
 } from './protobuf';
 import {
   PROMPTFOO_RESOURCE_ATTR_PARENT_SPAN_ID,
@@ -38,10 +39,17 @@ interface OTLPSpan {
   startTimeUnixNano: string;
   endTimeUnixNano?: string;
   attributes?: OTLPAttribute[];
+  events?: OTLPSpanEvent[];
   status?: {
     code: number;
     message?: string;
   };
+}
+
+interface OTLPSpanEvent {
+  timeUnixNano?: string;
+  name: string;
+  attributes?: OTLPAttribute[];
 }
 
 interface OTLPScopeSpan {
@@ -370,9 +378,14 @@ export class OTLPReceiver {
     // credential into an error message) must be scrubbed too — otherwise the secret leaks
     // through a span field the operator believes `redactAttributes` covers.
     const redactedSourceValues = new Set<string>();
-    for (const [key, value] of Object.entries(attributes)) {
-      if (typeof value === 'string' && this.shouldRedactAttribute(key, redactAttributePatterns)) {
-        redactedSourceValues.add(value);
+    for (const attributeSet of [
+      attributes,
+      ...(span.events ?? []).map((event) => event.attributes ?? {}),
+    ]) {
+      for (const [key, value] of Object.entries(attributeSet)) {
+        if (typeof value === 'string' && this.shouldRedactAttribute(key, redactAttributePatterns)) {
+          redactedSourceValues.add(value);
+        }
       }
     }
     // `redactedSourceValues` only holds strings, so an undefined statusMessage passes through.
@@ -384,6 +397,11 @@ export class OTLPReceiver {
       name: scrubEcho(span.name),
       statusMessage: scrubEcho(span.statusMessage),
       attributes: this.redactAttributes(attributes, redactAttributePatterns),
+      events: span.events?.map((event) => ({
+        ...event,
+        name: scrubEcho(event.name),
+        attributes: this.redactAttributes(event.attributes, redactAttributePatterns),
+      })),
     };
   }
 
@@ -713,6 +731,7 @@ export class OTLPReceiver {
             'otel.span.kind': spanKindName,
             'otel.span.kind_code': span.kind,
           };
+          const startTime = Number(span.startTimeUnixNano) / 1_000_000;
 
           traces.push({
             traceId,
@@ -720,9 +739,14 @@ export class OTLPReceiver {
               spanId,
               parentSpanId,
               name: span.name,
-              startTime: Number(span.startTimeUnixNano) / 1_000_000, // Convert to ms
+              startTime, // Convert to ms
               endTime: span.endTimeUnixNano ? Number(span.endTimeUnixNano) / 1_000_000 : undefined,
               attributes,
+              events: (span.events ?? []).map((event) => ({
+                name: event.name,
+                timestamp: event.timeUnixNano ? Number(event.timeUnixNano) / 1_000_000 : startTime,
+                attributes: this.parseAttributes(event.attributes),
+              })),
               statusCode: span.status?.code,
               statusMessage: span.status?.message,
             },
@@ -902,6 +926,14 @@ export class OTLPReceiver {
           'otel.span.kind': spanKindName,
           'otel.span.kind_code': spanKindCode,
         },
+        events: (span.events ?? []).map((event) => ({
+          name: event.name,
+          timestamp:
+            this.toMilliseconds(event.timeUnixNano) ??
+            this.toMilliseconds(span.startTimeUnixNano) ??
+            0,
+          attributes: this.parseDecodedAttributes(event.attributes),
+        })),
         statusCode: span.status?.code,
         statusMessage: span.status?.message,
       },
@@ -1101,7 +1133,7 @@ export class OTLPReceiver {
     if (value === undefined) {
       return undefined;
     }
-    return Number(value) / 1_000_000;
+    return longToNumber(value) / 1_000_000;
   }
 }
 

--- a/src/tracing/protobuf.ts
+++ b/src/tracing/protobuf.ts
@@ -106,6 +106,12 @@ export interface DecodedStatus {
   message?: string;
 }
 
+export interface DecodedSpanEvent {
+  timeUnixNano?: Long | number;
+  name: string;
+  attributes?: DecodedAttribute[];
+}
+
 /**
  * Decoded OTLP span
  */
@@ -119,7 +125,7 @@ export interface DecodedSpan {
   endTimeUnixNano?: Long | number;
   attributes?: DecodedAttribute[];
   status?: DecodedStatus;
-  events?: any[];
+  events?: DecodedSpanEvent[];
   links?: any[];
   droppedAttributesCount?: number;
   droppedEventsCount?: number;

--- a/src/tracing/store.ts
+++ b/src/tracing/store.ts
@@ -3,7 +3,7 @@ import { getDb } from '../database/index';
 import { spansTable, tracesTable } from '../database/tables';
 import logger from '../logger';
 
-import type { TraceData } from '../types/tracing';
+import type { TraceData, TraceSpanEvent } from '../types/tracing';
 
 interface StoreTraceData extends Omit<TraceData, 'spans'> {
   evaluationId: string;
@@ -18,6 +18,7 @@ export interface SpanData {
   startTime: number;
   endTime?: number;
   attributes?: Record<string, any>;
+  events?: TraceSpanEvent[];
   statusCode?: number;
   statusMessage?: string;
 }
@@ -121,6 +122,18 @@ function sanitizeAttributes(
   return sanitized;
 }
 
+function sanitizeEvents(
+  events: TraceSpanEvent[] | null | undefined,
+  shouldSanitizeAttributes: boolean,
+): TraceSpanEvent[] | undefined {
+  return events?.map((event) => ({
+    ...event,
+    attributes: shouldSanitizeAttributes
+      ? sanitizeAttributes(event.attributes)
+      : (event.attributes ?? undefined),
+  }));
+}
+
 function serializeSpan(
   span: typeof spansTable.$inferSelect,
   shouldSanitizeAttributes = true,
@@ -138,6 +151,11 @@ function serializeSpan(
         ? sanitizeAttributes(rawAttributes)
         : rawAttributes
       : undefined,
+    ...(span.events
+      ? {
+          events: sanitizeEvents(span.events, shouldSanitizeAttributes),
+        }
+      : {}),
     statusCode: span.statusCode ?? undefined,
     statusMessage: span.statusMessage ?? undefined,
   };
@@ -282,6 +300,7 @@ export class TraceStore {
           startTime: span.startTime,
           endTime: span.endTime,
           attributes: span.attributes,
+          ...(span.events ? { events: span.events } : {}),
           statusCode: span.statusCode,
           statusMessage: span.statusMessage,
         };
@@ -468,6 +487,7 @@ export class TraceStore {
           startTime: row.startTime,
           endTime: row.endTime ?? undefined,
           attributes: shouldSanitize ? sanitizeAttributes(rawAttributes) : rawAttributes,
+          ...(row.events ? { events: sanitizeEvents(row.events, shouldSanitize) } : {}),
           statusCode: row.statusCode ?? undefined,
           statusMessage: row.statusMessage ?? undefined,
         };

--- a/src/tracing/traceContext.ts
+++ b/src/tracing/traceContext.ts
@@ -130,7 +130,10 @@ function createTraceSpans(spans: SpanData[]): TraceSpan[] {
         message: span.statusMessage,
       },
       depth: depthMap.get(span.spanId) ?? 0,
-      events: [],
+      events: (span.events ?? []).map((event) => ({
+        ...event,
+        attributes: event.attributes ?? {},
+      })),
     };
   });
 }

--- a/src/types/tracing.ts
+++ b/src/types/tracing.ts
@@ -1,3 +1,9 @@
+export interface TraceSpanEvent {
+  name: string;
+  timestamp: number;
+  attributes?: Record<string, any>;
+}
+
 export interface TraceSpan {
   spanId: string;
   parentSpanId?: string;
@@ -5,6 +11,7 @@ export interface TraceSpan {
   startTime: number;
   endTime?: number;
   attributes?: Record<string, any>;
+  events?: TraceSpanEvent[];
   statusCode?: number;
   statusMessage?: string;
 }

--- a/test/tracing/localSpanExporter.test.ts
+++ b/test/tracing/localSpanExporter.test.ts
@@ -46,6 +46,7 @@ describe('LocalSpanExporter', () => {
       startTime: [number, number];
       endTime: [number, number];
       attributes: Record<string, unknown>;
+      events: ReadableSpan['events'];
       status: { code: number; message?: string };
     }> = {},
   ): ReadableSpan {
@@ -68,7 +69,7 @@ describe('LocalSpanExporter', () => {
       status: overrides.status ?? { code: 1 },
       kind: 2, // CLIENT
       links: [],
-      events: [],
+      events: overrides.events ?? [],
       resource: { attributes: {} },
       instrumentationLibrary: { name: 'test' },
       duration: [0, 700000000],
@@ -202,6 +203,38 @@ describe('LocalSpanExporter', () => {
             // Milliseconds: seconds * 1000 + nanoseconds / 1_000_000
             startTime: 100 * 1e3 + 500000000 / 1e6, // 100500 ms
             endTime: 101 * 1e3 + 750000000 / 1e6, // 101750 ms
+          }),
+        ],
+        expect.any(Object),
+      );
+    });
+
+    it('should preserve span events with millisecond timestamps', async () => {
+      const span = createMockSpan({
+        events: [
+          {
+            name: 'guardrail decision',
+            time: [102, 250000000],
+            attributes: { 'guardrails.decision': 'blocked' },
+            droppedAttributesCount: 0,
+          },
+        ],
+      });
+
+      const result = await exportSpans([span]);
+
+      expect(result.code).toBe(ExportResultCode.SUCCESS);
+      expect(mockAddSpans).toHaveBeenCalledWith(
+        expect.any(String),
+        [
+          expect.objectContaining({
+            events: [
+              {
+                name: 'guardrail decision',
+                timestamp: 102250,
+                attributes: { 'guardrails.decision': 'blocked' },
+              },
+            ],
           }),
         ],
         expect.any(Object),

--- a/test/tracing/otlpReceiver.test.ts
+++ b/test/tracing/otlpReceiver.test.ts
@@ -493,11 +493,20 @@ describe('OTLPReceiver', () => {
                     spanId: spanIdBytes,
                     name: 'protobuf-test-span',
                     kind: 2, // SPAN_KIND_SERVER
-                    startTimeUnixNano: 1700000000000000000n,
-                    endTimeUnixNano: 1700000001000000000n,
+                    startTimeUnixNano: '1700000000000000000',
+                    endTimeUnixNano: '1700000001000000000',
                     attributes: [
                       { key: 'http.method', value: { stringValue: 'POST' } },
                       { key: 'http.status_code', value: { intValue: 200 } },
+                    ],
+                    events: [
+                      {
+                        name: 'guardrail decision',
+                        timeUnixNano: '1700000000500000000',
+                        attributes: [
+                          { key: 'guardrails.decision', value: { stringValue: 'blocked' } },
+                        ],
+                      },
                     ],
                     status: {
                       code: 1, // STATUS_CODE_OK
@@ -535,6 +544,13 @@ describe('OTLPReceiver', () => {
               'otel.scope.name': 'opentelemetry.instrumentation.test',
               'otel.scope.version': '1.0.0',
             }),
+            events: [
+              {
+                name: 'guardrail decision',
+                timestamp: 1700000000500,
+                attributes: { 'guardrails.decision': 'blocked' },
+              },
+            ],
             statusCode: 1,
             statusMessage: 'Success',
           }),

--- a/test/tracing/store.test.ts
+++ b/test/tracing/store.test.ts
@@ -162,6 +162,13 @@ describe('TraceStore', () => {
           startTime: 1000,
           endTime: 2000,
           attributes: { key: 'value' },
+          events: [
+            {
+              name: 'guardrail decision',
+              timestamp: 1500,
+              attributes: { 'guardrails.decision': 'blocked' },
+            },
+          ],
         },
         {
           spanId: 'span-2',
@@ -191,6 +198,13 @@ describe('TraceStore', () => {
           startTime: 1000,
           endTime: 2000,
           attributes: { key: 'value' },
+          events: [
+            {
+              name: 'guardrail decision',
+              timestamp: 1500,
+              attributes: { 'guardrails.decision': 'blocked' },
+            },
+          ],
           statusCode: undefined,
           statusMessage: undefined,
         },
@@ -557,6 +571,16 @@ describe('TraceStore', () => {
               safe: 'ok',
             },
           },
+          events: [
+            {
+              name: 'tool error',
+              timestamp: 2250,
+              attributes: {
+                authorization: 'Bearer event-secret',
+                safe: 'ok',
+              },
+            },
+          ],
           statusCode: 1,
           statusMessage: 'ok',
         },
@@ -618,6 +642,16 @@ describe('TraceStore', () => {
                 safe: 'ok',
               },
             },
+            events: [
+              {
+                name: 'tool error',
+                timestamp: 2250,
+                attributes: {
+                  authorization: '<redacted>',
+                  safe: 'ok',
+                },
+              },
+            ],
             statusCode: 1,
             statusMessage: 'ok',
           },


### PR DESCRIPTION
## Summary

Persists OTEL span events (OTLP `span.events[]`) end-to-end so they survive ingestion, storage, redaction, and read-back. This is a focused slice extracted from the larger agentic-runtime PR #8871, carved out so the tracing infrastructure can land and be reviewed on its own.

### What changed

- **Schema / migration**: adds a nullable `events` (JSON) column to the `spans` table, backed by a new Drizzle migration.
- **Types** (`src/types/tracing.ts`): new `TraceSpanEvent` interface (`name`, `timestamp`, optional `attributes`) and an optional `events?: TraceSpanEvent[]` on `TraceSpan`.
- **OTLP receiver** (`src/tracing/otlpReceiver.ts`): parses `events` from both the JSON and protobuf OTLP paths, converts `timeUnixNano` to ms (via `longToNumber` for the decoded/protobuf path), and extends secret redaction to also scrub event attributes and event names.
- **Local exporter** (`src/tracing/localSpanExporter.ts`): maps SDK `ReadableSpan.events` into the stored shape with ms timestamps.
- **Store** (`src/tracing/store.ts`): serializes/deserializes `events`, with attribute sanitization applied to event attributes.
- **Trace context** (`src/tracing/traceContext.ts`): surfaces stored events instead of always emitting an empty array.
- **Tests**: span-event coverage for the exporter, store (including redaction), and the OTLP protobuf ingestion path.

### Migration renumbering

The source branch carried this as `0025_magenta_revanche`. Rather than copy that migration wholesale, the schema change was re-applied to `src/database/tables.ts` and the migration was regenerated against the current `main` schema with `npm run db:generate`, producing `0025_cheerful_changeling.sql` (`ALTER TABLE spans ADD events text;`) with a fresh journal entry and full snapshot. `0025` is the next free slot on current `main` (highest existing is `0024`), so there is no collision.

Verified:
- `PROMPTFOO_CONFIG_DIR=$(mktemp -d) npm run db:migrate` applies cleanly (exit 0); the migrated `spans` table has the `events` column.
- `npm run db:generate` reports no pending drift, confirming journal + snapshot + SQL are internally consistent with `tables.ts`.

### Independence from the agentic plugins

This PR contains **only** tracing infrastructure. It does not pull in the agentic-runtime plugins, the `src/redteam/agentic/*` parser, or any redteam grader. The one OTLP-receiver test in #8871 that fed span events through an agentic grader (`getGraderById('promptfoo:redteam:agentic:...')`) was intentionally **excluded**, as were the agentic-focused `site/docs/tracing.md` additions — both belong with the agentic plugins slice. No `agentic` / `redteam` code imports appear in this diff (the only `is_redteam` references are the pre-existing evals column captured by the full-schema snapshot).

### Verification

- `npx vitest run test/tracing/` — 259 passed (13 files)
- `npm run tsc` — clean
- `npm run l && npm run f` — clean
- `npm run architecture:check` — boundaries passed (no new cross-layer edges)

Extracted from #8871.
