### PR TITLE
docs(code-scan-action): fix broken Contributing link in README

### DIFF
--- a/code-scan-action/README.md
+++ b/code-scan-action/README.md
@@ -59,7 +59,7 @@ The action sets `sarif-path` only when a scan actually completes, so keep the up
 
 ## Contributing
 
-Please note that this a release-only repository. To contribute, refer to the [associated directory](https://github.com/promptfoo/promptfoo/tree/main/promptfoo/code-scan-action) in the main promptfoo repository.
+Please note that this a release-only repository. To contribute, refer to the [associated directory](https://github.com/promptfoo/promptfoo/tree/main/code-scan-action) in the main promptfoo repository.
 
 ## License
 


### PR DESCRIPTION
## What

Fixes the broken **Contributing** link in `code-scan-action/README.md`.

## Details

The Contributing section links to:

```
https://github.com/promptfoo/promptfoo/tree/main/promptfoo/code-scan-action
```

which 404s — the directory lives at the repo root, not under a `promptfoo/` subpath. Corrected to:

```
https://github.com/promptfoo/promptfoo/tree/main/code-scan-action
```

One-line change; no other edits.
