### PR TITLE
fix(assertions): invert score along with pass for search-rubric

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/search-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/search-rubric.md
@@ -200,6 +200,20 @@ assert:
     threshold: 0.9 # Requires 90% accuracy for economic data
 ```
 
+## Negation with `not-search-rubric`
+
+Prepend `not-` to invert the assertion — useful for "must not" criteria:
+
+```yaml
+assert:
+  - type: not-search-rubric
+    value: States a stock price that is more than 5% off the current market price
+```
+
+`not-search-rubric` passes when the rubric criterion does **not** match. The score is inverted alongside `pass` — a negated result scores `1 - score`, clamped to `[0, 1]` — so negated assertions aggregate correctly under `threshold` and weighted scoring.
+
+Transport or parse failures from the grader are reported as failures in both directions — a grader error is not treated as evidence that the criterion was or was not met, so inversion never silently turns a failed search call into a pass.
+
 ## Best Practices
 
 1. **Write clear rubrics**: Be specific about what information you expect

--- a/src/assertions/agentRubric.ts
+++ b/src/assertions/agentRubric.ts
@@ -1,5 +1,6 @@
 import { matchesAgentRubric } from '../matchers/agent';
 import { isGraderFailure } from '../matchers/llmGrading';
+import { invertScore } from '../matchers/shared';
 import invariant from '../util/invariant';
 
 import type { AssertionParams, GradingResult } from '../types/index';
@@ -37,9 +38,7 @@ export const handleAgentRubric = async ({
     return { ...resp, assertion };
   }
 
-  const score = inverse
-    ? Math.min(1, Math.max(0, 1 - (Number.isFinite(resp.score) ? resp.score : 0)))
-    : resp.score;
+  const score = inverse ? invertScore(resp.score) : resp.score;
   return {
     ...resp,
     pass: resp.pass !== inverse,

--- a/src/assertions/llmRubric.ts
+++ b/src/assertions/llmRubric.ts
@@ -1,4 +1,5 @@
 import { isGraderFailure, matchesLlmRubric } from '../matchers/llmGrading';
+import { invertScore } from '../matchers/shared';
 import invariant from '../util/invariant';
 
 import type { AssertionParams, GradingResult } from '../types/index';
@@ -39,11 +40,7 @@ export const handleLlmRubric = async ({
     return { ...resp, assertion };
   }
 
-  // Clamp only on inversion so a NaN or out-of-range grader score cannot turn
-  // `1 - score` into a misleading negative/inflated value.
-  const score = inverse
-    ? Math.min(1, Math.max(0, 1 - (Number.isFinite(resp.score) ? resp.score : 0)))
-    : resp.score;
+  const score = inverse ? invertScore(resp.score) : resp.score;
   return {
     ...resp,
     pass: resp.pass !== inverse,

--- a/src/assertions/searchRubric.ts
+++ b/src/assertions/searchRubric.ts
@@ -1,5 +1,6 @@
 import { isGraderFailure } from '../matchers/llmGrading';
 import { matchesSearchRubric } from '../matchers/search';
+import { invertScore } from '../matchers/shared';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 
@@ -32,13 +33,15 @@ export async function handleSearchRubric({
   }
 
   if (inverse) {
-    result.pass = !result.pass;
-    // Clamp only on inversion so a NaN or out-of-range grader score cannot
-    // turn `1 - score` into a misleading negative/inflated value.
-    result.score = Math.min(1, Math.max(0, 1 - (Number.isFinite(result.score) ? result.score : 0)));
-    result.reason = result.pass
-      ? `Output does not require web search verification: ${result.reason}`
-      : `Output requires web search verification: ${result.reason}`;
+    const pass = !result.pass;
+    return {
+      ...result,
+      pass,
+      score: invertScore(result.score),
+      reason: pass
+        ? `Output does not require web search verification: ${result.reason}`
+        : `Output requires web search verification: ${result.reason}`,
+    };
   }
 
   return result;

--- a/src/assertions/searchRubric.ts
+++ b/src/assertions/searchRubric.ts
@@ -1,3 +1,4 @@
+import { isGraderFailure } from '../matchers/llmGrading';
 import { matchesSearchRubric } from '../matchers/search';
 
 import type { AssertionParams, GradingResult } from '../types/index';
@@ -25,6 +26,10 @@ export async function handleSearchRubric({
     provider,
     providerCallContext,
   );
+
+  if (isGraderFailure(result)) {
+    return result;
+  }
 
   if (inverse) {
     result.pass = !result.pass;

--- a/src/assertions/searchRubric.ts
+++ b/src/assertions/searchRubric.ts
@@ -28,6 +28,9 @@ export async function handleSearchRubric({
 
   if (inverse) {
     result.pass = !result.pass;
+    // Clamp only on inversion so a NaN or out-of-range grader score cannot
+    // turn `1 - score` into a misleading negative/inflated value.
+    result.score = Math.min(1, Math.max(0, 1 - (Number.isFinite(result.score) ? result.score : 0)));
     result.reason = result.pass
       ? `Output does not require web search verification: ${result.reason}`
       : `Output requires web search verification: ${result.reason}`;

--- a/src/matchers/search.ts
+++ b/src/matchers/search.ts
@@ -6,7 +6,7 @@ import { hasWebSearchCapability, loadWebSearchProvider } from '../providers/webS
 import { extractFirstJsonObject } from '../util/json';
 import { callProviderWithContext, getGradingProvider } from './providers';
 import { loadRubricPrompt, renderLlmRubricPrompt } from './rubric';
-import { tryParse } from './shared';
+import { graderFail, tryParse } from './shared';
 
 import type {
   ApiProvider,
@@ -93,10 +93,10 @@ export async function matchesSearchRubric(
 
   if (resp.error || !resp.output) {
     return {
-      pass: false,
-      score: 0,
-      reason: `Search rubric evaluation failed: ${resp.error || 'No output'}`,
-      tokensUsed: resp.tokenUsage,
+      ...graderFail(
+        `Search rubric evaluation failed: ${resp.error || 'No output'}`,
+        resp.tokenUsage,
+      ),
       assertion,
     };
   }

--- a/src/matchers/shared.ts
+++ b/src/matchers/shared.ts
@@ -51,6 +51,16 @@ export function graderFail(
   };
 }
 
+/**
+ * Inverts a grader score for a negated assertion (the `not-` prefix).
+ *
+ * The result is clamped to `[0, 1]` so a NaN or out-of-range grader score cannot
+ * turn `1 - score` into a misleading negative/inflated value.
+ */
+export function invertScore(score: number): number {
+  return Math.min(1, Math.max(0, 1 - (Number.isFinite(score) ? score : 0)));
+}
+
 export function cosineSimilarity(vecA: number[], vecB: number[]): number {
   if (vecA.length !== vecB.length) {
     throw new Error('Vectors must be of equal length');

--- a/test/assertions/searchRubric.test.ts
+++ b/test/assertions/searchRubric.test.ts
@@ -165,6 +165,62 @@ describe('handleSearchRubric', () => {
     expect(result.score).toBeCloseTo(0.1);
   });
 
+  it('should clamp inverted score when grader emits an out-of-range score', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      inverse: true,
+      renderedValue: 'Contains outdated information',
+    };
+
+    mockMatchesSearchRubric.mockResolvedValue({ pass: true, score: 5, reason: 'matched' });
+
+    const result = await handleSearchRubric(params);
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+  });
+
+  it('should treat NaN scores as 0 when inverting', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      inverse: true,
+      renderedValue: 'Contains outdated information',
+    };
+
+    mockMatchesSearchRubric.mockResolvedValue({
+      pass: false,
+      score: Number.NaN,
+      reason: 'malformed',
+    });
+
+    const result = await handleSearchRubric(params);
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(1);
+  });
+
+  it('should propagate grader failures verbatim instead of inverting them', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      inverse: true,
+      renderedValue: 'Contains outdated information',
+    };
+
+    const graderFailure: GradingResult = {
+      pass: false,
+      score: 0,
+      reason: 'Search rubric evaluation failed: search unavailable',
+      metadata: { graderError: true },
+    };
+    mockMatchesSearchRubric.mockResolvedValue(graderFailure);
+
+    const result = await handleSearchRubric(params);
+
+    // A grader transport failure is not evidence about the criterion; it must
+    // not flip into a spurious pass (or a full inverted score) under `not-`.
+    expect(result).toEqual(graderFailure);
+  });
+
   it('should handle inverse assertion when original fails', async () => {
     const params: AssertionParams = {
       ...defaultParams,

--- a/test/assertions/searchRubric.test.ts
+++ b/test/assertions/searchRubric.test.ts
@@ -142,6 +142,29 @@ describe('handleSearchRubric', () => {
     expect(result.reason).toContain('requires web search verification');
   });
 
+  it('should invert score along with pass, not just pass/reason', async () => {
+    const params: AssertionParams = {
+      ...defaultParams,
+      inverse: true,
+      renderedValue: 'Contains outdated information',
+    };
+
+    const originalResult: GradingResult = {
+      pass: true,
+      score: 0.9,
+      reason: 'Strong match',
+    };
+
+    mockMatchesSearchRubric.mockResolvedValue(originalResult);
+
+    const result = await handleSearchRubric(params);
+
+    expect(result.pass).toBe(false);
+    // A failed inverse assertion must not still carry the original high
+    // score into weighted/threshold aggregation.
+    expect(result.score).toBeCloseTo(0.1);
+  });
+
   it('should handle inverse assertion when original fails', async () => {
     const params: AssertionParams = {
       ...defaultParams,

--- a/test/assertions/searchRubric.test.ts
+++ b/test/assertions/searchRubric.test.ts
@@ -218,7 +218,13 @@ describe('handleSearchRubric', () => {
 
     // A grader transport failure is not evidence about the criterion; it must
     // not flip into a spurious pass (or a full inverted score) under `not-`.
-    expect(result).toEqual(graderFailure);
+    // Assert literals rather than comparing to `graderFailure`: the handler
+    // mutates and returns the same object, so an identity comparison would
+    // pass even if the inversion branch had rewritten it.
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.metadata?.graderError).toBe(true);
+    expect(result.reason).toBe('Search rubric evaluation failed: search unavailable');
   });
 
   it('should handle inverse assertion when original fails', async () => {

--- a/test/assertions/searchRubric.test.ts
+++ b/test/assertions/searchRubric.test.ts
@@ -41,6 +41,14 @@ describe('handleSearchRubric', () => {
     },
   };
 
+  // Shared by the `not-search-rubric` cases below. Safe to reuse across tests:
+  // handleSearchRubric does not mutate its params.
+  const inverseParams: AssertionParams = {
+    ...defaultParams,
+    inverse: true,
+    renderedValue: 'Contains outdated information',
+  };
+
   it('should throw error when renderedValue is undefined', async () => {
     const params: AssertionParams = {
       ...defaultParams,
@@ -121,12 +129,6 @@ describe('handleSearchRubric', () => {
   });
 
   it('should handle inverse assertion (not:search-rubric)', async () => {
-    const params: AssertionParams = {
-      ...defaultParams,
-      inverse: true,
-      renderedValue: 'Contains outdated information',
-    };
-
     const originalResult: GradingResult = {
       pass: true,
       score: 1,
@@ -135,7 +137,7 @@ describe('handleSearchRubric', () => {
 
     mockMatchesSearchRubric.mockResolvedValue(originalResult);
 
-    const result = await handleSearchRubric(params);
+    const result = await handleSearchRubric(inverseParams);
 
     // Inverse should flip the pass value
     expect(result.pass).toBe(false);
@@ -143,12 +145,6 @@ describe('handleSearchRubric', () => {
   });
 
   it('should invert score along with pass, not just pass/reason', async () => {
-    const params: AssertionParams = {
-      ...defaultParams,
-      inverse: true,
-      renderedValue: 'Contains outdated information',
-    };
-
     const originalResult: GradingResult = {
       pass: true,
       score: 0.9,
@@ -157,7 +153,7 @@ describe('handleSearchRubric', () => {
 
     mockMatchesSearchRubric.mockResolvedValue(originalResult);
 
-    const result = await handleSearchRubric(params);
+    const result = await handleSearchRubric(inverseParams);
 
     expect(result.pass).toBe(false);
     // A failed inverse assertion must not still carry the original high
@@ -166,46 +162,28 @@ describe('handleSearchRubric', () => {
   });
 
   it('should clamp inverted score when grader emits an out-of-range score', async () => {
-    const params: AssertionParams = {
-      ...defaultParams,
-      inverse: true,
-      renderedValue: 'Contains outdated information',
-    };
-
     mockMatchesSearchRubric.mockResolvedValue({ pass: true, score: 5, reason: 'matched' });
 
-    const result = await handleSearchRubric(params);
+    const result = await handleSearchRubric(inverseParams);
 
     expect(result.pass).toBe(false);
     expect(result.score).toBe(0);
   });
 
   it('should treat NaN scores as 0 when inverting', async () => {
-    const params: AssertionParams = {
-      ...defaultParams,
-      inverse: true,
-      renderedValue: 'Contains outdated information',
-    };
-
     mockMatchesSearchRubric.mockResolvedValue({
       pass: false,
       score: Number.NaN,
       reason: 'malformed',
     });
 
-    const result = await handleSearchRubric(params);
+    const result = await handleSearchRubric(inverseParams);
 
     expect(result.pass).toBe(true);
     expect(result.score).toBe(1);
   });
 
   it('should propagate grader failures verbatim instead of inverting them', async () => {
-    const params: AssertionParams = {
-      ...defaultParams,
-      inverse: true,
-      renderedValue: 'Contains outdated information',
-    };
-
     const graderFailure: GradingResult = {
       pass: false,
       score: 0,
@@ -214,13 +192,13 @@ describe('handleSearchRubric', () => {
     };
     mockMatchesSearchRubric.mockResolvedValue(graderFailure);
 
-    const result = await handleSearchRubric(params);
+    const result = await handleSearchRubric(inverseParams);
 
     // A grader transport failure is not evidence about the criterion; it must
     // not flip into a spurious pass (or a full inverted score) under `not-`.
-    // Assert literals rather than comparing to `graderFailure`: the handler
-    // mutates and returns the same object, so an identity comparison would
-    // pass even if the inversion branch had rewritten it.
+    // Assert literals rather than comparing to `graderFailure`: the early
+    // return hands back the matcher's own object, so an identity comparison
+    // would pass even if the inversion branch had rewritten it.
     expect(result.pass).toBe(false);
     expect(result.score).toBe(0);
     expect(result.metadata?.graderError).toBe(true);
@@ -228,12 +206,6 @@ describe('handleSearchRubric', () => {
   });
 
   it('should handle inverse assertion when original fails', async () => {
-    const params: AssertionParams = {
-      ...defaultParams,
-      inverse: true,
-      renderedValue: 'Contains outdated information',
-    };
-
     const originalResult: GradingResult = {
       pass: false,
       score: 0,
@@ -242,7 +214,7 @@ describe('handleSearchRubric', () => {
 
     mockMatchesSearchRubric.mockResolvedValue(originalResult);
 
-    const result = await handleSearchRubric(params);
+    const result = await handleSearchRubric(inverseParams);
 
     // Inverse should flip the pass value
     expect(result.pass).toBe(true);

--- a/test/matchers/search-rubric.test.ts
+++ b/test/matchers/search-rubric.test.ts
@@ -171,6 +171,9 @@ describe('matchesSearchRubric', () => {
         pass: false,
         score: 0,
         reason: 'Search rubric evaluation failed: search unavailable',
+        // Tagged so inverse-aware callers propagate the failure verbatim
+        // instead of flipping a transport error into a spurious pass.
+        metadata: { graderError: true },
       }),
     );
   });


### PR DESCRIPTION
## Problem

Every sibling model-graded assertion handler (`llmRubric`, `agentRubric`, `classifier`, `moderation`, `bleu`/`gleu`, `perplexity`) inverts `score` alongside `pass` when the assertion is negated (`not:search-rubric`). `handleSearchRubric` only flipped `pass`/`reason`, leaving the original `score` untouched — a FAILED inverse assertion still contributed its original high score to weighted/threshold aggregation (`AssertionsResult` sums `score*weight` independent of `pass`), and a passing inverse assertion could show a near-zero score.

## Fix

Mirror `llmRubric`'s clamped `1 - score` inversion (clamping only on inversion so a `NaN` or out-of-range grader score can't produce a misleading negative/inflated value).

## Testing

- New test asserts score inversion alongside pass/reason for `not:search-rubric` — existing inverse tests only used `score` values of `0`/`1`, which coincidentally can't reveal this bug since neither asserted on `score` at all.
- Confirmed red→green: reverting only `searchRubric.ts` reproduces `expected 0.9 to be close to 0.1`; reapplying passes.
- Full `test/assertions/`: 1325 passed.
- `biome check` — clean.
- xref: #9939 ("feat(assertions): add grader variable allowlists") also touches `searchRubric.ts` but not the inversion logic — no overlap.

## Disclosure

Found and fixed with AI-assisted code review (Claude Code) as part of a broader pass over `src/assertions/`; I wrote/ran the repro and tests myself and reviewed the diff before opening this PR.