### PR TITLE
fix(providers): align Azure Responses service tier

### DIFF
--- a/src/providers/azure/responses.ts
+++ b/src/providers/azure/responses.ts
@@ -38,19 +38,21 @@ export class AzureResponsesProvider extends AzureGenericProvider {
       modelName: this.deploymentName,
       providerType: 'azure',
       functionCallbackHandler: this.functionCallbackHandler,
-      // The processor invokes costCalculator(modelName, data.usage, requestConfig). calculateAzureCost
-      // expects (modelName, config, promptTokens, completionTokens) — extract the token counts from
-      // the Responses-shaped usage object (input_tokens/output_tokens) so cost is non-zero. The
-      // request config is the effective body after passthrough fields are applied, so map its
-      // service tier into the passthrough-based cost contract to keep pricing aligned with the wire.
-      costCalculator: (modelName: string, usage: any, config?: any) =>
-        calculateAzureCost(
+      // calculateAzureCost expects (modelName, config, promptTokens, completionTokens). Extract
+      // token counts from Responses usage and map the tier Azure actually served into its
+      // passthrough-based cost contract, falling back to the effective requested tier.
+      costCalculator: (modelName: string, usage: any, config?: any, responseData?: any) => {
+        const { service_tier: requestedServiceTier, ...costConfig } = config ?? {};
+        const serviceTier = responseData?.service_tier ?? requestedServiceTier;
+        return calculateAzureCost(
           modelName,
           {
-            ...config,
+            ...costConfig,
             passthrough: {
-              ...config?.passthrough,
-              ...(config?.service_tier === undefined ? {} : { service_tier: config.service_tier }),
+              ...costConfig.passthrough,
+              ...(serviceTier === undefined || serviceTier === null
+                ? {}
+                : { service_tier: serviceTier }),
             },
           },
           usage?.prompt_tokens ?? usage?.input_tokens,
@@ -66,7 +68,8 @@ export class AzureResponsesProvider extends AzureGenericProvider {
             usage?.input_tokens_details?.cached_tokens_details?.image_tokens,
           usage?.completion_tokens_details?.image_tokens ??
             usage?.output_tokens_details?.image_tokens,
-        ),
+        );
+      },
     });
 
     if (this.config.mcp?.enabled) {
@@ -229,7 +232,9 @@ export class AzureResponsesProvider extends AzureGenericProvider {
         : {}),
       ...(config.stream ? { stream: config.stream } : {}),
       ...('store' in config ? { store: Boolean(config.store) } : {}),
-      ...(config.service_tier === undefined ? {} : { service_tier: config.service_tier }),
+      ...(config.service_tier === undefined || config.service_tier === null
+        ? {}
+        : { service_tier: config.service_tier }),
       ...(config.passthrough || {}),
     };
 

--- a/src/providers/azure/responses.ts
+++ b/src/providers/azure/responses.ts
@@ -19,21 +19,18 @@ import type {
   ProviderResponse,
 } from '../../types/index';
 import type { ReasoningEffort } from '../openai/types';
