### PR TITLE
fix(providers): avoid app-server config recursion

### DIFF
--- a/src/providers/openai/codex-app-server.ts
+++ b/src/providers/openai/codex-app-server.ts
@@ -1172,6 +1172,10 @@ export class OpenAICodexAppServerProvider implements ApiProvider {
       this.config,
       context?.prompt?.config as CodexAppServerConfig | undefined,
     );
+    // Promptfoo may attach the live target provider object to prompt config for
+    // generic provider workflows. Codex accepts this key for loader compatibility,
+    // but runtime variable rendering must not recurse into provider methods.
+    delete mergedConfig.provider;
     const config = renderVarsInObject(mergedConfig, context?.vars) as CodexAppServerConfig;
     const requestedModel =
       typeof config.model === 'string' && config.model ? config.model : undefined;

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -3542,8 +3542,9 @@ describe('OpenAICodexAppServerProvider', () => {
     const server = createMockAppServer();
     mocks.spawn.mockReturnValue(server.proc);
 
+    const attachedProviderId = vi.fn(() => 'attached-provider');
     const attachedProvider: Record<string, unknown> = {
-      id: () => 'attached-provider',
+      id: attachedProviderId,
     };
     attachedProvider.self = attachedProvider;
 
@@ -3622,6 +3623,7 @@ describe('OpenAICodexAppServerProvider', () => {
     });
 
     await expect(resultPromise).resolves.toMatchObject({ output: 'Rendered config done' });
+    expect(attachedProviderId).not.toHaveBeenCalled();
   });
 
   it('applies prompt-level server request policy for each turn on a reused connection', async () => {

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -3542,6 +3542,11 @@ describe('OpenAICodexAppServerProvider', () => {
     const server = createMockAppServer();
     mocks.spawn.mockReturnValue(server.proc);
 
+    const attachedProvider: Record<string, unknown> = {
+      id: () => 'attached-provider',
+    };
+    attachedProvider.self = attachedProvider;
+
     const provider = new OpenAICodexAppServerProvider({
       config: {
         thread_cleanup: 'none',
@@ -3559,6 +3564,7 @@ describe('OpenAICodexAppServerProvider', () => {
         config: {
           working_dir: '{{ workspaceDir }}',
           model: '{{ modelName }}',
+          provider: attachedProvider,
           cli_config: {
             rendered_config: '{{ envValue }}',
           },


### PR DESCRIPTION
## Summary

- remove compatibility-only live `provider` metadata before rendering Codex app-server prompt config
- preserve variable rendering for supported app-server configuration
- add regression coverage for circular provider objects

## Problem

Promptfoo resolves grading providers into live objects and can merge them into `prompt.config` through test options. The Codex app-server provider then recursively renders that merged config. A live provider can contain methods and circular references, so rendering can invoke provider methods or fail with `RangeError: Maximum call stack size exceeded` before the app-server request starts.

The app-server schema accepts the `provider` key for loader compatibility, but the runtime does not consume it. Removing that key from the fresh merged config before variable rendering avoids the recursion without mutating caller-owned config or changing supported config precedence.

## Validation

- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci`
- `npx vitest run test/providers/openai-codex-app-server.test.ts` (72 passed)
- `npm run tsc`
- `npm run l`
- `npm run f`
- `git diff --check`

An isolated test against unpatched `main` reproduced the stack overflow; the same test passes with this change.