### PR TITLE
fix(providers): restore OpenAI request isolation

### DIFF
--- a/src/providers/bedrock/mantleChat.ts
+++ b/src/providers/bedrock/mantleChat.ts
@@ -58,16 +58,16 @@ export function getBedrockMantleChatBaseUrl(region: string, modelName?: string):
  * configured mantle `apiBaseUrl`.
  */
 export class BedrockMantleChatProvider extends OpenAiChatCompletionProvider {
-  protected getCapabilityModelName(): string {
-    return this.modelName.replace(/^(openai|xai)\./, '');
+  protected getCapabilityModelName(modelName = this.modelName): string {
+    return modelName.replace(/^(openai|xai)\./, '');
   }
 
-  protected isReasoningModel(): boolean {
-    return isBedrockGrokModel(this.modelName) || super.isReasoningModel();
+  protected isReasoningModel(modelName = this.modelName): boolean {
+    return isBedrockGrokModel(modelName) || super.isReasoningModel(modelName);
   }
 
-  protected supportsTemperature(): boolean {
-    return isBedrockGrokModel(this.modelName) || super.supportsTemperature();
+  protected supportsTemperature(modelName = this.modelName): boolean {
+    return isBedrockGrokModel(modelName) || super.supportsTemperature(modelName);
   }
 
   async getOpenAiBody(

--- a/src/providers/groq/chat.ts
+++ b/src/providers/groq/chat.ts
@@ -22,16 +22,16 @@ export class GroqProvider extends OpenAiChatCompletionProvider {
     return this.config?.apiKey;
   }
 
-  protected isReasoningModel(): boolean {
-    return isGroqReasoningModel(this.modelName) || super.isReasoningModel();
+  protected isReasoningModel(modelName = this.modelName): boolean {
+    return isGroqReasoningModel(modelName) || super.isReasoningModel(modelName);
   }
 
-  protected supportsTemperature(): boolean {
+  protected supportsTemperature(modelName = this.modelName): boolean {
     // Groq's reasoning models support temperature, unlike OpenAI's o1 models
-    if (groqSupportsTemperature(this.modelName)) {
+    if (groqSupportsTemperature(modelName)) {
       return true;
     }
-    return super.supportsTemperature();
+    return super.supportsTemperature(modelName);
   }
 
   constructor(modelName: string, providerOptions: GroqProviderOptions) {

--- a/src/providers/hyperbolic/chat.ts
+++ b/src/providers/hyperbolic/chat.ts
@@ -240,11 +240,11 @@ export class HyperbolicProvider extends OpenAiChatCompletionProvider {
     return this.config?.apiKey;
   }
 
-  protected isReasoningModel(): boolean {
-    return HYPERBOLIC_REASONING_MODELS.includes(this.modelName);
+  protected isReasoningModel(modelName = this.modelName): boolean {
+    return HYPERBOLIC_REASONING_MODELS.includes(modelName);
   }
 
-  protected supportsTemperature(): boolean {
+  protected supportsTemperature(_modelName?: string): boolean {
     // Reasoning models may have limited temperature support
     return true;
   }

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -264,8 +264,10 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       capabilityModelName.includes('/o3') ||
       capabilityModelName.includes('/o4');
     const isGPT5Model = this.isGPT5Model(passthroughModel);
-    const isReasoningModel = this.isReasoningModel(passthroughModel);
-    const supportsTemperature = this.supportsTemperature(passthroughModel);
+    const isOpenAiReasoningModel = isGPT5Model || isOSeriesModel;
+    const isReasoningModel = this.isReasoningModel(passthroughModel) || isOpenAiReasoningModel;
+    const supportsTemperature =
+      this.supportsTemperature(passthroughModel) && !isOpenAiReasoningModel;
     const maxCompletionTokens = isReasoningModel
       ? (config.max_completion_tokens ?? getEnvInt('OPENAI_MAX_COMPLETION_TOKENS'))
       : undefined;

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -252,12 +252,10 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
 
     const passthroughModel =
       typeof config.passthrough?.model === 'string' ? config.passthrough.model : undefined;
-    const capabilityModelName = (passthroughModel ?? this.getCapabilityModelName()).replace(
+    const capabilityModelName = this.getCapabilityModelName(passthroughModel).replace(
       /(^|\/)ft:/,
       '$1',
     );
-    const capabilityModelIsGPT5 =
-      capabilityModelName.startsWith('gpt-5') || capabilityModelName.includes('/gpt-5');
     const isOSeriesModel =
       capabilityModelName.startsWith('o1') ||
       capabilityModelName.startsWith('o3') ||
@@ -265,13 +263,9 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       capabilityModelName.includes('/o1') ||
       capabilityModelName.includes('/o3') ||
       capabilityModelName.includes('/o4');
-    const isGPT5Model = passthroughModel === undefined ? this.isGPT5Model() : capabilityModelIsGPT5;
-    const isReasoningModel =
-      passthroughModel === undefined
-        ? this.isReasoningModel()
-        : capabilityModelIsGPT5 || isOSeriesModel;
-    const supportsTemperature =
-      passthroughModel === undefined ? this.supportsTemperature() : !isReasoningModel;
+    const isGPT5Model = this.isGPT5Model(passthroughModel);
+    const isReasoningModel = this.isReasoningModel(passthroughModel);
+    const supportsTemperature = this.supportsTemperature(passthroughModel);
     const maxCompletionTokens = isReasoningModel
       ? (config.max_completion_tokens ?? getEnvInt('OPENAI_MAX_COMPLETION_TOKENS'))
       : undefined;

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -256,10 +256,8 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       /(^|\/)ft:/,
       '$1',
     );
-    const isGPT5Model =
-      this.isGPT5Model() ||
-      capabilityModelName.startsWith('gpt-5') ||
-      capabilityModelName.includes('/gpt-5');
+    const capabilityModelIsGPT5 =
+      capabilityModelName.startsWith('gpt-5') || capabilityModelName.includes('/gpt-5');
     const isOSeriesModel =
       capabilityModelName.startsWith('o1') ||
       capabilityModelName.startsWith('o3') ||
@@ -267,9 +265,13 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
       capabilityModelName.includes('/o1') ||
       capabilityModelName.includes('/o3') ||
       capabilityModelName.includes('/o4');
-    const isPassthroughReasoningModel =
-      passthroughModel !== undefined && (isGPT5Model || isOSeriesModel);
-    const isReasoningModel = this.isReasoningModel() || isGPT5Model || isOSeriesModel;
+    const isGPT5Model = passthroughModel === undefined ? this.isGPT5Model() : capabilityModelIsGPT5;
+    const isReasoningModel =
+      passthroughModel === undefined
+        ? this.isReasoningModel()
+        : capabilityModelIsGPT5 || isOSeriesModel;
+    const supportsTemperature =
+      passthroughModel === undefined ? this.supportsTemperature() : !isReasoningModel;
     const maxCompletionTokens = isReasoningModel
       ? (config.max_completion_tokens ?? getEnvInt('OPENAI_MAX_COMPLETION_TOKENS'))
       : undefined;
@@ -286,10 +288,9 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
         ? undefined
         : getEnvFloat('OPENAI_TEMPERATURE')
       : getEnvFloat('OPENAI_TEMPERATURE', 0);
-    const temperature =
-      this.supportsTemperature() && !isPassthroughReasoningModel
-        ? (config.temperature ?? temperatureDefault)
-        : undefined;
+    const temperature = supportsTemperature
+      ? (config.temperature ?? temperatureDefault)
+      : undefined;
     const reasoningEffort = isReasoningModel
       ? (renderVarsInObject(config.reasoning_effort, context?.vars) as ReasoningEffort)
       : undefined;

--- a/src/providers/openai/index.ts
+++ b/src/providers/openai/index.ts
@@ -133,17 +133,17 @@ export class OpenAiGenericProvider implements ApiProvider {
    * Model id used for OpenAI capability and billing lookups. Subclasses can strip a vendor
    * prefix while retaining the real request model in {@link modelName}.
    */
-  protected getCapabilityModelName(): string {
-    return this.modelName;
+  protected getCapabilityModelName(modelName = this.modelName): string {
+    return modelName;
   }
 
-  protected isGPT5Model(): boolean {
-    const model = this.getCapabilityModelName().replace(/(^|\/)ft:/, '$1');
+  protected isGPT5Model(modelName?: string): boolean {
+    const model = this.getCapabilityModelName(modelName).replace(/(^|\/)ft:/, '$1');
     return model.startsWith('gpt-5') || model.includes('/gpt-5');
   }
 
-  protected isReasoningModel(): boolean {
-    const model = this.getCapabilityModelName().replace(/(^|\/)ft:/, '$1');
+  protected isReasoningModel(modelName?: string): boolean {
+    const model = this.getCapabilityModelName(modelName).replace(/(^|\/)ft:/, '$1');
     return (
       model.startsWith('o1') ||
       model.startsWith('o3') ||
@@ -151,12 +151,12 @@ export class OpenAiGenericProvider implements ApiProvider {
       model.includes('/o1') ||
       model.includes('/o3') ||
       model.includes('/o4') ||
-      this.isGPT5Model()
+      this.isGPT5Model(modelName)
     );
   }
 
-  protected supportsTemperature(): boolean {
-    return !this.isReasoningModel();
+  protected supportsTemperature(modelName?: string): boolean {
+    return !this.isReasoningModel(modelName);
   }
 
   protected getBillingModelName(_config: OpenAiSharedOptions): string {

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -387,7 +387,9 @@ async function createBackgroundResponseWithCancellation(
 ): Promise<FetchWithCacheResult<OpenAIResponsesResponse>> {
   const signal = request.signal;
   const cacheIdentity = getBackgroundCacheIdentity(url, request);
-  const canCoalesce = isCacheEnabled() && !bustCache && cacheIdentity.coalescable;
+  const cacheEnabled = isCacheEnabled() && !bustCache;
+  const canCoalesce = cacheEnabled && cacheIdentity.coalescable;
+  const canResume = cacheEnabled && cacheIdentity.cacheable;
   const effectiveCacheOptions = cacheIdentity.cacheable
     ? { bust: bustCache, cacheKey: cacheIdentity.key }
     : true;
@@ -433,7 +435,7 @@ async function createBackgroundResponseWithCancellation(
           return;
         }
         if (
-          !canCoalesce &&
+          !canResume &&
           created.data.id &&
           (created.data.status === 'queued' || created.data.status === 'in_progress')
         ) {

--- a/src/providers/openai/tts.ts
+++ b/src/providers/openai/tts.ts
@@ -28,7 +28,6 @@ import type { OpenAiSharedOptions } from './types';
 
 const VALID_RESPONSE_FORMATS = new Set(['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm']);
 const MAX_INPUT_CHARACTERS = 4096;
-const inFlightRequests = new Map<string, Promise<ProviderResponse>>();
 const abortSignalIds = new WeakMap<AbortSignal, number>();
 let nextAbortSignalId = 0;
 
@@ -166,6 +165,7 @@ function convertPcm16ToWav(pcmData: Buffer, sampleRate = 24_000): Buffer {
 }
 
 async function coalesceRequest(
+  inFlightRequests: Map<string, Promise<ProviderResponse>>,
   cacheKey: string,
   request: () => Promise<ProviderResponse>,
 ): Promise<ProviderResponse> {
@@ -201,6 +201,7 @@ export class OpenAiTtsProvider extends OpenAiGenericProvider {
   static OPENAI_TTS_MODEL_NAMES = OPENAI_TTS_MODELS.map((model) => model.id);
 
   config: OpenAiTtsOptions;
+  private readonly inFlightRequests = new Map<string, Promise<ProviderResponse>>();
 
   constructor(
     modelName: string,
@@ -281,6 +282,12 @@ export class OpenAiTtsProvider extends OpenAiGenericProvider {
     const hasSensitiveBody = hasSensitiveCacheValue(body);
     const hasTenantDiscriminator = Object.entries(cacheHeaders).some(
       ([key, value]) =>
+        /(?:^|[-_])(?:project|tenant|account|organization)(?:[-_]|$)/i.test(key) &&
+        typeof value === 'string' &&
+        value.trim().length > 0,
+    );
+    const hasProjectTenantOrAccountDiscriminator = Object.entries(cacheHeaders).some(
+      ([key, value]) =>
         /(?:^|[-_])(?:project|tenant|account)(?:[-_]|$)/i.test(key) &&
         typeof value === 'string' &&
         value.trim().length > 0,
@@ -307,14 +314,18 @@ export class OpenAiTtsProvider extends OpenAiGenericProvider {
     const usesAuthenticatedCustomEndpoint = !sendsToOpenAiApi && hasAuthentication;
     const usesAuthenticatedOpenAiApiWithoutTenantDiscriminator =
       sendsToOpenAiApi && hasAuthentication && !hasTenantDiscriminator;
-    const cacheEnabled =
+    const persistentCacheEnabled =
       isCacheEnabled() &&
       !hasSensitiveBody &&
       !hasSensitiveHeaderValue &&
       !hasSensitiveUrlPath &&
       !usesAuthenticatedCustomEndpoint &&
       !usesAuthenticatedOpenAiApiWithoutTenantDiscriminator &&
-      !(typeof body.voice === 'object' && body.voice !== null && !hasTenantDiscriminator);
+      !(
+        typeof body.voice === 'object' &&
+        body.voice !== null &&
+        !hasProjectTenantOrAccountDiscriminator
+      );
     const cacheKey = `openai:tts:${sha256(
       JSON.stringify(
         canonicalizeCacheValue({
@@ -324,9 +335,20 @@ export class OpenAiTtsProvider extends OpenAiGenericProvider {
         }),
       ),
     )}`;
+    const inFlightRequestKey = `openai:tts:in-flight:${sha256(
+      JSON.stringify(
+        canonicalizeCacheValue({
+          url,
+          body,
+          headers: requestHeaders,
+        }),
+      ),
+    )}`;
 
-    const useCache = cacheEnabled && !this.shouldBustCache(context);
-    if (useCache) {
+    const bustCache = this.shouldBustCache(context);
+    const usePersistentCache = persistentCacheEnabled && !bustCache;
+    const useInFlightCoalescing = isCacheEnabled() && !bustCache;
+    if (usePersistentCache) {
       const cachedResponse = await getCachedResponse(cacheKey, startedAt);
       if (cachedResponse) {
         return cachedResponse;
@@ -375,7 +397,7 @@ export class OpenAiTtsProvider extends OpenAiGenericProvider {
           latencyMs: Date.now() - startedAt,
         };
 
-        if (useCache) {
+        if (usePersistentCache) {
           await cacheResponse(cacheKey, result);
         }
 
@@ -404,9 +426,10 @@ export class OpenAiTtsProvider extends OpenAiGenericProvider {
       }
     };
 
-    return useCache
+    return useInFlightCoalescing
       ? coalesceRequest(
-          getInFlightCacheKey(getScopedCacheKey(cacheKey), callApiOptions?.abortSignal),
+          this.inFlightRequests,
+          getInFlightCacheKey(getScopedCacheKey(inFlightRequestKey), callApiOptions?.abortSignal),
           requestSpeech,
         )
       : requestSpeech();

--- a/src/providers/openai/tts.ts
+++ b/src/providers/openai/tts.ts
@@ -299,15 +299,21 @@ export class OpenAiTtsProvider extends OpenAiGenericProvider {
       hasSensitiveUrlCredentials = true;
       hasSensitiveUrlPath = true;
     }
-    const usesAuthenticatedCustomEndpoint =
-      !sendsToOpenAiApi &&
-      (hasSensitiveUrlCredentials || Object.keys(requestHeaders).some(isSensitiveCacheHeader));
+    const hasAuthentication =
+      hasSensitiveUrlCredentials ||
+      Object.entries(requestHeaders).some(
+        ([key, value]) => isSensitiveCacheHeader(key) && value.trim().length > 0,
+      );
+    const usesAuthenticatedCustomEndpoint = !sendsToOpenAiApi && hasAuthentication;
+    const usesAuthenticatedOpenAiApiWithoutTenantDiscriminator =
+      sendsToOpenAiApi && hasAuthentication && !hasTenantDiscriminator;
     const cacheEnabled =
       isCacheEnabled() &&
       !hasSensitiveBody &&
       !hasSensitiveHeaderValue &&
       !hasSensitiveUrlPath &&
       !usesAuthenticatedCustomEndpoint &&
+      !usesAuthenticatedOpenAiApiWithoutTenantDiscriminator &&
       !(typeof body.voice === 'object' && body.voice !== null && !hasTenantDiscriminator);
     const cacheKey = `openai:tts:${sha256(
       JSON.stringify(

--- a/src/providers/orcarouter.ts
+++ b/src/providers/orcarouter.ts
@@ -169,7 +169,11 @@ export class OrcaRouterProvider extends OpenAiChatCompletionProvider {
       (body.models as unknown[]).some(
         (m) => typeof m === 'string' && reasoningUpstreamRejectsTemperature(m),
       );
-    if ('temperature' in body && (!this.supportsTemperature() || anyFallbackRejectsTemperature)) {
+    if (
+      'temperature' in body &&
+      (!this.supportsTemperature(typeof body.model === 'string' ? body.model : undefined) ||
+        anyFallbackRejectsTemperature)
+    ) {
       delete body.temperature;
     }
 
@@ -183,11 +187,11 @@ export class OrcaRouterProvider extends OpenAiChatCompletionProvider {
    * OpenAI-style `temperature` is the parameter they reject.
    * Reference: https://docs.orcarouter.ai/advanced/reasoning
    */
-  protected supportsTemperature(): boolean {
-    if (!super.supportsTemperature()) {
+  protected supportsTemperature(modelName = this.modelName): boolean {
+    if (!super.supportsTemperature(modelName)) {
       return false;
     }
-    return !reasoningUpstreamRejectsTemperature(this.modelName);
+    return !reasoningUpstreamRejectsTemperature(modelName);
   }
 }
 

--- a/src/providers/truefoundry.ts
+++ b/src/providers/truefoundry.ts
@@ -213,9 +213,9 @@ export class TrueFoundryProvider extends OpenAiChatCompletionProvider {
    * Override isReasoningModel to correctly detect GPT-5 and other reasoning models
    * despite TrueFoundry's provider-account/model-name format
    */
-  protected isReasoningModel(): boolean {
+  protected isReasoningModel(modelName = this.modelName): boolean {
     // Extract the actual model name after the provider prefix (e.g., "openai/gpt-5-nano" -> "gpt-5-nano")
-    const actualModelName = this.modelName.split('/').pop() || this.modelName;
+    const actualModelName = modelName.split('/').pop() || modelName;
     return (
       actualModelName.startsWith('o1') ||
       actualModelName.startsWith('o3') ||

--- a/src/providers/xai/chat.ts
+++ b/src/providers/xai/chat.ts
@@ -642,8 +642,8 @@ class XAIProvider extends OpenAiChatCompletionProvider {
     return this.config?.apiKey;
   }
 
-  protected isReasoningModel(): boolean {
-    return GROK_REASONING_MODELS.includes(this.modelName);
+  protected isReasoningModel(modelName = this.modelName): boolean {
+    return GROK_REASONING_MODELS.includes(modelName);
   }
 
   protected supportsReasoningEffort(): boolean {
@@ -653,7 +653,7 @@ class XAIProvider extends OpenAiChatCompletionProvider {
     return GROK_REASONING_EFFORT_MODELS.includes(this.modelName);
   }
 
-  protected supportsTemperature(): boolean {
+  protected supportsTemperature(_modelName?: string): boolean {
     return true;
   }
 

--- a/test/providers/groq/chat.test.ts
+++ b/test/providers/groq/chat.test.ts
@@ -130,6 +130,26 @@ describe('GroqProvider', () => {
   });
 
   describe('getOpenAiBody', () => {
+    it('preserves Groq reasoning and temperature capabilities for a no-op model override', async () => {
+      const provider = new GroqProvider('openai/gpt-oss-120b', {
+        config: {
+          temperature: 0.7,
+          max_tokens: 123,
+          max_completion_tokens: 456,
+          passthrough: { model: 'openai/gpt-oss-120b' },
+        },
+      });
+
+      const { body } = await provider['getOpenAiBody']('Test prompt');
+
+      expect(body).toMatchObject({
+        model: 'openai/gpt-oss-120b',
+        temperature: 0.7,
+        max_completion_tokens: 456,
+      });
+      expect(body.max_tokens).toBeUndefined();
+    });
+
     it('should include reasoning_format when configured', async () => {
       const provider = new GroqProvider('openai/gpt-oss-120b', {
         config: {

--- a/test/providers/openai/chat.test.ts
+++ b/test/providers/openai/chat.test.ts
@@ -2191,6 +2191,40 @@ Therefore, there are 2 occurrences of the letter "r" in "strawberry".\n\nThere a
       expect(prefixedGpt5Body.max_completion_tokens).toBeUndefined();
     });
 
+    it('should classify capabilities from the passthrough model override', async () => {
+      const routedToRegular = new OpenAiChatCompletionProvider('gpt-5', {
+        config: {
+          temperature: 0.7,
+          max_tokens: 123,
+          passthrough: { model: 'gpt-4.1' },
+        },
+      });
+      const routedToReasoning = new OpenAiChatCompletionProvider('gpt-4.1', {
+        config: {
+          temperature: 0.7,
+          max_tokens: 123,
+          max_completion_tokens: 456,
+          passthrough: { model: 'o3' },
+        },
+      });
+
+      const { body: regularBody } = await routedToRegular.getOpenAiBody('Test prompt');
+      const { body: reasoningBody } = await routedToReasoning.getOpenAiBody('Test prompt');
+
+      expect(regularBody).toMatchObject({
+        model: 'gpt-4.1',
+        temperature: 0.7,
+        max_tokens: 123,
+      });
+      expect(regularBody.max_completion_tokens).toBeUndefined();
+      expect(reasoningBody).toMatchObject({
+        model: 'o3',
+        max_completion_tokens: 456,
+      });
+      expect(reasoningBody.temperature).toBeUndefined();
+      expect(reasoningBody.max_tokens).toBeUndefined();
+    });
+
     it('should strip max_tokens from passthrough for GPT-5 models', async () => {
       const mockResponse = {
         data: {

--- a/test/providers/openai/responses/request.test.ts
+++ b/test/providers/openai/responses/request.test.ts
@@ -1784,6 +1784,61 @@ describe('OpenAiResponsesProvider request building', () => {
     expect(deleteFromCache).toHaveBeenCalledOnce();
   });
 
+  it('should cancel a non-persistable coalesced background job after its sole subscriber aborts', async () => {
+    const controller = new AbortController();
+    const deleteFromCache = vi.fn().mockResolvedValue(undefined);
+    let acceptCreation: ((value: any) => void) | undefined;
+    vi.mocked(cache.fetchWithCache).mockImplementation(async (url, options) => {
+      if (String(url).endsWith('/responses') && options?.method === 'POST') {
+        return await new Promise<any>((resolve) => {
+          acceptCreation = resolve;
+        });
+      }
+      if (String(url).endsWith('/responses/resp_coalesced/cancel')) {
+        return { data: {}, cached: false, status: 200, statusText: 'OK' };
+      }
+      throw new Error(`Unexpected request: ${options?.method} ${String(url)}`);
+    });
+    const provider = new OpenAiResponsesProvider('gpt-4.1', {
+      config: { apiKey: 'default-key', background: true, maxRetries: 0 },
+    });
+
+    const pending = provider.callApi('Accept and then cancel', undefined, {
+      abortSignal: controller.signal,
+    });
+    await vi.waitFor(() => expect(acceptCreation).toBeDefined());
+    controller.abort(new Error('sole subscriber cancelled creation'));
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(cache.fetchWithCache).not.toHaveBeenCalledWith(
+      expect.stringContaining('/cancel'),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    acceptCreation?.({
+      data: { id: 'resp_coalesced', status: 'queued', output: [], usage: null },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      deleteFromCache,
+    });
+    await vi.waitFor(() =>
+      expect(cache.fetchWithCache).toHaveBeenCalledWith(
+        expect.stringContaining('/responses/resp_coalesced/cancel'),
+        expect.objectContaining({ method: 'POST' }),
+        expect.any(Number),
+        'json',
+        true,
+        0,
+      ),
+    );
+    expect(deleteFromCache).toHaveBeenCalledOnce();
+  });
+
   it('should bound polling retries by the overall background deadline', async () => {
     setOpenAiEnv({ PROMPTFOO_EVAL_TIMEOUT_MS: '20' });
     const deleteFromCache = vi.fn().mockResolvedValue(undefined);

--- a/test/providers/openai/tts.test.ts
+++ b/test/providers/openai/tts.test.ts
@@ -409,6 +409,59 @@ describe('OpenAiTtsProvider', () => {
     expect(cache.set).not.toHaveBeenCalled();
   });
 
+  it('does not coalesce concurrent default OpenAI speech responses across API keys', async () => {
+    mockedIsCacheEnabled.mockReturnValue(true);
+    mockedGetCache.mockReturnValue({ get: vi.fn(), set: vi.fn() } as any);
+    mockedFetch.mockImplementation(async (_url, options) => {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const authorization = new Headers(options?.headers).get('authorization');
+      return audioResponse(new TextEncoder().encode(`audio-for-${authorization}`));
+    });
+
+    const firstAccount = new OpenAiTtsProvider('tts-1', {
+      config: { apiKey: 'account-a' },
+    });
+    const secondAccount = new OpenAiTtsProvider('tts-1', {
+      config: { apiKey: 'account-b' },
+    });
+
+    const [first, second] = await Promise.all([
+      firstAccount.callApi('same input'),
+      secondAccount.callApi('same input'),
+    ]);
+
+    expect(Buffer.from(first.audio?.data ?? '', 'base64').toString()).toBe(
+      'audio-for-Bearer account-a',
+    );
+    expect(Buffer.from(second.audio?.data ?? '', 'base64').toString()).toBe(
+      'audio-for-Bearer account-b',
+    );
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses OpenAI organization as a persistent-cache discriminator', async () => {
+    const values = new Map<string, string>();
+    const cache = {
+      get: vi.fn(async (key: string) => values.get(key)),
+      set: vi.fn(async (key: string, value: string) => values.set(key, value)),
+    };
+    mockedIsCacheEnabled.mockReturnValue(true);
+    mockedGetCache.mockReturnValue(cache as any);
+    mockedFetch.mockResolvedValue(audioResponse());
+    const provider = new OpenAiTtsProvider('tts-1', {
+      config: { apiKey: 'test-key', organization: 'org-a' },
+    });
+
+    const first = await provider.callApi('same input');
+    const second = await provider.callApi('same input');
+
+    expect(first.cached).toBe(false);
+    expect(second).toMatchObject({ cached: true, cost: 0, audio: first.audio });
+    expect(mockedFetch).toHaveBeenCalledOnce();
+    expect(cache.get).toHaveBeenCalledTimes(2);
+    expect(cache.set).toHaveBeenCalledOnce();
+  });
+
   it('keeps custom-header tenants isolated without using secret auth headers in the cache key', async () => {
     const values = new Map<string, string>();
     const cache = {
@@ -513,9 +566,7 @@ describe('OpenAiTtsProvider', () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
       return audioResponse();
     });
-    const provider = new OpenAiTtsProvider('tts-1', {
-      config: { apiKey: 'test-key', headers: { 'OpenAI-Project': 'project-a' } },
-    });
+    const provider = new OpenAiTtsProvider('tts-1', { config: { apiKey: 'test-key' } });
 
     const results = await Promise.all([
       provider.callApi('same input'),
@@ -527,6 +578,8 @@ describe('OpenAiTtsProvider', () => {
     expect(results.filter((result) => result.cached === false)).toHaveLength(1);
     expect(results.filter((result) => result.cached === true)).toHaveLength(2);
     expect(results.filter((result) => result.cost === 0)).toHaveLength(2);
+    expect(cache.get).not.toHaveBeenCalled();
+    expect(cache.set).not.toHaveBeenCalled();
   });
 
   it('does not coalesce independently cancellable speech requests', async () => {

--- a/test/providers/openai/tts.test.ts
+++ b/test/providers/openai/tts.test.ts
@@ -359,7 +359,9 @@ describe('OpenAiTtsProvider', () => {
     mockedIsCacheEnabled.mockReturnValue(true);
     mockedGetCache.mockReturnValue(cache as any);
     mockedFetch.mockResolvedValue(audioResponse());
-    const provider = new OpenAiTtsProvider('tts-1', { config: { apiKey: 'test-key' } });
+    const provider = new OpenAiTtsProvider('tts-1', {
+      config: { apiKey: 'test-key', headers: { 'OpenAI-Project': 'project-a' } },
+    });
 
     const first = await provider.callApi('Cache this speech');
     const second = await provider.callApi('Cache this speech');
@@ -371,6 +373,40 @@ describe('OpenAiTtsProvider', () => {
     expect(busted.cached).toBe(false);
     expect(mockedFetch).toHaveBeenCalledTimes(2);
     expect(cache.set).toHaveBeenCalledOnce();
+  });
+
+  it('does not share default OpenAI speech responses across API keys', async () => {
+    const values = new Map<string, string>();
+    const cache = {
+      get: vi.fn(async (key: string) => values.get(key)),
+      set: vi.fn(async (key: string, value: string) => values.set(key, value)),
+    };
+    mockedIsCacheEnabled.mockReturnValue(true);
+    mockedGetCache.mockReturnValue(cache as any);
+    mockedFetch.mockImplementation(async (_url, options) => {
+      const authorization = new Headers(options?.headers).get('authorization');
+      return audioResponse(new TextEncoder().encode(`audio-for-${authorization}`));
+    });
+
+    const firstAccount = new OpenAiTtsProvider('tts-1', {
+      config: { apiKey: 'account-a' },
+    });
+    const secondAccount = new OpenAiTtsProvider('tts-1', {
+      config: { apiKey: 'account-b' },
+    });
+
+    const first = await firstAccount.callApi('same input');
+    const second = await secondAccount.callApi('same input');
+
+    expect(Buffer.from(first.audio?.data ?? '', 'base64').toString()).toBe(
+      'audio-for-Bearer account-a',
+    );
+    expect(Buffer.from(second.audio?.data ?? '', 'base64').toString()).toBe(
+      'audio-for-Bearer account-b',
+    );
+    expect(mockedFetch).toHaveBeenCalledTimes(2);
+    expect(cache.get).not.toHaveBeenCalled();
+    expect(cache.set).not.toHaveBeenCalled();
   });
 
   it('keeps custom-header tenants isolated without using secret auth headers in the cache key', async () => {
@@ -477,7 +513,9 @@ describe('OpenAiTtsProvider', () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
       return audioResponse();
     });
-    const provider = new OpenAiTtsProvider('tts-1', { config: { apiKey: 'test-key' } });
+    const provider = new OpenAiTtsProvider('tts-1', {
+      config: { apiKey: 'test-key', headers: { 'OpenAI-Project': 'project-a' } },
+    });
 
     const results = await Promise.all([
       provider.callApi('same input'),
@@ -955,10 +993,18 @@ describe('OpenAiTtsProvider', () => {
     mockedFetch.mockResolvedValue(audioResponse());
 
     const first = await new OpenAiTtsProvider('tts-1', {
-      config: { apiKey: 'test-key', passthrough: { vendor: { alpha: 1, beta: 2 } } },
+      config: {
+        apiKey: 'test-key',
+        headers: { 'OpenAI-Project': 'project-a' },
+        passthrough: { vendor: { alpha: 1, beta: 2 } },
+      },
     }).callApi('same input');
     const second = await new OpenAiTtsProvider('tts-1', {
-      config: { apiKey: 'test-key', passthrough: { vendor: { beta: 2, alpha: 1 } } },
+      config: {
+        apiKey: 'test-key',
+        headers: { 'OpenAI-Project': 'project-a' },
+        passthrough: { vendor: { beta: 2, alpha: 1 } },
+      },
     }).callApi('same input');
 
     expect(first.cached).toBe(false);

--- a/test/providers/truefoundry.test.ts
+++ b/test/providers/truefoundry.test.ts
@@ -70,6 +70,27 @@ describe('TrueFoundry', () => {
         const provider = new TrueFoundryProvider('vertex-ai/gemini-2.5-pro', {});
         expect((provider as any).isReasoningModel()).toBe(false);
       });
+
+      it('should preserve normalized o-series capabilities for a passthrough override', async () => {
+        const model = 'openai/ft:o4-mini-2025-04-16:company::model';
+        const provider = new TrueFoundryProvider(model, {
+          config: {
+            temperature: 0.7,
+            max_tokens: 123,
+            max_completion_tokens: 456,
+            passthrough: { model },
+          },
+        });
+
+        const { body } = await provider.getOpenAiBody('Test prompt');
+
+        expect(body).toMatchObject({
+          model,
+          max_completion_tokens: 456,
+        });
+        expect(body.temperature).toBeUndefined();
+        expect(body.max_tokens).toBeUndefined();
+      });
     });
 
     it('should return correct id', () => {


### PR DESCRIPTION
## Summary

PR #10125 aligned OpenAI provider behavior, but three edge cases could now cross account boundaries, drop valid chat parameters after model routing, or leave abandoned background work running.

This PR restores the intended behavior with focused changes:

- OpenAI TTS only uses persistent caching for authenticated requests when a stable, non-secret project, tenant, or account discriminator is present. Unauthenticated endpoints and explicitly discriminated requests remain cacheable, while API keys never enter cache identities.
- Chat capability checks use a string passthrough model as the effective model. Routing GPT-5 to gpt-4.1 now keeps temperature and max_tokens; routing a regular model to an o-series model applies reasoning limits. Subclass capability hooks remain unchanged when there is no override.
- Background Responses creation cancels a late-accepted queued job when its final subscriber has aborted and the job is not persistently resumable. Persisted shared jobs and jobs with another active subscriber remain alive.

## User impact

- One OpenAI account cannot receive speech audio cached for a different account when both use the default API endpoint.
- Routed chat requests retain or remove model-specific parameters according to the model actually sent upstream.
- Sole-caller cancellation no longer leaks accepted background work for provider-level API keys.

## Validation

- npx vitest run test/providers/openai/tts.test.ts test/providers/openai/chat.test.ts test/providers/openai/responses/request.test.ts (243 tests passed)
- npm run tsc
- npm run f
- npm run l
- git diff --check

## Review context

- TTS cache isolation: https://github.com/promptfoo/promptfoo/pull/10125#discussion_r3597586926
- Chat passthrough capabilities: https://github.com/promptfoo/promptfoo/pull/10125#discussion_r3604863186
- Background cancellation: https://github.com/promptfoo/promptfoo/pull/10125#discussion_r3598225198