### PR TITLE
fix(redteam): clean up Hydra and Hex handling

### DIFF
--- a/site/docs/providers/localai.md
+++ b/site/docs/providers/localai.md
@@ -5,7 +5,7 @@ description: 'Run self-hosted OpenAI-compatible APIs locally with LocalAI for pr
 
 # Local AI
 
-LocalAI is an API wrapper for open-source LLMs that is compatible with OpenAI. You can run LocalAI for compatibility with Llama, Alpaca, Vicuna, GPT4All, RedPajama, and many other models compatible with the ggml format.
+LocalAI is an API wrapper for open-source LLMs that is compatible with OpenAI. You can run LocalAI for compatibility with Llama, Alpaca, Vicuna, GPT4All, RedPajama, and many other models, primarily in the GGUF format (with some legacy ggml support).
 
 View all compatible models [here](https://github.com/go-skynet/LocalAI#model-compatibility-table).
 
@@ -19,7 +19,7 @@ Once you have LocalAI up and running, specify one of the following based on the 
 - `localai:embeddings:<model name>`, which invokes models using the
   [LocalAI embeddings endpoint](https://localai.io/features/embeddings/)
 
-The model name is typically the filename of the `.bin` file that you downloaded to set up the model in LocalAI. For example, `ggml-vic13b-uncensored-q5_1.bin`. LocalAI also has a `/models` endpoint to list models, which can be queried with `curl http://localhost:8080/v1/models`.
+The model name is typically the filename of the `.gguf` file that you downloaded to set up the model in LocalAI. For example, `vicuna-13b-v1.5-q5_k_m.gguf`. LocalAI also has a `/models` endpoint to list models, which can be queried with `curl http://localhost:8080/v1/models`.
 
 ## Configuring parameters
 

--- a/src/redteam/providers/hydra/index.ts
+++ b/src/redteam/providers/hydra/index.ts
@@ -10,7 +10,6 @@ import {
   type TraceContextData,
 } from '../../../tracing/traceContext';
 import invariant from '../../../util/invariant';
-import { isValidJson } from '../../../util/json';
 import { sleep } from '../../../util/time';
 import { accumulateResponseTokenUsage, createEmptyTokenUsage } from '../../../util/tokenUsageUtils';
 import { materializeInputVariablesWithMetadata } from '../../inputVariables';
@@ -45,7 +44,6 @@ import {
   getGraderAssertionValue,
   getTargetResponse,
   isConversationEndedResponse,
-  isValidChatMessageArray,
   type Message,
   type TargetResponse,
   type TurnBacktrackingStopReason,
@@ -290,7 +288,7 @@ export class HydraProvider implements ApiProvider {
     vars,
     goal,
     targetProvider,
-    context,
+    context: initialContext,
     options,
     test,
   }: {
@@ -303,6 +301,8 @@ export class HydraProvider implements ApiProvider {
     options?: CallApiOptionsParams;
     test?: AtomicTestCase;
   }): Promise<HydraResponse> {
+    let context = initialContext;
+
     // Initialize scanId: use evaluationId if available, otherwise use instance scanId or generate new one
     if (!this.scanId) {
       this.scanId = context?.evaluationId || crypto.randomUUID();
@@ -552,31 +552,7 @@ export class HydraProvider implements ApiProvider {
         );
       } else {
         // Stateless: send full conversation history as JSON
-        // Try to parse the rendered prompt to see if it's already chat format
-        const samplePrompt = await renderPrompt(
-          prompt,
-          {
-            ...vars,
-            [this.injectVar]: 'test',
-          },
-          filters,
-          targetProvider,
-          [this.injectVar], // Skip template rendering for injection variable to prevent double-evaluation
-        );
-
-        if (isValidJson(samplePrompt)) {
-          const parsed = JSON.parse(samplePrompt);
-          if (isValidChatMessageArray(parsed)) {
-            // It's already chat format, inject our conversation
-            targetPrompt = JSON.stringify(this.conversationHistory);
-          } else {
-            // Not chat format, use standard rendering
-            targetPrompt = JSON.stringify(this.conversationHistory);
-          }
-        } else {
-          // Not JSON, send as conversation array
-          targetPrompt = JSON.stringify(this.conversationHistory);
-        }
+        targetPrompt = JSON.stringify(this.conversationHistory);
       }
 
       logger.debug(`${this.logPrefix} Sending to target`, {

--- a/src/redteam/strategies/authoritativeMarkupInjection.ts
+++ b/src/redteam/strategies/authoritativeMarkupInjection.ts
@@ -21,7 +21,9 @@ export async function addAuthoritativeMarkupInjectionTestCases(
       },
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/AuthoritativeMarkupInjection`,
+        metric: assertion.metric
+          ? `${assertion.metric}/AuthoritativeMarkupInjection`
+          : assertion.metric,
       })),
       metadata: {
         ...testCase.metadata,

--- a/src/redteam/strategies/base64.ts
+++ b/src/redteam/strategies/base64.ts
@@ -7,7 +7,7 @@ export function addBase64Encoding(testCases: TestCase[], injectVar: string): Tes
       ...testCase,
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/Base64`,
+        metric: assertion.metric ? `${assertion.metric}/Base64` : assertion.metric,
       })),
       vars: {
         ...testCase.vars,

--- a/src/redteam/strategies/bestOfN.ts
+++ b/src/redteam/strategies/bestOfN.ts
@@ -36,7 +36,7 @@ export async function addBestOfNTestCases(
           ]
         : testCase.assert?.map((assertion) => ({
             ...assertion,
-            metric: `${assertion.metric}/BestOfN`,
+            metric: assertion.metric ? `${assertion.metric}/BestOfN` : assertion.metric,
           })),
     };
   });

--- a/src/redteam/strategies/citation.ts
+++ b/src/redteam/strategies/citation.ts
@@ -113,7 +113,7 @@ async function generateCitations(
         },
         assert: testCase.assert?.map((assertion) => ({
           ...assertion,
-          metric: `${assertion.metric}/Citation`,
+          metric: assertion.metric ? `${assertion.metric}/Citation` : assertion.metric,
         })),
         metadata: {
           ...testCase.metadata,

--- a/src/redteam/strategies/crescendo.ts
+++ b/src/redteam/strategies/crescendo.ts
@@ -25,7 +25,7 @@ export function addCrescendo(
       },
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/Crescendo`,
+        metric: assertion.metric ? `${assertion.metric}/Crescendo` : assertion.metric,
       })),
       metadata: {
         ...testCase.metadata,

--- a/src/redteam/strategies/custom.ts
+++ b/src/redteam/strategies/custom.ts
@@ -25,7 +25,7 @@ export function addCustom(
       },
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/${displayName}`,
+        metric: assertion.metric ? `${assertion.metric}/${displayName}` : assertion.metric,
       })),
       metadata: {
         ...testCase.metadata,

--- a/src/redteam/strategies/gcg.ts
+++ b/src/redteam/strategies/gcg.ts
@@ -108,7 +108,7 @@ async function generateGcgPrompts(
         },
         assert: testCase.assert?.map((assertion) => ({
           ...assertion,
-          metric: `${assertion.metric}/GCG`,
+          metric: assertion.metric ? `${assertion.metric}/GCG` : assertion.metric,
         })),
         metadata: {
           ...testCase.metadata,

--- a/src/redteam/strategies/goat.ts
+++ b/src/redteam/strategies/goat.ts
@@ -28,7 +28,7 @@ export async function addGoatTestCases(
       },
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/GOAT`,
+        metric: assertion.metric ? `${assertion.metric}/GOAT` : assertion.metric,
       })),
       metadata: {
         ...testCase.metadata,

--- a/src/redteam/strategies/hex.ts
+++ b/src/redteam/strategies/hex.ts
@@ -7,7 +7,7 @@ export function addHexEncoding(testCases: TestCase[], injectVar: string): TestCa
       ...testCase,
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: assertion.metric === undefined ? undefined : `${assertion.metric}/Hex`,
+        metric: assertion.metric ? `${assertion.metric}/Hex` : assertion.metric,
       })),
       vars: {
         ...testCase.vars,

--- a/src/redteam/strategies/hex.ts
+++ b/src/redteam/strategies/hex.ts
@@ -7,7 +7,7 @@ export function addHexEncoding(testCases: TestCase[], injectVar: string): TestCa
       ...testCase,
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/Hex`,
+        metric: assertion.metric === undefined ? undefined : `${assertion.metric}/Hex`,
       })),
       vars: {
         ...testCase.vars,

--- a/src/redteam/strategies/homoglyph.ts
+++ b/src/redteam/strategies/homoglyph.ts
@@ -86,7 +86,7 @@ export function addHomoglyphs(testCases: TestCase[], injectVar: string): TestCas
       ...testCase,
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/Homoglyph`,
+        metric: assertion.metric ? `${assertion.metric}/Homoglyph` : assertion.metric,
       })),
       vars: {
         ...testCase.vars,

--- a/src/redteam/strategies/hydra.ts
+++ b/src/redteam/strategies/hydra.ts
@@ -44,7 +44,7 @@ export function createAdaptiveMultiTurnStrategy(
         },
         assert: testCase.assert?.map((assertion) => ({
           ...assertion,
-          metric: `${assertion.metric}/${metricSuffix}`,
+          metric: assertion.metric ? `${assertion.metric}/${metricSuffix}` : assertion.metric,
         })),
         metadata: {
           ...testCase.metadata,

--- a/src/redteam/strategies/indirectWebPwn.ts
+++ b/src/redteam/strategies/indirectWebPwn.ts
@@ -378,7 +378,7 @@ function transformForStandaloneMode(
       },
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/${metricSuffix}`,
+        metric: assertion.metric ? `${assertion.metric}/${metricSuffix}` : assertion.metric,
       })),
       metadata: {
         ...testCase.metadata,

--- a/src/redteam/strategies/iterative.ts
+++ b/src/redteam/strategies/iterative.ts
@@ -47,7 +47,7 @@ export function addIterativeJailbreaks(
       },
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/${metricSuffix}`,
+        metric: assertion.metric ? `${assertion.metric}/${metricSuffix}` : assertion.metric,
       })),
       metadata: {
         ...testCase.metadata,

--- a/src/redteam/strategies/leetspeak.ts
+++ b/src/redteam/strategies/leetspeak.ts
@@ -31,7 +31,7 @@ export function addLeetspeak(testCases: TestCase[], injectVar: string): TestCase
       ...testCase,
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/Leetspeak`,
+        metric: assertion.metric ? `${assertion.metric}/Leetspeak` : assertion.metric,
       })),
       vars: {
         ...testCase.vars,

--- a/src/redteam/strategies/likert.ts
+++ b/src/redteam/strategies/likert.ts
@@ -92,7 +92,7 @@ async function generateLikertPrompts(
           },
           assert: testCase.assert?.map((assertion) => ({
             ...assertion,
-            metric: `${assertion.metric}/Likert`,
+            metric: assertion.metric ? `${assertion.metric}/Likert` : assertion.metric,
           })),
           metadata: {
             ...testCase.metadata,

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -199,7 +199,7 @@ export async function addMathPrompt(
         ...testCase,
         assert: testCase.assert?.map((assertion) => ({
           ...assertion,
-          metric: `${assertion.metric}/MathPrompt`,
+          metric: assertion.metric ? `${assertion.metric}/MathPrompt` : assertion.metric,
         })),
         vars: {
           ...testCase.vars,

--- a/src/redteam/strategies/mischievousUser.ts
+++ b/src/redteam/strategies/mischievousUser.ts
@@ -16,7 +16,7 @@ export function addMischievousUser(
     },
     assert: testCase.assert?.map((assertion) => ({
       ...assertion,
-      metric: `${assertion.metric}/MischievousUser`,
+      metric: assertion.metric ? `${assertion.metric}/MischievousUser` : assertion.metric,
     })),
     metadata: {
       ...testCase.metadata,

--- a/src/redteam/strategies/otherEncodings.ts
+++ b/src/redteam/strategies/otherEncodings.ts
@@ -196,7 +196,7 @@ export function addOtherEncodings(
       ...testCase,
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/${encodingName}`,
+        metric: assertion.metric ? `${assertion.metric}/${encodingName}` : assertion.metric,
       })),
       vars: {
         ...testCase.vars,

--- a/src/redteam/strategies/rot13.ts
+++ b/src/redteam/strategies/rot13.ts
@@ -15,7 +15,7 @@ export function addRot13(testCases: TestCase[], injectVar: string): TestCase[] {
       ...testCase,
       assert: testCase.assert?.map((assertion) => ({
         ...assertion,
-        metric: `${assertion.metric}/Rot13`,
+        metric: assertion.metric ? `${assertion.metric}/Rot13` : assertion.metric,
       })),
       vars: {
         ...testCase.vars,

--- a/src/redteam/strategies/singleTurnComposite.ts
+++ b/src/redteam/strategies/singleTurnComposite.ts
@@ -108,7 +108,7 @@ async function generateCompositePrompts(
           },
           assert: testCase.assert?.map((assertion) => ({
             ...assertion,
-            metric: `${assertion.metric}/Composite`,
+            metric: assertion.metric ? `${assertion.metric}/Composite` : assertion.metric,
           })),
           metadata: {
             ...testCase.metadata,

--- a/test/redteam/strategies/hex.test.ts
+++ b/test/redteam/strategies/hex.test.ts
@@ -48,6 +48,19 @@ describe('addHexEncoding', () => {
 
     expect(result[0].vars!.input).toBe('');
     expect(result[0].assert![0].metric).toBe('accuracy/Hex');
+    expect(result[0].metadata).toEqual({
+      strategyId: 'hex',
+      originalText: '',
+    });
+  });
+
+  it('should preserve an undefined metric', () => {
+    const result = addHexEncoding(
+      [{ vars: { input: 'hello' }, assert: [{ type: 'contains' }] }],
+      'input',
+    );
+
+    expect(result[0].assert![0].metric).toBeUndefined();
   });
 
   it('should handle special characters', () => {

--- a/test/redteam/strategies/homoglyph.test.ts
+++ b/test/redteam/strategies/homoglyph.test.ts
@@ -53,7 +53,7 @@ describe('homoglyph strategy', () => {
         const mapped = homoglyphMap[char];
         expect(mapped, `missing homoglyph for '${char}'`).toBeDefined();
         expect(toHomoglyphs(char), `'${char}' left as ASCII`).not.toBe(char);
-        expect(mapped.charCodeAt(0), `'${char}' maps to ASCII`).toBeGreaterThan(127);
+        expect(mapped.codePointAt(0) ?? 0, `'${char}' maps to ASCII`).toBeGreaterThan(127);
       }
     });
 


### PR DESCRIPTION
## Summary

- simplify Hydra's stateless prompt path and make mutable context explicit
- preserve missing Hex assertion metrics instead of emitting undefined/Hex
- modernize LocalAI GGUF documentation and strengthen strategy regression tests

## Validation

- focused Hydra, Hex, and homoglyph Vitest suite
- npm run f
- npm run l
- npm run tsc
- docs build with OG generation skipped