### PR TITLE
chore: remove unused NormalizedTokenUsage type

### DIFF
--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -4,16 +4,6 @@ import {
   type TokenUsage,
 } from '../types/shared';
 
-export type NormalizedTokenUsage = Omit<
-  Required<TokenUsage>,
-  'assertions' | 'completionDetails'
-> & {
-  completionDetails: Required<CompletionTokenDetails>;
-  assertions: Omit<Required<NonNullable<TokenUsage['assertions']>>, 'completionDetails'> & {
-    completionDetails: Required<CompletionTokenDetails>;
-  };
-};
-
 /**
  * Safely extract token usage carried by a thrown value.
  */


### PR DESCRIPTION
## Summary
- `NormalizedTokenUsage` landed in #9969 with zero consumers (in-repo, in-file, and none in promptfoo-cloud, which compiles `@promptfoo/*` from this repo's `src/`).
- #10046 enabled the full Knip audit in Style Check, so main's combined state now fails CI — this was a semantic conflict between two independently-green PRs.

## Validation
- `npm run knip -- --no-progress` — clean
- `npm run tsc` — clean
- `npx vitest run test/util/tokenUsage` — 64/64