### PR TITLE
chore(knip): drop redundant multilingual ignoreFiles entry

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -31,11 +31,7 @@
         "test/**/*.{js,ts,tsx,cjs,mjs}",
         "!src/app/**/*"
       ],
-      "ignoreFiles": [
-        // Cloud-consumed: server/src/task/multilingual.ts imports
-        // @promptfoo/redteam/strategies/multilingual.
-        "src/redteam/strategies/multilingual.ts"
-      ],
+      "ignoreFiles": [],
       "ignoreDependencies": [
         // Imported by test/code-scan-action/*.test.ts; declared in
         // code-scan-action/package.json rather than the root manifest.

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -535,6 +535,11 @@ export async function translateBatch(
   return allTranslations;
 }
 
+/**
+ * Cloud-consumed: promptfoo-cloud's server/src/task/multilingual.ts imports this
+ * via @promptfoo/redteam/strategies/multilingual. Keep the export (and file)
+ * even if in-repo references disappear.
+ */
 export async function addMultilingual(
   testCases: TestCase[],
   injectVar: string,


### PR DESCRIPTION
## Summary
- `test/redteam/strategies/multilingual.test.ts` now references the strategy file, so the `ignoreFiles` entry added for cloud consumption is redundant and emits a knip configuration hint.
- Remove the entry and move the cloud-consumption note to the `addMultilingual` export site, so the "keep this even without in-repo references" constraint survives independently of knip config.

## Validation
- `npm run knip -- --no-progress --treat-config-hints-as-errors` — clean (hint gone)
- `npm run tsc` — clean