### PR TITLE
fix(assertions): allow numeric 0 as contains/icontains value

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -104,6 +104,9 @@ assert:
     value: 'The expected substring'
 ```
 
+Both assertions accept string or number values. Numbers are converted to strings, so `value: 0`
+matches output containing `0`.
+
 ### Contains-All
 
 The `contains-all` assertion checks if the LLM output contains all of the specified values.

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -116,8 +116,8 @@ These metrics are programmatic tests that are run on LLM output. [See all detail
 | Assertion Type                                                                                                     | Returns true if...                                                 |
 | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
 | [equals](/docs/configuration/expected-outputs/deterministic/#equality)                                             | output matches exactly                                             |
-| [contains](/docs/configuration/expected-outputs/deterministic/#contains)                                           | output contains substring                                          |
-| [icontains](/docs/configuration/expected-outputs/deterministic/#contains)                                          | output contains substring, case insensitive                        |
+| [contains](/docs/configuration/expected-outputs/deterministic/#contains)                                           | output contains a string or number as text                         |
+| [icontains](/docs/configuration/expected-outputs/deterministic/#contains)                                          | output contains a string or number as text, case insensitive       |
 | [regex](/docs/configuration/expected-outputs/deterministic/#regex)                                                 | output matches regex                                               |
 | [starts-with](/docs/configuration/expected-outputs/deterministic/#starts-with)                                     | output starts with string                                          |
 | [contains-any](/docs/configuration/expected-outputs/deterministic/#contains-any)                                   | output contains any of the listed substrings                       |

--- a/src/app/src/pages/eval-creator/components/assertionValueValidation.test.ts
+++ b/src/app/src/pages/eval-creator/components/assertionValueValidation.test.ts
@@ -23,13 +23,9 @@ describe('getRunnableAssertionValueError', () => {
       );
     });
 
-    it('rejects numeric 0 because runtime treats it as an absent contains value', () => {
-      expect(getRunnableAssertionValueError(make({ type: 'contains', value: 0 }))).toMatch(
-        /Enter an expected value/,
-      );
-      expect(getRunnableAssertionValueError(make({ type: 'icontains', value: 0 }))).toMatch(
-        /Enter an expected value/,
-      );
+    it('accepts numeric 0 because runtime supports it as a contains value', () => {
+      expect(getRunnableAssertionValueError(make({ type: 'contains', value: 0 }))).toBeUndefined();
+      expect(getRunnableAssertionValueError(make({ type: 'icontains', value: 0 }))).toBeUndefined();
     });
 
     it('accepts non-blank strings and finite numbers', () => {

--- a/src/app/src/pages/eval-creator/components/assertionValueValidation.ts
+++ b/src/app/src/pages/eval-creator/components/assertionValueValidation.ts
@@ -552,11 +552,7 @@ function getBasicExpectedValueError(assertion: Assertion): string | undefined {
   if (
     REQUIRED_TEXT_OR_NUMBER_ASSERTION_TYPES.has(assertion.type) &&
     !hasNonBlankString(assertion.value) &&
-    !(
-      typeof assertion.value === 'number' &&
-      Number.isFinite(assertion.value) &&
-      assertion.value !== 0
-    )
+    !(typeof assertion.value === 'number' && Number.isFinite(assertion.value))
   ) {
     return 'Enter an expected value before saving this check.';
   }

--- a/src/assertions/contains.ts
+++ b/src/assertions/contains.ts
@@ -115,7 +115,10 @@ export const handleContains = ({
   inverse,
 }: AssertionParams): GradingResult => {
   const value = valueFromScript ?? renderedValue;
-  invariant(value, '"contains" assertion type must have a string or number value');
+  invariant(
+    value !== undefined && value !== null && value !== '',
+    '"contains" assertion type must have a string or number value',
+  );
   invariant(
     typeof value === 'string' || typeof value === 'number',
     '"contains" assertion type must have a string or number value',
@@ -139,7 +142,10 @@ export const handleIContains = ({
   inverse,
 }: AssertionParams): GradingResult => {
   const value = valueFromScript ?? renderedValue;
-  invariant(value, '"icontains" assertion type must have a string or number value');
+  invariant(
+    value !== undefined && value !== null && value !== '',
+    '"icontains" assertion type must have a string or number value',
+  );
   invariant(
     typeof value === 'string' || typeof value === 'number',
     '"icontains" assertion type must have a string or number value',

--- a/src/assertions/contains.ts
+++ b/src/assertions/contains.ts
@@ -116,11 +116,8 @@ export const handleContains = ({
 }: AssertionParams): GradingResult => {
   const value = valueFromScript ?? renderedValue;
   invariant(
-    value !== undefined && value !== null && value !== '',
-    '"contains" assertion type must have a string or number value',
-  );
-  invariant(
-    typeof value === 'string' || typeof value === 'number',
+    (typeof value === 'string' && value !== '') ||
+      (typeof value === 'number' && !Number.isNaN(value)),
     '"contains" assertion type must have a string or number value',
   );
   const pass = outputString.includes(String(value)) !== inverse;
@@ -143,11 +140,8 @@ export const handleIContains = ({
 }: AssertionParams): GradingResult => {
   const value = valueFromScript ?? renderedValue;
   invariant(
-    value !== undefined && value !== null && value !== '',
-    '"icontains" assertion type must have a string or number value',
-  );
-  invariant(
-    typeof value === 'string' || typeof value === 'number',
+    (typeof value === 'string' && value !== '') ||
+      (typeof value === 'number' && !Number.isNaN(value)),
     '"icontains" assertion type must have a string or number value',
   );
   const pass = outputString.toLowerCase().includes(String(value).toLowerCase()) !== inverse;

--- a/src/assertions/contains.ts
+++ b/src/assertions/contains.ts
@@ -107,6 +107,13 @@ export function parseCommaSeparatedValues(value: string): string[] {
   return results;
 }
 
+function isContainsValue(value: unknown): value is string | number {
+  return (
+    (typeof value === 'string' && value !== '') ||
+    (typeof value === 'number' && !Number.isNaN(value))
+  );
+}
+
 export const handleContains = ({
   assertion,
   renderedValue,
@@ -115,11 +122,7 @@ export const handleContains = ({
   inverse,
 }: AssertionParams): GradingResult => {
   const value = valueFromScript ?? renderedValue;
-  invariant(
-    (typeof value === 'string' && value !== '') ||
-      (typeof value === 'number' && !Number.isNaN(value)),
-    '"contains" assertion type must have a string or number value',
-  );
+  invariant(isContainsValue(value), '"contains" assertion type must have a string or number value');
   const pass = outputString.includes(String(value)) !== inverse;
   return {
     pass,
@@ -140,8 +143,7 @@ export const handleIContains = ({
 }: AssertionParams): GradingResult => {
   const value = valueFromScript ?? renderedValue;
   invariant(
-    (typeof value === 'string' && value !== '') ||
-      (typeof value === 'number' && !Number.isNaN(value)),
+    isContainsValue(value),
     '"icontains" assertion type must have a string or number value',
   );
   const pass = outputString.toLowerCase().includes(String(value).toLowerCase()) !== inverse;

--- a/test/assertions/contains.test.ts
+++ b/test/assertions/contains.test.ts
@@ -71,26 +71,8 @@ describe('handleContains', () => {
   it('should handle number values', () => {
     const params: AssertionParams = {
       ...defaultParams,
-      assertion: { type: 'contains', value: '42' },
-      renderedValue: '42' as AssertionValue,
-      outputString: 'The answer is 42',
-      inverse: false,
-    };
-
-    const result = handleContains(params);
-    expect(result).toEqual({
-      pass: true,
-      score: 1,
-      reason: 'Assertion passed',
-      assertion: params.assertion,
-    });
-  });
-
-  it('should handle the numeric value 0 (regression: 0 is a valid number)', () => {
-    const params: AssertionParams = {
-      ...defaultParams,
       assertion: { type: 'contains', value: 0 },
-      renderedValue: 0 as unknown as AssertionValue,
+      renderedValue: 0,
       outputString: 'There are 0 errors',
       inverse: false,
     };
@@ -108,7 +90,7 @@ describe('handleContains', () => {
     const params: AssertionParams = {
       ...defaultParams,
       assertion: { type: 'contains', value: 0 },
-      renderedValue: 0 as unknown as AssertionValue,
+      renderedValue: 0,
       outputString: 'no digits here',
       inverse: false,
     };
@@ -209,6 +191,47 @@ describe('handleIContains', () => {
       reason: 'Assertion passed',
       assertion: params.assertion,
     });
+  });
+
+  it.each([
+    { outputString: 'There are 0 errors', pass: true },
+    { outputString: 'no digits here', pass: false },
+  ])('should handle numeric 0 when pass is $pass', ({ outputString, pass }) => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'icontains', value: 0 },
+      renderedValue: 0,
+      outputString,
+      inverse: false,
+    };
+
+    const result = handleIContains(params);
+    expect(result).toEqual({
+      pass,
+      score: pass ? 1 : 0,
+      reason: pass ? 'Assertion passed' : 'Expected output to contain "0"',
+      assertion: params.assertion,
+    });
+  });
+});
+
+describe.each([
+  ['contains', handleContains],
+  ['icontains', handleIContains],
+] as const)('%s numeric validation', (type, handler) => {
+  it('should reject NaN', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      baseType: type,
+      assertion: { type, value: Number.NaN },
+      renderedValue: Number.NaN,
+      outputString: 'NaN',
+      inverse: false,
+    };
+
+    expect(() => handler(params)).toThrow(
+      `"${type}" assertion type must have a string or number value`,
+    );
   });
 });
 

--- a/test/assertions/contains.test.ts
+++ b/test/assertions/contains.test.ts
@@ -68,42 +68,6 @@ describe('handleContains', () => {
     });
   });
 
-  it('should handle number values', () => {
-    const params: AssertionParams = {
-      ...defaultParams,
-      assertion: { type: 'contains', value: 0 },
-      renderedValue: 0,
-      outputString: 'There are 0 errors',
-      inverse: false,
-    };
-
-    const result = handleContains(params);
-    expect(result).toEqual({
-      pass: true,
-      score: 1,
-      reason: 'Assertion passed',
-      assertion: params.assertion,
-    });
-  });
-
-  it('should fail (not throw) when output does not contain the numeric value 0', () => {
-    const params: AssertionParams = {
-      ...defaultParams,
-      assertion: { type: 'contains', value: 0 },
-      renderedValue: 0,
-      outputString: 'no digits here',
-      inverse: false,
-    };
-
-    const result = handleContains(params);
-    expect(result).toEqual({
-      pass: false,
-      score: 0,
-      reason: 'Expected output to contain "0"',
-      assertion: params.assertion,
-    });
-  });
-
   it('should handle inverse assertion correctly', () => {
     const params: AssertionParams = {
       ...defaultParams,
@@ -192,33 +156,41 @@ describe('handleIContains', () => {
       assertion: params.assertion,
     });
   });
-
-  it.each([
-    { outputString: 'There are 0 errors', pass: true },
-    { outputString: 'no digits here', pass: false },
-  ])('should handle numeric 0 when pass is $pass', ({ outputString, pass }) => {
-    const params: AssertionParams = {
-      ...defaultParams,
-      assertion: { type: 'icontains', value: 0 },
-      renderedValue: 0,
-      outputString,
-      inverse: false,
-    };
-
-    const result = handleIContains(params);
-    expect(result).toEqual({
-      pass,
-      score: pass ? 1 : 0,
-      reason: pass ? 'Assertion passed' : 'Expected output to contain "0"',
-      assertion: params.assertion,
-    });
-  });
 });
 
 describe.each([
   ['contains', handleContains],
   ['icontains', handleIContains],
-] as const)('%s numeric validation', (type, handler) => {
+] as const)('%s numeric values', (type, handler) => {
+  it.each([
+    {
+      outputString: 'There are 0 errors',
+      pass: true,
+      reason: 'Assertion passed',
+    },
+    {
+      outputString: 'no digits here',
+      pass: false,
+      reason: 'Expected output to contain "0"',
+    },
+  ])('should return pass=$pass for 0', ({ outputString, pass, reason }) => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      baseType: type,
+      assertion: { type, value: 0 },
+      renderedValue: 0,
+      outputString,
+      inverse: false,
+    };
+
+    expect(handler(params)).toEqual({
+      pass,
+      score: pass ? 1 : 0,
+      reason,
+      assertion: params.assertion,
+    });
+  });
+
   it('should reject NaN', () => {
     const params: AssertionParams = {
       ...defaultParams,

--- a/test/assertions/contains.test.ts
+++ b/test/assertions/contains.test.ts
@@ -86,6 +86,42 @@ describe('handleContains', () => {
     });
   });
 
+  it('should handle the numeric value 0 (regression: 0 is a valid number)', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains', value: 0 },
+      renderedValue: 0 as unknown as AssertionValue,
+      outputString: 'There are 0 errors',
+      inverse: false,
+    };
+
+    const result = handleContains(params);
+    expect(result).toEqual({
+      pass: true,
+      score: 1,
+      reason: 'Assertion passed',
+      assertion: params.assertion,
+    });
+  });
+
+  it('should fail (not throw) when output does not contain the numeric value 0', () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: { type: 'contains', value: 0 },
+      renderedValue: 0 as unknown as AssertionValue,
+      outputString: 'no digits here',
+      inverse: false,
+    };
+
+    const result = handleContains(params);
+    expect(result).toEqual({
+      pass: false,
+      score: 0,
+      reason: 'Expected output to contain "0"',
+      assertion: params.assertion,
+    });
+  });
+
   it('should handle inverse assertion correctly', () => {
     const params: AssertionParams = {
       ...defaultParams,

--- a/test/assertions/scriptValueResolution.test.ts
+++ b/test/assertions/scriptValueResolution.test.ts
@@ -209,12 +209,28 @@ describe('Script value resolution', () => {
         },
         test: { vars: {} },
         providerResponse: {
-          output: 'The answer is 42',
+          output: 'There are 0 errors',
           tokenUsage: { total: 0, prompt: 0, completion: 0 },
         },
       });
 
       expect(result.pass).toBe(true);
+    });
+
+    it('should reject NaN script output for inverse contains assertions', async () => {
+      await expect(
+        runAssertion({
+          assertion: {
+            type: 'not-contains',
+            value: 'file://rubric-generator.cjs:nanValue',
+          },
+          test: { vars: {} },
+          providerResponse: {
+            output: 'ordinary output',
+            tokenUsage: { total: 0, prompt: 0, completion: 0 },
+          },
+        }),
+      ).rejects.toThrow('"contains" assertion type must have a string or number value');
     });
   });
 

--- a/test/fixtures/file-script-assertions/comprehensive-llm-rubric-test.yaml
+++ b/test/fixtures/file-script-assertions/comprehensive-llm-rubric-test.yaml
@@ -233,7 +233,7 @@ tests:
   # Test 24: contains with file:// numeric return
   - description: 'contains with file:// numeric return'
     vars:
-      prompt: 'The answer is 42'
+      prompt: 'The answer is 0'
     assert:
       - type: contains
         value: file://rubric-generator.cjs:numericValue

--- a/test/fixtures/file-script-assertions/e2e-test-config.yaml
+++ b/test/fixtures/file-script-assertions/e2e-test-config.yaml
@@ -54,7 +54,7 @@ tests:
   # Test 6: contains with numeric return
   - description: 'contains should handle numeric script output'
     vars:
-      prompt: 'The answer is 42'
+      prompt: 'The answer is 0'
     assert:
       - type: contains
         value: file://rubric-generator.cjs:numericValue

--- a/test/fixtures/file-script-assertions/rubric-generator.cjs
+++ b/test/fixtures/file-script-assertions/rubric-generator.cjs
@@ -17,7 +17,10 @@ module.exports.rubricObject = () => ({
 });
 
 // Returns a number for contains assertion
-module.exports.numericValue = () => 42;
+module.exports.numericValue = () => 0;
+
+// Returns an invalid numeric result for contains assertion
+module.exports.nanValue = () => Number.NaN;
 
 // Returns an array for bleu/gleu assertions
 module.exports.referenceArray = () => ['reference one', 'reference two'];


### PR DESCRIPTION
### problem
`handleContains` / `handleIContains` guard the value with `invariant(value, ...)`, which is a truthiness check and so rejects the numeric value `0`:

```
Invariant failed: "contains" assertion type must have a string or number value
```

but the very next line (`invariant(typeof value === 'string' || typeof value === 'number', ...)`) and `String(value)` show the handler is meant to accept numbers, and `AssertionValue` includes `number`. so `contains: 0` (e.g. asserting output contains "0 errors") is a supported config that throws. numeric values flow through unchanged (`index.ts` only re-renders string values), so `0` reaches the handler as `0`.

### fix
replace the truthiness guard with an explicit `undefined`/`null`/`''` check in both handlers - the same idiom already used in `src/assertions/wordCount.ts` (`invariant(value != null, ...)`). missing/empty values are still rejected; `0` is now allowed.

### test
added two cases to `test/assertions/contains.test.ts` (`contains` with numeric `0` matching and non-matching). before: `contains: 0` throws; after: matches -> pass, non-match -> fail (not throw); `undefined`/`null`/`''` still throw; strings unaffected; `icontains` fixed too.
