### PR TITLE
docs(site): modernize retired model IDs in example configs

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
@@ -72,7 +72,7 @@ assert:
   - type: answer-relevance
     threshold: 0.8
     provider:
-      text: anthropic:claude-2
+      text: anthropic:claude-sonnet-4-6
       embedding: cohere:embed-english-v3.0
 ```
 

--- a/site/docs/configuration/expected-outputs/model-graded/conversation-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/conversation-relevance.md
@@ -174,7 +174,7 @@ Or set it globally:
 ```yaml
 defaultTest:
   options:
-    provider: anthropic:claude-3-7-sonnet-latest
+    provider: anthropic:claude-sonnet-4-6
 ```
 
 ## See also

--- a/site/docs/configuration/expected-outputs/model-graded/max-score.md
+++ b/site/docs/configuration/expected-outputs/model-graded/max-score.md
@@ -162,7 +162,7 @@ prompts:
   - 'Explain {{concept}} with examples'
 
 providers:
-  - anthropic:claude-3-haiku-20240307
+  - anthropic:claude-haiku-4-5
 
 tests:
   - vars:

--- a/site/docs/configuration/parameters.md
+++ b/site/docs/configuration/parameters.md
@@ -171,7 +171,7 @@ prompts:
 
 providers:
   - openai:gpt-5-mini
-  - anthropic:claude-3-haiku
+  - anthropic:claude-haiku-4-5
 
 tests:
   # Inline test cases

--- a/site/docs/configuration/prompts.md
+++ b/site/docs/configuration/prompts.md
@@ -348,9 +348,9 @@ prompts:
     label: claude_prompt
 
 providers:
-  - id: openai:gpt-4
+  - id: openai:gpt-5.6
     prompts: [gpt_prompt]
-  - id: anthropic:claude-3
+  - id: anthropic:claude-sonnet-4-6
     prompts: [claude_prompt]
 ```
 

--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -85,9 +85,9 @@ Control which providers run specific tests using the `providers` field. This all
 
 ```yaml
 providers:
-  - id: openai:gpt-3.5-turbo
+  - id: openai:gpt-5-mini
     label: fast-model
-  - id: openai:gpt-4
+  - id: openai:gpt-5.6
     label: smart-model
 
 tests:
@@ -112,12 +112,12 @@ tests:
 
 **Matching syntax:**
 
-| Pattern        | Matches                                                              |
-| -------------- | -------------------------------------------------------------------- |
-| `fast-model`   | Exact label match                                                    |
-| `openai:gpt-4` | Exact provider ID match                                              |
-| `openai:*`     | Wildcard - any provider starting with `openai:`                      |
-| `openai`       | Legacy prefix - matches `openai:gpt-4`, `openai:gpt-3.5-turbo`, etc. |
+| Pattern          | Matches                                                             |
+| ---------------- | ------------------------------------------------------------------- |
+| `fast-model`     | Exact label match                                                   |
+| `openai:gpt-5.6` | Exact provider ID match                                             |
+| `openai:*`       | Wildcard - any provider starting with `openai:`                     |
+| `openai`         | Legacy prefix - matches `openai:gpt-5.6`, `openai:gpt-5-mini`, etc. |
 
 **Apply to all tests using `defaultTest`:**
 
@@ -156,7 +156,7 @@ prompts:
     raw: 'You are a creative writer. Answer: {{question}}'
 
 providers:
-  - openai:gpt-4o-mini
+  - openai:gpt-5-mini
 
 tests:
   # This test only runs with the Factual Assistant prompt

--- a/site/docs/configuration/tools.md
+++ b/site/docs/configuration/tools.md
@@ -309,7 +309,7 @@ providers:
         Content-Type: application/json
       transformToolsFormat: openai # Tools already in OpenAI format, pass through
       body:
-        model: gpt-4
+        model: gpt-5.6
         messages: '{{ prompt }}'
         tools: '{{ tools }}'
         tool_choice: '{{ tool_choice }}'

--- a/site/docs/configuration/tools.md
+++ b/site/docs/configuration/tools.md
@@ -82,7 +82,7 @@ Define tools in OpenAI format:
 
 ```yaml
 providers:
