### PR TITLE
fix(redteam): reflow cards at tablet widths

### DIFF
--- a/src/app/src/pages/redteam/report/components/StrategyStats.test.tsx
+++ b/src/app/src/pages/redteam/report/components/StrategyStats.test.tsx
@@ -156,7 +156,7 @@ describe('StrategyStats', () => {
     });
 
     it('keeps the strategy cards single-column through tablet widths', () => {
-      const { container } = render(
+      render(
         <StrategyStats
           strategyStats={strategyStats}
           failuresByPlugin={failuresByPlugin}
@@ -165,11 +165,15 @@ describe('StrategyStats', () => {
         />,
       );
 
-      expect(container.querySelector('.grid')).toHaveClass(
+      const attackMethodsGrid = screen
+        .getByRole('region', { name: 'Attack Methods Statistics' })
+        .querySelector('.grid');
+
+      expect(attackMethodsGrid).toHaveClass(
         'grid-cols-1',
         'lg:grid-cols-[repeat(auto-fill,minmax(300px,1fr))]',
       );
-      expect(container.querySelector('.grid')).not.toHaveClass(
+      expect(attackMethodsGrid).not.toHaveClass(
         'sm:grid-cols-[repeat(auto-fill,minmax(300px,1fr))]',
       );
     });

--- a/src/app/src/pages/redteam/report/components/StrategyStats.test.tsx
+++ b/src/app/src/pages/redteam/report/components/StrategyStats.test.tsx
@@ -155,7 +155,7 @@ describe('StrategyStats', () => {
       expect(totalAttemptsValue).toBeInTheDocument();
     });
 
-    it('keeps the strategy cards within the mobile content width', () => {
+    it('keeps the strategy cards single-column through tablet widths', () => {
       const { container } = render(
         <StrategyStats
           strategyStats={strategyStats}
@@ -167,6 +167,9 @@ describe('StrategyStats', () => {
 
       expect(container.querySelector('.grid')).toHaveClass(
         'grid-cols-1',
+        'lg:grid-cols-[repeat(auto-fill,minmax(300px,1fr))]',
+      );
+      expect(container.querySelector('.grid')).not.toHaveClass(
         'sm:grid-cols-[repeat(auto-fill,minmax(300px,1fr))]',
       );
     });

--- a/src/app/src/pages/redteam/report/components/StrategyStats.tsx
+++ b/src/app/src/pages/redteam/report/components/StrategyStats.tsx
@@ -448,7 +448,7 @@ const StrategyStats = ({
       >
         <CardContent className="p-6">
           <h2 className="mb-4 text-xl font-semibold">Attack Methods</h2>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-[repeat(auto-fill,minmax(300px,1fr))]">
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-[repeat(auto-fill,minmax(300px,1fr))]">
             {strategies.map(([strategy, { total, failCount }]) => {
               const asr = calculateAttackSuccessRate(total, failCount);
               return (


### PR DESCRIPTION
## Summary

- keep attack-method cards single-column through tablet widths
- restore the existing auto-fill multi-column layout at the desktop breakpoint
- add focused coverage for the responsive class contract

## Tests

- `npm run test:app -- src/pages/redteam/report/components/StrategyStats.test.tsx --run` (19 passed)
- `npm --prefix src/app run tsc -- --noEmit`
- `npm exec -- biome check src/app/src/pages/redteam/report/components/StrategyStats.tsx src/app/src/pages/redteam/report/components/StrategyStats.test.tsx`
- `git diff --check`

The responsive regression was proven fail-first against the previous `sm:` breakpoint before the fix was restored.

## Risk and rollback

Risk is limited to the report's attack-method card layout between the small and large breakpoints. Accessibility and card interaction semantics are unchanged. Roll back by reverting this PR.
