### PR TITLE
docs(site): improve blog search results

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -74,7 +74,7 @@ const config: Config = {
         },
         blog: {
           blogDescription:
-            'Explore AI security research, hands-on LLM red teaming and evaluation guides, real-world vulnerability analysis, and the latest Promptfoo product updates.',
+            'Learn how to test and secure AI applications with practical guides on LLM red teaming, evaluations, real-world vulnerabilities, and updates from Promptfoo.',
           showReadingTime: false,
           blogSidebarCount: 0,
           postsPerPage: 20,

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -73,6 +73,8 @@ const config: Config = {
           ],
         },
         blog: {
+          blogDescription:
+            'Explore practical guides on AI red teaming, LLM evaluations, model security, and building reliable AI applications from the Promptfoo team and contributors.',
           showReadingTime: false,
           blogSidebarCount: 0,
           postsPerPage: 20,

--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -74,7 +74,7 @@ const config: Config = {
         },
         blog: {
           blogDescription:
-            'Explore practical guides on AI red teaming, LLM evaluations, model security, and building reliable AI applications from the Promptfoo team and contributors.',
+            'Explore AI security research, hands-on LLM red teaming and evaluation guides, real-world vulnerability analysis, and the latest Promptfoo product updates.',
           showReadingTime: false,
           blogSidebarCount: 0,
           postsPerPage: 20,

--- a/site/src/components/Blog/BlogPostGrid.test.tsx
+++ b/site/src/components/Blog/BlogPostGrid.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import BlogPostGrid from './BlogPostGrid';
+
+vi.mock('./BlogPostCard', () => ({
+  default: () => null,
+}));
+
+describe('BlogPostGrid', () => {
+  it('renders the latest posts heading on the first page', () => {
+    render(<BlogPostGrid posts={[]} />);
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Latest Posts' })).toBeInTheDocument();
+  });
+
+  it('separates the older posts heading from the page number', () => {
+    render(<BlogPostGrid posts={[]} title="Older Posts • Page 2" />);
+
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('Older Posts 2');
+  });
+});

--- a/site/src/components/Blog/BlogPostGrid.tsx
+++ b/site/src/components/Blog/BlogPostGrid.tsx
@@ -36,8 +36,7 @@ export default function BlogPostGrid({
   return (
     <div className={styles.blogPostGridContainer}>
       <h2 className={styles.blogPostGridTitle} data-is-paginated={isPaginatedPage}>
-        {mainTitle}
-        {pageNumber && ' '}
+        {pageNumber ? `${mainTitle} ` : mainTitle}
         {pageNumber}
       </h2>
       <div className={styles.blogPostGrid}>

--- a/site/src/components/Blog/BlogPostGrid.tsx
+++ b/site/src/components/Blog/BlogPostGrid.tsx
@@ -37,6 +37,7 @@ export default function BlogPostGrid({
     <div className={styles.blogPostGridContainer}>
       <h2 className={styles.blogPostGridTitle} data-is-paginated={isPaginatedPage}>
         {mainTitle}
+        {pageNumber && ' '}
         {pageNumber}
       </h2>
       <div className={styles.blogPostGrid}>


### PR DESCRIPTION
## Summary

- replace the generic `Blog` meta description with a clear, reader-focused summary of the Promptfoo blog so search engines have useful snippet text
- keep the separator in the paginated title text node, fixing `Older Posts2`/`Older Posts3` in search results without adding another flex item
- add a regression test that reproduces the concatenated heading

## Validation

- `npm test` in `site/` (105 passed)
- `npm run typecheck` in `site/`
- `npm run l && npm run f`
- `Build Docs`, `Site tests`, `Style Check`, and Codecov patch/project checks passed in CI
- verified the generated blog metadata, self-canonical pagination URLs, and heading text during production-style build validation
