### PR TITLE
fix(python): keep worker control markers on their own line

### DIFF
--- a/src/python/persistent_wrapper.py
+++ b/src/python/persistent_wrapper.py
@@ -439,7 +439,7 @@ def handle_call(command_line, user_module, default_function_name):
 
         # Signal completion with the response path so provider stdout cannot
         # accidentally satisfy another request's control message.
-        print(f"DONE|{response_file}", flush=True)
+        print(f"\nDONE|{response_file}", flush=True)
 
     except Exception as e:
         print(f"ERROR handling call: {e}", file=sys.stderr, flush=True)
@@ -468,7 +468,7 @@ def handle_call(command_line, user_module, default_function_name):
                 )
 
             # Signal done so Node can read the error response.
-            print(f"DONE|{response_file}", flush=True)
+            print(f"\nDONE|{response_file}", flush=True)
         # No DONE| when response_file is unknown: Node's path match would fail
         # and the call would resolve via timeout anyway; the stderr is the signal.
 

--- a/src/python/persistent_wrapper.py
+++ b/src/python/persistent_wrapper.py
@@ -8,8 +8,13 @@ via a simple control protocol over stdin/stdout.
 Protocol:
   - Node sends: "CALL|<function_name>|<request_file>|<response_file>\n"
   - Worker executes function, writes response to file
-  - Worker sends: "DONE|<response_file>\n"
+  - Worker sends: "\nDONE|<response_file>\n"
   - Node sends: "SHUTDOWN\n" to exit
+
+Control messages (READY, DONE|) are matched line-anchored by Node, so they are
+emitted with a leading newline: user code may leave stdout mid-line (a write
+without a trailing newline), and a control marker glued onto that partial line
+would never match.
 
 Data transfer uses files (proven UTF-8 handling), control uses stdin/stdout.
 Note: Using pipe (|) delimiter to avoid conflicts with Windows drive letters (C:).
@@ -341,8 +346,9 @@ def main():
         print(traceback.format_exc(), file=sys.stderr, flush=True)
         sys.exit(1)
 
-    # Signal ready
-    print("READY", flush=True)
+    # Signal ready. Leading newline: the user module may have left stdout
+    # mid-line during import (same rationale as the \nDONE| signals below).
+    print("\nREADY", flush=True)
 
     # Main loop - wait for commands
     while True:

--- a/src/python/persistent_wrapper_test.py
+++ b/src/python/persistent_wrapper_test.py
@@ -339,6 +339,30 @@ class TestMain(unittest.TestCase):
         finally:
             os.unlink(script_path)
 
+    def test_ready_signal_survives_partial_stdout_during_import(self) -> None:
+        """Regression (#10097): a user module that leaves stdout mid-line at
+        import time must not clobber the READY marker - Node matches it as a
+        whole line."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write('import sys\nsys.stdout.write("loading")\ndef test_func(): pass\n')
+            f.flush()
+            script_path = f.name
+
+        try:
+            stdout_capture = io.StringIO()
+            stdin_mock = io.StringIO("SHUTDOWN\n")
+
+            with patch.object(
+                sys, "argv", ["persistent_wrapper.py", script_path, "test_func"]
+            ):
+                with patch("sys.stdin", stdin_mock):
+                    with patch("sys.stdout", stdout_capture):
+                        persistent_wrapper.main()
+
+            self.assertIn("READY", stdout_capture.getvalue().splitlines())
+        finally:
+            os.unlink(script_path)
+
     def test_handles_stdin_close(self) -> None:
         """Tests graceful exit when stdin is closed."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
@@ -451,6 +475,33 @@ class TestHandleCall(unittest.TestCase):
             response = json.load(f)
         self.assertEqual(response["type"], "result")
         self.assertEqual(response["data"], 5)
+
+    def test_done_marker_starts_own_line_after_partial_stdout(self) -> None:
+        """Regression (#10097): user code that leaves stdout mid-line must not
+        clobber the DONE| marker - Node matches it line-anchored."""
+
+        def partial_stdout_func():
+            sys.stdout.write("partial provider output")
+            return {"ok": True}
+
+        self.mock_module.partial_stdout_func = partial_stdout_func
+        with open(self.request_file, "w") as f:
+            json.dump([], f)
+
+        stdout_capture = io.StringIO()
+        with patch("sys.stdout", stdout_capture):
+            persistent_wrapper.handle_call(
+                f"CALL|partial_stdout_func|{self.request_file}|{self.response_file}",
+                self.mock_module,
+                "default_func",
+            )
+
+        done_lines = [
+            line
+            for line in stdout_capture.getvalue().splitlines()
+            if line.startswith("DONE|")
+        ]
+        self.assertEqual(done_lines, [f"DONE|{self.response_file}"])
 
     def test_legacy_format_success(self) -> None:
         """Tests successful CALL with legacy 3-part format."""

