### PR TITLE
fix(util): handle single-quoted escaped paths

### DIFF
--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -191,7 +191,7 @@ export function convertSlashCommentsToHash(str: string): string {
           case 'singleQuote':
             result += char;
             // Check for string end, but ignore apostrophes in words
-            if (char === "'" && prevChar !== '\\' && !/[a-zA-Z]/.test(nextChar)) {
+            if (char === "'" && !isEscapedQuote(line, i) && !/[a-zA-Z]/.test(nextChar)) {
               state = 'normal';
             }
             break;

--- a/test/util/json.test.ts
+++ b/test/util/json.test.ts
@@ -414,6 +414,12 @@ describe('json utilities', () => {
         expect(convertSlashCommentsToHash(input)).toBe(expected);
       });
 
+      it('should convert comments after a single-quoted string ending with even backslashes', () => {
+        const input = String.raw`path: 'C:\\' // comment`;
+        const expected = String.raw`path: 'C:\\' # comment`;
+        expect(convertSlashCommentsToHash(input)).toBe(expected);
+      });
+
       it('should handle multiple sequential comment markers', () => {
         const input = 'text //// double comment';
         const expected = 'text ## double comment';

--- a/test/util/json.test.ts
+++ b/test/util/json.test.ts
@@ -420,6 +420,11 @@ describe('json utilities', () => {
         expect(convertSlashCommentsToHash(input)).toBe(expected);
       });
 
+      it('should keep slashes inside a single-quoted string with an escaped quote', () => {
+        const input = String.raw`path: 'C:\' // still inside the string'`;
+        expect(convertSlashCommentsToHash(input)).toBe(input);
+      });
+
       it('should handle multiple sequential comment markers', () => {
         const input = 'text //// double comment';
         const expected = 'text ## double comment';


### PR DESCRIPTION
## Summary

- handle even backslash runs before single-quoted string terminators when converting slash comments
- add regression coverage for trailing comments after single-quoted Windows-style paths

## Test Plan

- `source ~/.nvm/nvm.sh && nvm use && node node_modules/vitest/vitest.mjs run test/util/json.test.ts --sequence.shuffle=false`
- `source ~/.nvm/nvm.sh && nvm use && npm run l && npm run f`
