### PR TITLE
docs(providers): correct OpenCode SDK port @default to 0

### DIFF
--- a/src/providers/opencode-sdk.ts
+++ b/src/providers/opencode-sdk.ts
@@ -280,7 +280,7 @@ export interface OpenCodeSDKConfig {
 
   /**
    * Port for the OpenCode server (when starting a new server)
-   * @default 4096
+   * @default 0 (random available port)
    */
   port?: number;
 


### PR DESCRIPTION

```markdown
## What

The `OpenCodeSDKConfig.port` JSDoc claims `@default 4096`, but the provider never
uses `4096`. When it starts a server it falls back to `config.port ?? 0`, and port
`0` tells the OS to pick a random available port:

https://github.com/promptfoo/promptfoo/blob/main/src/providers/opencode-sdk.ts#L1170

```ts
port: config.port ?? 0,
```

So the documented default is wrong two ways:
- it names a port (`4096`) that the code never selects, and
- it contradicts the provider's own docs table, which already lists the `port`
  default as `Auto-select`
  ([providers/opencode-sdk.md](https://www.promptfoo.dev/docs/providers/opencode-sdk/#configuration)).

The incorrect `@default 4096` has been there since the provider was first added
(#6423); the code has always used `?? 0`.

## Fix

Update only the JSDoc to state the real default:

```diff
   /**
    * Port for the OpenCode server (when starting a new server)
-   * @default 4096
+   * @default 0 (random available port)
    */
   port?: number;
```

This matches the runtime behavior and the docs table, and reuses the exact wording
the codebase already uses for the analogous `serverPort` field in
`src/providers/openai/chatkit-types.ts` (`@default 0 (random available port)`).

## Tests

Documentation-comment change only; no behavior change, so no test is added or
modified. For sanity I confirmed the diff does not disturb anything:

```
npx vitest run test/providers/opencode-sdk.test.ts   # 78/78 pass
npm run tsc                                           # exit 0
npm run l && npm run f                                # no changes
```

(The `4096` in `test/providers/opencode-sdk.test.ts` is an unrelated mock server
URL, `http://127.0.0.1:4096`, not an assertion of the default; it is untouched.)
```