--- a/test/python/worker.test.ts
+++ b/test/python/worker.test.ts
@@ -315,6 +315,7 @@ describeOrSkip('PythonWorker', () => {
   let loggingWorker: PythonWorker;
   let protocolCollisionWorker: PythonWorker;
   let forgedMarkerWorker: PythonWorker;
+  let noNewlineWorker: PythonWorker;
   const fixturesDir = path.join(__dirname, 'fixtures');
   const testScriptPath = path.join(__dirname, 'fixtures', 'simple_provider.py');
   const multiApiPath = path.join(__dirname, 'fixtures', 'multi_api_provider.py');
@@ -325,6 +326,7 @@ describeOrSkip('PythonWorker', () => {
   const loggingPath = path.join(__dirname, 'fixtures', 'logging_provider.py');
   const protocolCollisionPath = path.join(__dirname, 'fixtures', 'protocol_collision_provider.py');
   const forgedMarkerPath = path.join(__dirname, 'fixtures', 'forged_marker_provider.py');
+  const noNewlinePath = path.join(__dirname, 'fixtures', 'no_trailing_newline_provider.py');
 
   beforeAll(async () => {
     // Create test fixture
@@ -405,6 +407,23 @@ def call_api(prompt, options, context):
 `,
     );
 
+    // Leaves the stdout cursor mid-line at import time and per call. Pre-fix,
+    // the wrapper's READY / DONE|<path> markers glued onto the partial line
+    // ("loading moduleREADY", "...DONE|/path"), Node's line-anchored matches
+    // never fired, and init/calls hung until their timeouts.
+    await fs.promises.writeFile(
+      noNewlinePath,
+      `
+import sys
+
+sys.stdout.write("loading module")
+
+def call_api(prompt, options, context):
+    sys.stdout.write(f"partial output for {prompt}")
+    return {"output": f"Completed: {prompt}"}
+`,
+    );
+
     await Promise.all([
       fs.promises.access(nonexistentPath),
       fs.promises.access(wrongNamePath),
@@ -420,6 +439,7 @@ def call_api(prompt, options, context):
     loggingWorker = new PythonWorker(loggingPath, 'call_api');
     protocolCollisionWorker = new PythonWorker(protocolCollisionPath, 'call_api');
     forgedMarkerWorker = new PythonWorker(forgedMarkerPath, 'call_api');
+    noNewlineWorker = new PythonWorker(noNewlinePath, 'call_api');
 
     await Promise.all([
       sharedWorker.initialize(),
@@ -431,6 +451,7 @@ def call_api(prompt, options, context):
       loggingWorker.initialize(),
       protocolCollisionWorker.initialize(),
       forgedMarkerWorker.initialize(),
+      noNewlineWorker.initialize(),
     ]);
   });
 
@@ -446,6 +467,7 @@ def call_api(prompt, options, context):
         loggingWorker,
         protocolCollisionWorker,
         forgedMarkerWorker,
+        noNewlineWorker,
       ]
         .filter((worker): worker is PythonWorker => Boolean(worker))
         .map((worker) => worker.shutdown()),
@@ -458,6 +480,7 @@ def call_api(prompt, options, context):
       loggingPath,
       protocolCollisionPath,
       forgedMarkerPath,
+      noNewlinePath,
     ]) {
       if (fs.existsSync(fixturePath)) {
         fs.unlinkSync(fixturePath);
@@ -580,6 +603,22 @@ def call_api(prompt, options, context):
       expect(JSON.stringify(vi.mocked(logger.debug).mock.calls)).not.toContain(
         'sensitive-provider-marker',
       );
+    },
+    TEST_TIMEOUT,
+  );
+
+  it(
+    'should complete when provider stdout ends without a trailing newline',
+    async () => {
+      const result = (await noNewlineWorker.call('call_api', ['hello', {}, {}])) as {
+        output: string;
+      };
+      const secondResult = (await noNewlineWorker.call('call_api', ['again', {}, {}])) as {
+        output: string;
+      };
+
+      expect(result.output).toBe('Completed: hello');
+      expect(secondResult.output).toBe('Completed: again');
     },
     TEST_TIMEOUT,
   );


### PR DESCRIPTION
The messages seen by worker.ts split by newlines, and if the `DONE|` signal gets clobbered into a stdout line from agent output, then it never gets picked up by the promptfoo process and the test hangs.

ref: https://github.com/promptfoo/promptfoo/blob/0.121.17/src/python/worker.ts#L75-L87