### PR TITLE
chore(deps): pin js-yaml to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "http-z": "^8.1.1",
         "istextorbinary": "^9.5.0",
         "js-rouge": "^3.2.0",
-        "js-yaml": "^5.0.0",
+        "js-yaml": "5.2.0",
         "json5": "^2.2.3",
         "keyv": "^5.6.0",
         "keyv-file": "^5.3.3",
@@ -29101,9 +29101,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.1.0.tgz",
-      "integrity": "sha512-s8VA5jkR8f22S3NAXmhKPFqGUduqZGlsufabVOgN14iTdw/RXcym7bKkbwjxLK9Yw2lEvvmJjFp119+KPeo8Kg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
+      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
       "funding": [
         {
           "type": "github",
@@ -45328,7 +45328,7 @@
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "dompurify": "^3.4.8",
-        "js-yaml": "^5.0.0",
+        "js-yaml": "5.2.0",
         "react-countup": "^6.5.3",
         "swiper": "^12.1.2"
       },
@@ -45436,7 +45436,7 @@
         "csv-stringify": "^6.7.0",
         "diff": "^9.0.0",
         "idb-keyval": "^6.2.2",
-        "js-yaml": "^5.0.0",
+        "js-yaml": "5.2.0",
         "jsdom": "^29.0.0",
         "lucide-react": "^1.0.0",
         "postcss": "^8.5.10",

--- a/package.json
+++ b/package.json
@@ -370,7 +370,7 @@
     "http-z": "^8.1.1",
     "istextorbinary": "^9.5.0",
     "js-rouge": "^3.2.0",
-    "js-yaml": "^5.0.0",
+    "js-yaml": "5.2.0",
     "json5": "^2.2.3",
     "keyv": "^5.6.0",
     "keyv-file": "^5.3.3",

--- a/site/package.json
+++ b/site/package.json
@@ -90,7 +90,7 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "dompurify": "^3.4.8",
-    "js-yaml": "^5.0.0",
+    "js-yaml": "5.2.0",
     "react-countup": "^6.5.3",
     "swiper": "^12.1.2"
   }

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -55,7 +55,7 @@
     "csv-stringify": "^6.7.0",
     "diff": "^9.0.0",
     "idb-keyval": "^6.2.2",
-    "js-yaml": "^5.0.0",
+    "js-yaml": "5.2.0",
     "jsdom": "^29.0.0",
     "lucide-react": "^1.0.0",
     "postcss": "^8.5.10",


### PR DESCRIPTION
## Summary
- Pin root and app js-yaml specifiers to 5.2.0.
- Update package-lock to resolve js-yaml 5.2.0.

## Why
Cloud is moving to js-yaml v5 and should match the upstream submodule version directly. Pinning the manifest avoids downstream consumers needing to decide whether to match a range or a resolved package version.

## Test plan
- npm install --package-lock-only --ignore-scripts
- npx @biomejs/biome check --write package.json src/app/package.json package-lock.json
- npm run tsc
- npm --prefix src/app run tsc