### PR TITLE
fix(providers): correct Claude context pricing by platform

### DIFF
--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -182,7 +182,7 @@ const CLAUDE_SONNET_5_PATTERN = /(^|[^a-z0-9])claude-sonnet-5(?![0-9])/i;
 const CLAUDE_OPUS_48_PATTERN = /(^|[^a-z0-9])claude-opus-4-8(?![0-9])/i;
 const CLAUDE_OPUS_47_PATTERN = /(^|[^a-z0-9])claude-opus-4-7(?![0-9])/i;
 // Opus/Sonnet 4.5 and 4.6, and Haiku 4.5 — regional premium only (no other deprecations).
-const CLAUDE_4_5_AND_4_6_TIER_PATTERN =
+const CLAUDE_4_5_AND_4_6_REGIONAL_PREMIUM_PATTERN =
   /(^|[^a-z0-9])claude-(?:opus|sonnet|haiku)-4-(?:5|6)(?![0-9])/i;
 
 interface ClaudeModelFamily {
@@ -232,7 +232,7 @@ const CLAUDE_MODEL_FAMILIES: readonly ClaudeModelFamily[] = [
     samplingParamsDeprecated: true,
     regionalPremium: true,
   },
-  { match: CLAUDE_4_5_AND_4_6_TIER_PATTERN, regionalPremium: true },
+  { match: CLAUDE_4_5_AND_4_6_REGIONAL_PREMIUM_PATTERN, regionalPremium: true },
 ];
 
 function hasClaudeCapability(
@@ -329,7 +329,8 @@ export const CLAUDE_REGIONAL_ENDPOINT_PREMIUM = 1.1;
  * Mark a cost config for the Claude regional endpoint premium (see isClaudeRegionalPremiumModel),
  * unless the user supplied an explicit `cost`/`inputCost`/`outputCost` override. The premium is a
  * flat multiplier that calculateAnthropicCost applies to the *final* computed cost, so it composes
- * with cache pricing rather than overriding it. Callers decide whether the request is regional.
+ * with provider-selected long-context and cache pricing rather than overriding either. Callers
+ * decide whether the request is regional.
  */
 export function applyClaudeRegionalPremium(modelName: string, config: any): any {
   if (
@@ -519,7 +520,7 @@ export function calculateAnthropicCost(
     ? applyClaudeRegionalPremium(modelName, config)
     : config;
   // Apply the regional endpoint premium (if any) as a flat multiplier on the final cost, so it
-  // composes with cache pricing rather than overriding it.
+  // composes with long-context and cache pricing rather than overriding either.
   const regionalPremiumMultiplier: number = effectiveConfig.regionalPremiumMultiplier ?? 1;
   const withRegionalPremium = (cost: number | undefined): number | undefined =>
     cost == null ? cost : cost * regionalPremiumMultiplier;
@@ -560,9 +561,8 @@ export function calculateAnthropicCost(
   const cacheRead = cacheReadTokens ?? 0;
   const cacheCreation = cacheCreationTokens ?? 0;
 
-  // Per-token rates are flat regardless of prompt size — every model bills its full
-  // context window at the standard rate. Apply cache pricing only when cache tokens
-  // are present.
+  // This shared helper does not infer size-based tiers. Provider-specific callers can supply
+  // explicit input/output rates, while cache pricing is applied whenever cache tokens are present.
   if (cacheRead || cacheCreation) {
     if (modelInfo) {
       const inputCost = effectiveConfig.inputCost ?? effectiveConfig.cost ?? modelInfo.cost.input;

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -24,11 +24,8 @@ export const ANTHROPIC_MODELS = [
   })),
   // Claude Sonnet 5 — the most agentic Sonnet, with a 1M context window and effort
   // levels. Uses standard list pricing ($3/$15); the launch introductory pricing
-  // ($2/$10, through Aug 31, 2026) is intentionally not encoded here. Per Anthropic's
-  // pricing docs, Sonnet 5 bills its FULL 1M context at the standard rate — there is
-  // no >200K long-context tier (a 900k-token request bills at the same per-token rate
-  // as a 9k-token request), so it is intentionally left OUT of `hasTieredPricing`
-  // below. (This differs from Sonnet 4.5, which does carry the >200K tier.)
+  // ($2/$10, through Aug 31, 2026) is intentionally not encoded here. The full 1M
+  // context bills at this flat rate — prompt size never changes the per-token price.
   ...['claude-sonnet-5'].map((model) => ({
     id: model,
     cost: {
@@ -332,8 +329,7 @@ export const CLAUDE_REGIONAL_ENDPOINT_PREMIUM = 1.1;
  * Mark a cost config for the Claude regional endpoint premium (see isClaudeRegionalPremiumModel),
  * unless the user supplied an explicit `cost`/`inputCost`/`outputCost` override. The premium is a
  * flat multiplier that calculateAnthropicCost applies to the *final* computed cost, so it composes
- * correctly with tiered long-context pricing (the >200K tier is selected first, then multiplied)
- * and with cache pricing. Callers decide whether the request is regional.
+ * with cache pricing rather than overriding it. Callers decide whether the request is regional.
  */
 export function applyClaudeRegionalPremium(modelName: string, config: any): any {
   if (
@@ -523,7 +519,7 @@ export function calculateAnthropicCost(
     ? applyClaudeRegionalPremium(modelName, config)
     : config;
   // Apply the regional endpoint premium (if any) as a flat multiplier on the final cost, so it
-  // composes with tiered long-context and cache pricing rather than overriding either.
+  // composes with cache pricing rather than overriding it.
   const regionalPremiumMultiplier: number = effectiveConfig.regionalPremiumMultiplier ?? 1;
   const withRegionalPremium = (cost: number | undefined): number | undefined =>
     cost == null ? cost : cost * regionalPremiumMultiplier;
@@ -564,32 +560,9 @@ export function calculateAnthropicCost(
   const cacheRead = cacheReadTokens ?? 0;
   const cacheCreation = cacheCreationTokens ?? 0;
 
-  // Anthropic docs: the >200k threshold considers input + cache read + cache creation tokens
-  const effectiveInputTokens = promptTokens + cacheRead + cacheCreation;
-
-  // Claude Sonnet models with 1M context support have tiered pricing based on prompt size
-  const hasTieredPricing = [
-    'claude-sonnet-4-5',
-    'claude-sonnet-4-5-20250929',
-    'claude-sonnet-4-5-latest',
-    'claude-sonnet-4-6',
-    'claude-sonnet-4-6-latest',
-  ].includes(pricingModelName);
-
-  if (hasTieredPricing) {
-    const isLongContext = effectiveInputTokens > 200_000;
-    const baseInputRate =
-      effectiveConfig.inputCost ?? effectiveConfig.cost ?? (isLongContext ? 6 / 1e6 : 3 / 1e6);
-    const outputRate =
-      effectiveConfig.outputCost ?? effectiveConfig.cost ?? (isLongContext ? 22.5 / 1e6 : 15 / 1e6);
-
-    return withRegionalPremium(
-      calculateCacheInputCost(baseInputRate, promptTokens, cacheRead, cacheCreation) +
-        completionTokens * outputRate,
-    );
-  }
-
-  // For non-tiered models, apply cache pricing only when cache tokens are present
+  // Per-token rates are flat regardless of prompt size — every model bills its full
+  // context window at the standard rate. Apply cache pricing only when cache tokens
+  // are present.
   if (cacheRead || cacheCreation) {
     if (modelInfo) {
       const inputCost = effectiveConfig.inputCost ?? effectiveConfig.cost ?? modelInfo.cost.input;

--- a/src/providers/azure/defaults.ts
+++ b/src/providers/azure/defaults.ts
@@ -695,11 +695,11 @@ export const AZURE_MODELS: AzureModelCost[] = [
   },
   {
     id: 'claude-haiku-4-5',
-    cost: { input: 0.8 / 1000000, output: 4 / 1000000 },
+    cost: { input: 1 / 1000000, output: 5 / 1000000 },
   },
   {
     id: 'claude-haiku-4-5-20251001',
-    cost: { input: 0.8 / 1000000, output: 4 / 1000000 },
+    cost: { input: 1 / 1000000, output: 5 / 1000000 },
   },
 
   // =============================================================================

--- a/src/providers/bedrock/pricing.ts
+++ b/src/providers/bedrock/pricing.ts
@@ -26,8 +26,7 @@ const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   'anthropic.claude-opus-4-5': { input: 5, output: 25 },
   // Claude Opus 4/4.1
   'anthropic.claude-opus-4': { input: 15, output: 75 },
-  // Claude Sonnet 5 (standard list pricing; full 1M context bills at the standard
-  // rate — no >200K long-context tier, unlike Sonnet 4.5)
+  // Claude Sonnet 5 (standard list pricing; full 1M context bills at the standard rate)
   'anthropic.claude-sonnet-5': { input: 3, output: 15 },
   // Claude Sonnet 4/4.5
   'anthropic.claude-sonnet-4': { input: 3, output: 15 },
@@ -379,14 +378,7 @@ export function calculateBedrockCost(
   }
 
   const normalizedModelId = modelId.toLowerCase();
-  // Only Sonnet 4.5/4.6 carry the >200K long-context tier. Sonnet 5 bills its full
-  // 1M context at the standard rate (Anthropic pricing docs), so it is excluded here.
-  const isLongContextClaudeSonnet =
-    /anthropic\.claude-sonnet-4-(?:5|6)(?!\d)/.test(normalizedModelId) &&
-    promptTokens + cacheReadTokens + cacheWriteTokens > 200_000;
-  const pricing = isLongContextClaudeSonnet
-    ? { input: 6, output: 22.5 }
-    : getBedrockPricing(normalizedModelId, region);
+  const pricing = getBedrockPricing(normalizedModelId, region);
   if (!pricing) {
     return undefined;
   }

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -70,6 +70,47 @@ import type {
 // Type for Google API errors - using 'any' to avoid gaxios dependency
 type GaxiosError = any;
 
+// Vertex retains the Sonnet 4.5 1M preview and its >200K pricing tier. Native Anthropic and
+// Bedrock Sonnet 4.5 requests are capped at 200K, so only this provider opts into these rates.
+const VERTEX_CLAUDE_SONNET_4_5_MODELS = new Set([
+  'claude-sonnet-4-5',
+  'claude-sonnet-4-5-20250929',
+  'claude-sonnet-4-5-latest',
+]);
+const VERTEX_CLAUDE_SONNET_4_5_LONG_CONTEXT_PRICING = {
+  threshold: 200_000,
+  input: 6 / 1e6,
+  output: 22.5 / 1e6,
+};
+
+function applyVertexClaudeLongContextPricing(
+  modelName: string,
+  config: GoogleProviderConfig,
+  inputTokens?: number,
+  cacheReadTokens?: number,
+  cacheCreationTokens?: number,
+): GoogleProviderConfig {
+  const effectiveInputTokens =
+    (inputTokens ?? 0) + (cacheReadTokens ?? 0) + (cacheCreationTokens ?? 0);
+  if (
+    !VERTEX_CLAUDE_SONNET_4_5_MODELS.has(modelName) ||
+    effectiveInputTokens <= VERTEX_CLAUDE_SONNET_4_5_LONG_CONTEXT_PRICING.threshold
+  ) {
+    return config;
+  }
+
+  // `cost` already supplies both rates and intentionally overrides tier-specific pricing.
+  if (config.cost != null) {
+    return config;
+  }
+
+  return {
+    ...config,
+    inputCost: config.inputCost ?? VERTEX_CLAUDE_SONNET_4_5_LONG_CONTEXT_PRICING.input,
+    outputCost: config.outputCost ?? VERTEX_CLAUDE_SONNET_4_5_LONG_CONTEXT_PRICING.output,
+  };
+}
+
 type VertexEmbeddingPredictResponse = {
   predictions?: Array<{
     embeddings?: {
@@ -426,15 +467,24 @@ export class VertexChatProvider extends GoogleGenericProvider {
         this.getRegion() === 'global'
           ? this.config
           : applyClaudeRegionalPremium(normalizedModelName, this.config);
+      const effectivePricingConfig = applyVertexClaudeLongContextPricing(
+        normalizedModelName,
+        pricingConfig,
+        data.usage?.input_tokens,
+        data.usage?.cache_read_input_tokens,
+        data.usage?.cache_creation_input_tokens,
+      );
       const response = {
         cached: false,
         output,
         tokenUsage,
         cost: calculateAnthropicCost(
           normalizedModelName,
-          pricingConfig,
+          effectivePricingConfig,
           data.usage?.input_tokens,
           data.usage?.output_tokens,
+          data.usage?.cache_read_input_tokens,
+          data.usage?.cache_creation_input_tokens,
         ),
       };
 

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -171,49 +171,38 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(0.0055); // (0.000005 * 100) + (0.000025 * 200) - $5/MTok input, $25/MTok output
     });
 
-    it('should calculate tiered cost for Claude Sonnet 4.5 with prompt <= 200k tokens', () => {
-      // Test with 150k tokens (below threshold)
+    it('bills Claude Sonnet 4.5 at the standard rate below 200k tokens', () => {
       const cost = calculateAnthropicCost('claude-sonnet-4-5-20250929', {}, 150_000, 10_000);
       expect(cost).toBe(0.6); // (3/1e6 * 150,000) + (15/1e6 * 10,000) = 0.45 + 0.15 = 0.6
     });
 
-    it('should calculate tiered cost for Claude Sonnet 4.5 with prompt exactly 200k tokens', () => {
-      // Test with exactly 200k tokens (at threshold, should use lower tier)
-      const cost = calculateAnthropicCost('claude-sonnet-4-5-20250929', {}, 200_000, 10_000);
-      expect(cost).toBe(0.75); // (3/1e6 * 200,000) + (15/1e6 * 10,000) = 0.6 + 0.15 = 0.75
-    });
-
-    it('should calculate tiered cost for Claude Sonnet 4.5 with prompt > 200k tokens', () => {
-      // Test with 250k tokens (above threshold)
+    it('bills Claude Sonnet 4.5 at the standard rate above 200k tokens (no long-context tier)', () => {
+      // Guards against a >200K surcharge sneaking back in: the per-token rate must
+      // not change with prompt size.
       const cost = calculateAnthropicCost('claude-sonnet-4-5-20250929', {}, 250_000, 10_000);
-      expect(cost).toBe(1.725); // (6/1e6 * 250,000) + (22.5/1e6 * 10,000) = 1.5 + 0.225 = 1.725
+      expect(cost).toBe(0.9); // (3/1e6 * 250,000) + (15/1e6 * 10,000) = 0.75 + 0.15 = 0.9
     });
 
-    it('should calculate tiered cost for Claude Sonnet 4.5 20250929 with > 200k tokens', () => {
-      const cost = calculateAnthropicCost('claude-sonnet-4-5-20250929', {}, 300_000, 20_000);
-      // (6/1e6 * 300,000) + (22.5/1e6 * 20,000) = 1.8 + 0.45 = 2.25
-      expect(cost).toBe(2.25);
+    it('bills the Claude Sonnet 4.5 latest alias at the standard rate above 200k tokens', () => {
+      const cost = calculateAnthropicCost('claude-sonnet-4-5-latest', {}, 300_000, 20_000);
+      expect(cost).toBe(1.2); // (3/1e6 * 300,000) + (15/1e6 * 20,000) = 0.9 + 0.3 = 1.2
     });
 
-    it('should calculate tiered cost for Claude Sonnet 4.5 latest alias', () => {
-      const cost = calculateAnthropicCost('claude-sonnet-4-5-latest', {}, 250_000, 10_000);
-      expect(cost).toBe(1.725); // (6/1e6 * 250,000) + (22.5/1e6 * 10,000) = 1.5 + 0.225 = 1.725
-    });
-
-    it('should calculate tiered cost for Claude Sonnet 4.6 with prompt <= 200k tokens', () => {
+    it('bills Claude Sonnet 4.6 at the standard rate below 200k tokens', () => {
       const cost = calculateAnthropicCost('claude-sonnet-4-6', {}, 150_000, 10_000);
       expect(cost).toBe(0.6); // (3/1e6 * 150,000) + (15/1e6 * 10,000) = 0.45 + 0.15 = 0.6
     });
 
-    it('should calculate tiered cost for Claude Sonnet 4.6 with prompt > 200k tokens', () => {
+    it('bills Claude Sonnet 4.6 at the standard rate above 200k tokens (full 1M at standard pricing)', () => {
+      // Per Anthropic pricing, Sonnet 4.6 includes the full 1M context window at
+      // standard pricing — a 900k-token request bills at the same per-token rate as 9k.
       const cost = calculateAnthropicCost('claude-sonnet-4-6', {}, 300_000, 20_000);
-      // (6/1e6 * 300,000) + (22.5/1e6 * 20,000) = 1.8 + 0.45 = 2.25
-      expect(cost).toBe(2.25);
+      expect(cost).toBe(1.2); // (3/1e6 * 300,000) + (15/1e6 * 20,000) = 0.9 + 0.3 = 1.2
     });
 
-    it('should calculate tiered cost for Claude Sonnet 4.6 latest alias', () => {
+    it('bills the Claude Sonnet 4.6 latest alias at the standard rate above 200k tokens', () => {
       const cost = calculateAnthropicCost('claude-sonnet-4-6-latest', {}, 250_000, 10_000);
-      expect(cost).toBe(1.725); // (6/1e6 * 250,000) + (22.5/1e6 * 10,000) = 1.5 + 0.225 = 1.725
+      expect(cost).toBe(0.9); // (3/1e6 * 250,000) + (15/1e6 * 10,000) = 0.75 + 0.15 = 0.9
     });
 
     it('should calculate default cost for Claude Sonnet 5 model', () => {
@@ -228,14 +217,14 @@ describe('Anthropic utilities', () => {
 
     it('bills Claude Sonnet 5 at the standard rate above 200k tokens (no long-context tier)', () => {
       // Per Anthropic pricing, Sonnet 5 bills its full 1M context at the standard rate —
-      // unlike Sonnet 4.5, there is no >200K surcharge.
+      // there is no >200K surcharge.
       const cost = calculateAnthropicCost('claude-sonnet-5', {}, 300_000, 20_000);
-      // (3/1e6 * 300,000) + (15/1e6 * 20,000) = 0.9 + 0.3 = 1.2 (NOT the 2.25 tiered rate)
+      // (3/1e6 * 300,000) + (15/1e6 * 20,000) = 0.9 + 0.3 = 1.2 (no >200K surcharge applies)
       expect(cost).toBe(1.2);
     });
 
     it('should use base pricing for other Claude Sonnet 4 models', () => {
-      // Other Sonnet 4 models don't have tiered pricing
+      // Other Sonnet 4 models bill at the same standard rate
       const models = ['claude-sonnet-4-20250514', 'claude-sonnet-4-0', 'claude-sonnet-4-latest'];
 
       models.forEach((model) => {
@@ -246,7 +235,7 @@ describe('Anthropic utilities', () => {
     });
 
     it('should respect config.cost override for Claude Sonnet 4.5 models', () => {
-      // When config.cost is provided, it should override tiered pricing
+      // When config.cost is provided, it should override list pricing
       const cost = calculateAnthropicCost(
         'claude-sonnet-4-5-20250929',
         { cost: 0.02 },
@@ -256,7 +245,7 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(5200); // (0.02 * 250,000) + (0.02 * 10,000) = 5000 + 200 = 5200
     });
 
-    it('should respect separate config input and output cost overrides for tiered models', () => {
+    it('should respect separate config input and output cost overrides for Sonnet 4.5 models', () => {
       const cost = calculateAnthropicCost(
         'claude-sonnet-4-5-20250929',
         { inputCost: 0.01, outputCost: 0.03 },
@@ -278,7 +267,7 @@ describe('Anthropic utilities', () => {
       expect(cost).toBeUndefined();
     });
 
-    it('should apply cache pricing for non-tiered models with cache tokens', () => {
+    it('should apply cache pricing for Claude 3.5 models with cache tokens', () => {
       // claude-3-5-sonnet: $3/MTok input, $15/MTok output
       // Anthropic: input_tokens is the uncached portion; cache tokens are additive
       // 100 uncached input, 50 cache_read, 30 cache_write, 200 output
@@ -288,7 +277,7 @@ describe('Anthropic utilities', () => {
       expect(cost).toBeCloseTo(expected, 10);
     });
 
-    it('should apply separate config input and output cost overrides to non-tiered cache pricing', () => {
+    it('should apply separate config input and output cost overrides to Claude 3.5 cache pricing', () => {
       const cost = calculateAnthropicCost(
         'claude-3-5-sonnet-20241022',
         { inputCost: 0.01, outputCost: 0.03 },
@@ -301,10 +290,9 @@ describe('Anthropic utilities', () => {
       expect(cost).toBeCloseTo(expected, 10);
     });
 
-    it('should apply cache pricing for Sonnet 4.5 tiered model with cache tokens', () => {
-      // Sonnet 4.5 below 200k threshold: $3/MTok input, $15/MTok output
+    it('should apply cache pricing for Sonnet 4.5 with cache tokens', () => {
+      // Sonnet 4.5: $3/MTok input, $15/MTok output
       // 100k uncached input, 20k cache_read, 10k cache_write, 10k output
-      // effective total input = 100k + 20k + 10k = 130k (below 200k threshold)
       const cost = calculateAnthropicCost(
         'claude-sonnet-4-5-20250929',
         {},
@@ -321,7 +309,7 @@ describe('Anthropic utilities', () => {
       expect(cost).toBeCloseTo(expected, 10);
     });
 
-    it('should apply separate config input and output cost overrides to tiered cache pricing', () => {
+    it('should apply separate config input and output cost overrides to Sonnet 4.5 cache pricing', () => {
       const cost = calculateAnthropicCost(
         'claude-sonnet-4-5-20250929',
         { inputCost: 0.01, outputCost: 0.03 },
@@ -334,7 +322,7 @@ describe('Anthropic utilities', () => {
       expect(cost).toBeCloseTo(expected, 10);
     });
 
-    it('should prefer inputCost/outputCost over cost and preserve tiered cache math when all are set', () => {
+    it('should prefer inputCost/outputCost over cost and preserve cache math when all are set', () => {
       const cost = calculateAnthropicCost(
         'claude-sonnet-4-5-20250929',
         { cost: 0.99, inputCost: 0.01, outputCost: 0.03 },
@@ -347,7 +335,7 @@ describe('Anthropic utilities', () => {
       expect(cost).toBeCloseTo(expected, 6);
     });
 
-    it('should use config.cost as fallback for the unset side on tiered cache pricing', () => {
+    it('should use config.cost as fallback for the unset side on Sonnet 4.5 cache pricing', () => {
       const cost = calculateAnthropicCost(
         'claude-sonnet-4-5-20250929',
         { cost: 0.02, inputCost: 0.01 },
@@ -360,7 +348,7 @@ describe('Anthropic utilities', () => {
       expect(cost).toBeCloseTo(expected, 6);
     });
 
-    it('should use config.cost as fallback for the unset side on non-tiered cache pricing', () => {
+    it('should use config.cost as fallback for the unset side on Claude 3.5 cache pricing', () => {
       const cost = calculateAnthropicCost(
         'claude-3-5-sonnet-20241022',
         { cost: 0.02, outputCost: 0.03 },
@@ -373,9 +361,10 @@ describe('Anthropic utilities', () => {
       expect(cost).toBeCloseTo(expected, 6);
     });
 
-    it('should use long-context tier when cache tokens push past 200k', () => {
-      // Sonnet 4.5 with effective input > 200k due to cache tokens
-      // 150k uncached input, 60k cache_read, 10k cache_write = 220k effective (>200k)
+    it('bills standard rates even when cache tokens push effective input past 200k', () => {
+      // 150k uncached input, 60k cache_read, 10k cache_write = 220k effective input,
+      // billed at the standard $3/$15 with the usual cache multipliers — cache tokens
+      // pushing effective input past 200k must not change the per-token rate.
       const cost = calculateAnthropicCost(
         'claude-sonnet-4-5-20250929',
         {},
@@ -385,10 +374,10 @@ describe('Anthropic utilities', () => {
         10_000,
       );
       const expected =
-        150_000 * (6 / 1e6) +
-        60_000 * (6 / 1e6) * 0.1 +
-        10_000 * (6 / 1e6) * 1.25 +
-        10_000 * (22.5 / 1e6);
+        150_000 * (3 / 1e6) +
+        60_000 * (3 / 1e6) * 0.1 +
+        10_000 * (3 / 1e6) * 1.25 +
+        10_000 * (15 / 1e6);
       expect(cost).toBeCloseTo(expected, 10);
     });
 
@@ -1855,20 +1844,20 @@ describe('Anthropic utilities', () => {
       );
     });
 
-    it('composes the regional premium with the Sonnet 4.5/4.6 long-context tier', () => {
-      // Regression: the regional premium must multiply the tier-selected rate, not override it.
-      // >200K regional Sonnet 4.6 bills at 1.1x the $6/$22.5 long-context tier.
+    it('composes the regional premium with standard Sonnet 4.6 pricing above 200k tokens', () => {
+      // Sonnet 4.6 bills its full 1M context at standard rates; the regional premium
+      // applies as a flat 1.1x multiplier regardless of prompt size.
       expect(
         calculateAnthropicCost('us.anthropic.claude-sonnet-4-6', {}, 300_000, 20_000),
-      ).toBeCloseTo(((300_000 / 1e6) * 6 + (20_000 / 1e6) * 22.5) * 1.1, 6);
-      // <=200K regional bills at 1.1x the $3/$15 base tier.
+      ).toBeCloseTo(((300_000 / 1e6) * 3 + (20_000 / 1e6) * 15) * 1.1, 6);
+      // <=200K regional bills at 1.1x the same $3/$15 standard rate.
       expect(
         calculateAnthropicCost('eu.anthropic.claude-sonnet-4-6', {}, 150_000, 10_000),
       ).toBeCloseTo(((150_000 / 1e6) * 3 + (10_000 / 1e6) * 15) * 1.1, 6);
-      // The global endpoint bills at the tier rate with no premium.
+      // The global endpoint bills at the standard rate with no premium.
       expect(
         calculateAnthropicCost('global.anthropic.claude-sonnet-4-6', {}, 300_000, 20_000),
-      ).toBeCloseTo((300_000 / 1e6) * 6 + (20_000 / 1e6) * 22.5, 6);
+      ).toBeCloseTo((300_000 / 1e6) * 3 + (20_000 / 1e6) * 15, 6);
     });
   });
 

--- a/test/providers/azure/util.test.ts
+++ b/test/providers/azure/util.test.ts
@@ -275,8 +275,8 @@ describe('AZURE_MODELS cost coverage', () => {
     expect(calculateAzureCost(id, {}, 1000, 1000)).toBeGreaterThan(0);
   });
 
-  // Exact standard-tier per-1M input/output rates for entries added/corrected from the Azure
-  // Retail Prices API. Probing input and output separately catches a swapped input/output or a
+  // Exact standard-tier per-1M input/output rates for entries added/corrected from official
+  // pricing sources. Probing input and output separately catches a swapped input/output or a
   // transcription typo. Input is probed at 100k tokens — below every long-context threshold —
   // so tiered models (gpt-5.4-pro, gpt-5.5) assert their standard input rate here, while the
   // long-context tiers are pinned by the dedicated boundary tests above.
@@ -297,6 +297,8 @@ describe('AZURE_MODELS cost coverage', () => {
     ['gpt-5.4-pro', 30, 180],
     ['gpt-5.4-mini', 0.75, 4.5],
     ['gpt-5.4-nano', 0.2, 1.25],
+    ['claude-haiku-4-5', 1, 5],
+    ['claude-haiku-4-5-20251001', 1, 5],
     ['o3', 2, 8],
     ['gpt-realtime', 4, 16],
     ['gpt-audio-mini', 0.6, 2.4],

--- a/test/providers/bedrock/pricing.test.ts
+++ b/test/providers/bedrock/pricing.test.ts
@@ -84,10 +84,10 @@ describe('calculateBedrockCost', () => {
     expect(calculateBedrockCost('cohere.command-r-plus-v1:0', 1e6, 1e6)).toBeCloseTo(18, 6);
   });
 
-  it('uses Claude Sonnet long-context rates above 200k effective input tokens', () => {
-    // Global endpoint isolates the long-context tier from the regional premium.
+  it('bills Claude Sonnet 4.6 at standard rates above 200k effective input tokens', () => {
+    // The full 1M context bills at the flat $3/$15 — no surcharge above 200K tokens.
     expect(calculateBedrockCost('global.anthropic.claude-sonnet-4-6', 200_001, 1_000)).toBeCloseTo(
-      (200_001 / 1e6) * 6 + (1_000 / 1e6) * 22.5,
+      (200_001 / 1e6) * 3 + (1_000 / 1e6) * 15,
       6,
     );
   });
@@ -101,9 +101,8 @@ describe('calculateBedrockCost', () => {
   });
 
   it('bills Claude Sonnet 5 at the standard rate above 200k tokens (no long-context tier)', () => {
-    // Unlike Sonnet 4.5/4.6, Sonnet 5 bills its full 1M context at the standard rate, so a
-    // >200K request must NOT switch to the $6/$22.5 tier. Use the global endpoint to isolate
-    // this from the regional premium.
+    // Sonnet 5 bills its full 1M context at the standard rate. Use the global endpoint to
+    // isolate this from the regional premium.
     expect(calculateBedrockCost('global.anthropic.claude-sonnet-5', 300_000, 20_000)).toBeCloseTo(
       (300_000 / 1e6) * 3 + (20_000 / 1e6) * 15,
       6,

--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -2343,7 +2343,7 @@ describe('VertexChatProvider.callLlamaApi', () => {
   });
 });
 
-describe('VertexChatProvider.callClaudeApi parameter naming', () => {
+describe('VertexChatProvider.callClaudeApi', () => {
   let provider: VertexChatProvider;
 
   beforeEach(() => {
@@ -2352,6 +2352,7 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
     mockCacheGet.mockResolvedValue(null);
     mockCacheSet.mockReset();
 
+    mockIsCacheEnabled.mockReset();
     mockIsCacheEnabled.mockReturnValue(true);
   });
 
@@ -2581,6 +2582,81 @@ describe('VertexChatProvider.callClaudeApi parameter naming', () => {
     expect(sentBody.top_p).toBeUndefined();
     expect(sentBody.top_k).toBeUndefined();
     expect(sentBody.max_tokens).toBe(32);
+  });
+
+  it.each([
+    {
+      name: 'at the 200K boundary',
+      region: 'global',
+      inputTokens: 200_000,
+      outputTokens: 10_000,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      pricingOverrides: {},
+      expectedCost: 0.75,
+    },
+    {
+      name: 'above 200K globally',
+      region: 'global',
+      inputTokens: 300_000,
+      outputTokens: 20_000,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      pricingOverrides: {},
+      expectedCost: 2.25,
+    },
+    {
+      name: 'when cache tokens cross 200K regionally',
+      region: 'us-central1',
+      inputTokens: 150_000,
+      outputTokens: 10_000,
+      cacheReadTokens: 60_000,
+      cacheCreationTokens: 10_000,
+      pricingOverrides: {},
+      expectedCost: 1.3596,
+    },
+    {
+      name: 'with custom regional rates above 200K',
+      region: 'us-central1',
+      inputTokens: 300_000,
+      outputTokens: 20_000,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      pricingOverrides: { inputCost: 2 / 1e6, outputCost: 7 / 1e6 },
+      expectedCost: 0.74,
+    },
+  ])('prices Vertex Sonnet 4.5 $name', async ({
+    region,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheCreationTokens,
+    pricingOverrides,
+    expectedCost,
+  }) => {
+    const model = 'claude-sonnet-4-5@20250929';
+    provider = new VertexChatProvider(model, {
+      config: { region, max_tokens: 32, ...pricingOverrides },
+    });
+    mockVertexRequest({
+      id: 'test-id',
+      type: 'message',
+      role: 'assistant',
+      model,
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        cache_read_input_tokens: cacheReadTokens,
+        cache_creation_input_tokens: cacheCreationTokens,
+      },
+    });
+
+    const result = await provider.callClaudeApi('test prompt');
+
+    expect(result.cost).toBeCloseTo(expectedCost, 6);
   });
 
   it('supports Claude Fable 5 with adaptive-safe parameters and regional pricing', async () => {


### PR DESCRIPTION
## Summary

Correct Claude pricing by provider without applying one platform's context rules to another:

- **Anthropic API and Amazon Bedrock:** remove obsolete >200K tier handling for Sonnet 4.6, whose full context window uses standard $3/$15 per MTok pricing.
- **Google Vertex AI:** preserve Sonnet 4.5's 1M preview tier at $6/$22.50 per MTok above 200K effective input tokens, including cached tokens and the existing regional endpoint premium.
- **Azure Foundry:** correct Claude Haiku 4.5 from the old Haiku 3.5 rate to $1/$5 per MTok.

## Details

### Provider-specific long-context pricing

Anthropic's current pricing and model docs show flat full-context pricing for Sonnet 4.6, while Sonnet 4.5 is capped at 200K on the first-party API. Bedrock's supported Sonnet context is likewise handled at its standard rate, so the shared Anthropic and Bedrock surcharge logic is removed.

Google Vertex still offers [Claude Sonnet 4.5 with a 1M context preview](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/sonnet-4-5) and publishes a [separate >200K pricing tier](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing). The Vertex provider now owns that rule explicitly instead of leaking it into the shared Anthropic calculator. The threshold uses uncached input plus cache reads and cache writes, and regional pricing remains a final 1.1x multiplier. User-provided cost overrides continue to take precedence.

### Azure Haiku 4.5 regression coverage

Both `claude-haiku-4-5` and `claude-haiku-4-5-20251001` now have exact-rate assertions for $1 input / $5 output per MTok, so the prior $0.80/$4 values cannot pass via the generic positive-cost test.

## Testing

- `npx vitest run test/providers/anthropic/util.test.ts test/providers/azure/util.test.ts test/providers/google/vertex.test.ts test/providers/bedrock/pricing.test.ts` — 358 tests passed
- `npm run tsc` — passed
- `npm run l` and `npm run f` — passed (existing non-blocking Vertex complexity warnings remain)