-  - id: openai:gpt-4
+  - id: openai:gpt-5.6
     config:
       tools:
         - type: function
@@ -181,7 +181,7 @@ Tool choice controls _when_ and _how_ the model uses the tools you've defined. B
 
 ```yaml
 providers:
-  - id: openai:gpt-4
+  - id: openai:gpt-5.6
     config:
       tools:
         - type: function
@@ -269,7 +269,7 @@ Tools can be loaded from external files:
 
 ```yaml
 providers:
-  - id: openai:gpt-4
+  - id: openai:gpt-5.6
     config:
       tools: file://tools/my-tools.json
 ```

--- a/site/docs/red-team/troubleshooting/inference-limit.md
+++ b/site/docs/red-team/troubleshooting/inference-limit.md
@@ -84,7 +84,7 @@ redteam:
   provider: file://./custom-redteam-grader-provider.ts
 
   # OR use a built-in provider for grading
-  # provider: openai:gpt-4  # Use GPT-4 to grade results
+  # provider: openai:gpt-5.6  # Use GPT-5.6 to grade results
 
   # Remote generation (open-source)
   numTests: 10
@@ -99,7 +99,7 @@ redteam:
 Using this configuration, the flow would be:
 
 1. Promptfoo generates red team probes (strategies/plugins)
-2. Target system (openai:gpt-4) responds to each probe
+2. Target system (openai:gpt-5.6) responds to each probe
 3. Your custom `redteam.provider` grades each response
 
 ## Enterprise Solutions

--- a/site/docs/red-team/troubleshooting/inference-limit.md
+++ b/site/docs/red-team/troubleshooting/inference-limit.md
@@ -75,7 +75,7 @@ You can also configure a custom `redteam.provider` that would allow you to use P
 ```yaml
 # The provider being tested (target system)
 providers:
-  - id: openai:gpt-4
+  - id: openai:gpt-5.6
     # This is what you're evaluating for safety
 
 # Red team configuration


### PR DESCRIPTION
## Summary

Follow-up to #10022. Modernizes example configs across the docs that still reference retired model IDs. Scope is illustrative **example configs** only — accurate provider model-availability reference docs (Azure, Helicone, GitHub, etc., which correctly document `gpt-4o`/`gpt-4` as real available models) are intentionally left unchanged.

| File | Change |
| --- | --- |
| `model-graded/answer-relevance.md` | `anthropic:claude-2` → `claude-sonnet-4-6` |
| `model-graded/conversation-relevance.md` | `anthropic:claude-3-7-sonnet-latest` → `claude-sonnet-4-6` |
| `model-graded/max-score.md` | `anthropic:claude-3-haiku-20240307` → `claude-haiku-4-5` |
| `configuration/parameters.md` | `anthropic:claude-3-haiku` → `claude-haiku-4-5` |
| `configuration/prompts.md` | `openai:gpt-4` → `gpt-5.6`, `anthropic:claude-3` → `claude-sonnet-4-6` |
| `configuration/tools.md` | `openai:gpt-4` (×3 `- id:` + HTTP-body `model:`) → `openai:gpt-5.6` |
| `configuration/test-cases.md` | `gpt-3.5-turbo`/`gpt-4` → `gpt-5-mini`/`gpt-5.6` — config **and** the matching-syntax table kept in sync; `gpt-4o-mini` → `gpt-5-mini` |
| `red-team/troubleshooting/inference-limit.md` | `openai:gpt-4` (target + grader + prose) → `openai:gpt-5.6` |

Cheap-grader / fast-model examples stay on the mini/Haiku tier; others use current defaults (`claude-sonnet-4-6`, `gpt-5.6`). Every target ID was verified to exist in the provider model lists.

### Review feedback addressed

Copilot flagged that `inference-limit.md` had become internally inconsistent (prose said the target was `gpt-5.6` while the YAML target was still `gpt-4`). Fixed so the config, grader, and flow prose all agree on `openai:gpt-5.6`. A follow-up audit across `- id:`, `provider:`, and `model:` field shapes then caught the remaining stale examples.

## Validation

- `cd site && SKIP_OG_GENERATION=true npm run build` — succeeds
- `npm run f` — clean
