### PR TITLE
fix(redteam): add missing lowercase f to homoglyph map

### DIFF
--- a/src/redteam/strategies/homoglyph.ts
+++ b/src/redteam/strategies/homoglyph.ts
@@ -7,6 +7,7 @@ export const homoglyphMap: { [key: string]: string } = {
   c: 'с', // Cyrillic с (U+0441)
   d: 'ԁ', // Cyrillic д (U+0501)
   e: 'е', // Cyrillic е (U+0435)
+  f: 'ƒ', // Latin small letter f with hook (U+0192)
   g: 'ɡ', // Latin small letter script g
   h: 'һ', // Cyrillic һ (U+04BB)
   i: 'і', // Cyrillic і (U+0456)

--- a/test/redteam/strategies/homoglyph.test.ts
+++ b/test/redteam/strategies/homoglyph.test.ts
@@ -47,6 +47,16 @@ describe('homoglyph strategy', () => {
       expect(toHomoglyphs('9')).toBe(homoglyphMap['9']);
     });
 
+    it('should map every alphanumeric character to a non-ASCII homoglyph', () => {
+      const alphanumeric = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+      for (const char of alphanumeric) {
+        const mapped = homoglyphMap[char];
+        expect(mapped, `missing homoglyph for '${char}'`).toBeDefined();
+        expect(toHomoglyphs(char), `'${char}' left as ASCII`).not.toBe(char);
+        expect(mapped.charCodeAt(0), `'${char}' maps to ASCII`).toBeGreaterThan(127);
+      }
+    });
+
     it('should handle empty strings', () => {
       expect(toHomoglyphs('')).toBe('');
     });


### PR DESCRIPTION
## Problem

The homoglyph strategy's character map is missing lowercase `f` (the map jumps `e` → `g`; uppercase `F` is present). Since `toHomoglyphs` falls back to the original character on a map miss, any payload containing `f` leaks the literal ASCII `f`, weakening the obfuscation. The existing test only checks the whole alphabet string changes, so it missed the gap.

## Fix

- Add `f: 'ƒ'` (U+0192) to the map.
- Add a regression test asserting every alphanumeric character maps to a non-ASCII homoglyph.

## Testing

`npx vitest run test/redteam/strategies/homoglyph.test.ts` — 18 passed; verified the new test fails without the fix.