### PR TITLE
refactor(providers): simplify Vertex cache hashing

### DIFF
--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -144,7 +144,7 @@ function getVertexBodyCacheKey(prefix: string, body: unknown, apiHost: string): 
   return `${prefix}:${createHmac('sha256', 'promptfoo:vertex:cache-key:v1')
     .update(apiHost)
     .update('\0')
-    .update(serialized ?? String(body))
+    .update(serialized)
     .digest('hex')}`;
 }
 


### PR DESCRIPTION
## Summary
- remove the unreachable fallback from Vertex request-body cache hashing
- preserve the existing HMAC cache-key structure and serialized request input

## Validation
- npx vitest run test/providers/google/vertex.test.ts --sequence.shuffle=false
- npm run l
- npm run f
- npm run tsc