### PR TITLE
fix(providers): preserve Responses schema strict false

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -1541,9 +1541,18 @@ The Responses API uses the flattened format:
     },
     "required": ["event_name", "date", "location"],
     "additionalProperties": false
-  }
+  },
+  "strict": true
 }
 ```
+
+`strict` is optional and defaults to `true`. Set it to `false` when your schema uses
+JSON Schema keywords that [strict mode does not support](https://platform.openai.com/docs/guides/structured-outputs#supported-schemas)
+(for example `minimum`/`maximum`, `pattern`, or omitting `additionalProperties: false`).
+An explicit `false` is passed through to the API rather than being forced to `true`. The
+nested `json_schema.strict` form is also honored and takes precedence over a top-level
+`strict`. This applies to the `openai:responses`, `azure:responses`, and `xai:responses`
+providers.
 
 You can also use nested file references for the schema itself, which is useful for sharing schemas across multiple response formats:
 

--- a/src/providers/azure/responses.ts
+++ b/src/providers/azure/responses.ts
@@ -184,13 +184,14 @@ export class AzureResponsesProvider extends AzureGenericProvider {
         const schema = responseFormat.schema || responseFormat.json_schema?.schema;
         const schemaName =
           responseFormat.json_schema?.name || responseFormat.name || 'response_schema';
+        const strict = responseFormat.json_schema?.strict ?? responseFormat.strict ?? true;
 
         textFormat = {
           format: {
             type: 'json_schema',
             name: schemaName,
             schema,
-            strict: true,
+            strict,
           },
         };
       } else {

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -939,13 +939,14 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
         const schema = responseFormat.schema || responseFormat.json_schema?.schema;
         const schemaName =
           responseFormat.json_schema?.name || responseFormat.name || 'response_schema';
+        const strict = responseFormat.json_schema?.strict ?? responseFormat.strict ?? true;
 
         textFormat = {
           format: {
             type: 'json_schema',
             name: schemaName,
             schema,
-            strict: true,
+            strict,
           },
         };
       } else {

--- a/src/providers/xai/responses.ts
+++ b/src/providers/xai/responses.ts
@@ -116,12 +116,13 @@ function buildTextFormat(responseFormat: any) {
   if (responseFormat.type === 'json_schema') {
     const schema = responseFormat.schema || responseFormat.json_schema?.schema;
     const schemaName = responseFormat.json_schema?.name || responseFormat.name || 'response_schema';
+    const strict = responseFormat.json_schema?.strict ?? responseFormat.strict ?? true;
     return {
       format: {
         type: 'json_schema',
         name: schemaName,
         schema,
-        strict: true,
+        strict,
       },
     };
   }

--- a/test/providers/azure/responses.test.ts
+++ b/test/providers/azure/responses.test.ts
@@ -199,6 +199,43 @@ describe('AzureResponsesProvider', () => {
       });
     });
 
+    it('should preserve explicit false for json_schema strict mode', async () => {
+      // For inline schemas, maybeLoadResponseFormatFromExternalFile should return the object unchanged
+      mockMaybeLoadResponseFormatFromExternalFile.mockImplementation(function (input: any) {
+        return input;
+      });
+
+      const provider = new AzureResponsesProvider('gpt-4.1-test', {
+        config: {
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              name: 'loose_schema',
+              strict: false,
+              schema: {
+                type: 'object',
+                properties: { result: { type: 'string' } },
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+      });
+
+      const body = await provider.getAzureResponsesBody('Hello world');
+
+      expect(body.text.format).toMatchObject({
+        type: 'json_schema',
+        name: 'loose_schema',
+        schema: {
+          type: 'object',
+          properties: { result: { type: 'string' } },
+          additionalProperties: false,
+        },
+        strict: false,
+      });
+    });
+
     it('should not include temperature for reasoning models', async () => {
       const provider = new AzureResponsesProvider('o1-preview', {
         config: { temperature: 0.7 },

--- a/test/providers/openai/responses/responseFormat.test.ts
+++ b/test/providers/openai/responses/responseFormat.test.ts
@@ -177,6 +177,123 @@ describe('OpenAiResponsesProvider response formats', () => {
       expect(body.text.format.strict).toBe(false);
     });
 
+    it('should default json_schema strict mode to true when not specified', async () => {
+      const mockApiResponse = {
+        id: 'resp_strict_default',
+        status: 'completed',
+        model: 'gpt-4o',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: '{"result": "success"}',
+              },
+            ],
+          },
+        ],
+        usage: { input_tokens: 15, output_tokens: 10, total_tokens: 25 },
+      };
+
+      vi.mocked(cache.fetchWithCache).mockResolvedValue({
+        data: mockApiResponse,
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const config = {
+        apiKey: 'test-key',
+        response_format: {
+          type: 'json_schema' as const,
+          json_schema: {
+            name: 'no_strict_schema',
+            schema: {
+              type: 'object' as const,
+              properties: {
+                result: { type: 'string' },
+              },
+              required: ['result'],
+              additionalProperties: false,
+            },
+          },
+        },
+      } as any;
+
+      const provider = new OpenAiResponsesProvider('gpt-4o', { config });
+
+      await provider.callApi('Test prompt');
+
+      const mockCall = vi.mocked(cache.fetchWithCache).mock.calls[0];
+      const reqOptions = mockCall[1] as { body: string };
+      const body = JSON.parse(reqOptions.body);
+
+      expect(body.text.format.type).toBe('json_schema');
+      expect(body.text.format.name).toBe('no_strict_schema');
+      expect(body.text.format.schema).toBeDefined();
+      expect(body.text.format.strict).toBe(true);
+    });
+
+    it('should preserve explicit false for top-level strict mode', async () => {
+      const mockApiResponse = {
+        id: 'resp_strict_top_level',
+        status: 'completed',
+        model: 'gpt-4o',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: '{"result": "success"}',
+              },
+            ],
+          },
+        ],
+        usage: { input_tokens: 15, output_tokens: 10, total_tokens: 25 },
+      };
+
+      vi.mocked(cache.fetchWithCache).mockResolvedValue({
+        data: mockApiResponse,
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const config = {
+        apiKey: 'test-key',
+        response_format: {
+          type: 'json_schema' as const,
+          name: 'top_level_schema',
+          strict: false,
+          schema: {
+            type: 'object' as const,
+            properties: {
+              result: { type: 'string' },
+            },
+            required: ['result'],
+            additionalProperties: false,
+          },
+        },
+      } as any;
+
+      const provider = new OpenAiResponsesProvider('gpt-4o', { config });
+
+      await provider.callApi('Test prompt');
+
+      const mockCall = vi.mocked(cache.fetchWithCache).mock.calls[0];
+      const reqOptions = mockCall[1] as { body: string };
+      const body = JSON.parse(reqOptions.body);
+
+      expect(body.text.format.type).toBe('json_schema');
+      expect(body.text.format.name).toBe('top_level_schema');
+      expect(body.text.format.schema).toBeDefined();
+      expect(body.text.format.strict).toBe(false);
+    });
+
     it('should handle json_schema format with default name when not provided', async () => {
       const mockApiResponse = {
         id: 'resp_def456',

--- a/test/providers/openai/responses/responseFormat.test.ts
+++ b/test/providers/openai/responses/responseFormat.test.ts
@@ -117,6 +117,66 @@ describe('OpenAiResponsesProvider response formats', () => {
       expect(body.text.format.strict).toBe(true);
     });
 
+    it('should preserve explicit false for json_schema strict mode', async () => {
+      const mockApiResponse = {
+        id: 'resp_strict_false',
+        status: 'completed',
+        model: 'gpt-4o',
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: '{"result": "success"}',
+              },
+            ],
+          },
+        ],
+        usage: { input_tokens: 15, output_tokens: 10, total_tokens: 25 },
+      };
+
+      vi.mocked(cache.fetchWithCache).mockResolvedValue({
+        data: mockApiResponse,
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const config = {
+        apiKey: 'test-key',
+        response_format: {
+          type: 'json_schema' as const,
+          json_schema: {
+            name: 'loose_schema',
+            strict: false,
+            schema: {
+              type: 'object' as const,
+              properties: {
+                result: { type: 'string' },
+              },
+              required: ['result'],
+              additionalProperties: false,
+            },
+          },
+        },
+      } as any;
+
+      const provider = new OpenAiResponsesProvider('gpt-4o', { config });
+
+      await provider.callApi('Test prompt');
+
+      const mockCall = vi.mocked(cache.fetchWithCache).mock.calls[0];
+      const reqOptions = mockCall[1] as { body: string };
+      const body = JSON.parse(reqOptions.body);
+
+      expect(body.text.format.type).toBe('json_schema');
+      expect(body.text.format.name).toBe('loose_schema');
+      expect(body.text.format.schema).toBeDefined();
+      expect(body.text.format.strict).toBe(false);
+    });
+
     it('should handle json_schema format with default name when not provided', async () => {
       const mockApiResponse = {
         id: 'resp_def456',

--- a/test/providers/xai/responses.test.ts
+++ b/test/providers/xai/responses.test.ts
@@ -165,6 +165,57 @@ describe('XAIResponsesProvider', () => {
     expect(body.max_tool_calls).toBe(4);
   });
 
+  it.each([
+    {
+      description: 'nested json_schema strict false',
+      response_format: {
+        type: 'json_schema',
+        json_schema: { name: 'loose_schema', strict: false, schema: { type: 'object' } },
+      },
+      expectedName: 'loose_schema',
+      expectedStrict: false,
+    },
+    {
+      description: 'top-level strict false',
+      response_format: {
+        type: 'json_schema',
+        name: 'top_level_schema',
+        strict: false,
+        schema: { type: 'object' },
+      },
+      expectedName: 'top_level_schema',
+      expectedStrict: false,
+    },
+    {
+      description: 'strict omitted defaults to true',
+      response_format: {
+        type: 'json_schema',
+        json_schema: { name: 'no_strict_schema', schema: { type: 'object' } },
+      },
+      expectedName: 'no_strict_schema',
+      expectedStrict: true,
+    },
+  ])('resolves json_schema strict mode: $description', async ({
+    response_format,
+    expectedName,
+    expectedStrict,
+  }) => {
+    const provider = new XAIResponsesProvider('grok-4.3', {
+      config: { apiKey: 'test-key', response_format },
+    });
+
+    await provider.callApi('hello');
+
+    const [, request] = mockFetchWithCache.mock.calls[0];
+    const body = JSON.parse(request.body);
+
+    expect(body.text.format).toMatchObject({
+      type: 'json_schema',
+      name: expectedName,
+      strict: expectedStrict,
+    });
+  });
+
   it('uses regional endpoints when configured', () => {
     const provider = new TestableXAIResponsesProvider('grok-4.3', {
       config: {


### PR DESCRIPTION
Preserve explicit `response_format.json_schema.strict: false` when building OpenAI and Azure Responses API request bodies.

## What Problem This Solves

OpenAI Responses and Azure Responses both accepted `response_format` objects that include `json_schema.strict`, but their request builders always emitted `text.format.strict: true` for JSON Schema formats.

That meant an explicit user configuration like `strict: false` was indistinguishable from an omitted value by the time promptfoo sent the request. This matters because provider APIs treat strict mode as a real schema-enforcement switch, and strict mode only supports a subset of JSON Schema.

## Change

The Responses request builders now preserve the configured strict value using the same fallback shape already used by the Azure Foundry Agent provider:

```ts
const strict = responseFormat.json_schema?.strict ?? responseFormat.strict ?? true;
```

The default remains `true` when no strict value is provided. The change only affects OpenAI Responses and Azure Responses JSON Schema request body construction.

## Evidence

Before this change, both request builders hardcoded `strict: true`, so `strict: false` could not reach `text.format`.

Added focused regression coverage for both provider paths:

- OpenAI Responses preserves `body.text.format.strict === false`
- Azure Responses preserves `body.text.format.strict === false`

## Possible call chain / impact

```text
promptfoo provider config
  -> response_format: { type: json_schema, json_schema: { strict: false, ... } }
  -> maybeLoadResponseFormatFromExternalFile(...)
  -> OpenAiResponsesProvider.getOpenAiBody(...) / AzureResponsesProvider.getAzureResponsesBody(...)
  -> request text.format.strict
```

Sibling surface checked: Azure Foundry Agent already preserves `strict: false`; this PR aligns the Responses providers with that behavior without changing `json_object`, plain text, tools, or schema file loading.

## Validation

- `npm ci`
- `npx @biomejs/biome check --write src/providers/openai/responses.ts src/providers/azure/responses.ts test/providers/openai/responses/responseFormat.test.ts test/providers/azure/responses.test.ts`
- `npx vitest run test/providers/openai/responses/responseFormat.test.ts test/providers/azure/responses.test.ts` — 2 files, 50 tests passed
- `npx vitest run test/providers/openai/responses test/providers/azure/responses.test.ts` — 15 files, 237 tests passed
- `git diff --check`
- `npm run tsc`