-import type { AzureChatResponsesOptions, AzureProviderOptions } from './types';
+import type { AzureProviderOptions, AzureResponsesOptions } from './types';
 
 // Azure Responses API uses the v1 preview API version
 const AZURE_RESPONSES_API_VERSION = 'preview';
 
 export class AzureResponsesProvider extends AzureGenericProvider {
-  declare config: AzureChatResponsesOptions;
+  declare config: AzureResponsesOptions;
 
   private functionCallbackHandler = new FunctionCallbackHandler();
   private processor: ResponsesProcessor;
 
-  constructor(
-    deploymentName: string,
-    options: AzureProviderOptions<AzureChatResponsesOptions> = {},
-  ) {
+  constructor(deploymentName: string, options: AzureProviderOptions<AzureResponsesOptions> = {}) {
     super(deploymentName, options);
 
     // Initialize the shared response processor
@@ -43,7 +40,9 @@ export class AzureResponsesProvider extends AzureGenericProvider {
       functionCallbackHandler: this.functionCallbackHandler,
       // The processor invokes costCalculator(modelName, data.usage, requestConfig). calculateAzureCost
       // expects (modelName, config, promptTokens, completionTokens) — extract the token counts from
-      // the Responses-shaped usage object (input_tokens/output_tokens) so cost is non-zero.
+      // the Responses-shaped usage object (input_tokens/output_tokens) so cost is non-zero. The
+      // request config is the effective body after passthrough fields are applied, so map its
+      // service tier into the passthrough-based cost contract to keep pricing aligned with the wire.
       costCalculator: (modelName: string, usage: any, config?: any) =>
         calculateAzureCost(
           modelName,
@@ -230,6 +229,7 @@ export class AzureResponsesProvider extends AzureGenericProvider {
         : {}),
       ...(config.stream ? { stream: config.stream } : {}),
       ...('store' in config ? { store: Boolean(config.store) } : {}),
+      ...(config.service_tier === undefined ? {} : { service_tier: config.service_tier }),
       ...(config.passthrough || {}),
     };
 

--- a/src/providers/azure/types.ts
+++ b/src/providers/azure/types.ts
@@ -128,7 +128,7 @@ export interface AzureResponsesOptions extends AzureChatResponsesOptions {
   /**
    * Specifies the latency tier used to process the request.
    */
-  service_tier?: 'auto' | 'default' | 'flex' | 'scale' | 'priority' | null;
+  service_tier?: 'auto' | 'default' | 'flex' | 'priority' | null;
 }
 
 export interface AzureModelCost {

--- a/src/providers/azure/types.ts
+++ b/src/providers/azure/types.ts
@@ -121,6 +121,16 @@ export interface AzureChatResponsesOptions extends AzureCompletionOptions {
   omitDefaults?: boolean;
 }
 
+/**
+ * Options specific to the Azure Responses provider.
+ */
+export interface AzureResponsesOptions extends AzureChatResponsesOptions {
+  /**
+   * Specifies the latency tier used to process the request.
+   */
+  service_tier?: 'auto' | 'default' | 'flex' | 'scale' | 'priority' | null;
+}
+
 export interface AzureModelCost {
   id: string;
   cost: {

--- a/src/providers/responses/processor.ts
+++ b/src/providers/responses/processor.ts
@@ -98,7 +98,12 @@ export class ResponsesProcessor {
       };
 
       const processedOutput = await this.processOutput(data.output, context);
-      const cost = this.config.costCalculator(this.config.modelName, data.usage, requestConfig);
+      const cost = this.config.costCalculator(
+        this.config.modelName,
+        data.usage,
+        requestConfig,
+        data,
+      );
 
       if (processedOutput.isRefusal) {
         return {

--- a/src/providers/responses/types.ts
+++ b/src/providers/responses/types.ts
@@ -4,7 +4,12 @@ export interface ProcessorConfig {
   modelName: string;
   providerType: 'openai' | 'azure' | 'xai';
   functionCallbackHandler: FunctionCallbackHandler;
-  costCalculator: (modelName: string, usage: any, config?: any) => number | undefined;
+  costCalculator: (
+    modelName: string,
+    usage: any,
+    config?: any,
+    responseData?: any,
+  ) => number | undefined;
 }
 
 export interface ProcessorContext {

--- a/test/providers/azure/responses.test.ts
+++ b/test/providers/azure/responses.test.ts
@@ -371,6 +371,29 @@ describe('AzureResponsesProvider', () => {
       });
       expect(body.text.verbosity).toBeUndefined();
     });
+
+    it('should include top-level service_tier in the request body', async () => {
+      const provider = new AzureResponsesProvider('gpt-5.6-sol', {
+        config: { service_tier: 'priority' },
+      });
+
+      const body = await provider.getAzureResponsesBody('Hello world');
+
+      expect(body.service_tier).toBe('priority');
+    });
+
+    it('should prefer passthrough service_tier over the top-level option', async () => {
+      const provider = new AzureResponsesProvider('gpt-5.6-sol', {
+        config: {
+          service_tier: 'priority',
+          passthrough: { service_tier: 'default' },
+        },
+      });
+
+      const body = await provider.getAzureResponsesBody('Hello world');
+
+      expect(body.service_tier).toBe('default');
+    });
   });
 
   describe('callApi', () => {
@@ -567,6 +590,67 @@ describe('AzureResponsesProvider', () => {
       const result = await provider.callApi('What is 2+2?');
 
       expect(result.cost).toBeCloseTo((2 * (1_500 * 5 + 500 * 0.5 + 1_000 * 30)) / 1e6, 12);
+    });
+
+    it('keeps top-level service_tier request and cost accounting consistent', async () => {
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          output: [
+            { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '4' }] },
+          ],
+          usage: {
+            input_tokens: 2_000,
+            input_tokens_details: { cached_tokens: 500 },
+            output_tokens: 1_000,
+          },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+      const provider = new AzureResponsesProvider('gpt-5.6-sol', {
+        config: { service_tier: 'priority' },
+      });
+
+      const result = await provider.callApi('What is 2+2?');
+      const requestBody = JSON.parse(
+        mockFetchWithCache.mock.calls[0]![1]!.body as string,
+      ) as Record<string, unknown>;
+
+      expect(requestBody.service_tier).toBe('priority');
+      expect(result.cost).toBeCloseTo((2 * (1_500 * 5 + 500 * 0.5 + 1_000 * 30)) / 1e6, 12);
+    });
+
+    it('prices the passthrough service_tier that overrides the top-level option', async () => {
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          output: [
+            { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '4' }] },
+          ],
+          usage: {
+            input_tokens: 2_000,
+            input_tokens_details: { cached_tokens: 500 },
+            output_tokens: 1_000,
+          },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+      const provider = new AzureResponsesProvider('gpt-5.6-sol', {
+        config: {
+          service_tier: 'priority',
+          passthrough: { service_tier: 'default' },
+        },
+      });
+
+      const result = await provider.callApi('What is 2+2?');
+      const requestBody = JSON.parse(
+        mockFetchWithCache.mock.calls[0]![1]!.body as string,
+      ) as Record<string, unknown>;
+
+      expect(requestBody.service_tier).toBe('default');
+      expect(result.cost).toBeCloseTo((1_500 * 5 + 500 * 0.5 + 1_000 * 30) / 1e6, 12);
     });
 
     it('prices image-token usage from Azure Responses details', async () => {

--- a/test/providers/azure/responses.test.ts
+++ b/test/providers/azure/responses.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { AzureResponsesProvider } from '../../../src/providers/azure/responses';
 import * as azureUtil from '../../../src/providers/azure/util';
 import { maybeLoadResponseFormatFromExternalFile } from '../../../src/util/file';
 import { mockProcessEnv } from '../../util/utils';
 import type { MockedFunction } from 'vitest';
+
+import type { AzureResponsesOptions } from '../../../src/providers/azure/types';
 
 // Mock external dependencies
 vi.mock('../../../src/cache');
@@ -59,6 +61,12 @@ describe('AzureResponsesProvider', () => {
       const provider = new AzureResponsesProvider('gpt-4.1-test');
       expect(provider).toBeInstanceOf(AzureResponsesProvider);
       expect(provider.deploymentName).toBe('gpt-4.1-test');
+    });
+
+    it('should type only Azure-supported request service tiers', () => {
+      expectTypeOf<AzureResponsesOptions['service_tier']>().toEqualTypeOf<
+        'auto' | 'default' | 'flex' | 'priority' | null | undefined
+      >();
     });
   });
 

--- a/test/providers/azure/responses.test.ts
+++ b/test/providers/azure/responses.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { AzureResponsesProvider } from '../../../src/providers/azure/responses';
+import * as azureUtil from '../../../src/providers/azure/util';
 import { maybeLoadResponseFormatFromExternalFile } from '../../../src/util/file';
 import { mockProcessEnv } from '../../util/utils';
 import type { MockedFunction } from 'vitest';
@@ -394,6 +395,25 @@ describe('AzureResponsesProvider', () => {
 
       expect(body.service_tier).toBe('default');
     });
+
+    it('should omit a null top-level service_tier while preserving passthrough overrides', async () => {
+      const provider = new AzureResponsesProvider('gpt-5.6-sol', {
+        config: {
+          service_tier: null,
+          passthrough: { service_tier: 'priority' },
+        },
+      });
+      const providerWithoutOverride = new AzureResponsesProvider('gpt-5.6-sol', {
+        config: { service_tier: null },
+      });
+
+      const body = await provider.getAzureResponsesBody('Hello world');
+      const bodyWithoutOverride =
+        await providerWithoutOverride.getAzureResponsesBody('Hello world');
+
+      expect(body.service_tier).toBe('priority');
+      expect(bodyWithoutOverride).not.toHaveProperty('service_tier');
+    });
   });
 
   describe('callApi', () => {
@@ -592,7 +612,7 @@ describe('AzureResponsesProvider', () => {
       expect(result.cost).toBeCloseTo((2 * (1_500 * 5 + 500 * 0.5 + 1_000 * 30)) / 1e6, 12);
     });
 
-    it('keeps top-level service_tier request and cost accounting consistent', async () => {
+    it('falls back to the requested top-level service_tier when the response omits it', async () => {
       mockFetchWithCache.mockResolvedValue({
         data: {
           output: [
@@ -651,6 +671,99 @@ describe('AzureResponsesProvider', () => {
 
       expect(requestBody.service_tier).toBe('default');
       expect(result.cost).toBeCloseTo((1_500 * 5 + 500 * 0.5 + 1_000 * 30) / 1e6, 12);
+    });
+
+    it('prices the default tier Azure served instead of requested priority', async () => {
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          service_tier: 'default',
+          output: [
+            { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '4' }] },
+          ],
+          usage: {
+            input_tokens: 2_000,
+            input_tokens_details: { cached_tokens: 500 },
+            output_tokens: 1_000,
+          },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+      const provider = new AzureResponsesProvider('gpt-5.6-sol', {
+        config: { service_tier: 'priority' },
+      });
+
+      const result = await provider.callApi('What is 2+2?');
+      const requestBody = JSON.parse(
+        mockFetchWithCache.mock.calls[0]![1]!.body as string,
+      ) as Record<string, unknown>;
+
+      expect(requestBody.service_tier).toBe('priority');
+      expect(result.cost).toBeCloseTo((1_500 * 5 + 500 * 0.5 + 1_000 * 30) / 1e6, 12);
+    });
+
+    it('prices the priority tier Azure served instead of requested auto', async () => {
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          service_tier: 'priority',
+          output: [
+            { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '4' }] },
+          ],
+          usage: {
+            input_tokens: 2_000,
+            input_tokens_details: { cached_tokens: 500 },
+            output_tokens: 1_000,
+          },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+      const provider = new AzureResponsesProvider('gpt-5.6-sol', {
+        config: { service_tier: 'auto' },
+      });
+
+      const result = await provider.callApi('What is 2+2?');
+      const requestBody = JSON.parse(
+        mockFetchWithCache.mock.calls[0]![1]!.body as string,
+      ) as Record<string, unknown>;
+
+      expect(requestBody.service_tier).toBe('auto');
+      expect(result.cost).toBeCloseTo((2 * (1_500 * 5 + 500 * 0.5 + 1_000 * 30)) / 1e6, 12);
+    });
+
+    it('omits a null service_tier from the request and cost config', async () => {
+      const costSpy = vi.spyOn(azureUtil, 'calculateAzureCost');
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          output: [
+            { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '4' }] },
+          ],
+          usage: {
+            input_tokens: 2_000,
+            input_tokens_details: { cached_tokens: 500 },
+            output_tokens: 1_000,
+          },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+      const provider = new AzureResponsesProvider('gpt-5.6-sol', {
+        config: { service_tier: null },
+      });
+
+      await provider.callApi('What is 2+2?');
+      const requestBody = JSON.parse(
+        mockFetchWithCache.mock.calls[0]![1]!.body as string,
+      ) as Record<string, unknown>;
+      const costConfig = costSpy.mock.calls[0]![1];
+      costSpy.mockRestore();
+
+      expect(requestBody).not.toHaveProperty('service_tier');
+      expect(costConfig).not.toHaveProperty('service_tier');
+      expect(costConfig.passthrough).not.toHaveProperty('service_tier');
     });
 
     it('prices image-token usage from Azure Responses details', async () => {

--- a/test/providers/responses/processor.test.ts
+++ b/test/providers/responses/processor.test.ts
@@ -415,7 +415,12 @@ describe('ResponsesProcessor', () => {
       const result = await azureProcessor.processResponseOutput(mockData, {}, false);
 
       expect(result.output).toBe('Azure response');
-      expect(mockCostCalculator).toHaveBeenCalledWith('gpt-4.1-deployment', mockData.usage, {});
+      expect(mockCostCalculator).toHaveBeenCalledWith(
+        'gpt-4.1-deployment',
+        mockData.usage,
+        {},
+        mockData,
+      );
       expect(result.metadata).toEqual({
         responseId: 'resp_azure001',
         model: 'gpt-4.1-deployment',


### PR DESCRIPTION
## Summary

The Azure provider documentation supports top-level `service_tier: priority` for `azure:responses`. The provider previously neither typed nor forwarded that option, while its cost adapter could still apply priority pricing from the configuration. As a result, a documented configuration could send a standard-tier request but report priority-tier cost.

This change:

- adds a Responses-only typed `service_tier` option without changing the shared Azure chat/completion options, which continue to use raw passthrough
- forwards the top-level option into the Azure Responses request body
- keeps raw passthrough fields last, so an explicit `passthrough.service_tier` overrides the top-level option
- derives cost from the effective request body, keeping reported pricing aligned with the tier sent to Azure
- preserves the existing passthrough-only priority path

## Validation

- `source ~/.nvm/nvm.sh && nvm use && npm ci`
- `npx vitest run test/providers/azure/responses.test.ts test/providers/azure/util.test.ts` (227 tests passed)
- `npm run tsc`
- `npm run f`
- `npm run l` (passes with the pre-existing cognitive-complexity warning in `getAzureResponsesBody`)