### PR TITLE
fix(util): remove unused NormalizedTokenUsage export

### DIFF
--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -4,16 +4,6 @@ import {
   type TokenUsage,
 } from '../types/shared';
 
-export type NormalizedTokenUsage = Omit<
-  Required<TokenUsage>,
-  'assertions' | 'completionDetails'
-> & {
-  completionDetails: Required<CompletionTokenDetails>;
-  assertions: Omit<Required<NonNullable<TokenUsage['assertions']>>, 'completionDetails'> & {
-    completionDetails: Required<CompletionTokenDetails>;
-  };
-};
-
 /**
  * Safely extract token usage carried by a thrown value.
  */


### PR DESCRIPTION
## Summary

Main's tip is going red on the Style Check job: the Knip audit added by #10046 flags `NormalizedTokenUsage` in `src/util/tokenUsageUtils.ts` as an unused exported type. The type landed in #9969 with no references — in-file or external — so the two individually-green PRs conflict semantically now that both are on main. Per the Knip guidance in AGENTS.md, dead code gets deleted; `Required<TokenUsage>` remains available for callers needing the strict shape.

This also unblocks #9867, whose merged-with-main CI tree hits the same failure.

## Validation

- `npm run knip -- --no-progress` — clean (only the pre-existing, non-enforced `multilingual.ts` config hint remains)
- `npm run tsc` — clean
- `npx vitest run test/util/tokenUsage*` — 64 tests pass