### PR TITLE
ci: pin npm to 11.18.0 instead of @latest

### DIFF
--- a/.github/workflows/deploy-launcher.yml
+++ b/.github/workflows/deploy-launcher.yml
@@ -30,9 +30,11 @@ jobs:
           node-version-file: '.nvmrc'
           package-manager-cache: false
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,9 +232,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: |
@@ -304,9 +306,11 @@ jobs:
         with:
           python-version: '3.13'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: npm ci
@@ -373,9 +377,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: npm ci
@@ -404,9 +410,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       # Install root dependencies first (code-scan-action imports from ../../src/types/codeScan.ts which needs zod)
       - name: Install Root Dependencies
@@ -442,9 +450,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: npm ci
@@ -493,9 +503,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: npm ci
@@ -537,9 +549,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Use Python 3.14
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -572,9 +586,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Use Python 3.14
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -612,9 +628,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: npm ci
@@ -707,9 +725,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: npm ci
@@ -735,9 +755,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/tusk-test-runner-app-vitest-unit-tests.yml
+++ b/.github/workflows/tusk-test-runner-app-vitest-unit-tests.yml
@@ -43,9 +43,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/tusk-test-runner-vitest-unit-tests.yml
+++ b/.github/workflows/tusk-test-runner-vitest-unit-tests.yml
@@ -47,9 +47,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669).
+      # Pinned exact (not @latest): npm 12.0.0 blocks postinstall scripts not covered by
+      # allowScripts, which silently skips e.g. the Playwright browser download.
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
## Summary

npm 12.0.0 (published 2026-07-08 21:06 UTC) blocks postinstall scripts that aren't covered by an `allowScripts` allowlist. Every CI job that runs `npm install -g npm@latest` now silently skips `@playwright/browser-chromium`'s browser download (plus `sharp`, `esbuild`, `@swc/core`, `onnxruntime-node`, `core-js` postinstalls), which fails **webui tests** deterministically on every branch:

```
npm warn install-scripts 8 packages had install scripts blocked because they are not covered by allowScripts
Error: browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1228/...
```

First observed on PR #9980's runs today (twice, deterministic); the last green `main` run (2026-07-08 21:08 UTC) still resolved npm 11.18.0.

## Fix

Pin the 14 `npm install -g npm@latest` steps across `main.yml`, `deploy-launcher.yml`, and the two tusk runner workflows to the exact `npm@11.18.0` — per `.github/AGENTS.md` ("Pin exact versions for any tooling installed at workflow runtime … `npm install -g npm@11.11.0`, not `@latest`"), and matching the pins already used in `release-please.yml` and `docker.yml`. 11.18.0 still contains the npm/cli#8669 lockfile fix these upgrade steps exist for.

## Follow-up

Adopting npm 12 properly means committing a deliberate `allowScripts` allowlist for the 8 packages that need install scripts — that's a security-policy decision worth its own PR rather than a side effect of unbreaking CI.