### PR TITLE
fix(providers): address xAI response edge cases

### DIFF
--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -479,10 +479,14 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
 
         // Check if this is an invalid_prompt error code (indicates refusal)
         if (typeof data === 'object' && data?.error?.code === 'invalid_prompt') {
+          const cost = this.calculateResponseCost(data, config, cached);
+
           return {
             output: errorMessage,
             tokenUsage: data?.usage ? getTokenUsage(data, cached) : undefined,
+            cached,
             latencyMs,
+            ...(cost === undefined ? {} : { cost }),
             isRefusal: true,
             guardrails: {
               flagged: true,

--- a/src/providers/xai/responses.ts
+++ b/src/providers/xai/responses.ts
@@ -5,6 +5,7 @@ import { fetchWithProxy } from '../../util/fetch/index';
 import {
   maybeLoadResponseFormatFromExternalFile,
   maybeLoadToolsFromExternalFile,
+  renderVarsInObject,
 } from '../../util/index';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { ResponsesProcessor } from '../responses/index';
@@ -444,6 +445,10 @@ export class XAIResponsesProvider implements ApiProvider {
       ...(config.user ? { user: config.user } : {}),
       ...(config.passthrough || {}),
     };
+
+    if (body.reasoning !== undefined) {
+      body.reasoning = renderVarsInObject(body.reasoning, context?.vars);
+    }
 
     // Filter unsupported parameters for Grok 4-family models
     if (GROK_4_MODELS.includes(this.modelName)) {

--- a/test/providers/xai/chat.test.ts
+++ b/test/providers/xai/chat.test.ts
@@ -1333,6 +1333,38 @@ describe('xAI Chat Provider', () => {
       expect(result.cost).toBe(0.0123456789);
     });
 
+    it('preserves exact billed ticks on non-2xx invalid_prompt refusals', async () => {
+      mockFetchWithCache.mockResolvedValueOnce({
+        data: {
+          error: {
+            code: 'invalid_prompt',
+            message: 'The prompt was rejected by the safety system.',
+          },
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 10,
+            total_tokens: 110,
+            cost_in_usd_ticks: 123_456_789,
+          },
+        },
+        cached: false,
+        status: 400,
+        statusText: 'Bad Request',
+      });
+
+      const provider = createXAIProvider('xai:grok-4.5', {
+        config: { apiKey: 'test-key' } as any,
+      });
+
+      const result = await provider.callApi('blocked prompt');
+
+      expect(result.error).toBeUndefined();
+      expect(result.isRefusal).toBe(true);
+      expect(result.cached).toBe(false);
+      expect(result.tokenUsage).toMatchObject({ prompt: 100, completion: 10, total: 110 });
+      expect(result.cost).toBe(0.0123456789);
+    });
+
     it('honors explicit custom cost overrides instead of reported ticks', async () => {
       mockFetchWithCache.mockResolvedValueOnce({
         data: {

--- a/test/providers/xai/responses.test.ts
+++ b/test/providers/xai/responses.test.ts
@@ -188,6 +188,32 @@ describe('XAIResponsesProvider', () => {
     }
   });
 
+  it('renders templated Grok 4.5 reasoning effort before validation', async () => {
+    const provider = new XAIResponsesProvider('grok-4.5', {
+      config: { reasoning: { effort: '{{effort}}' as any } },
+    });
+
+    const { body } = await provider.getRequestBody('hello', {
+      prompt: { raw: 'hello', label: 'hello' },
+      vars: { effort: 'high' },
+    });
+
+    expect(body.reasoning).toEqual({ effort: 'high' });
+  });
+
+  it('rejects unsupported templated Grok 4.5 reasoning effort after rendering', async () => {
+    const provider = new XAIResponsesProvider('grok-4.5', {
+      config: { passthrough: { reasoning: { effort: '{{effort}}' } } },
+    });
+
+    await expect(
+      provider.getRequestBody('hello', {
+        prompt: { raw: 'hello', label: 'hello' },
+        vars: { effort: 'none' },
+      }),
+    ).rejects.toThrow('xAI model grok-4.5 does not support reasoning.effort "none"');
+  });
+
   it('preserves broader reasoning effort values for models that support them', async () => {
     const grok43 = new XAIResponsesProvider('grok-4.3', {
       config: { reasoning: { effort: 'none' } },


### PR DESCRIPTION
## Summary

- preserve exact xAI billed cost and cache metadata for non-2xx safety refusals
- render templated Responses API reasoning values before Grok 4.5 validation, including passthrough overrides
- add focused regression coverage for both late findings from #10032

## Context

Two actionable review comments arrived after #10032 had already been squash-merged. Both were reproduced against the merged commit and fixed here.

## Test plan

- `npx vitest run test/providers/openai/chat.test.ts test/providers/xai` (360 tests)
- `npm run tsc`
- `npm run knip -- --no-progress`
- `npm run build`
- `git diff --check origin/main...HEAD`
