### PR TITLE
fix(matchers): count missing faithfulness verdicts as unsupported

### DIFF
--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -411,14 +411,18 @@ export async function matchesContextFaithfulness(
       verdicts = verdicts.slice(verdicts.indexOf(finalAnswer) + finalAnswer.length);
       const parsedVerdicts = verdicts.split('.').filter((answer) => answer.trim() !== '');
       if (parsedVerdicts.length > 0) {
-        score =
-          1 - parsedVerdicts.filter((answer) => !answer.includes('yes')).length / statements.length;
+        const unsupportedVerdicts = parsedVerdicts.filter(
+          (answer) => !answer.includes('yes'),
+        ).length;
+        const missingVerdicts = Math.max(0, statements.length - parsedVerdicts.length);
+        score = 1 - (unsupportedVerdicts + missingVerdicts) / statements.length;
       }
     } else {
       const noVerdictCount = verdicts.split('verdict: no').length - 1;
       const yesVerdictCount = verdicts.split('verdict: yes').length - 1;
       if (noVerdictCount + yesVerdictCount > 0) {
-        score = 1 - noVerdictCount / statements.length;
+        const missingVerdicts = Math.max(0, statements.length - noVerdictCount - yesVerdictCount);
+        score = 1 - (noVerdictCount + missingVerdicts) / statements.length;
       }
     }
   }

--- a/test/matchers/context-faithfulness.test.ts
+++ b/test/matchers/context-faithfulness.test.ts
@@ -166,6 +166,86 @@ describe('matchesContextFaithfulness', () => {
     });
   });
 
+  it('should count missing final-answer verdicts as unsupported', async () => {
+    const query = 'Query text';
+    const output = 'Output text';
+    const context = 'Context text';
+    const threshold = 0.5;
+
+    const mockCallApi = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          output: 'Statement 1\nStatement 2\nStatement 3',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        });
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          output: 'Final verdict for each statement in order: Yes.',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        });
+      });
+
+    const callApiSpy = vi.spyOn(DefaultGradingProvider, 'callApi');
+    callApiSpy.mockReset();
+    callApiSpy.mockImplementation(mockCallApi);
+
+    await expect(matchesContextFaithfulness(query, output, context, threshold)).resolves.toEqual({
+      pass: false,
+      reason: 'Faithfulness 0.33 is < 0.5',
+      score: expect.closeTo(0.33, 0.01),
+      tokensUsed: {
+        total: expect.any(Number),
+        prompt: expect.any(Number),
+        completion: expect.any(Number),
+        cached: expect.any(Number),
+        completionDetails: expect.any(Object),
+        numRequests: 0,
+      },
+    });
+  });
+
+  it('should count missing line-by-line verdicts as unsupported', async () => {
+    const query = 'Query text';
+    const output = 'Output text';
+    const context = 'Context text';
+    const threshold = 0.5;
+
+    const mockCallApi = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          output: 'Statement 1\nStatement 2\nStatement 3',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        });
+      })
+      .mockImplementationOnce(() => {
+        return Promise.resolve({
+          output: 'Statement 1\nverdict: yes',
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        });
+      });
+
+    const callApiSpy = vi.spyOn(DefaultGradingProvider, 'callApi');
+    callApiSpy.mockReset();
+    callApiSpy.mockImplementation(mockCallApi);
+
+    await expect(matchesContextFaithfulness(query, output, context, threshold)).resolves.toEqual({
+      pass: false,
+      reason: 'Faithfulness 0.33 is < 0.5',
+      score: expect.closeTo(0.33, 0.01),
+      tokensUsed: {
+        total: expect.any(Number),
+        prompt: expect.any(Number),
+        completion: expect.any(Number),
+        cached: expect.any(Number),
+        completionDetails: expect.any(Object),
+        numRequests: 0,
+      },
+    });
+  });
+
   it('should clamp score when verdict count exceeds statement count', async () => {
     const query = 'Query text';
     const output = 'Output text';


### PR DESCRIPTION
## Summary

- Count missing `context-faithfulness` verdicts as unsupported instead of treating them as implicitly supported
- Apply the same accounting to both final-answer verdict output and the line-by-line `verdict: yes/no` fallback
- Add regression coverage for incomplete verdict output over multiple extracted statements

Fixes #9978.

## Changes

- Include missing parsed verdicts in the unsupported verdict count before computing the faithfulness score
- Keep existing score clamping and complete-verdict behavior unchanged
- Cover incomplete final-answer and line-by-line verdict output in `context-faithfulness` tests

## Verification

```sh
npm run test -- test/matchers/context-faithfulness.test.ts
npm run test -- test/matchers/context-faithfulness.test.ts test/matchers/context-recall.test.ts test/matchers/context-relevance.test.ts test/assertions/contextFaithfulness.test.ts
npm run tsc
npm run lint:src
npm run lint:tests
```
