### PR TITLE
fix(azure): avoid crash on empty completion choices

### DIFF
--- a/src/providers/azure/completion.ts
+++ b/src/providers/azure/completion.ts
@@ -92,13 +92,16 @@ export class AzureCompletionProvider extends AzureGenericProvider {
         };
       }
 
-      const choice = data.choices[0];
+      // Optional-chain choices so an empty array or a degenerate 200 response
+      // with no `choices` takes the graceful no-output path instead of throwing,
+      // matching the chat path (#9867).
+      const choice = data.choices?.[0];
       const finishReason = normalizeFinishReason(choice?.finish_reason);
 
       // Check if content was filtered based on finish_reason
       const contentFilterTriggered = finishReason === 'content_filter';
 
-      let output = choice.text;
+      let output = choice?.text;
       if (output == null) {
         if (contentFilterTriggered) {
           output =

--- a/test/providers/azure/completion.test.ts
+++ b/test/providers/azure/completion.test.ts
@@ -130,6 +130,43 @@ describe('AzureCompletionProvider', () => {
     );
   });
 
+  it('returns graceful output instead of crashing on an empty choices array', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValueOnce({
+      data: {
+        choices: [],
+        usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
+      },
+      cached: false,
+    } as any);
+
+    const provider = new AzureCompletionProvider('test', {
+      config: { apiHost: 'test.azure.com' },
+    });
+    setAuthHeaders(provider);
+
+    const result = await provider.callApi('test prompt');
+    expect(result.error).toBeUndefined();
+    expect(result.output).toBe('');
+  });
+
+  it('returns graceful output when the response has no choices field', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValueOnce({
+      data: {
+        usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
+      },
+      cached: false,
+    } as any);
+
+    const provider = new AzureCompletionProvider('test', {
+      config: { apiHost: 'test.azure.com' },
+    });
+    setAuthHeaders(provider);
+
+    const result = await provider.callApi('test prompt');
+    expect(result.error).toBeUndefined();
+    expect(result.output).toBe('');
+  });
+
   it('should handle API errors', async () => {
     vi.mocked(fetchWithCache).mockRejectedValueOnce(new Error('API Error'));
 


### PR DESCRIPTION
## Summary

`AzureCompletionProvider.callApi` read `data.choices[0].text` directly. An empty `choices` array — or a degenerate 200 response with no `choices` field — makes `data.choices[0]` (or `choice`) undefined, so `choice.text` threw a `TypeError` that the surrounding catch turned into an opaque `API response error: TypeError...` instead of a usable result.

Interestingly the same function already optional-chains `choice?.finish_reason` and `choice?.content_filter_results`, so only `data.choices[0]` and `choice.text` were left unguarded.

This optional-chains both so those responses take the same graceful no-output path (empty output, or the content-filter fallback) that the chat path already takes since #9867. Empty/missing choices now return `output: ''` with no error.

## Test

Added two regression tests in `test/providers/azure/completion.test.ts`: an empty `choices: []` array and a response with no `choices` field both return graceful empty output instead of an error. The full azure completion suite passes (13 tests) locally.
