### PR TITLE
fix(providers): bill GPT-5.6 image input tokens

### DIFF
--- a/src/providers/openai/billing.ts
+++ b/src/providers/openai/billing.ts
@@ -843,6 +843,13 @@ export function calculateOpenAIUsageCost(
     usage.textOutputTokens = 0;
   }
 
+  if (!rates.image) {
+    usage.textInputTokens += usage.imageInputTokens;
+    usage.cachedTextInputTokens += usage.cachedImageInputTokens;
+    usage.imageInputTokens = 0;
+    usage.cachedImageInputTokens = 0;
+  }
+
   const cachedInput = splitCachedInputTokens(usage);
   const textCost = calculateTextCost(rates.text, usage, cachedInput.textInputTokens, config);
   const audioCost = calculateModalCost(

--- a/test/providers/openai/billing.test.ts
+++ b/test/providers/openai/billing.test.ts
@@ -138,6 +138,45 @@ describe('OpenAI billing helpers', () => {
     );
   });
 
+  it.each([
+    ['gpt-5.6', 5, 30],
+    ['gpt-5.6-sol', 5, 30],
+    ['gpt-5.6-terra', 2.5, 15],
+    ['gpt-5.6-luna', 1, 6],
+  ])('prices %s image input tokens at the text input rate', (model, inputRate, outputRate) => {
+    expect(
+      calculateOpenAIUsageCost(
+        model,
+        {},
+        {
+          input_tokens: 1_000,
+          output_tokens: 100,
+          input_tokens_details: { image_tokens: 200, cache_write_tokens: 0 },
+        },
+      ),
+    ).toBeCloseTo((1_000 * inputRate + 100 * outputRate) / 1e6, 10);
+  });
+
+  it('prices cached GPT-5.6 image input tokens at the cached text input rate', () => {
+    expect(
+      calculateOpenAIUsageCost(
+        'gpt-5.6',
+        {},
+        {
+          input_tokens: 1_000,
+          output_tokens: 100,
+          input_tokens_details: {
+            text_tokens: 800,
+            image_tokens: 200,
+            cached_tokens: 200,
+            cached_tokens_details: { image_tokens: 200 },
+            cache_write_tokens: 0,
+          },
+        },
+      ),
+    ).toBeCloseTo((800 * 5 + 200 * 0.5 + 100 * 30) / 1e6, 10);
+  });
+
   it('prices GPT-5.6 explicit cache writes at 1.25x input', () => {
     expect(
       calculateOpenAIUsageCost(


### PR DESCRIPTION
## Summary

Follow up #10040 so GPT-5.6 evaluations account for image-input tokens using the published text-input and cached-text rates when no separate image rate exists.

This covers `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` while preserving models with dedicated image-token pricing.

## Validation

- 496 affected-provider tests and 65 focused OpenAI billing tests
- TypeScript, Biome, and Prettier checks
- Direct four-tier pricing smoke and local CLI eval (1/1)
- Three independent high-reasoning review passes plus 58-, 750-, and 1,296-case billing matrices covering cache reads/writes, service tiers, regional uplift, long context, and dedicated image/realtime meters
