### PR TITLE
fix(util): handle even backslashes before slash comments

### DIFF
--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -129,6 +129,14 @@ export function safeJsonStringify<T>(value: T, prettyPrint: boolean = false): st
   }
 }
 
+function isEscapedQuote(line: string, quoteIndex: number): boolean {
+  let backslashCount = 0;
+  for (let i = quoteIndex - 1; i >= 0 && line[i] === '\\'; i--) {
+    backslashCount++;
+  }
+  return backslashCount % 2 === 1;
+}
+
 export function convertSlashCommentsToHash(str: string): string {
   // Split into lines, process each line, then join back
   return str
@@ -190,7 +198,7 @@ export function convertSlashCommentsToHash(str: string): string {
 
           case 'doubleQuote':
             result += char;
-            if (char === '"' && prevChar !== '\\') {
+            if (char === '"' && !isEscapedQuote(line, i)) {
               state = 'normal';
             }
             break;

--- a/test/util/json.test.ts
+++ b/test/util/json.test.ts
@@ -408,6 +408,12 @@ describe('json utilities', () => {
         expect(convertSlashCommentsToHash(input)).toBe(expected);
       });
 
+      it('should convert comments after a string ending with an even backslash sequence', () => {
+        const input = String.raw`{ "path": "C:\\" } // comment`;
+        const expected = String.raw`{ "path": "C:\\" } # comment`;
+        expect(convertSlashCommentsToHash(input)).toBe(expected);
+      });
+
       it('should handle multiple sequential comment markers', () => {
         const input = 'text //// double comment';
         const expected = 'text ## double comment';


### PR DESCRIPTION
## Summary
- count consecutive backslashes before a double quote when scanning slash comments instead of checking only the immediately previous character
- keep trailing `//` comment rewriting working after JSON strings that end with an even backslash sequence such as Windows-style path values
- add a focused regression test for the even-backslash case

Closes #9895.

## Testing
- `npx vitest run test/util/json.test.ts --sequence.shuffle=false`
- `npm run tsc`
- `git diff --check`
