### PR TITLE
fix: preserve session IDs in sanitized logs

### DIFF
--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -137,7 +137,6 @@ export const SECRET_FIELD_NAMES = new Set([
   'xcsrftoken', // x-csrf-token
   'xsessiondata', // x-session-data
   'csrftoken', // csrf-token
-  'sessionid', // session-id
   'session', // session
   'cookie',
   'setcookie', // set-cookie

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1405,6 +1405,21 @@ describe('logger', () => {
       );
     });
 
+    it('should preserve session IDs while sanitizing credentials', () => {
+      logger.setStructuredLogging(true);
+
+      logger.default.info('session event', {
+        sessionID: 'session-123',
+        apiKey: 'secret-key',
+      });
+
+      expect(customLogger.info).toHaveBeenCalledWith({
+        message: 'session event',
+        sessionID: 'session-123',
+        apiKey: '[REDACTED]',
+      });
+    });
+
     it('should pass plain string when no context provided', () => {
       logger.setStructuredLogging(true);
 

--- a/test/providers/http/core.test.ts
+++ b/test/providers/http/core.test.ts
@@ -1862,7 +1862,7 @@ describe('HttpProvider', () => {
       });
     });
 
-    it('should redact various authentication header patterns', async () => {
+    it('should redact authentication headers while preserving session IDs', async () => {
       const provider = new HttpProvider(mockUrl, {
         config: {
           method: 'GET',
@@ -1909,7 +1909,7 @@ describe('HttpProvider', () => {
         Password: '[REDACTED]',
         Cookie: '[REDACTED]',
         'X-CSRF-Token': '[REDACTED]',
-        'Session-Id': '[REDACTED]',
+        'Session-Id': 'session456',
         'Content-Type': 'application/json',
         Accept: 'application/json',
         'User-Agent': 'test-agent',

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -481,6 +481,17 @@ describe('sanitizeObject', () => {
         expect(sanitizeObject({ 'x-auth': 'token123' })).toEqual({ 'x-auth': '[REDACTED]' });
       });
 
+      it('should preserve session ID fields', () => {
+        const sessionIds = {
+          sessionId: 'session-camel',
+          sessionID: 'session-capitalized',
+          session_id: 'session-snake',
+          'session-id': 'session-kebab',
+        };
+
+        expect(sanitizeObject(sessionIds)).toEqual(sessionIds);
+      });
+
       it('should redact cookie', () => {
         expect(sanitizeObject({ cookie: 'session=abc123' })).toEqual({ cookie: '[REDACTED]' });
       });
@@ -1192,6 +1203,12 @@ describe('sanitizeObject', () => {
       expect(result.requestBody).not.toContain('plain-secret');
     });
 
+    it('should preserve session IDs in URL-encoded request bodies', () => {
+      const requestBody = 'sessionID=session-123&session_id=session-456';
+
+      expect(sanitizeObject({ requestBody })).toEqual({ requestBody });
+    });
+
     it('should not collapse multiline key-value diagnostic text into one form field', () => {
       const text = 'token=short-value\nowner=user@example.com\n';
 
@@ -1572,6 +1589,12 @@ describe('sanitizeUrl', () => {
   });
 
   describe('query parameter sanitization', () => {
+    it('should preserve session ID parameters', () => {
+      const url = 'https://example.com/api?sessionID=session-123&session_id=session-456';
+
+      expect(sanitizeUrl(url)).toBe(url);
+    });
+
     describe('api key patterns', () => {
       it('should redact api_key parameter', () => {
         const url = 'https://example.com/api?api_key=secret123&data=public';


### PR DESCRIPTION
## Summary

- Preserve `sessionId`, `sessionID`, `session_id`, and `session-id` fields during sanitization.
- Preserve session ID values in structured log context, URL query parameters, and form-encoded request bodies.
- Continue redacting credentials, cookies, and generic `session` fields.

## Why

Promptfoo uses session IDs as operational metadata for tracing requests and debugging session continuity. The shared secret-field list classified the normalized `sessionid` field as a credential, so the sanitizer removed this metadata from logs and related diagnostic output.

## Validation

- `npm run l`
- `npm run f`
- `npx vitest run test/util/sanitizer.test.ts test/logger.test.ts` (301 tests passed)
- `npm run tsc`