### PR TITLE
fix(assertions): default conversation-relevance threshold to 0.5

### DIFF
--- a/examples/eval-conversation-relevance/README.md
+++ b/examples/eval-conversation-relevance/README.md
@@ -52,7 +52,7 @@ Shows a high-quality technical support conversation with a high relevance thresh
 
 ## Configuration Options
 
-- `threshold`: Minimum score required to pass (0-1)
+- `threshold`: Minimum score required to pass (0-1, default: 0.5)
 - `config.windowSize`: Number of messages in each sliding window (default: 5)
 - `provider`: Override the default grading model
 

--- a/site/docs/configuration/expected-outputs/model-graded/conversation-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/conversation-relevance.md
@@ -23,6 +23,8 @@ assert:
     threshold: 0.8
 ```
 
+The threshold defaults to `0.5` when omitted. Set it explicitly to `0` to accept any score.
+
 ## Using with conversations
 
 The assertion works with the special `_conversation` variable that contains an array of input/output pairs:

--- a/src/external/assertions/deepeval.ts
+++ b/src/external/assertions/deepeval.ts
@@ -16,6 +16,7 @@ const DEFAULT_WINDOW_SIZE = 5;
 
 export const handleConversationRelevance = async ({
   assertion,
+  inverse,
   outputString,
   prompt,
   providerCallContext,
@@ -74,7 +75,7 @@ export const handleConversationRelevance = async ({
   }
 
   const score = totalWindows > 0 ? relevantCount / totalWindows : 0;
-  const pass = score >= threshold - Number.EPSILON;
+  const pass = score >= threshold - Number.EPSILON !== inverse;
 
   // Generate a comprehensive reason if there are irrelevancies
   let reason: string;
@@ -125,7 +126,7 @@ export const handleConversationRelevance = async ({
   return {
     assertion,
     pass,
-    score,
+    score: inverse ? 1 - score : score,
     reason,
     tokensUsed: tokensUsed.total > 0 ? tokensUsed : undefined,
   };

--- a/src/external/assertions/deepeval.ts
+++ b/src/external/assertions/deepeval.ts
@@ -1,6 +1,7 @@
 // These assertions are ported from DeepEval.
 // https://docs.confident-ai.com/docs/metrics-conversation-relevancy. See APACHE_LICENSE for license.
 
+import { isGraderFailure } from '../../matchers/llmGrading';
 import { callProviderWithContext, getAndCheckProvider } from '../../matchers/providers';
 import { getDefaultProviders } from '../../providers/defaults';
 import invariant from '../../util/invariant';
@@ -56,6 +57,10 @@ export const handleConversationRelevance = async ({
       test.options,
       providerCallContext,
     );
+
+    if (isGraderFailure(result)) {
+      return { ...result, assertion };
+    }
 
     if (result.pass) {
       relevantCount++;

--- a/src/external/assertions/deepeval.ts
+++ b/src/external/assertions/deepeval.ts
@@ -1,7 +1,6 @@
 // These assertions are ported from DeepEval.
 // https://docs.confident-ai.com/docs/metrics-conversation-relevancy. See APACHE_LICENSE for license.
 
-import { isGraderFailure } from '../../matchers/llmGrading';
 import { callProviderWithContext, getAndCheckProvider } from '../../matchers/providers';
 import { getDefaultProviders } from '../../providers/defaults';
 import invariant from '../../util/invariant';
@@ -58,8 +57,16 @@ export const handleConversationRelevance = async ({
       providerCallContext,
     );
 
-    if (isGraderFailure(result)) {
-      return { ...result, assertion };
+    if (result.tokensUsed) {
+      accumulateTokenUsage(tokensUsed, result.tokensUsed);
+    }
+
+    if (result.metadata?.graderError === true) {
+      return {
+        ...result,
+        assertion,
+        tokensUsed: tokensUsed.total > 0 ? tokensUsed : undefined,
+      };
     }
 
     if (result.pass) {
@@ -69,11 +76,6 @@ export const handleConversationRelevance = async ({
       result.reason !== 'Response is not relevant to the conversation context'
     ) {
       irrelevancies.push(result.reason);
-    }
-
-    // Accumulate token usage
-    if (result.tokensUsed) {
-      accumulateTokenUsage(tokensUsed, result.tokensUsed);
     }
 
     totalWindows++;

--- a/src/external/assertions/deepeval.ts
+++ b/src/external/assertions/deepeval.ts
@@ -38,7 +38,7 @@ export const handleConversationRelevance = async ({
     ];
   }
   const windowSize = assertion.config?.windowSize || DEFAULT_WINDOW_SIZE;
-  const threshold = assertion.threshold || 0;
+  const threshold = assertion.threshold ?? 0.5;
   let relevantCount = 0;
   let totalWindows = 0;
   const irrelevancies: string[] = [];

--- a/src/external/assertions/deepeval.ts
+++ b/src/external/assertions/deepeval.ts
@@ -13,6 +13,8 @@ import type { AssertionParams, GradingResult } from '../../types/index';
 import type { Message } from '../matchers/deepeval';
 
 const DEFAULT_WINDOW_SIZE = 5;
+// DeepEval's default pass threshold for the conversation relevancy metric.
+const DEFAULT_THRESHOLD = 0.5;
 
 export const handleConversationRelevance = async ({
   assertion,
@@ -39,7 +41,7 @@ export const handleConversationRelevance = async ({
     ];
   }
   const windowSize = assertion.config?.windowSize || DEFAULT_WINDOW_SIZE;
-  const threshold = assertion.threshold ?? 0.5;
+  const threshold = assertion.threshold ?? DEFAULT_THRESHOLD;
   let relevantCount = 0;
   let totalWindows = 0;
   const irrelevancies: string[] = [];

--- a/src/external/matchers/deepeval.ts
+++ b/src/external/matchers/deepeval.ts
@@ -2,7 +2,7 @@
 // https://docs.confident-ai.com/docs/metrics-conversation-relevancy. See APACHE_LICENSE for license.
 import { callProviderWithContext, getAndCheckProvider } from '../../matchers/providers';
 import { loadRubricPrompt } from '../../matchers/rubric';
-import { fail } from '../../matchers/shared';
+import { graderFail } from '../../matchers/shared';
 import { getDefaultProviders } from '../../providers/defaults';
 import invariant from '../../util/invariant';
 import { extractJsonObjects } from '../../util/json';
@@ -86,7 +86,7 @@ export async function matchesConversationRelevance(
     providerCallContext,
   );
   if (resp.error || !resp.output) {
-    return fail(resp.error || 'No output', resp.tokenUsage);
+    return graderFail(resp.error || 'No output', resp.tokenUsage);
   }
 
   invariant(
@@ -112,6 +112,6 @@ export async function matchesConversationRelevance(
       tokensUsed: resp.tokenUsage as TokenUsage,
     };
   } catch (err) {
-    return fail(`Error parsing output: ${(err as Error).message}`, resp.tokenUsage);
+    return graderFail(`Error parsing output: ${(err as Error).message}`, resp.tokenUsage);
   }
 }

--- a/src/external/matchers/deepeval.ts
+++ b/src/external/matchers/deepeval.ts
@@ -101,6 +101,9 @@ export async function matchesConversationRelevance(
     }
 
     const result = jsonObjects[0] as VerdictResult;
+    if (result.verdict !== 'yes' && result.verdict !== 'no') {
+      throw new Error('Conversation relevance grader returned an invalid verdict');
+    }
     const pass = result.verdict === 'yes';
     const score = pass ? 1 : 0;
 

--- a/test/external/assertions.test.ts
+++ b/test/external/assertions.test.ts
@@ -340,4 +340,21 @@ describe('handleConversationRelevance', () => {
     expect(result.score).toBe(1);
     expect(result.pass).toBe(true);
   });
+
+  it('should not pass a negated assertion when the conversation grader fails', async () => {
+    const provider = createFactoryProvider({ response: { error: 'grader unavailable' } });
+    const result = await handleConversationRelevance({
+      ...defaultParams,
+      assertion: { type: 'not-conversation-relevance' },
+      inverse: true,
+      prompt: 'What is the weather like?',
+      outputString: 'The capital of France is Paris.',
+      test: { vars: {}, options: { provider } },
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.reason).toContain('grader unavailable');
+    expect(result.metadata).toEqual({ graderError: true });
+  });
 });

--- a/test/external/assertions.test.ts
+++ b/test/external/assertions.test.ts
@@ -357,4 +357,38 @@ describe('handleConversationRelevance', () => {
     expect(result.reason).toContain('grader unavailable');
     expect(result.metadata).toEqual({ graderError: true });
   });
+
+  it('should preserve prior conversation-grader usage when a later window fails', async () => {
+    const provider = createFactoryProvider({
+      callApi: vi
+        .fn<ApiProvider['callApi']>()
+        .mockResolvedValueOnce({
+          output: JSON.stringify({ verdict: 'yes' }),
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        })
+        .mockResolvedValueOnce({
+          error: 'grader unavailable',
+          tokenUsage: { total: 12, prompt: 7, completion: 5 },
+        }),
+    });
+
+    const result = await handleConversationRelevance({
+      ...defaultParams,
+      assertion: { type: 'not-conversation-relevance' },
+      inverse: true,
+      test: {
+        vars: {
+          _conversation: [
+            { input: 'First question', output: 'First answer' },
+            { input: 'Second question', output: 'Second answer' },
+          ],
+        },
+        options: { provider },
+      },
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.tokensUsed).toMatchObject({ total: 22, prompt: 12, completion: 10 });
+  });
 });

--- a/test/external/assertions.test.ts
+++ b/test/external/assertions.test.ts
@@ -318,4 +318,26 @@ describe('handleConversationRelevance', () => {
     expect(result.score).toBe(0);
     expect(result.pass).toBe(true);
   });
+
+  it('should honor an omitted threshold for a negated assertion', async () => {
+    const provider = createMockProvider('no');
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: {
+        type: 'not-conversation-relevance',
+      },
+      inverse: true,
+      prompt: 'What is the weather like?',
+      outputString: 'The capital of France is Paris.',
+      test: {
+        vars: {},
+        options: { provider },
+      },
+    };
+
+    const result = await handleConversationRelevance(params);
+
+    expect(result.score).toBe(1);
+    expect(result.pass).toBe(true);
+  });
 });

--- a/test/external/assertions.test.ts
+++ b/test/external/assertions.test.ts
@@ -358,6 +358,23 @@ describe('handleConversationRelevance', () => {
     expect(result.metadata).toEqual({ graderError: true });
   });
 
+  it('should not pass a negated assertion when the conversation grader returns an invalid verdict', async () => {
+    const provider = createMockProvider('maybe');
+    const result = await handleConversationRelevance({
+      ...defaultParams,
+      assertion: { type: 'not-conversation-relevance' },
+      inverse: true,
+      prompt: 'What is the weather like?',
+      outputString: 'The capital of France is Paris.',
+      test: { vars: {}, options: { provider } },
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.reason).toContain('invalid verdict');
+    expect(result.metadata).toEqual({ graderError: true });
+  });
+
   it('should preserve prior conversation-grader usage when a later window fails', async () => {
     const provider = createFactoryProvider({
       callApi: vi

--- a/test/external/assertions.test.ts
+++ b/test/external/assertions.test.ts
@@ -17,6 +17,22 @@ const createMockProvider = (output: string, reason?: string) =>
     },
   });
 
+// Grades every conversation window as relevant except the ones whose prompt contains
+// `marker`, so a test can pin the exact relevant/total ratio the handler scores.
+const createMarkerAwareProvider = (marker: string) =>
+  createFactoryProvider({
+    callApi: vi.fn<ApiProvider['callApi']>().mockImplementation(async (prompt) => {
+      const isIrrelevant = (prompt as string).includes(marker);
+      return {
+        output: JSON.stringify({
+          verdict: isIrrelevant ? 'no' : 'yes',
+          ...(isIrrelevant && { reason: 'The response is unrelated to the question asked' }),
+        }),
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0 },
+      };
+    }),
+  });
+
 // Mock getAndCheckProvider
 vi.mock('../../src/matchers/providers', async () => {
   const actual = await vi.importActual('../../src/matchers/providers');
@@ -409,5 +425,68 @@ describe('handleConversationRelevance', () => {
     expect(result.pass).toBe(false);
     expect(result.score).toBe(0);
     expect(result.tokensUsed).toMatchObject({ total: 22, prompt: 12, completion: 10 });
+  });
+
+  // The next two tests bracket the omitted-threshold default so it cannot drift away
+  // from the documented 0.5 without a test failing.
+  it('should pass a score that lands exactly on the default threshold', async () => {
+    const conversation = [
+      { input: 'Hi', output: 'Hello! How can I help you?' },
+      { input: 'What is 2+2?', output: 'The capital of France is Paris.' }, // Irrelevant response
+    ];
+
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: {
+        type: 'conversation-relevance',
+      },
+      outputString: 'This should be ignored',
+      test: {
+        vars: {
+          _conversation: conversation,
+        },
+        options: {
+          provider: createMarkerAwareProvider('Paris'),
+        },
+      },
+    };
+
+    const result = await handleConversationRelevance(params);
+
+    // Windows are cumulative prefixes, so only the second one sees the irrelevant turn.
+    expect(result.score).toBe(0.5);
+    expect(result.pass).toBe(true);
+  });
+
+  it('should fail a score just below the default threshold', async () => {
+    const conversation = [
+      { input: 'Hi', output: 'Hello! How can I help you?' },
+      { input: 'What is the weather like?', output: 'The weather is sunny today.' },
+      { input: 'What is 2+2?', output: 'The capital of France is Paris.' }, // Irrelevant response
+      { input: 'Thanks!', output: "You're welcome! Enjoy the sunshine!" },
+      { input: 'Anything else?', output: 'Let me know if you need anything.' },
+    ];
+
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: {
+        type: 'conversation-relevance',
+      },
+      outputString: 'This should be ignored',
+      test: {
+        vars: {
+          _conversation: conversation,
+        },
+        options: {
+          provider: createMarkerAwareProvider('Paris'),
+        },
+      },
+    };
+
+    const result = await handleConversationRelevance(params);
+
+    // The last three cumulative windows all contain the irrelevant turn, so 2 of 5 pass.
+    expect(result.score).toBe(0.4);
+    expect(result.pass).toBe(false);
   });
 });

--- a/test/external/assertions.test.ts
+++ b/test/external/assertions.test.ts
@@ -376,6 +376,8 @@ describe('handleConversationRelevance', () => {
       ...defaultParams,
       assertion: { type: 'not-conversation-relevance' },
       inverse: true,
+      prompt: 'Second question',
+      outputString: 'Second answer',
       test: {
         vars: {
           _conversation: [

--- a/test/external/assertions.test.ts
+++ b/test/external/assertions.test.ts
@@ -274,4 +274,48 @@ describe('handleConversationRelevance', () => {
     expect(result.pass).toBe(true);
     expect(result.score).toBe(1);
   });
+
+  // https://github.com/promptfoo/promptfoo/issues/10141
+  it('should use the DeepEval default threshold when threshold is omitted for Issue #10141', async () => {
+    const provider = createMockProvider('no');
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: {
+        type: 'conversation-relevance',
+      },
+      prompt: 'What is the weather like?',
+      outputString: 'The capital of France is Paris.',
+      test: {
+        vars: {},
+        options: { provider },
+      },
+    };
+
+    const result = await handleConversationRelevance(params);
+
+    expect(result.score).toBe(0);
+    expect(result.pass).toBe(false);
+  });
+
+  it('should preserve an explicit zero threshold', async () => {
+    const provider = createMockProvider('no');
+    const params: AssertionParams = {
+      ...defaultParams,
+      assertion: {
+        type: 'conversation-relevance',
+        threshold: 0,
+      },
+      prompt: 'What is the weather like?',
+      outputString: 'The capital of France is Paris.',
+      test: {
+        vars: {},
+        options: { provider },
+      },
+    };
+
+    const result = await handleConversationRelevance(params);
+
+    expect(result.score).toBe(0);
+    expect(result.pass).toBe(true);
+  });
 });

--- a/test/external/conversationRelevancy.test.ts
+++ b/test/external/conversationRelevancy.test.ts
@@ -137,7 +137,7 @@ describe('handleConversationRelevance with reason generation', () => {
       callApi: vi.fn().mockImplementation(async (prompt: string) => {
         callCount++;
         // First few calls are verdicts, last one is reason generation
-        if (prompt.includes('irrelevancies')) {
+        if (prompt.includes('Below is a list of irrelevancies')) {
           // This is the reason generation call
           return {
             output: JSON.stringify({


### PR DESCRIPTION
## Summary

Fixes #10141.

`conversation-relevance` currently treats an omitted threshold as `0`. Because its score is a proportion in `[0, 1]`, even an entirely irrelevant conversation with a score of `0` passes.

This change uses the `0.5` default from DeepEval's `ConversationRelevancyMetric`. It uses nullish coalescing so an explicit `threshold: 0` remains valid, and documents both behaviors.

The regression test failed on current `main` with `score === 0` and `pass === true`. With the fix, an omitted threshold fails at that score while the explicit-zero inverse case continues to pass.

## Verification

- `npx vitest run test/external/assertions.test.ts --sequence.shuffle=false` (9 tests)
- `npx vitest run test/external/assertions.test.ts --sequence.seed=10141` (9 tests)
- `npx vitest run test/external --sequence.shuffle=false` (24 tests)
- `npm run tsc`
- `npm run architecture:check`
- `npm run build` (library and 3,297-module app build)
- Targeted Biome/Prettier formatting and `git diff --check`
