### PR TITLE
docs(site): refresh Langfuse model example

### DIFF
--- a/site/docs/integrations/langfuse.md
+++ b/site/docs/integrations/langfuse.md
@@ -79,7 +79,7 @@ prompts:
   - 'langfuse://chat-prompt:2:chat' # Numeric → version 2
 
 providers:
-  - openai:gpt-5-mini
+  - openai:gpt-5.4-mini
 
 tests:
   - vars:


### PR DESCRIPTION
## Summary

- refresh the Langfuse integration example to use openai:gpt-5.4-mini
- resolve the current GitHub Security AI finding without adopting its stale gpt-4o-mini suggestion

## Validation

- Prettier check for site/docs/integrations/langfuse.md
- TypeScript no-emit check
- git diff --check

## Notes

- The isolated worktree had incomplete local npm executable links, so the checks used the matching dependency tree from the main checkout.
- Local Docusaurus build output was not usable in this worktree; the PR docs CI is the authoritative build gate.
