### PR TITLE
fix(redteam): encode hex strategy payloads as UTF-8 bytes

### DIFF
--- a/src/redteam/strategies/hex.ts
+++ b/src/redteam/strategies/hex.ts
@@ -11,9 +11,8 @@ export function addHexEncoding(testCases: TestCase[], injectVar: string): TestCa
       })),
       vars: {
         ...testCase.vars,
-        [injectVar]: originalText
-          .split('')
-          .map((char) => char.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0'))
+        [injectVar]: Array.from(Buffer.from(originalText, 'utf8'))
+          .map((byte) => byte.toString(16).toUpperCase().padStart(2, '0'))
           .join(' '),
       },
       metadata: {

--- a/test/redteam/strategies/hex.test.ts
+++ b/test/redteam/strategies/hex.test.ts
@@ -92,6 +92,50 @@ describe('addHexEncoding', () => {
     expect(result[0].assert![0].metric).toBe('accuracy/Hex');
   });
 
+  it('should encode multibyte characters as UTF-8 bytes', () => {
+    const testCases: TestCase[] = [
+      {
+        vars: {
+          input: '€100',
+        },
+      },
+    ];
+
+    const result = addHexEncoding(testCases, 'input');
+
+    // € is 3 UTF-8 bytes (E2 82 AC), not its UTF-16 code unit (20AC)
+    expect(result[0].vars!.input).toBe('E2 82 AC 31 30 30');
+  });
+
+  it('should encode 2-byte UTF-8 characters as bytes', () => {
+    const result = addHexEncoding([{ vars: { input: 'café' } }], 'input');
+
+    // é is 2 UTF-8 bytes (C3 A9), not its UTF-16 code unit (E9)
+    expect(result[0].vars!.input).toBe('63 61 66 C3 A9');
+  });
+
+  it('should encode characters outside the BMP (emoji) as UTF-8 bytes', () => {
+    const testCases: TestCase[] = [
+      {
+        vars: {
+          input: '😊',
+        },
+      },
+    ];
+
+    const result = addHexEncoding(testCases, 'input');
+
+    // Not the UTF-16 surrogate pair (D83D DE0A)
+    expect(result[0].vars!.input).toBe('F0 9F 98 8A');
+  });
+
+  it('should round-trip multibyte payloads back to the original text', () => {
+    const original = 'café ☕ 日本語 😊';
+    const result = addHexEncoding([{ vars: { input: original } }], 'input');
+    const bytes = (result[0].vars!.input as string).split(' ').map((h) => parseInt(h, 16));
+    expect(Buffer.from(bytes).toString('utf8')).toBe(original);
+  });
+
   it('should handle test case without assertions', () => {
     const testCases: TestCase[] = [
       {


### PR DESCRIPTION
## Problem

The hex strategy hex-encoded each character's UTF-16 code unit (`char.charCodeAt(0)`), so any non-ASCII payload was mis-encoded:

- Characters above U+00FF produced variable-width tokens: `€` → `20AC` instead of the UTF-8 bytes `E2 82 AC`.
- Characters outside the BMP were split into surrogate halves: `😊` → `D83D DE0A` instead of `F0 9F 98 8A`.

A model asked to decode the hex as bytes cannot reconstruct the original text, so the attack is silently invalid for multilingual/emoji payloads. ASCII payloads were unaffected.

## Fix

Encode the UTF-8 bytes via `Buffer.from(originalText, 'utf8')`, matching the sibling `base64` strategy. Per-byte `padStart(2, '0')` is now always correct since bytes are 0–255.

## Testing

`npx vitest run test/redteam/strategies/hex.test.ts` — 9 passed. Added multibyte (`€`, `é`), emoji, and round-trip regression tests; verified they fail without the fix. Existing ASCII tests unchanged.