### PR TITLE
chore(util): remove unused NormalizedTokenUsage type

### DIFF
--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -4,16 +4,6 @@ import {
   type TokenUsage,
 } from '../types/shared';
 
-export type NormalizedTokenUsage = Omit<
-  Required<TokenUsage>,
-  'assertions' | 'completionDetails'
-> & {
-  completionDetails: Required<CompletionTokenDetails>;
-  assertions: Omit<Required<NonNullable<TokenUsage['assertions']>>, 'completionDetails'> & {
-    completionDetails: Required<CompletionTokenDetails>;
-  };
-};
-
 /**
  * Safely extract token usage carried by a thrown value.
  */


### PR DESCRIPTION
## Summary

`NormalizedTokenUsage` (added in #9969) is not referenced anywhere in `src/` or tests. #9969 merged just before Knip enforcement landed (#10046), so the newly-enforced dead-code check now flags it and reddens `main`'s Style Check.

The type was evidently intended as a tighter return type for `normalizeTokenUsage`, but wiring it in correctly would require deeper nested normalization (`Required<CompletionTokenDetails>` on nested fields) — a behavior change that belongs with the larger token-accounting work in #9162, not a dead-code cleanup. So this removes the unused type for now; it can return alongside its consumer.

## Verification

- `npm run knip -- --no-progress` → exits clean (0), no unused exports.
- `npm run tsc` clean (`CompletionTokenDetails` import is still used by `createEmptyCompletionDetails`).
- `npx vitest run test/util/tokenUsageUtils.test.ts test/util/tokenUsage.test.ts` → 41 passing.
