### PR TITLE
fix(deps): align Renovate npm registry

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "constraints": {
     "npm": ">= 11"
   },
+  "npmrc": "registry=https://registry.npmjs.org/\nengine-strict=true",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [


### PR DESCRIPTION
## Summary
- set Renovate npmrc to the public npm registry host used by checked-in lockfiles
- preserve engine-strict during Renovate lockfile generation
- keep npm allow-remote protection intact while avoiding false remote classification for registry tarballs

## Why
Renovate PR #10101 fails artifact generation with EALLOWREMOTE for an ordinary registry.npmjs.org Tailwind optional tarball. Both repository lockfiles resolve only from registry.npmjs.org, but Mend hosted Renovate appears to generate lockfiles with a different configured registry host. npm 11.15 classifies that host mismatch as remote.

## Validation
- jq empty renovate.json
- npm run l
- npm run f
- git diff --check origin/main...HEAD
- attempted Renovate config validator; sandboxed run hit npm cache EPERM, escalated internal-registry retries hit stale ETARGET metadata, and the public-registry retry was denied by environment policy. The dedicated Validate Renovate Config CI job will provide the authoritative validator result.