### PR TITLE
fix(ui): preserve WebSocket protocol input

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { renderWithProviders } from '@app/utils/testutils';
-import { fireEvent, screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import WebSocketEndpointConfiguration from './WebSocketEndpointConfiguration';
@@ -156,38 +156,33 @@ describe('WebSocketEndpointConfiguration', () => {
   it('preserves a trailing comma during an active edit and applies external protocols on blur', async () => {
     const user = userEvent.setup();
     const update = vi.fn();
+    let updateProtocolsExternally = () => {
+      throw new Error('StatefulConfiguration was not rendered');
+    };
 
     const StatefulConfiguration = () => {
       const [provider, setProvider] = useState<ProviderOptions>({
         ...baseProvider,
         config: { ...baseProvider.config, protocols: ['json'] },
       });
+      updateProtocolsExternally = () =>
+        setProvider({
+          ...baseProvider,
+          config: { ...baseProvider.config, protocols: ['mqtt'] },
+        });
 
       return (
-        <>
-          <button
-            type="button"
-            onClick={() =>
-              setProvider({
-                ...baseProvider,
-                config: { ...baseProvider.config, protocols: ['mqtt'] },
-              })
-            }
-          >
-            Update protocols externally
-          </button>
-          <WebSocketEndpointConfiguration
-            selectedTarget={provider}
-            updateWebSocketTarget={(field, value) => {
-              update(field, value);
-              setProvider((current) => ({
-                ...current,
-                config: { ...current.config, [field]: value },
-              }));
-            }}
-            urlError={null}
-          />
-        </>
+        <WebSocketEndpointConfiguration
+          selectedTarget={provider}
+          updateWebSocketTarget={(field, value) => {
+            update(field, value);
+            setProvider((current) => ({
+              ...current,
+              config: { ...current.config, [field]: value },
+            }));
+          }}
+          urlError={null}
+        />
       );
     };
 
@@ -201,7 +196,7 @@ describe('WebSocketEndpointConfiguration', () => {
     expect(protocolsField).toHaveValue('json,');
     expect(update).toHaveBeenLastCalledWith('protocols', ['json']);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Update protocols externally' }));
+    act(updateProtocolsExternally);
 
     expect(protocolsField).toHaveFocus();
     expect(protocolsField).toHaveValue('json,');

--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
@@ -109,6 +109,50 @@ describe('WebSocketEndpointConfiguration', () => {
     expect(protocolsField).toHaveValue('json, graphql-transport-ws');
   });
 
+  it('syncs WebSocket subprotocols when the parent loads a different target', async () => {
+    const user = userEvent.setup();
+
+    const StatefulConfiguration = () => {
+      const [provider, setProvider] = useState<ProviderOptions>({
+        ...baseProvider,
+        config: { ...baseProvider.config, protocols: ['json'] },
+      });
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() =>
+              setProvider({
+                ...baseProvider,
+                config: {
+                  ...baseProvider.config,
+                  protocols: ['mqtt', 'graphql-transport-ws'],
+                },
+              })
+            }
+          >
+            Load target
+          </button>
+          <WebSocketEndpointConfiguration
+            selectedTarget={provider}
+            updateWebSocketTarget={() => {}}
+            urlError={null}
+          />
+        </>
+      );
+    };
+
+    renderWithProviders(<StatefulConfiguration />);
+
+    const protocolsField = screen.getByLabelText('WebSocket Subprotocols');
+    expect(protocolsField).toHaveValue('json');
+
+    await user.click(screen.getByRole('button', { name: 'Load target' }));
+
+    expect(protocolsField).toHaveValue('mqtt, graphql-transport-ws');
+  });
+
   it('preserves raw Sec-WebSocket-Protocol headers and shows migration guidance', () => {
     const update = vi.fn();
     const providerWithHeader: ProviderOptions = {

--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { renderWithProviders } from '@app/utils/testutils';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -71,23 +73,40 @@ describe('WebSocketEndpointConfiguration', () => {
     expect(update).toHaveBeenCalledWith('messageTemplate', 'Hey {{name}}');
   });
 
-  it('updates WebSocket subprotocols as a string array', async () => {
+  it('allows typing multiple WebSocket subprotocols and trims them on blur', async () => {
     const user = userEvent.setup();
     const update = vi.fn();
 
-    renderWithProviders(
-      <WebSocketEndpointConfiguration
-        selectedTarget={baseProvider}
-        updateWebSocketTarget={update}
-        urlError={null}
-      />,
-    );
+    const StatefulConfiguration = () => {
+      const [provider, setProvider] = useState(baseProvider);
+
+      return (
+        <WebSocketEndpointConfiguration
+          selectedTarget={provider}
+          updateWebSocketTarget={(field, value) => {
+            update(field, value);
+            setProvider((current) => ({
+              ...current,
+              config: { ...current.config, [field]: value },
+            }));
+          }}
+          urlError={null}
+        />
+      );
+    };
+
+    renderWithProviders(<StatefulConfiguration />);
 
     const protocolsField = screen.getByLabelText('WebSocket Subprotocols');
-    await user.click(protocolsField);
-    await user.paste('json, graphql-transport-ws');
+    await user.type(protocolsField, 'json,  graphql-transport-ws  ');
+
+    expect(protocolsField).toHaveValue('json,  graphql-transport-ws  ');
 
     expect(update).toHaveBeenCalledWith('protocols', ['json', 'graphql-transport-ws']);
+
+    await user.tab();
+
+    expect(protocolsField).toHaveValue('json, graphql-transport-ws');
   });
 
   it('preserves raw Sec-WebSocket-Protocol headers and shows migration guidance', () => {

--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
@@ -156,7 +156,7 @@ describe('WebSocketEndpointConfiguration', () => {
   it('preserves a trailing comma during an active edit and applies external protocols on blur', async () => {
     const user = userEvent.setup();
     const update = vi.fn();
-    let updateProtocolsExternally = () => {
+    let updateProtocolsExternally: () => void = () => {
       throw new Error('StatefulConfiguration was not rendered');
     };
 

--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { renderWithProviders } from '@app/utils/testutils';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import WebSocketEndpointConfiguration from './WebSocketEndpointConfiguration';
@@ -151,6 +151,64 @@ describe('WebSocketEndpointConfiguration', () => {
     await user.click(screen.getByRole('button', { name: 'Load target' }));
 
     expect(protocolsField).toHaveValue('mqtt, graphql-transport-ws');
+  });
+
+  it('preserves a trailing comma during an active edit and applies external protocols on blur', async () => {
+    const user = userEvent.setup();
+    const update = vi.fn();
+
+    const StatefulConfiguration = () => {
+      const [provider, setProvider] = useState<ProviderOptions>({
+        ...baseProvider,
+        config: { ...baseProvider.config, protocols: ['json'] },
+      });
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() =>
+              setProvider({
+                ...baseProvider,
+                config: { ...baseProvider.config, protocols: ['mqtt'] },
+              })
+            }
+          >
+            Update protocols externally
+          </button>
+          <WebSocketEndpointConfiguration
+            selectedTarget={provider}
+            updateWebSocketTarget={(field, value) => {
+              update(field, value);
+              setProvider((current) => ({
+                ...current,
+                config: { ...current.config, [field]: value },
+              }));
+            }}
+            urlError={null}
+          />
+        </>
+      );
+    };
+
+    renderWithProviders(<StatefulConfiguration />);
+
+    const protocolsField = screen.getByLabelText('WebSocket Subprotocols');
+    await user.click(protocolsField);
+    await user.type(protocolsField, ',');
+
+    expect(protocolsField).toHaveFocus();
+    expect(protocolsField).toHaveValue('json,');
+    expect(update).toHaveBeenLastCalledWith('protocols', ['json']);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update protocols externally' }));
+
+    expect(protocolsField).toHaveFocus();
+    expect(protocolsField).toHaveValue('json,');
+
+    await user.tab();
+
+    expect(protocolsField).toHaveValue('mqtt');
   });
 
   it('preserves raw Sec-WebSocket-Protocol headers and shows migration guidance', () => {

--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.tsx
@@ -65,6 +65,9 @@ const WebSocketEndpointConfiguration = ({
   updateWebSocketTarget,
   urlError,
 }: WebSocketEndpointConfigurationProps) => {
+  const [protocolsInput, setProtocolsInput] = useState(() =>
+    formatProtocols(selectedTarget.config.protocols),
+  );
   const [streamResponse, setStreamResponse] = useState(
     Boolean(selectedTarget.config.streamResponse),
   );
@@ -97,8 +100,12 @@ const WebSocketEndpointConfiguration = ({
           <Label htmlFor="websocket-protocols">WebSocket Subprotocols</Label>
           <Input
             id="websocket-protocols"
-            value={formatProtocols(selectedTarget.config.protocols)}
-            onChange={(e) => updateWebSocketTarget('protocols', parseProtocols(e.target.value))}
+            value={protocolsInput}
+            onChange={(e) => {
+              setProtocolsInput(e.target.value);
+              updateWebSocketTarget('protocols', parseProtocols(e.target.value));
+            }}
+            onBlur={() => setProtocolsInput(formatProtocols(parseProtocols(protocolsInput)))}
             placeholder="json, graphql-transport-ws"
           />
           <p className="text-sm text-muted-foreground">

--- a/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import Editor from '@app/components/ui/code-editor';
 import { HelperText } from '@app/components/ui/helper-text';
@@ -65,12 +65,17 @@ const WebSocketEndpointConfiguration = ({
   updateWebSocketTarget,
   urlError,
 }: WebSocketEndpointConfigurationProps) => {
-  const [protocolsInput, setProtocolsInput] = useState(() =>
-    formatProtocols(selectedTarget.config.protocols),
-  );
+  const formattedProtocols = formatProtocols(selectedTarget.config.protocols);
+  const [protocolsInput, setProtocolsInput] = useState(() => formattedProtocols);
+  const isProtocolsInputFocused = useRef(false);
   const [streamResponse, setStreamResponse] = useState(
     Boolean(selectedTarget.config.streamResponse),
   );
+  useEffect(() => {
+    if (!isProtocolsInputFocused.current) {
+      setProtocolsInput(formattedProtocols);
+    }
+  }, [formattedProtocols]);
   return (
     <div className="mt-4">
       <h3 className="mb-4 text-lg font-semibold">Custom WebSocket Endpoint Configuration</h3>
@@ -105,7 +110,13 @@ const WebSocketEndpointConfiguration = ({
               setProtocolsInput(e.target.value);
               updateWebSocketTarget('protocols', parseProtocols(e.target.value));
             }}
-            onBlur={() => setProtocolsInput(formatProtocols(parseProtocols(protocolsInput)))}
+            onFocus={() => {
+              isProtocolsInputFocused.current = true;
+            }}
+            onBlur={() => {
+              isProtocolsInputFocused.current = false;
+              setProtocolsInput(formattedProtocols);
+            }}
             placeholder="json, graphql-transport-ws"
           />
           <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

- keep the raw subprotocol text while users type so trailing commas are not discarded
- continue storing trimmed protocol arrays and normalize the visible value on blur
- cover character-by-character typing with a stateful component test

## Test plan

- npm run test:app -- src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx --run
- npm --prefix src/app run build
- npx biome check src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.tsx src/app/src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx