### PR TITLE
test(assertions): pin literal '*' defaults semantics in tool-args-match

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -798,7 +798,7 @@ With the configuration above:
 | `{ status: 'Q', page: 2 }`               | fail    | `page: 2` does not equal the declared default (1), so it stays in the payload; `exact` mode then rejects the unexpected extra |
 | `{ status: 'Q', delete_database: true }` | fail    | `delete_database` is not in `args` or `defaults`                                                                              |
 
-`defaults` are compared with deep equality, so structured default values (objects, arrays) are supported. Only top-level keys are stripped; a nested default value is compared as a whole and is not partially stripped.
+`defaults` are compared with deep equality, so structured default values (objects, arrays) are supported. Only top-level keys are stripped; a nested default value is compared as a whole and is not partially stripped. A `defaults` entry always requires the observed value to equal the declared default — even a default of `"*"` is matched literally. To tolerate an argument regardless of its value, such as a pagination cursor or other agent-generated token, list it under [`ignore`](#trajectory-tool-args-match-ignore) instead.
 
 :::note
 
@@ -808,7 +808,7 @@ Stripping runs before matching in both modes, but `partial` mode already ignores
 
 #### Ignoring arguments {#trajectory-tool-args-match-ignore}
 
-Use `ignore` when an argument should be left out of the comparison entirely, regardless of its value — for example a volatile `request_id` or `idempotency_key` that changes on every call. Where `defaults` tolerates a key only when it equals a specific value, `ignore` removes the named key unconditionally. The named keys are dropped from both the observed and expected payloads before matching.
+Use `ignore` when an argument should be left out of the comparison entirely, regardless of its value — for example a pagination `cursor`, a volatile `request_id`, or an `idempotency_key` that changes on every call. Where `defaults` tolerates a key only when it equals a specific value, `ignore` removes the named key unconditionally. The named keys are dropped from both the observed and expected payloads before matching.
 
 ```yaml
 tests:

--- a/test/assertions/trajectory.test.ts
+++ b/test/assertions/trajectory.test.ts
@@ -2242,6 +2242,47 @@ describe('trajectory assertions', () => {
           'trajectory:tool-args-match assertion defaults must be an object mapping argument names to default values',
         );
       });
+
+      it('strips a literal "*" default only when the observed value is exactly "*"', () => {
+        // A default of "*" is an ordinary value compared with deep equality — it must not
+        // act as an any-value wildcard (#9842); use `ignore` to drop a key unconditionally.
+        const runWithFields = (fields: string) => {
+          const trace: TraceData = {
+            ...mockTraceData,
+            spans: [
+              {
+                spanId: 'literal-star-default',
+                name: 'tool.call',
+                startTime: 1000,
+                endTime: 1100,
+                attributes: {
+                  'tool.name': 'search_orders',
+                  'tool.arguments': JSON.stringify({ status: 'Q', fields }),
+                },
+              },
+            ],
+          };
+          const value = {
+            name: 'search_orders',
+            mode: 'exact',
+            args: { status: 'Q' },
+            defaults: { fields: '*' },
+          };
+          return handleTrajectoryToolArgsMatch({
+            ...defaultParams,
+            assertionValueContext: { ...defaultParams.assertionValueContext, trace },
+            baseType: 'trajectory:tool-args-match',
+            assertion: { type: 'trajectory:tool-args-match', value },
+            renderedValue: value,
+          } as AssertionParams);
+        };
+
+        const stripped = runWithFields('*');
+        expect(stripped.pass).toBe(true);
+        expect(stripped.reason).toContain('Ignored default argument(s): fields');
+
+        expect(runWithFields('ssn,password').pass).toBe(false);
+      });
     });
 
     describe('ignore', () => {


### PR DESCRIPTION
## Summary

Follow-up to the discussion on #10010 — credit to @muhammadshayan124 for surfacing both gaps addressed here while investigating #9842. 🙏

- Add a regression test pinning that a `defaults` entry of `"*"` in `trajectory:tool-args-match` is an ordinary literal value compared with deep equality: it strips the key only when the observed value is exactly `"*"`, and a different observed value still fails `mode: exact`. No existing test covered this — a change that repurposed `"*"` as an any-value wildcard passed the entire suite (see #10010).
- Docs: the `defaults` section of `deterministic.md` now states that defaults are always matched literally (including `"*"`) and cross-references `ignore` for "tolerate this argument regardless of its value" cases. The `ignore` section's motivating example now also mentions pagination cursors. This discoverability gap is the likely root cause of #9842: the requested capability already exists as `ignore` (#9466, glob patterns in #9484), which shipped shortly before the issue was filed.

Closes #9842.

## Test plan

- [x] `npx vitest run test/assertions/trajectory.test.ts` — 99/99 passing
- [x] Verified the new test catches the regression it guards against: with the wildcard-sentinel change from #10010 applied locally, the test fails; on `main` semantics it passes
- [x] `npm run l && npm run f` — clean