### PR TITLE
docs(redteam): add Goblin to strategy navigation

### DIFF
--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -198,6 +198,7 @@ const redTeamSidebar = [
           'red-team/strategies/iterative',
           'red-team/strategies/meta',
           'red-team/strategies/hydra',
+          'red-team/strategies/goblin',
           'red-team/strategies/tree',
           'red-team/strategies/composite-jailbreaks',
         ],


### PR DESCRIPTION
## Summary

- add the existing Goblin strategy page to the Agentic navigation group
- place Goblin directly after Hydra so the related multi-turn strategies stay together

## Root cause

The red-team strategy sidebar is manually enumerated. Goblin already had a strategy page and catalog entry, but its route was missing from `site/sidebars.js`, so it did not appear in the docs navigation.

## Validation

- `npm run l`
- `npm run f`
- `SKIP_OG_GENERATION=true npm run build` from `site/`
- verified the rendered Hydra page sidebar contains the Goblin route and label