### PR TITLE
fix(assertions): invert tool-call-f1 score under not-

### DIFF
--- a/src/assertions/toolCallF1.ts
+++ b/src/assertions/toolCallF1.ts
@@ -220,7 +220,9 @@ export const handleToolCallF1 = ({
 
   return {
     pass,
-    score: f1,
+    // F1 is structurally within [0, 1], so plain 1 - f1 matches the
+    // bleu/gleu inversion convention without clamping.
+    score: inverse ? 1 - f1 : f1,
     reason: pass
       ? `Tool Call F1: ${f1.toFixed(3)} (precision=${precision.toFixed(3)}, recall=${recall.toFixed(3)}). ` +
         `Expected: [${expectedList}], Called: [${actualList}]`

--- a/test/assertions/toolCallF1.test.ts
+++ b/test/assertions/toolCallF1.test.ts
@@ -410,9 +410,11 @@ describe('handleToolCallF1', () => {
 
       const result = handleToolCallF1(params);
 
-      // F1=1.0 would normally pass, but inverse makes it fail
+      // F1=1.0 would normally pass, but inverse makes it fail — and the
+      // inverted score (0) must not feed the original full score into
+      // weighted/threshold aggregation.
       expect(result.pass).toBe(false);
-      expect(result.score).toBe(1);
+      expect(result.score).toBe(0);
     });
 
     it('should pass inverse assertion when F1 is below threshold', () => {
@@ -423,9 +425,32 @@ describe('handleToolCallF1', () => {
 
       const result = handleToolCallF1(params);
 
-      // F1=0 would normally fail, but inverse makes it pass
+      // F1=0 would normally fail, but inverse makes it pass with full score
       expect(result.pass).toBe(true);
-      expect(result.score).toBe(0);
+      expect(result.score).toBe(1);
+    });
+
+    it('should invert mid-range scores, not just the 0/1 extremes', () => {
+      // expected {get_weather, search}, called {get_weather, calculator, search}:
+      // precision=2/3, recall=1 -> F1=0.8
+      const output = {
+        tool_calls: [
+          { function: { name: 'get_weather', arguments: '{}' } },
+          { function: { name: 'calculator', arguments: '{}' } },
+          { function: { name: 'search', arguments: '{}' } },
+        ],
+      };
+      const params = createParams(output, ['get_weather', 'search'], {
+        inverse: true,
+        threshold: 0.5,
+      });
+
+      const result = handleToolCallF1(params);
+
+      // F1=0.8 >= 0.5 would normally pass, so the inverse fails — with the
+      // inverted score 0.2 rather than the raw 0.8.
+      expect(result.pass).toBe(false);
+      expect(result.score).toBeCloseTo(0.2);
     });
   });
 


### PR DESCRIPTION
## Problem

`handleToolCallF1` flips `pass` for `not-tool-call-f1` but returns the raw F1 as `score`. A failed inverse assertion therefore still contributes its original high score to weighted/threshold aggregation (`AssertionsResult` sums `score*weight` independent of `pass`), and a passing inverse assertion reports a near-zero score. Verified empirically on main: inverse + perfect tool match returns `{ pass: false, score: 1 }`.

Two existing tests locked in the wrong behavior (`score: 1` on a failed inverse, `score: 0` on a passing one).

This is the same bug class fixed for `search-rubric` in #10103; `bleu`/`gleu`/`llm-rubric` all already invert (`gleu.ts`: `score: inverse ? 1 - score : score`).

## Fix

Mirror the `bleu`/`gleu` convention: `score: inverse ? 1 - f1 : f1`. No clamp needed — F1 is structurally within [0, 1] (harmonic mean of set-derived precision/recall behind a `precision + recall > 0` guard).

## Test plan

- Corrected the two inverse-test expectations (failed inverse → 0, passing inverse → 1).
- Added a mid-range case (F1=0.8, threshold 0.5, inverse → fails with score 0.2) so the inversion isn't coincidentally invisible at the 0/1 extremes.
- `npx vitest run test/assertions/toolCallF1.test.ts` — 34/34 pass; red/green verified against the unfixed handler.