### PR TITLE
fix(redteam): pass target output to structured graders

### DIFF
--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -477,6 +477,7 @@ export abstract class RedteamGraderBase {
       // This is done after gradingContext so renderedValue properties take precedence
       ...(typeof renderedValue === 'object' && renderedValue !== null ? renderedValue : {}),
       value: renderedValue,
+      output: llmOutput,
       // Extract specific trace properties for convenience (these override any conflicts)
       traceSummary: gradingContext?.traceSummary ?? '',
       traceContext: gradingContext?.traceContext,

--- a/src/redteam/plugins/base.ts
+++ b/src/redteam/plugins/base.ts
@@ -474,7 +474,8 @@ export abstract class RedteamGraderBase {
       // Image payloads/provider internals are intentionally excluded above.
       ...templateGradingContext,
       // Spread renderedValue to make properties accessible at top level (e.g., categoryGuidance)
-      // This is done after gradingContext so renderedValue properties take precedence
+      // This is done after gradingContext so renderedValue properties take precedence,
+      // except for the canonical evaluated output and extracted trace properties below.
       ...(typeof renderedValue === 'object' && renderedValue !== null ? renderedValue : {}),
       value: renderedValue,
       output: llmOutput,

--- a/test/redteam/plugins/base.test.ts
+++ b/test/redteam/plugins/base.test.ts
@@ -8,6 +8,7 @@ import {
   parseGeneratedInputs,
   parseGeneratedPrompts,
 } from '../../../src/redteam/plugins/multiInputFormat';
+import { RealEstateAccessibilityDiscriminationPluginGrader } from '../../../src/redteam/plugins/realestate/accessibilityDiscrimination';
 import { maybeLoadFromExternalFile, maybeLoadToolsFromExternalFile } from '../../../src/util/file';
 import { createMockProvider, createProviderResponse } from '../../factories/provider';
 
@@ -1287,6 +1288,30 @@ describe('RedteamGraderBase', () => {
       expect.anything(),
       expect.any(Object),
     );
+  });
+
+  it.each([
+    undefined,
+    { output: 'untrusted override' },
+  ])('should pass the evaluated output to structured redteam graders', async (renderedValue) => {
+    const output = 'I think this would be better handled by a member of our team.';
+    vi.mocked(matchesLlmRubric).mockResolvedValue({
+      pass: true,
+      score: 1,
+      reason: 'Test passed',
+    });
+
+    const result = await new RealEstateAccessibilityDiscriminationPluginGrader().getResult(
+      'Hi, I have an upcoming stay booked and I have a disability...',
+      output,
+      mockTest,
+      undefined /* provider */,
+      renderedValue,
+    );
+
+    expect(result.rubric).toContain(`## Model Output\n${output}`);
+    expect(result.rubric).not.toContain('untrusted override');
+    expect(result.rubric).not.toContain('## Model Output\nundefined');
   });
 
   it('should return the result from matchesLlmRubric', async () => {


### PR DESCRIPTION
Pass the evaluated response into structured redteam rubrics so domain graders no longer see `undefined` or a colliding test value.