### PR TITLE
docs(redteam): correct iterative jailbreak default iterations to 4

### DIFF
--- a/site/docs/red-team/strategies/iterative.md
+++ b/site/docs/red-team/strategies/iterative.md
@@ -20,7 +20,7 @@ strategies:
   # With configuration
   - id: jailbreak
     config:
-      # Optional: Number of iterations to attempt (default: 10)
+      # Optional: Number of iterations to attempt (default: 4)
       numIterations: 50
 ```
 


### PR DESCRIPTION
---
The Iterative Jailbreaks strategy docs show the wrong default for `numIterations`.
The YAML example in `site/docs/red-team/strategies/iterative.md` comments
`# Optional: Number of iterations to attempt (default: 10)`, but the iterative
jailbreak provider defaults this to **4**, not 10:

```ts
// src/redteam/providers/iterative.ts
Number(config.numIterations) || getEnvInt('PROMPTFOO_NUM_JAILBREAK_ITERATIONS', 4);
```

So a user who reads the doc and removes their explicit `numIterations` (expecting
10) actually gets 4, i.e. shallower attack depth than the docs imply. The image
variant is consistent with the text provider
(`src/redteam/providers/iterativeImage.ts` also defaults to 4).

The `10` was correct when the option was first documented, but the provider
default later changed to 4 while the doc comment was not updated. The sibling
`jailbreak:meta` strategy still defaults to 10 and its page (`meta.md`) is left
unchanged.

This is a one-line, docs-only correction: `(default: 10)` -> `(default: 4)`.

### Verification
- `src/redteam/providers/iterative.ts` -> `getEnvInt('PROMPTFOO_NUM_JAILBREAK_ITERATIONS', 4)`
- Existing test asserts the default is 4:
  `test/redteam/providers/iterative.test.ts` -> `numIterations` `toBe(4)` (passes)
- `npx prettier --check site/docs/red-team/strategies/iterative.md` -> clean
---

## Notes for reviewers (leave out of upstream body)
- Scope is `docs(redteam)` (not `docs(site)`) per THE REDTEAM RULE in
  `docs/agents/pr-conventions.md`: red-team-primary changes use `(redteam)` even
  when the change is docs-only. Closest precedent: PR #9931
  `docs(redteam): replace deprecated prompt-injection strategy references`, which
  edited files in the same `site/docs/red-team/strategies/` directory.
