### PR TITLE
fix(server): return 413 for oversized eval JSON exports

### DIFF
--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -12,8 +12,6 @@ import {
   ComparisonEvalNotFoundError,
   evalTableToJson,
   generateEvalCsv,
-  getEvalTableOutputPromptLocationsBySize,
-  getEvalTablePromptStrippedPayload,
   mergeComparisonTables,
 } from '../../util/eval/evalTableUtils';
 import invariant from '../../util/invariant';
@@ -26,6 +24,7 @@ import { shouldShareResults } from '../../util/sharing';
 import { evalJobService } from '../services/evalJobService';
 import { setDownloadHeaders } from '../utils/downloadHelpers';
 import { replyValidationError, sendError } from '../utils/errors';
+import { sendJsonResponse } from '../utils/safeJsonResponse';
 import type { Request, Response } from 'express';
 
 import type {
@@ -50,83 +49,14 @@ function sendEvalTableResponse(res: Response, evalId: string, responsePayload: E
     return;
   }
 
-  try {
-    res.json(parsedPayload);
-  } catch (error) {
-    if (!(error instanceof RangeError)) {
-      throw error;
-    }
-
-    logger.warn('[GET /:id/table] Response too large, stripping per-cell prompts by size', {
-      evalId,
-    });
-
-    const promptLocations = getEvalTableOutputPromptLocationsBySize(parsedPayload);
-    if (promptLocations.length === 0) {
-      logger.error('[GET /:id/table] Response too large and has no prompts to strip', {
-        evalId,
-      });
-      res.status(413).json({ error: 'Eval too large to display. Try reducing the page size.' });
-      return;
-    }
-
-    const tryStringifyWithStrippedPrompts = (promptCountToStrip: number): string | null => {
-      const responseWithoutPrompts = getEvalTablePromptStrippedPayload(
-        parsedPayload,
-        promptLocations,
-        promptCountToStrip,
-      );
-      try {
-        const responseBody = JSON.stringify(responseWithoutPrompts);
-        invariant(typeof responseBody === 'string', 'Eval table response must serialize to JSON');
-        return responseBody;
-      } catch (retryError) {
-        if (!(retryError instanceof RangeError)) {
-          throw retryError;
-        }
-        return null;
-      }
-    };
-
-    let lowerBound = 0;
-    let upperBound = 1;
-    let responseBody: string | null = null;
-
-    while (upperBound < promptLocations.length) {
-      responseBody = tryStringifyWithStrippedPrompts(upperBound);
-      if (responseBody) {
-        break;
-      }
-      lowerBound = upperBound;
-      upperBound *= 2;
-    }
-
-    if (!responseBody) {
-      upperBound = promptLocations.length;
-      responseBody = tryStringifyWithStrippedPrompts(upperBound);
-    }
-
-    if (responseBody) {
-      while (upperBound - lowerBound > 1) {
-        const midPoint = lowerBound + Math.floor((upperBound - lowerBound) / 2);
-        const midpointResponseBody = tryStringifyWithStrippedPrompts(midPoint);
-        if (midpointResponseBody) {
-          upperBound = midPoint;
-          responseBody = midpointResponseBody;
-        } else {
-          lowerBound = midPoint;
-        }
-      }
-
-      res.type('json').send(responseBody);
-      return;
-    }
-
-    logger.error('[GET /:id/table] Response still too large after stripping prompts', {
-      evalId,
-    });
-    res.status(413).json({ error: 'Eval too large to display. Try reducing the page size.' });
-  }
+  // Send the full, contract-shaped table. If it exceeds V8's maximum JSON string
+  // length (issue #7649), sendJsonResponse returns HTTP 413 instead of throwing
+  // an unhandled RangeError — without trimming/corrupting the response body.
+  sendJsonResponse(res, parsedPayload, {
+    evalId,
+    logger,
+    tooLargeMessage: 'Eval too large to display. Try reducing the page size.',
+  });
 }
 
 evalRouter.post('/job', async (req: Request, res: Response): Promise<void> => {
@@ -420,8 +350,15 @@ evalRouter.get('/:id/table', async (req: Request, res: Response): Promise<void> 
   if (format === 'json') {
     const jsonData = evalTableToJson(returnTable);
 
-    setDownloadHeaders(res, `${id}.json`, 'application/json');
-    res.json(jsonData);
+    // Guard the export against the same RangeError as the table response
+    // (issue #7649). Download headers are only set once serialization succeeds,
+    // so an oversized export returns a plain 413 rather than a truncated file.
+    sendJsonResponse(res, jsonData, {
+      beforeSend: () => setDownloadHeaders(res, `${id}.json`, 'application/json'),
+      evalId: id,
+      logger,
+      tooLargeMessage: 'Eval JSON export is too large to serialize.',
+    });
     return;
   }
 

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -12,6 +12,8 @@ import {
   ComparisonEvalNotFoundError,
   evalTableToJson,
   generateEvalCsv,
+  getEvalTableOutputPromptLocationsBySize,
+  getEvalTablePromptStrippedPayload,
   mergeComparisonTables,
 } from '../../util/eval/evalTableUtils';
 import invariant from '../../util/invariant';
@@ -49,14 +51,83 @@ function sendEvalTableResponse(res: Response, evalId: string, responsePayload: E
     return;
   }
 
-  // Send the full, contract-shaped table. If it exceeds V8's maximum JSON string
-  // length (issue #7649), sendJsonResponse returns HTTP 413 instead of throwing
-  // an unhandled RangeError — without trimming/corrupting the response body.
-  sendJsonResponse(res, parsedPayload, {
-    evalId,
-    logger,
-    tooLargeMessage: 'Eval too large to display. Try reducing the page size.',
-  });
+  try {
+    res.json(parsedPayload);
+  } catch (error) {
+    if (!(error instanceof RangeError)) {
+      throw error;
+    }
+
+    logger.warn('[GET /:id/table] Response too large, stripping per-cell prompts by size', {
+      evalId,
+    });
+
+    const promptLocations = getEvalTableOutputPromptLocationsBySize(parsedPayload);
+    if (promptLocations.length === 0) {
+      logger.error('[GET /:id/table] Response too large and has no prompts to strip', {
+        evalId,
+      });
+      res.status(413).json({ error: 'Eval too large to display. Try reducing the page size.' });
+      return;
+    }
+
+    const tryStringifyWithStrippedPrompts = (promptCountToStrip: number): string | null => {
+      const responseWithoutPrompts = getEvalTablePromptStrippedPayload(
+        parsedPayload,
+        promptLocations,
+        promptCountToStrip,
+      );
+      try {
+        const responseBody = JSON.stringify(responseWithoutPrompts);
+        invariant(typeof responseBody === 'string', 'Eval table response must serialize to JSON');
+        return responseBody;
+      } catch (retryError) {
+        if (!(retryError instanceof RangeError)) {
+          throw retryError;
+        }
+        return null;
+      }
+    };
+
+    let lowerBound = 0;
+    let upperBound = 1;
+    let responseBody: string | null = null;
+
+    while (upperBound < promptLocations.length) {
+      responseBody = tryStringifyWithStrippedPrompts(upperBound);
+      if (responseBody) {
+        break;
+      }
+      lowerBound = upperBound;
+      upperBound *= 2;
+    }
+
+    if (!responseBody) {
+      upperBound = promptLocations.length;
+      responseBody = tryStringifyWithStrippedPrompts(upperBound);
+    }
+
+    if (responseBody) {
+      while (upperBound - lowerBound > 1) {
+        const midPoint = lowerBound + Math.floor((upperBound - lowerBound) / 2);
+        const midpointResponseBody = tryStringifyWithStrippedPrompts(midPoint);
+        if (midpointResponseBody) {
+          upperBound = midPoint;
+          responseBody = midpointResponseBody;
+        } else {
+          lowerBound = midPoint;
+        }
+      }
+
+      res.type('json').send(responseBody);
+      return;
+    }
+
+    logger.error('[GET /:id/table] Response still too large after stripping prompts', {
+      evalId,
+    });
+    res.status(413).json({ error: 'Eval too large to display. Try reducing the page size.' });
+  }
 }
 
 evalRouter.post('/job', async (req: Request, res: Response): Promise<void> => {
@@ -350,9 +421,8 @@ evalRouter.get('/:id/table', async (req: Request, res: Response): Promise<void> 
   if (format === 'json') {
     const jsonData = evalTableToJson(returnTable);
 
-    // Guard the export against the same RangeError as the table response
-    // (issue #7649). Download headers are only set once serialization succeeds,
-    // so an oversized export returns a plain 413 rather than a truncated file.
+    // Serialize before setting download headers. If V8 reaches a JSON
+    // serialization limit, return a regular 413 error response.
     sendJsonResponse(res, jsonData, {
       beforeSend: () => setDownloadHeaders(res, `${id}.json`, 'application/json'),
       evalId: id,

--- a/src/server/utils/safeJsonResponse.ts
+++ b/src/server/utils/safeJsonResponse.ts
@@ -1,0 +1,88 @@
+import type { Response } from 'express';
+
+/**
+ * Matches the `RangeError`s V8 throws from `JSON.stringify` when a payload
+ * cannot be serialized because it hits an engine limit: the maximum string
+ * length (~512MB, "Invalid string length") or the maximum call-stack depth for
+ * an extremely deep payload. These are the failure modes behind issue #7649,
+ * where `GET /eval/:id/table` crashed for very large evals (e.g. base64 images
+ * or huge per-cell prompts).
+ */
+const JSON_SERIALIZATION_LIMIT_ERROR_RE =
+  /Invalid string length|Cannot create a string longer than|ERR_STRING_TOO_LONG|Maximum call stack size exceeded/i;
+
+export const DEFAULT_TOO_LARGE_MESSAGE = 'Response payload is too large to serialize';
+
+type JsonResponseLogger = {
+  warn: (message: string, context: Record<string, unknown>) => void;
+};
+
+/**
+ * Returns true when `error` is a `RangeError` that `JSON.stringify` throws for a
+ * payload that exceeds V8's serialization limits (maximum string length or
+ * maximum call-stack depth). Other errors — including circular-reference
+ * `TypeError`s — are intentionally not matched so they surface normally.
+ */
+export function isJsonSerializationLimitError(error: unknown): error is RangeError {
+  return error instanceof RangeError && JSON_SERIALIZATION_LIMIT_ERROR_RE.test(error.message);
+}
+
+/**
+ * Serializes `payload` and sends it as `application/json`, guarding against the
+ * `RangeError` `JSON.stringify` throws when a response would exceed V8's maximum
+ * string length (issue #7649).
+ *
+ * This is a size *guard*, not a trimmer: every payload that fits is sent in full
+ * and byte-for-byte identical to `res.json(payload)`, so the public response
+ * contract is preserved. A payload that cannot be serialized fails loudly with
+ * HTTP 413 and a clear error message rather than throwing an unhandled
+ * `RangeError` — and, crucially, without silently stripping or corrupting the
+ * body into something that no longer matches the response contract.
+ *
+ * @param res - Express response to write to.
+ * @param payload - Value to serialize and send.
+ * @param options.beforeSend - Invoked immediately before a successful body is
+ *   sent (e.g. to set download headers). It is intentionally *not* called on the
+ *   413 path, so error responses do not inherit success-only headers.
+ * @param options.evalId - Optional eval id included in the oversized-payload log.
+ * @param options.logger - Optional logger used to warn when the 413 guard fires.
+ * @param options.tooLargeMessage - Client-facing message for the 413 response.
+ */
+export function sendJsonResponse<T>(
+  res: Response,
+  payload: T,
+  {
+    beforeSend,
+    evalId,
+    logger,
+    tooLargeMessage = DEFAULT_TOO_LARGE_MESSAGE,
+  }: {
+    beforeSend?: () => void;
+    evalId?: string;
+    logger?: JsonResponseLogger;
+    tooLargeMessage?: string;
+  } = {},
+): void {
+  let body: string;
+  try {
+    body = JSON.stringify(payload);
+  } catch (error) {
+    if (!isJsonSerializationLimitError(error)) {
+      throw error;
+    }
+
+    logger?.warn(
+      '[sendJsonResponse] Response exceeded the maximum JSON string length; returning 413',
+      { error, evalId },
+    );
+
+    res.status(413);
+    res.type('application/json');
+    res.send(JSON.stringify({ error: tooLargeMessage }));
+    return;
+  }
+
+  beforeSend?.();
+  res.type('application/json');
+  res.send(body);
+}

--- a/src/server/utils/safeJsonResponse.ts
+++ b/src/server/utils/safeJsonResponse.ts
@@ -1,49 +1,28 @@
+import { sendError } from './errors';
 import type { Response } from 'express';
 
-/**
- * Matches the `RangeError`s V8 throws from `JSON.stringify` when a payload
- * cannot be serialized because it hits an engine limit: the maximum string
- * length (~512MB, "Invalid string length") or the maximum call-stack depth for
- * an extremely deep payload. These are the failure modes behind issue #7649,
- * where `GET /eval/:id/table` crashed for very large evals (e.g. base64 images
- * or huge per-cell prompts).
- */
 const JSON_SERIALIZATION_LIMIT_ERROR_RE =
   /Invalid string length|Cannot create a string longer than|ERR_STRING_TOO_LONG|Maximum call stack size exceeded/i;
 
-export const DEFAULT_TOO_LARGE_MESSAGE = 'Response payload is too large to serialize';
+const DEFAULT_TOO_LARGE_MESSAGE = 'Response payload is too large to serialize';
 
 type JsonResponseLogger = {
   warn: (message: string, context: Record<string, unknown>) => void;
 };
 
-/**
- * Returns true when `error` is a `RangeError` that `JSON.stringify` throws for a
- * payload that exceeds V8's serialization limits (maximum string length or
- * maximum call-stack depth). Other errors — including circular-reference
- * `TypeError`s — are intentionally not matched so they surface normally.
- */
-export function isJsonSerializationLimitError(error: unknown): error is RangeError {
+function isJsonSerializationLimitError(error: unknown): error is RangeError {
   return error instanceof RangeError && JSON_SERIALIZATION_LIMIT_ERROR_RE.test(error.message);
 }
 
 /**
- * Serializes `payload` and sends it as `application/json`, guarding against the
- * `RangeError` `JSON.stringify` throws when a response would exceed V8's maximum
- * string length (issue #7649).
- *
- * This is a size *guard*, not a trimmer: every payload that fits is sent in full
- * and byte-for-byte identical to `res.json(payload)`, so the public response
- * contract is preserved. A payload that cannot be serialized fails loudly with
- * HTTP 413 and a clear error message rather than throwing an unhandled
- * `RangeError` — and, crucially, without silently stripping or corrupting the
- * body into something that no longer matches the response contract.
+ * Serialize a JSON response before applying success-only headers. V8
+ * serialization-limit errors become a standard 413 response; other errors are
+ * rethrown so callers do not lose useful failures.
  *
  * @param res - Express response to write to.
  * @param payload - Value to serialize and send.
  * @param options.beforeSend - Invoked immediately before a successful body is
- *   sent (e.g. to set download headers). It is intentionally *not* called on the
- *   413 path, so error responses do not inherit success-only headers.
+ *   sent, so a 413 response does not inherit download headers.
  * @param options.evalId - Optional eval id included in the oversized-payload log.
  * @param options.logger - Optional logger used to warn when the 413 guard fires.
  * @param options.tooLargeMessage - Client-facing message for the 413 response.
@@ -63,7 +42,7 @@ export function sendJsonResponse<T>(
     tooLargeMessage?: string;
   } = {},
 ): void {
-  let body: string;
+  let body: string | undefined;
   try {
     body = JSON.stringify(payload);
   } catch (error) {
@@ -71,14 +50,12 @@ export function sendJsonResponse<T>(
       throw error;
     }
 
-    logger?.warn(
-      '[sendJsonResponse] Response exceeded the maximum JSON string length; returning 413',
-      { error, evalId },
-    );
+    logger?.warn('[sendJsonResponse] JSON serialization hit an engine limit; returning 413', {
+      error,
+      evalId,
+    });
 
-    res.status(413);
-    res.type('application/json');
-    res.send(JSON.stringify({ error: tooLargeMessage }));
+    sendError(res, 413, tooLargeMessage);
     return;
   }
 

--- a/test/server/eval.test.ts
+++ b/test/server/eval.test.ts
@@ -6,6 +6,7 @@ import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
 import EvalResult from '../../src/models/evalResult';
 import { createApp } from '../../src/server/server';
+import { STRIPPED_TABLE_CELL_PROMPT } from '../../src/util/eval/evalTableUtils';
 import invariant from '../../src/util/invariant';
 import EvalFactory from '../factories/evalFactory';
 
@@ -63,16 +64,23 @@ describe('eval routes', () => {
     vi.resetAllMocks();
   });
 
-  // Forces the oversized-payload RangeError (#7649) for the first JSON.stringify
-  // call whose argument matches `matches`, without allocating a ~512MB string.
-  function mockJsonStringifyRangeError(matches: (value: unknown) => boolean) {
+  // Forces the oversized-payload RangeError (#7649) for matching JSON.stringify
+  // calls without allocating a ~512MB string.
+  function mockJsonStringifyRangeError(
+    matches: (value: unknown) => boolean,
+    shouldThrow: (attempt: number) => boolean = () => true,
+  ) {
     const originalStringify = JSON.stringify;
+    let matchingAttempts = 0;
 
     return vi
       .spyOn(JSON, 'stringify')
       .mockImplementation((...args: Parameters<typeof JSON.stringify>) => {
         if (matches(args[0])) {
-          throw new RangeError('Invalid string length');
+          matchingAttempts += 1;
+          if (shouldThrow(matchingAttempts)) {
+            throw new RangeError('Invalid string length');
+          }
         }
         return originalStringify.apply(JSON, args);
       });
@@ -87,6 +95,18 @@ describe('eval routes', () => {
     'head' in value &&
     'body' in value &&
     !('table' in value);
+
+  async function setResultPromptRaws(eval_: Eval, raws: string[]) {
+    const results = await eval_.getResults();
+    await Promise.all(
+      raws.map(async (raw, index) => {
+        const result = results[index];
+        invariant(result instanceof EvalResult, 'EvalResult is required');
+        result.prompt = { ...result.prompt, raw };
+        await result.save();
+      }),
+    );
+  }
 
   function createManualRatingPayload(originalResult: any, pass: boolean) {
     const payload = { ...originalResult.gradingResult };
@@ -438,53 +458,84 @@ describe('eval routes', () => {
       expect(updatedEval.config.description).toBe('renamed eval');
     });
 
-    it('returns the full, untrimmed table for a normal eval (contract preserved)', async () => {
+    it('returns table data with only the largest per-cell prompt stripped when possible', async () => {
       const eval_ = await EvalFactory.create({ numResults: 3 });
       testEvalIds.add(eval_.id);
+      await setResultPromptRaws(eval_, ['small prompt', 'x'.repeat(100), 'x'.repeat(50)]);
+
+      mockJsonStringifyRangeError(isTablePayload, (attempt) => attempt === 1);
 
       const res = await api.get(`/api/eval/${eval_.id}/table`);
 
       expect(res.status).toBe(200);
-      expect(res.headers['content-type']).toContain('application/json');
       expect(res.body).toHaveProperty('table');
-      expect(res.body).toHaveProperty('totalCount');
-      expect(res.body).toHaveProperty('config');
-      // Full per-cell prompts are present and never replaced with a placeholder.
+      expect(res.body.table.body.length).toBeGreaterThan(0);
+      expect(res.body.config.tests).toHaveLength(2);
+
       const prompts: Array<string | undefined> = res.body.table.body.flatMap(
         (row: { outputs: Array<{ prompt?: string }> }) =>
           row.outputs.map((output) => output?.prompt),
       );
-      expect(prompts.length).toBeGreaterThan(0);
-      expect(prompts.every((prompt) => typeof prompt === 'string' && prompt.length > 0)).toBe(true);
+      expect(prompts.filter((prompt) => prompt === STRIPPED_TABLE_CELL_PROMPT)).toHaveLength(1);
+      expect(prompts).toContain('small prompt');
+      expect(prompts).toContain('x'.repeat(50));
     });
 
-    it('returns 413 without stripping content when the table exceeds the serialization limit (#7649)', async () => {
+    it('strips per-cell prompts largest first until the response serializes', async () => {
       const eval_ = await EvalFactory.create({ numResults: 3 });
+      testEvalIds.add(eval_.id);
+      await setResultPromptRaws(eval_, ['small prompt', 'x'.repeat(100), 'x'.repeat(50)]);
+
+      mockJsonStringifyRangeError(isTablePayload, (attempt) => attempt <= 2);
+
+      const res = await api.get(`/api/eval/${eval_.id}/table`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('table');
+      expect(res.body.config.tests).toHaveLength(2);
+
+      const prompts: Array<string | undefined> = res.body.table.body.flatMap(
+        (row: { outputs: Array<{ prompt?: string }> }) =>
+          row.outputs.map((output) => output?.prompt),
+      );
+      expect(prompts.filter((prompt) => prompt === STRIPPED_TABLE_CELL_PROMPT)).toHaveLength(2);
+      expect(prompts).toContain('small prompt');
+    });
+
+    it('returns 413 when the table response is still too large after stripping prompts', async () => {
+      const eval_ = await EvalFactory.create();
       testEvalIds.add(eval_.id);
 
       mockJsonStringifyRangeError(isTablePayload);
 
       const res = await api.get(`/api/eval/${eval_.id}/table`);
 
-      // Fails loudly (413) rather than throwing a RangeError (500) or silently
-      // returning a trimmed/corrupted table body.
       expect(res.status).toBe(413);
       expect(res.body).toEqual({
         error: 'Eval too large to display. Try reducing the page size.',
       });
-      expect(res.body).not.toHaveProperty('table');
     });
 
     it('returns the full JSON export for a normal eval', async () => {
       const eval_ = await EvalFactory.create({ numResults: 2 });
       testEvalIds.add(eval_.id);
+      await setResultPromptRaws(eval_, ['json export prompt one', 'json export prompt two']);
 
       const res = await api.get(`/api/eval/${eval_.id}/table?format=json`);
 
       expect(res.status).toBe(200);
-      expect(res.headers['content-disposition']).toContain('attachment');
+      expect(res.headers['content-disposition']).toBe(`attachment; filename="${eval_.id}.json"`);
+      expect(res.headers['cache-control']).toBe('no-cache, no-store, must-revalidate');
       expect(res.body).toHaveProperty('head');
       expect(res.body).toHaveProperty('body');
+      const prompts: Array<string | undefined> = res.body.body.flatMap(
+        (row: { outputs: Array<{ prompt?: string }> }) =>
+          row.outputs.map((output) => output?.prompt),
+      );
+      expect(prompts).toHaveLength(2);
+      expect(prompts).toEqual(
+        expect.arrayContaining(['json export prompt one', 'json export prompt two']),
+      );
     });
 
     it('returns 413 when the JSON export exceeds the serialization limit (#7649)', async () => {
@@ -497,8 +548,8 @@ describe('eval routes', () => {
 
       expect(res.status).toBe(413);
       expect(res.body).toEqual({ error: 'Eval JSON export is too large to serialize.' });
-      // The oversized-export guard must not emit a truncated download.
       expect(res.headers['content-disposition']).toBeUndefined();
+      expect(res.headers['cache-control']).toBeUndefined();
     });
   });
 

--- a/test/server/eval.test.ts
+++ b/test/server/eval.test.ts
@@ -6,7 +6,6 @@ import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
 import EvalResult from '../../src/models/evalResult';
 import { createApp } from '../../src/server/server';
-import { STRIPPED_TABLE_CELL_PROMPT } from '../../src/util/eval/evalTableUtils';
 import invariant from '../../src/util/invariant';
 import EvalFactory from '../factories/evalFactory';
 
@@ -64,35 +63,30 @@ describe('eval routes', () => {
     vi.resetAllMocks();
   });
 
-  function mockTablePayloadRangeError(shouldThrow: (attempt: number) => boolean) {
+  // Forces the oversized-payload RangeError (#7649) for the first JSON.stringify
+  // call whose argument matches `matches`, without allocating a ~512MB string.
+  function mockJsonStringifyRangeError(matches: (value: unknown) => boolean) {
     const originalStringify = JSON.stringify;
-    let tablePayloadAttempts = 0;
 
     return vi
       .spyOn(JSON, 'stringify')
       .mockImplementation((...args: Parameters<typeof JSON.stringify>) => {
-        const value = args[0];
-        if (value && typeof value === 'object' && 'table' in value && 'totalCount' in value) {
-          tablePayloadAttempts += 1;
-          if (shouldThrow(tablePayloadAttempts)) {
-            throw new RangeError('Invalid string length');
-          }
+        if (matches(args[0])) {
+          throw new RangeError('Invalid string length');
         }
         return originalStringify.apply(JSON, args);
       });
   }
 
-  async function setResultPromptRaws(eval_: Eval, raws: string[]) {
-    const results = await eval_.getResults();
-    await Promise.all(
-      raws.map(async (raw, index) => {
-        const result = results[index];
-        invariant(result instanceof EvalResult, 'EvalResult is required');
-        result.prompt = { ...result.prompt, raw };
-        await result.save();
-      }),
-    );
-  }
+  const isTablePayload = (value: unknown): boolean =>
+    !!value && typeof value === 'object' && 'table' in value && 'totalCount' in value;
+
+  const isJsonExportPayload = (value: unknown): boolean =>
+    !!value &&
+    typeof value === 'object' &&
+    'head' in value &&
+    'body' in value &&
+    !('table' in value);
 
   function createManualRatingPayload(originalResult: any, pass: boolean) {
     const payload = { ...originalResult.gradingResult };
@@ -444,62 +438,67 @@ describe('eval routes', () => {
       expect(updatedEval.config.description).toBe('renamed eval');
     });
 
-    it('returns table data with only the largest per-cell prompt stripped when possible', async () => {
+    it('returns the full, untrimmed table for a normal eval (contract preserved)', async () => {
       const eval_ = await EvalFactory.create({ numResults: 3 });
       testEvalIds.add(eval_.id);
-      await setResultPromptRaws(eval_, ['small prompt', 'x'.repeat(100), 'x'.repeat(50)]);
-
-      mockTablePayloadRangeError((attempt) => attempt === 1);
 
       const res = await api.get(`/api/eval/${eval_.id}/table`);
 
       expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('application/json');
       expect(res.body).toHaveProperty('table');
-      expect(res.body.table.body.length).toBeGreaterThan(0);
-      expect(res.body.config.tests).toHaveLength(2);
-
+      expect(res.body).toHaveProperty('totalCount');
+      expect(res.body).toHaveProperty('config');
+      // Full per-cell prompts are present and never replaced with a placeholder.
       const prompts: Array<string | undefined> = res.body.table.body.flatMap(
         (row: { outputs: Array<{ prompt?: string }> }) =>
           row.outputs.map((output) => output?.prompt),
       );
-      expect(prompts.filter((prompt) => prompt === STRIPPED_TABLE_CELL_PROMPT)).toHaveLength(1);
-      expect(prompts).toContain('small prompt');
-      expect(prompts).toContain('x'.repeat(50));
+      expect(prompts.length).toBeGreaterThan(0);
+      expect(prompts.every((prompt) => typeof prompt === 'string' && prompt.length > 0)).toBe(true);
     });
 
-    it('strips per-cell prompts largest first until the response serializes', async () => {
+    it('returns 413 without stripping content when the table exceeds the serialization limit (#7649)', async () => {
       const eval_ = await EvalFactory.create({ numResults: 3 });
       testEvalIds.add(eval_.id);
-      await setResultPromptRaws(eval_, ['small prompt', 'x'.repeat(100), 'x'.repeat(50)]);
 
-      mockTablePayloadRangeError((attempt) => attempt <= 2);
-
-      const res = await api.get(`/api/eval/${eval_.id}/table`);
-
-      expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty('table');
-      expect(res.body.config.tests).toHaveLength(2);
-
-      const prompts: Array<string | undefined> = res.body.table.body.flatMap(
-        (row: { outputs: Array<{ prompt?: string }> }) =>
-          row.outputs.map((output) => output?.prompt),
-      );
-      expect(prompts.filter((prompt) => prompt === STRIPPED_TABLE_CELL_PROMPT)).toHaveLength(2);
-      expect(prompts).toContain('small prompt');
-    });
-
-    it('returns 413 when the table response is still too large after stripping prompts', async () => {
-      const eval_ = await EvalFactory.create();
-      testEvalIds.add(eval_.id);
-
-      mockTablePayloadRangeError(() => true);
+      mockJsonStringifyRangeError(isTablePayload);
 
       const res = await api.get(`/api/eval/${eval_.id}/table`);
 
+      // Fails loudly (413) rather than throwing a RangeError (500) or silently
+      // returning a trimmed/corrupted table body.
       expect(res.status).toBe(413);
       expect(res.body).toEqual({
         error: 'Eval too large to display. Try reducing the page size.',
       });
+      expect(res.body).not.toHaveProperty('table');
+    });
+
+    it('returns the full JSON export for a normal eval', async () => {
+      const eval_ = await EvalFactory.create({ numResults: 2 });
+      testEvalIds.add(eval_.id);
+
+      const res = await api.get(`/api/eval/${eval_.id}/table?format=json`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-disposition']).toContain('attachment');
+      expect(res.body).toHaveProperty('head');
+      expect(res.body).toHaveProperty('body');
+    });
+
+    it('returns 413 when the JSON export exceeds the serialization limit (#7649)', async () => {
+      const eval_ = await EvalFactory.create({ numResults: 2 });
+      testEvalIds.add(eval_.id);
+
+      mockJsonStringifyRangeError(isJsonExportPayload);
+
+      const res = await api.get(`/api/eval/${eval_.id}/table?format=json`);
+
+      expect(res.status).toBe(413);
+      expect(res.body).toEqual({ error: 'Eval JSON export is too large to serialize.' });
+      // The oversized-export guard must not emit a truncated download.
+      expect(res.headers['content-disposition']).toBeUndefined();
     });
   });
 

--- a/test/server/routes/eval.export.test.ts
+++ b/test/server/routes/eval.export.test.ts
@@ -150,29 +150,6 @@ describe('evalRouter - GET /:id/table with export formats', () => {
     expect(sendMock).toHaveBeenCalledWith(mockCsvData);
   });
 
-  it('should return JSON when format=json is specified', async () => {
-    mockReq.query = { format: 'json' };
-    const mockJsonData = { table: mockTable };
-    mockedEvalTableToJson.mockReturnValue(mockJsonData);
-
-    // Simulate the route handler (simplified version)
-    const eval_ = await Eval.findById(mockReq.params!.id as string);
-    const table = await eval_!.getTablePage({
-      offset: 0,
-      limit: Number.MAX_SAFE_INTEGER,
-      filterMode: 'all',
-      searchQuery: '',
-      filters: [],
-    });
-
-    const jsonData = mockedEvalTableToJson(table);
-    setDownloadHeaders(mockRes as Response, 'test-eval-id-results.json', 'application/json');
-    (mockRes as Response).json(jsonData);
-
-    expect(mockedEvalTableToJson).toHaveBeenCalledWith(expect.anything());
-    expect(jsonMock).toHaveBeenCalledWith(mockJsonData);
-  });
-
   it('should include red team conversation columns in CSV for red team evaluations', async () => {
     mockReq.query = { format: 'csv' };
 

--- a/test/server/utils/safeJsonResponse.test.ts
+++ b/test/server/utils/safeJsonResponse.test.ts
@@ -1,9 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import {
-  DEFAULT_TOO_LARGE_MESSAGE,
-  isJsonSerializationLimitError,
-  sendJsonResponse,
-} from '../../../src/server/utils/safeJsonResponse';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sendJsonResponse } from '../../../src/server/utils/safeJsonResponse';
 import type { Response } from 'express';
 
 function createMockResponse() {
@@ -23,6 +19,11 @@ function createMockResponse() {
       this.body = value;
       return this;
     }),
+    json: vi.fn(function json(this: typeof res, value: unknown) {
+      this.contentType = 'application/json';
+      this.body = JSON.stringify(value);
+      return this;
+    }),
   };
   return res;
 }
@@ -40,38 +41,13 @@ function oversizedPayload(message = 'Invalid string length') {
   };
 }
 
-describe('isJsonSerializationLimitError', () => {
-  it('matches the oversized-string RangeError variants', () => {
-    expect(isJsonSerializationLimitError(new RangeError('Invalid string length'))).toBe(true);
-    expect(
-      isJsonSerializationLimitError(
-        new RangeError('Cannot create a string longer than 0x1fffffe8 characters'),
-      ),
-    ).toBe(true);
-    expect(isJsonSerializationLimitError(new RangeError('ERR_STRING_TOO_LONG'))).toBe(true);
-  });
-
-  it('matches the max call-stack RangeError', () => {
-    expect(isJsonSerializationLimitError(new RangeError('Maximum call stack size exceeded'))).toBe(
-      true,
-    );
-  });
-
-  it('does not match unrelated errors', () => {
-    // Circular-reference serialization failures are TypeErrors, not RangeErrors.
-    expect(
-      isJsonSerializationLimitError(new TypeError('Converting circular structure to JSON')),
-    ).toBe(false);
-    expect(isJsonSerializationLimitError(new RangeError('some other range error'))).toBe(false);
-    // A non-RangeError with a matching message must not match.
-    expect(isJsonSerializationLimitError(new Error('Invalid string length'))).toBe(false);
-    expect(isJsonSerializationLimitError('Invalid string length')).toBe(false);
-    expect(isJsonSerializationLimitError(undefined)).toBe(false);
-  });
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetAllMocks();
 });
 
 describe('sendJsonResponse', () => {
-  it('sends the full payload byte-for-byte identical to res.json for normal payloads', () => {
+  it('serializes normal payloads without modification', () => {
     const res = createMockResponse();
     const payload = {
       table: { head: { prompts: ['p'], vars: ['v'] }, body: [{ outputs: [{ prompt: 'hi' }] }] },
@@ -81,8 +57,6 @@ describe('sendJsonResponse', () => {
 
     sendJsonResponse(res as unknown as Response, payload);
 
-    // Contract preservation: identical serialization to `res.json(payload)`,
-    // which uses `JSON.stringify(payload)` with Express's default settings.
     expect(res.send).toHaveBeenCalledTimes(1);
     expect(res.body).toBe(JSON.stringify(payload));
     expect(res.contentType).toBe('application/json');
@@ -104,6 +78,16 @@ describe('sendJsonResponse', () => {
 
     expect(beforeSend).toHaveBeenCalledTimes(1);
     expect(calls).toEqual(['beforeSend', 'send']);
+  });
+
+  it('preserves JSON.stringify semantics for an undefined payload', () => {
+    const res = createMockResponse();
+
+    sendJsonResponse(res as unknown as Response, undefined);
+
+    expect(res.send).toHaveBeenCalledWith(undefined);
+    expect(res.contentType).toBe('application/json');
+    expect(res.statusCode).toBe(200);
   });
 
   it('returns HTTP 413 with a clear error instead of throwing for oversized payloads (#7649)', () => {
@@ -128,18 +112,19 @@ describe('sendJsonResponse', () => {
     expect(beforeSend).not.toHaveBeenCalled();
   });
 
-  it('degrades a max call-stack RangeError to 413 as well', () => {
+  it.each([
+    'Cannot create a string longer than 0x1fffffe8 characters',
+    'ERR_STRING_TOO_LONG',
+    'Maximum call stack size exceeded',
+  ])('returns 413 for the V8 serialization-limit message %s', (message) => {
     const res = createMockResponse();
 
     expect(() =>
-      sendJsonResponse(
-        res as unknown as Response,
-        oversizedPayload('Maximum call stack size exceeded'),
-      ),
+      sendJsonResponse(res as unknown as Response, oversizedPayload(message)),
     ).not.toThrow();
 
     expect(res.statusCode).toBe(413);
-    expect(res.body).toBe(JSON.stringify({ error: DEFAULT_TOO_LARGE_MESSAGE }));
+    expect(res.body).toBe(JSON.stringify({ error: 'Response payload is too large to serialize' }));
   });
 
   it('logs a warning with the eval id when the guard fires', () => {
@@ -148,20 +133,39 @@ describe('sendJsonResponse', () => {
 
     sendJsonResponse(res as unknown as Response, oversizedPayload(), { evalId: 'eval-1', logger });
 
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    expect(logger.warn.mock.calls[0][1]).toMatchObject({ evalId: 'eval-1' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[sendJsonResponse] JSON serialization hit an engine limit; returning 413',
+      expect.objectContaining({ evalId: 'eval-1' }),
+    );
   });
 
-  it('rethrows errors that are not serialization-limit RangeErrors', () => {
+  it.each([
+    new Error('Invalid string length'),
+    new RangeError('some other range error'),
+    new TypeError('Converting circular structure to JSON'),
+  ])('rethrows non-limit serialization errors', (error) => {
     const res = createMockResponse();
     const payload = {
       toJSON() {
-        throw new Error('boom');
+        throw error;
       },
     };
 
-    expect(() => sendJsonResponse(res as unknown as Response, payload)).toThrow('boom');
+    expect(() => sendJsonResponse(res as unknown as Response, payload)).toThrow(error);
     expect(res.send).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(200);
+  });
+
+  it('rethrows native BigInt and circular-reference serialization errors', () => {
+    const bigintResponse = createMockResponse();
+    expect(() => sendJsonResponse(bigintResponse as unknown as Response, 1n)).toThrow(TypeError);
+
+    const circularResponse = createMockResponse();
+    const circularPayload: { self?: unknown } = {};
+    circularPayload.self = circularPayload;
+    expect(() =>
+      sendJsonResponse(circularResponse as unknown as Response, circularPayload),
+    ).toThrow(TypeError);
   });
 });

--- a/test/server/utils/safeJsonResponse.test.ts
+++ b/test/server/utils/safeJsonResponse.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_TOO_LARGE_MESSAGE,
+  isJsonSerializationLimitError,
+  sendJsonResponse,
+} from '../../../src/server/utils/safeJsonResponse';
+import type { Response } from 'express';
+
+function createMockResponse() {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    contentType: undefined as string | undefined,
+    status: vi.fn(function status(this: typeof res, code: number) {
+      this.statusCode = code;
+      return this;
+    }),
+    type: vi.fn(function type(this: typeof res, value: string) {
+      this.contentType = value;
+      return this;
+    }),
+    send: vi.fn(function send(this: typeof res, value: unknown) {
+      this.body = value;
+      return this;
+    }),
+  };
+  return res;
+}
+
+/**
+ * A payload whose `toJSON` throws the exact V8 RangeError we care about, so that
+ * `JSON.stringify(payload)` reproduces the issue #7649 failure deterministically
+ * without allocating a ~512MB string.
+ */
+function oversizedPayload(message = 'Invalid string length') {
+  return {
+    toJSON() {
+      throw new RangeError(message);
+    },
+  };
+}
+
+describe('isJsonSerializationLimitError', () => {
+  it('matches the oversized-string RangeError variants', () => {
+    expect(isJsonSerializationLimitError(new RangeError('Invalid string length'))).toBe(true);
+    expect(
+      isJsonSerializationLimitError(
+        new RangeError('Cannot create a string longer than 0x1fffffe8 characters'),
+      ),
+    ).toBe(true);
+    expect(isJsonSerializationLimitError(new RangeError('ERR_STRING_TOO_LONG'))).toBe(true);
+  });
+
+  it('matches the max call-stack RangeError', () => {
+    expect(isJsonSerializationLimitError(new RangeError('Maximum call stack size exceeded'))).toBe(
+      true,
+    );
+  });
+
+  it('does not match unrelated errors', () => {
+    // Circular-reference serialization failures are TypeErrors, not RangeErrors.
+    expect(
+      isJsonSerializationLimitError(new TypeError('Converting circular structure to JSON')),
+    ).toBe(false);
+    expect(isJsonSerializationLimitError(new RangeError('some other range error'))).toBe(false);
+    // A non-RangeError with a matching message must not match.
+    expect(isJsonSerializationLimitError(new Error('Invalid string length'))).toBe(false);
+    expect(isJsonSerializationLimitError('Invalid string length')).toBe(false);
+    expect(isJsonSerializationLimitError(undefined)).toBe(false);
+  });
+});
+
+describe('sendJsonResponse', () => {
+  it('sends the full payload byte-for-byte identical to res.json for normal payloads', () => {
+    const res = createMockResponse();
+    const payload = {
+      table: { head: { prompts: ['p'], vars: ['v'] }, body: [{ outputs: [{ prompt: 'hi' }] }] },
+      config: { description: 'my eval', tests: [{ vars: { a: 1 } }] },
+      totalCount: 1,
+    };
+
+    sendJsonResponse(res as unknown as Response, payload);
+
+    // Contract preservation: identical serialization to `res.json(payload)`,
+    // which uses `JSON.stringify(payload)` with Express's default settings.
+    expect(res.send).toHaveBeenCalledTimes(1);
+    expect(res.body).toBe(JSON.stringify(payload));
+    expect(res.contentType).toBe('application/json');
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('invokes beforeSend before sending a successful body', () => {
+    const res = createMockResponse();
+    const calls: string[] = [];
+    const beforeSend = vi.fn(() => calls.push('beforeSend'));
+    (res.send as unknown as { mockImplementation: (fn: () => void) => void }).mockImplementation(
+      () => {
+        calls.push('send');
+        return res;
+      },
+    );
+
+    sendJsonResponse(res as unknown as Response, { ok: true }, { beforeSend });
+
+    expect(beforeSend).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['beforeSend', 'send']);
+  });
+
+  it('returns HTTP 413 with a clear error instead of throwing for oversized payloads (#7649)', () => {
+    const res = createMockResponse();
+    const beforeSend = vi.fn();
+
+    expect(() =>
+      sendJsonResponse(res as unknown as Response, oversizedPayload(), {
+        beforeSend,
+        evalId: 'abc123',
+        tooLargeMessage: 'Eval too large to display. Try reducing the page size.',
+      }),
+    ).not.toThrow();
+
+    expect(res.statusCode).toBe(413);
+    expect(res.contentType).toBe('application/json');
+    // The body is exactly the error contract — no stripped/partial payload leaks.
+    expect(res.body).toBe(
+      JSON.stringify({ error: 'Eval too large to display. Try reducing the page size.' }),
+    );
+    // Success-only side effects (e.g. download headers) must not run on the 413 path.
+    expect(beforeSend).not.toHaveBeenCalled();
+  });
+
+  it('degrades a max call-stack RangeError to 413 as well', () => {
+    const res = createMockResponse();
+
+    expect(() =>
+      sendJsonResponse(
+        res as unknown as Response,
+        oversizedPayload('Maximum call stack size exceeded'),
+      ),
+    ).not.toThrow();
+
+    expect(res.statusCode).toBe(413);
+    expect(res.body).toBe(JSON.stringify({ error: DEFAULT_TOO_LARGE_MESSAGE }));
+  });
+
+  it('logs a warning with the eval id when the guard fires', () => {
+    const res = createMockResponse();
+    const logger = { warn: vi.fn() };
+
+    sendJsonResponse(res as unknown as Response, oversizedPayload(), { evalId: 'eval-1', logger });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0][1]).toMatchObject({ evalId: 'eval-1' });
+  });
+
+  it('rethrows errors that are not serialization-limit RangeErrors', () => {
+    const res = createMockResponse();
+    const payload = {
+      toJSON() {
+        throw new Error('boom');
+      },
+    };
+
+    expect(() => sendJsonResponse(res as unknown as Response, payload)).toThrow('boom');
+    expect(res.send).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

- Return `413` from `GET /api/eval/:id/table?format=json` when V8 hits a JSON serialization size or call-stack limit.
- Serialize before setting download headers, so failed exports return `{ "error": "Eval JSON export is too large to serialize." }` without `Content-Disposition` or cache headers.
- Keep successful export payloads and headers unchanged.
- Retain the existing prompt-stripping recovery for regular table responses.

## Implementation

Adds `sendJsonResponse`, which serializes once and converts only recognized serialization-limit `RangeError`s to the standard server error response. Circular-reference, `BigInt`, and unrelated serialization errors are rethrown.

Route coverage now exercises the actual Express endpoint for successful and oversized JSON exports. The older test that manually reconstructed the JSON branch was removed.

## Verification

- `node node_modules/vitest/vitest.mjs run test/server/utils/safeJsonResponse.test.ts test/server/eval.test.ts test/server/routes/eval.export.test.ts --reporter=dot` — 3 files, 43 tests passed
- `npm run tsc` — passed
- `npm run build` — passed
- `npm run f` — passed
- `npm run l` — passed

OpenAPI already documents a `413` response for `GET /api/eval/{id}/table`, so no documentation change is needed.

Refs #7649.
