### PR TITLE
fix(providers): render openinterpreter config before path checks

### DIFF
--- a/src/providers/openinterpreter.ts
+++ b/src/providers/openinterpreter.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import { z } from 'zod';
 import cliState from '../cliState';
+import { renderVarsInObject } from '../util/render';
 import {
   CodexAppServerConfigSchema,
   OpenAICodexAppServerProvider,
@@ -355,21 +356,26 @@ export class OpenInterpreterProvider implements ApiProvider {
         cli_config: mergeRecords(this.config.cli_config, promptConfig?.cli_config),
         cli_env: { ...(this.config.cli_env ?? {}), ...(promptConfig?.cli_env ?? {}) },
       };
-      validateThreadPersistence(effectiveConfig);
+      // Prompt-level config can reference test vars. Render before this wrapper
+      // resolves/validates paths, but avoid traversing an attached provider object.
+      const configToRender = { ...effectiveConfig };
+      delete configToRender.provider;
+      const renderedConfig = renderVarsInObject(configToRender, context?.vars);
+      validateThreadPersistence(renderedConfig);
 
-      if (!effectiveConfig.working_dir) {
+      if (!renderedConfig.working_dir) {
         temporaryWorkspace = fs.mkdtempSync(
           path.join(os.tmpdir(), 'promptfoo-openinterpreter-workspace-'),
         );
       }
-      const interpreterHome = resolveInterpreterHome(effectiveConfig) ?? this.interpreterHome;
-      const normalized = normalizePrompt(prompt, effectiveConfig, temporaryWorkspace);
+      const interpreterHome = resolveInterpreterHome(renderedConfig) ?? this.interpreterHome;
+      const normalized = normalizePrompt(prompt, renderedConfig, temporaryWorkspace);
       if (normalized.error) {
         return { error: normalized.error };
       }
 
       const mappedConfig = toCodexAppServerConfig(
-        effectiveConfig,
+        renderedConfig,
         interpreterHome,
         temporaryWorkspace,
       );
@@ -412,7 +418,7 @@ export class OpenInterpreterProvider implements ApiProvider {
           ...restMetadata,
           openInterpreter: {
             ...(isRecord(codexMetadata) ? codexMetadata : {}),
-            harness: effectiveConfig.harness,
+            harness: renderedConfig.harness,
           },
         },
       };

--- a/test/providers/openinterpreter.test.ts
+++ b/test/providers/openinterpreter.test.ts
@@ -619,6 +619,48 @@ describe('OpenInterpreterProvider', () => {
     await expect(defaultPromise).resolves.toMatchObject({ output: 'temporary' });
   });
 
+  it('renders prompt-level config templates before validating structured input paths', async () => {
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'openinterpreter-rendered-config-'));
+    temporaryRoots.push(root);
+    const workspace = path.join(root, 'workspace');
+    fs.mkdirSync(workspace);
+    fs.writeFileSync(path.join(workspace, 'inside.png'), 'fake image');
+
+    const server = createMockAppServer();
+    mocks.spawn.mockReturnValue(server.proc);
+    const providerId = vi.fn(() => 'attached-provider');
+    const attachedProvider: Record<string, unknown> = { id: providerId };
+    attachedProvider.self = attachedProvider;
+    const provider = new OpenInterpreterProvider();
+
+    const resultPromise = provider.callApi(
+      JSON.stringify([{ type: 'local_image', path: 'inside.png' }]),
+      {
+        vars: { envValue: 'rendered-env', workspaceDir: workspace },
+        prompt: {
+          raw: 'Rendered structured input',
+          config: {
+            working_dir: '{{ workspaceDir }}',
+            skip_git_repo_check: true,
+            provider: attachedProvider,
+            cli_env: { RENDERED_VALUE: '{{ envValue }}' },
+          },
+        },
+      } as any,
+    );
+
+    const { threadStart, turnStart } = await startTurn(server);
+    expect(threadStart.params.cwd).toBe(workspace);
+    expect(turnStart.params.input).toEqual([
+      { type: 'localImage', path: fs.realpathSync(path.join(workspace, 'inside.png')) },
+    ]);
+    expect(mocks.spawn.mock.calls[0][2].env.RENDERED_VALUE).toBe('rendered-env');
+    expect(providerId).not.toHaveBeenCalled();
+    completeTurn(server, 'rendered structured input');
+    await expect(resultPromise).resolves.toMatchObject({ output: 'rendered structured input' });
+  });
+
   it.each([
     ['native', 'harness=""'],
     ['claude-code', 'harness="claude-code"'],


### PR DESCRIPTION
## Summary
- Open Interpreter wraps the Codex app-server provider, which supports rendering prompt-level config templates with each row's test vars before use.
- Open Interpreter also validates structured local inputs before delegating. It was doing that validation against the unrendered merged config, so `working_dir: "{{ workspaceDir }}"` made `local_image` paths resolve under a literal template directory and fail before the runtime started.
- Render the merged Open Interpreter config before workspace/home/path handling, while dropping an attached provider object before rendering so provider methods are not traversed.
- Add a regression for templated `working_dir`, templated `cli_env`, and structured `local_image` input.

## Testing
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci`
- `npx vitest test/providers/openinterpreter.test.ts --run`
- `npx vitest test/providers/openinterpreter.test.ts test/providers/bedrock/openaiResponses.test.ts test/providers/xai/responses.test.ts test/assertions/openai.test.ts test/models/eval.test.ts test/redteam/strategies/hex.test.ts test/util/json.test.ts test/providers/openai-codex-app-server.test.ts --run`
- `npm run tsc`
- `npm run l`
- `npm run f`
- `git diff --check`