### PR TITLE
fix(providers): correct Gemini Omni interactions

### DIFF
--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -416,7 +416,7 @@ See the [Google Imagen example](https://github.com/promptfoo/promptfoo/tree/main
 
 ### Video Generation Models (Gemini Omni Flash)
 
-Gemini Omni Flash uses the Gemini Interactions API rather than `generateContent`; Promptfoo automatically routes both `google:gemini-omni-flash-preview` and `vertex:gemini-omni-flash-preview` to the correct endpoint and stores returned video in blob storage. Vertex uses OAuth and the configured Google Cloud project. Use `store: true` and `previousInteractionId` with the Google AI Studio route to conversationally edit a prior result; Vertex does not currently support follow-up interactions. Omni does not support grounding, code execution, or function-calling tools.
+Gemini Omni Flash uses the Gemini Interactions API rather than `generateContent`; Promptfoo automatically routes both `google:gemini-omni-flash-preview` and `vertex:gemini-omni-flash-preview` to the correct endpoint and stores returned video in blob storage. Vertex uses OAuth, the configured Google Cloud project, and the required `global` location even when the provider's ordinary Vertex region is set. Use `store: true` and `previousInteractionId` with the Google AI Studio route to conversationally edit a prior result; Vertex does not currently support follow-up interactions. Omni does not support custom safety settings, grounding, code execution, or function-calling tools; Promptfoo rejects these options before sending a request.
 
 ```yaml
 providers:

--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -44,6 +44,7 @@ export async function storeBlob(
   data: Buffer,
   mimeType: string,
   refContext?: {
+    abortSignal?: AbortSignal;
     evalId?: string;
     testIdx?: number;
     promptIdx?: number;
@@ -52,12 +53,17 @@ export async function storeBlob(
   },
 ): Promise<BlobStoreResult> {
   const provider = getBlobStorageProvider();
+  refContext?.abortSignal?.throwIfAborted();
   const result = await provider.store(data, mimeType);
+  const referenceId = refContext?.evalId ? randomUUID() : undefined;
+  let transactionCommitted = false;
 
   // Track asset and reference in DB for dedup/auth/cascade
   const db = await getDb();
   try {
+    refContext?.abortSignal?.throwIfAborted();
     await db.transaction(async (tx) => {
+      refContext?.abortSignal?.throwIfAborted();
       await tx
         .insert(blobAssetsTable)
         .values({
@@ -69,11 +75,12 @@ export async function storeBlob(
         .onConflictDoNothing()
         .run();
 
-      if (refContext?.evalId) {
+      refContext?.abortSignal?.throwIfAborted();
+      if (refContext?.evalId && referenceId) {
         await tx
           .insert(blobReferencesTable)
           .values({
-            id: randomUUID(),
+            id: referenceId,
             blobHash: result.ref.hash,
             evalId: refContext.evalId,
             testIdx: refContext.testIdx,
@@ -84,13 +91,43 @@ export async function storeBlob(
           .onConflictDoNothing()
           .run();
       }
+      refContext?.abortSignal?.throwIfAborted();
     });
+    transactionCommitted = true;
+    refContext?.abortSignal?.throwIfAborted();
   } catch (error) {
-    // Roll back filesystem write if DB persistence fails
+    let shouldDeleteBlob = !result.deduplicated || !refContext?.abortSignal?.aborted;
     try {
-      await provider.deleteByHash(result.ref.hash);
+      if (transactionCommitted && refContext?.abortSignal?.aborted) {
+        await db.transaction(async (tx) => {
+          if (referenceId) {
+            await tx
+              .delete(blobReferencesTable)
+              .where(eq(blobReferencesTable.id, referenceId))
+              .run();
+          }
+          if (!result.deduplicated) {
+            const remainingReference = await tx
+              .select({ id: blobReferencesTable.id })
+              .from(blobReferencesTable)
+              .where(eq(blobReferencesTable.blobHash, result.ref.hash))
+              .get();
+            if (remainingReference) {
+              shouldDeleteBlob = false;
+            } else {
+              await tx
+                .delete(blobAssetsTable)
+                .where(eq(blobAssetsTable.hash, result.ref.hash))
+                .run();
+            }
+          }
+        });
+      }
+      if (shouldDeleteBlob) {
+        await provider.deleteByHash(result.ref.hash);
+      }
     } catch (cleanupError) {
-      logger.warn('[BlobStorage] Failed to rollback blob after DB error', {
+      logger.warn('[BlobStorage] Failed to rollback blob after storage error or cancellation', {
         error: cleanupError,
         hash: result.ref.hash,
       });

--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -56,7 +56,6 @@ export async function storeBlob(
   refContext?.abortSignal?.throwIfAborted();
   const result = await provider.store(data, mimeType);
   const referenceId = refContext?.evalId ? randomUUID() : undefined;
-  let transactionCommitted = false;
 
   // Track asset and reference in DB for dedup/auth/cascade
   const db = await getDb();
@@ -93,12 +92,11 @@ export async function storeBlob(
       }
       refContext?.abortSignal?.throwIfAborted();
     });
-    transactionCommitted = true;
     refContext?.abortSignal?.throwIfAborted();
   } catch (error) {
     let shouldDeleteBlob = !result.deduplicated || !refContext?.abortSignal?.aborted;
     try {
-      if (transactionCommitted && refContext?.abortSignal?.aborted) {
+      if (refContext?.abortSignal?.aborted) {
         await db.transaction(async (tx) => {
           if (referenceId) {
             await tx

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -3301,7 +3301,7 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
     }
 
     if (row.cost === undefined) {
-      if (row.response && !row.response.error) {
+      if (row.response && !row.response.error && !row.response.cached) {
         metrics.cost = undefined;
       }
     } else if (promptEvalCount === 1) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -95,7 +95,7 @@ import { TokenUsageTracker } from './util/tokenUsage';
 import {
   accumulateAssertionTokenUsage,
   accumulateGradingRequest,
-  accumulateResponseTokenUsage,
+  accumulateResponseTokenUsagePreservingUnknown,
   createEmptyAssertions,
   createEmptyTokenUsage,
 } from './util/tokenUsageUtils';
@@ -1560,7 +1560,7 @@ async function runEvalInternal({
 
     // Update token usage stats
     if (response.tokenUsage) {
-      accumulateResponseTokenUsage(ret.tokenUsage, response);
+      accumulateResponseTokenUsagePreservingUnknown(ret.tokenUsage, response);
     }
 
     if (test.options?.storeOutputAs && ret.response?.output && registers) {
@@ -3227,7 +3227,9 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
     }
 
     if (row.tokenUsage) {
-      accumulateResponseTokenUsage(this.stats.tokenUsage, { tokenUsage: row.tokenUsage });
+      accumulateResponseTokenUsagePreservingUnknown(this.stats.tokenUsage, {
+        tokenUsage: row.tokenUsage,
+      });
     }
   }
 
@@ -3292,13 +3294,21 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
     metrics.assertFailCount +=
       row.gradingResult?.componentResults?.filter((r) => !r.pass).length || 0;
     metrics.totalLatencyMs += row.latencyMs || 0;
-    accumulateResponseTokenUsage(metrics.tokenUsage, row.response);
+    accumulateResponseTokenUsagePreservingUnknown(metrics.tokenUsage, row.response);
 
     if (row.gradingResult?.tokensUsed) {
       updateAssertionMetrics(metrics, row.gradingResult.tokensUsed);
     }
 
-    metrics.cost += row.cost || 0;
+    if (row.cost === undefined) {
+      if (row.response && !row.response.error) {
+        metrics.cost = undefined;
+      }
+    } else if (promptEvalCount === 1) {
+      metrics.cost = row.cost;
+    } else if (metrics.cost !== undefined) {
+      metrics.cost += row.cost;
+    }
   }
 
   private async processEvalStep(
@@ -4459,12 +4469,22 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
       avgLatencyMs: Math.round(avgLatencyMs),
       concurrencyUsed: concurrency,
       timeoutOccurred,
-      totalTokens: this.stats.tokenUsage.total,
-      promptTokens: this.stats.tokenUsage.prompt,
-      completionTokens: this.stats.tokenUsage.completion,
-      cachedTokens: this.stats.tokenUsage.cached,
-      totalCost: prompts.reduce((acc, p) => acc + (p.metrics?.cost || 0), 0),
-      totalRequests: this.stats.tokenUsage.numRequests,
+      ...(this.stats.tokenUsage.total === undefined
+        ? {}
+        : { totalTokens: this.stats.tokenUsage.total }),
+      ...(this.stats.tokenUsage.prompt === undefined
+        ? {}
+        : { promptTokens: this.stats.tokenUsage.prompt }),
+      ...(this.stats.tokenUsage.completion === undefined
+        ? {}
+        : { completionTokens: this.stats.tokenUsage.completion }),
+      ...(this.stats.tokenUsage.cached === undefined
+        ? {}
+        : { cachedTokens: this.stats.tokenUsage.cached }),
+      ...(prompts.some((prompt) => prompt.metrics?.cost === undefined)
+        ? {}
+        : { totalCost: prompts.reduce((acc, prompt) => acc + (prompt.metrics?.cost ?? 0), 0) }),
+      totalRequests: this.stats.tokenUsage.numRequests ?? 0,
       ...assertionStats,
       usesConversationVar,
       usesTransforms: usesTransforms(testSuite, tests),

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1559,9 +1559,7 @@ async function runEvalInternal({
     });
 
     // Update token usage stats
-    if (response.tokenUsage) {
-      accumulateResponseTokenUsagePreservingUnknown(ret.tokenUsage, response);
-    }
+    accumulateResponseTokenUsagePreservingUnknown(ret.tokenUsage, response);
 
     if (test.options?.storeOutputAs && ret.response?.output && registers) {
       // Save the output in a register for later use
@@ -3304,8 +3302,6 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
       if (row.response && !row.response.error && !row.response.cached) {
         metrics.cost = undefined;
       }
-    } else if (promptEvalCount === 1) {
-      metrics.cost = row.cost;
     } else if (metrics.cost !== undefined) {
       metrics.cost += row.cost;
     }

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -43,7 +43,10 @@ import { isNonTransientHttpStatus, NON_TRANSIENT_HTTP_STATUSES } from '../util/f
 import invariant from '../util/invariant';
 import { sanitizeRuntimeOptions } from '../util/sanitizer';
 import { getCurrentTimestamp } from '../util/time';
-import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageUtils';
+import {
+  accumulateTokenUsagePreservingUnknown,
+  createEmptyTokenUsage,
+} from '../util/tokenUsageUtils';
 import {
   invalidateEvaluationCache,
   notifyEvaluationChanged,
@@ -1411,7 +1414,7 @@ export default class Eval {
       stats.failures += prompt.metrics?.testFailCount ?? 0;
       stats.errors += prompt.metrics?.testErrorCount ?? 0;
 
-      accumulateTokenUsage(stats.tokenUsage, prompt.metrics?.tokenUsage);
+      accumulateTokenUsagePreservingUnknown(stats.tokenUsage, prompt.metrics?.tokenUsage);
     }
 
     return stats;

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -25,11 +25,13 @@ import { isSecretField, REDACTED, sanitizeObject } from '../util/sanitizer';
 import { getCurrentTimestamp } from '../util/time';
 import {
   accumulateGradingRequest,
-  accumulateResponseTokenUsage,
+  accumulateResponseTokenUsagePreservingUnknown,
   createEmptyTokenUsage,
 } from '../util/tokenUsageUtils';
 import { invalidateEvaluationCache } from './evalMutation';
 import { clearCountCache } from './evalPerformance';
+
+import type { TokenUsage } from '../types/shared';
 
 function sanitizeProviderConfig(config: ProviderConfig): ProviderConfig {
   return sanitizeObject(JSON.parse(safeJsonStringify(config) as string), {
@@ -877,7 +879,7 @@ export default class EvalResult {
   namedScores: Record<string, number>;
   provider: ProviderOptions;
   latencyMs: number;
-  cost: number;
+  cost?: number;
   // biome-ignore lint/suspicious/noExplicitAny: I think this can truly be any?
   metadata: Record<string, any>;
   traceId?: string;
@@ -924,7 +926,7 @@ export default class EvalResult {
     this.namedScores = opts.namedScores || {};
     this.provider = opts.provider;
     this.latencyMs = opts.latencyMs || 0;
-    this.cost = opts.cost || 0;
+    this.cost = opts.cost ?? undefined;
     ({
       metadata: this.metadata,
       traceId: this.traceId,
@@ -983,19 +985,24 @@ export default class EvalResult {
       stripMetadata: shouldStripMetadata,
       stripVars: shouldStripTestVars,
     });
-    // Mirror the live accounting in the evaluator: a response counts as one provider
-    // request even when it reports no token usage, and a grading result counts as one
-    // assertion request (with its tokens folded in when present).
-    const tokenUsage = createEmptyTokenUsage();
+    const tokenUsage: TokenUsage = createEmptyTokenUsage();
     if (this.response) {
-      accumulateResponseTokenUsage(tokenUsage, this.response);
+      accumulateResponseTokenUsagePreservingUnknown(tokenUsage, this.response);
     }
     if (this.gradingResult) {
+      tokenUsage.assertions ??= {};
       accumulateGradingRequest(tokenUsage.assertions, this.gradingResult.tokensUsed);
+    } else if (
+      tokenUsage.prompt === undefined &&
+      tokenUsage.completion === undefined &&
+      tokenUsage.cached === undefined &&
+      tokenUsage.total === undefined
+    ) {
+      delete tokenUsage.assertions;
     }
 
     return {
-      cost: this.cost,
+      ...(this.cost === undefined ? {} : { cost: this.cost }),
       description: this.description || undefined,
       error: this.error || undefined,
       gradingResult: shouldStripGradingResult ? null : this.gradingResult,

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -31,8 +31,6 @@ import {
 import { invalidateEvaluationCache } from './evalMutation';
 import { clearCountCache } from './evalPerformance';
 
-import type { TokenUsage } from '../types/shared';
-
 function sanitizeProviderConfig(config: ProviderConfig): ProviderConfig {
   return sanitizeObject(JSON.parse(safeJsonStringify(config) as string), {
     context: 'provider config',
@@ -985,7 +983,7 @@ export default class EvalResult {
       stripMetadata: shouldStripMetadata,
       stripVars: shouldStripTestVars,
     });
-    const tokenUsage: TokenUsage = createEmptyTokenUsage();
+    const tokenUsage: NonNullable<ProviderResponse['tokenUsage']> = createEmptyTokenUsage();
     if (this.response) {
       accumulateResponseTokenUsagePreservingUnknown(tokenUsage, this.response);
     }

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -57,7 +57,10 @@ import { promptfooCommand } from '../util/promptfooCommand';
 import { checkProviderApiKeys } from '../util/provider';
 import { shouldShareResults } from '../util/sharing';
 import { TokenUsageTracker } from '../util/tokenUsage';
-import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageUtils';
+import {
+  accumulateTokenUsagePreservingUnknown,
+  createEmptyTokenUsage,
+} from '../util/tokenUsageUtils';
 import { isUuid } from '../util/uuid';
 import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from './retry';
 import { notCloudEnabledShareInstructions } from './shareInstructions';
@@ -938,7 +941,7 @@ export async function doEval(
       if (prompt.metrics?.testErrorCount) {
         errors += prompt.metrics.testErrorCount;
       }
-      accumulateTokenUsage(tokenUsage, prompt.metrics?.tokenUsage);
+      accumulateTokenUsagePreservingUnknown(tokenUsage, prompt.metrics?.tokenUsage);
     }
     const totalTests = successes + failures + errors;
     const passRate = (successes / totalTests) * 100;

--- a/src/node/retry.ts
+++ b/src/node/retry.ts
@@ -251,7 +251,7 @@ export async function recalculatePromptMetrics(evalRecord: Eval): Promise<void> 
         const promptResultCount =
           metrics.testPassCount + metrics.testFailCount + metrics.testErrorCount;
         if (result.cost === undefined) {
-          if (result.response && !result.response.error) {
+          if (result.response && !result.response.error && !result.response.cached) {
             metrics.cost = undefined;
           }
         } else if (promptResultCount === 1) {

--- a/src/node/retry.ts
+++ b/src/node/retry.ts
@@ -21,7 +21,7 @@ import { getOutputFileFormat } from '../util/outputFormats';
 import { shouldShareResults } from '../util/sharing';
 import {
   accumulateAssertionTokenUsage,
-  accumulateResponseTokenUsage,
+  accumulateResponseTokenUsagePreservingUnknown,
   createEmptyAssertions,
   createEmptyTokenUsage,
 } from '../util/tokenUsageUtils';
@@ -196,7 +196,7 @@ export async function recalculatePromptMetrics(evalRecord: Eval): Promise<void> 
       namedScores: Record<string, number>;
       namedScoresCount: Record<string, number>;
       namedScoreWeights?: Record<string, number>;
-      cost: number;
+      cost?: number;
     }
   >();
 
@@ -248,7 +248,17 @@ export async function recalculatePromptMetrics(evalRecord: Eval): Promise<void> 
         // Update scores and other metrics
         metrics.score += result.score ?? 0;
         metrics.totalLatencyMs += result.latencyMs || 0;
-        metrics.cost += result.cost || 0;
+        const promptResultCount =
+          metrics.testPassCount + metrics.testFailCount + metrics.testErrorCount;
+        if (result.cost === undefined) {
+          if (result.response && !result.response.error) {
+            metrics.cost = undefined;
+          }
+        } else if (promptResultCount === 1) {
+          metrics.cost = result.cost;
+        } else if (metrics.cost !== undefined) {
+          metrics.cost += result.cost;
+        }
 
         for (const [key, value] of Object.entries(result.namedScores || {})) {
           accumulateNamedMetric(metrics, {
@@ -270,10 +280,8 @@ export async function recalculatePromptMetrics(evalRecord: Eval): Promise<void> 
         }
 
         // Update token usage
-        if (result.response?.tokenUsage) {
-          accumulateResponseTokenUsage(metrics.tokenUsage, {
-            tokenUsage: result.response.tokenUsage,
-          });
+        if (result.response) {
+          accumulateResponseTokenUsagePreservingUnknown(metrics.tokenUsage, result.response);
         }
 
         // Update assertion token usage

--- a/src/providers/google/interactions.ts
+++ b/src/providers/google/interactions.ts
@@ -10,7 +10,12 @@ import { GoogleAuthManager } from './auth';
 import { calculateGoogleCost, mergeGoogleCompletionOptions } from './util';
 
 import type { EnvOverrides } from '../../types/env';
-import type { ApiProvider, CallApiContextParams, ProviderResponse } from '../../types/index';
+import type {
+  ApiProvider,
+  CallApiContextParams,
+  CallApiOptionsParams,
+  ProviderResponse,
+} from '../../types/index';
 import type { CompletionOptions, GoogleProviderConfig } from './types';
 
 type InteractionContent = {
@@ -52,6 +57,38 @@ function normalizeAudioMimeType(format?: string): string {
     return 'audio/pcm';
   }
   return `audio/${format || 'mpeg'}`;
+}
+
+function getAbortError(signal: AbortSignal): Error {
+  const reason = signal.reason;
+  if (reason instanceof Error && reason.name === 'AbortError') {
+    return reason;
+  }
+  const error = new Error(reason instanceof Error ? reason.message : 'Request was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+async function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    await sleep(ms);
+    return;
+  }
+  if (signal.aborted) {
+    throw getAbortError(signal);
+  }
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener('abort', onAbort);
+      reject(getAbortError(signal));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function parseInteractionInput(prompt: string): string | unknown[] | Record<string, unknown> {
@@ -107,7 +144,17 @@ function parseInteractionInput(prompt: string): string | unknown[] | Record<stri
             }
             return part;
           }
-          const imagePart = part as { type?: string; image_url?: string | { url?: string } };
+          const imagePart = part as {
+            type?: string;
+            text?: string;
+            image_url?: string | { url?: string };
+          };
+          if (
+            (imagePart.type === 'input_text' || imagePart.type === 'output_text') &&
+            typeof imagePart.text === 'string'
+          ) {
+            return { type: 'text', text: imagePart.text };
+          }
           if (imagePart.type === 'input_audio') {
             const inputAudio = (part as { input_audio?: { data?: string; format?: string } })
               .input_audio;
@@ -165,15 +212,6 @@ function parseInteractionInput(prompt: string): string | unknown[] | Record<stri
   }
 }
 
-function normalizeInteractionSafetySettings(
-  safetySettings: NonNullable<CompletionOptions['safetySettings']>,
-) {
-  return safetySettings.map(({ category, threshold, probability }) => ({
-    type: category.replace(/^HARM_CATEGORY_/i, '').toLowerCase(),
-    ...(threshold || probability ? { threshold: (threshold || probability)?.toLowerCase() } : {}),
-  }));
-}
-
 function getInteractionModalityTokenCount(
   details: Array<{ modality?: string; tokens?: number }> | undefined,
   modalities: string[],
@@ -221,20 +259,14 @@ function getVertexInteractionsEndpoint(
   projectId: string,
   env?: EnvOverrides,
 ): string {
-  const region =
-    config.region ||
-    env?.VERTEX_REGION ||
-    getEnvString('VERTEX_REGION') ||
-    getEnvString('GOOGLE_CLOUD_LOCATION') ||
-    'global';
   const configuredHost =
     config.apiBaseUrl ||
     config.apiHost ||
     env?.VERTEX_API_HOST ||
     getEnvString('VERTEX_API_HOST') ||
-    (region === 'global' ? 'aiplatform.googleapis.com' : `${region}-aiplatform.googleapis.com`);
+    'aiplatform.googleapis.com';
   const host = /^https?:\/\//i.test(configuredHost) ? configuredHost : `https://${configuredHost}`;
-  return `${host.replace(/\/$/, '')}/v1beta1/projects/${encodeURIComponent(projectId)}/locations/${encodeURIComponent(region)}/interactions`;
+  return `${host.replace(/\/$/, '')}/v1beta1/projects/${encodeURIComponent(projectId)}/locations/global/interactions`;
 }
 
 export class GoogleInteractionsProvider implements ApiProvider {
@@ -261,7 +293,15 @@ export class GoogleInteractionsProvider implements ApiProvider {
     return `[Google Interactions Provider ${this.modelName}]`;
   }
 
-  async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    callApiOptions?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
+    const abortSignal = callApiOptions?.abortSignal;
+    if (abortSignal?.aborted) {
+      throw getAbortError(abortSignal);
+    }
     if (!prompt.trim()) {
       return { error: 'Prompt is required for Gemini Interactions API' };
     }
@@ -270,12 +310,25 @@ export class GoogleInteractionsProvider implements ApiProvider {
       this.config,
       context?.prompt?.config as Partial<CompletionOptions> | undefined,
     ) as GoogleProviderConfig;
-    const passthroughPreviousInteractionId =
-      config.passthrough?.previous_interaction_id ?? config.passthrough?.previousInteractionId;
-    if (config.vertexai && (config.previousInteractionId || passthroughPreviousInteractionId)) {
+    if (
+      config.vertexai &&
+      (config.previousInteractionId !== undefined ||
+        config.passthrough?.previous_interaction_id !== undefined ||
+        config.passthrough?.previousInteractionId !== undefined)
+    ) {
       return {
         error:
           'Gemini Omni on Vertex AI does not support previousInteractionId. Use the Google AI Studio route for conversational video editing.',
+      };
+    }
+    if (
+      config.safetySettings !== undefined ||
+      config.passthrough?.safetySettings !== undefined ||
+      config.passthrough?.safety_settings !== undefined
+    ) {
+      return {
+        error:
+          'Gemini Omni Flash does not support custom safety settings through the Interactions API.',
       };
     }
     if (
@@ -356,6 +409,9 @@ export class GoogleInteractionsProvider implements ApiProvider {
         ...config.headers,
       };
     }
+    if (abortSignal?.aborted) {
+      throw getAbortError(abortSignal);
+    }
     const unsupportedGenerationFields = new Set([
       ...(config.vertexai ? [] : ['temperature', 'top_p', 'topP']),
       'stop_sequences',
@@ -414,9 +470,6 @@ export class GoogleInteractionsProvider implements ApiProvider {
         ? { previous_interaction_id: config.previousInteractionId }
         : {}),
       ...(config.store === undefined ? {} : { store: config.store }),
-      ...(config.safetySettings
-        ? { safety_settings: normalizeInteractionSafetySettings(config.safetySettings) }
-        : {}),
       ...(Object.keys(generationConfig).length > 0 ? { generation_config: generationConfig } : {}),
       ...passthrough,
       background: false,
@@ -439,6 +492,7 @@ export class GoogleInteractionsProvider implements ApiProvider {
           method: 'POST',
           headers,
           body: JSON.stringify(body),
+          signal: abortSignal,
         } as RequestInit,
         getRequestTimeoutMs(),
         'json',
@@ -446,6 +500,9 @@ export class GoogleInteractionsProvider implements ApiProvider {
         true,
       )) as { data: InteractionResponse; cached: boolean; status: number; statusText: string });
     } catch (err) {
+      if (abortSignal?.aborted) {
+        throw getAbortError(abortSignal);
+      }
       return { error: `Gemini Interactions API error: ${String(err)}` };
     }
 
@@ -464,6 +521,9 @@ export class GoogleInteractionsProvider implements ApiProvider {
     const pollStartedAt = Date.now();
     let pollCount = 0;
     while (data.status === 'in_progress' && data.id) {
+      if (abortSignal?.aborted) {
+        throw getAbortError(abortSignal);
+      }
       const elapsed = Date.now() - pollStartedAt;
       if (elapsed >= pollTimeoutMs) {
         return {
@@ -472,7 +532,7 @@ export class GoogleInteractionsProvider implements ApiProvider {
         };
       }
       if (pollCount > 0) {
-        await sleep(Math.min(1_000, pollTimeoutMs - elapsed));
+        await sleepWithAbort(Math.min(1_000, pollTimeoutMs - elapsed), abortSignal);
       }
       try {
         ({
@@ -481,12 +541,15 @@ export class GoogleInteractionsProvider implements ApiProvider {
           statusText: httpStatusText,
         } = (await fetchWithCache(
           `${endpoint}/${encodeURIComponent(data.id)}`,
-          { method: 'GET', headers } as RequestInit,
+          { method: 'GET', headers, signal: abortSignal } as RequestInit,
           Math.max(pollTimeoutMs - (Date.now() - pollStartedAt), 1),
           'json',
           true,
         )) as { data: InteractionResponse; cached: boolean; status: number; statusText: string });
       } catch (err) {
+        if (abortSignal?.aborted) {
+          throw getAbortError(abortSignal);
+        }
         return { error: `Gemini Interactions API polling error: ${String(err)}` };
       }
       pollCount++;
@@ -500,6 +563,9 @@ export class GoogleInteractionsProvider implements ApiProvider {
           raw: data,
         };
       }
+    }
+    if (abortSignal?.aborted) {
+      throw getAbortError(abortSignal);
     }
     if (data.status && data.status !== 'completed') {
       return { error: `Gemini interaction did not complete (status: ${data.status})`, raw: data };
@@ -569,6 +635,7 @@ export class GoogleInteractionsProvider implements ApiProvider {
               method: 'GET',
               headers: downloadHeaders,
               redirect: 'manual',
+              signal: abortSignal,
             },
             getRequestTimeoutMs(),
           );
@@ -592,6 +659,7 @@ export class GoogleInteractionsProvider implements ApiProvider {
                 method: 'GET',
                 ...(redirectUrl.origin === downloadUrl.origin ? { headers: downloadHeaders } : {}),
                 redirect: 'manual',
+                signal: abortSignal,
               },
               getRequestTimeoutMs(),
             );
@@ -603,6 +671,9 @@ export class GoogleInteractionsProvider implements ApiProvider {
             };
           }
           videoBuffer = Buffer.from(await response.arrayBuffer());
+          if (abortSignal?.aborted) {
+            throw getAbortError(abortSignal);
+          }
         } else {
           // Not on the download allowlist — keep the raw URI in the output, but say why
           // the video was not fetched instead of silently returning a link we never followed.
@@ -612,10 +683,16 @@ export class GoogleInteractionsProvider implements ApiProvider {
           );
         }
       } catch (err) {
+        if (abortSignal?.aborted) {
+          throw getAbortError(abortSignal);
+        }
         return { error: `Failed to download Gemini interaction video: ${String(err)}` };
       }
     }
     if (videoBuffer) {
+      if (abortSignal?.aborted) {
+        throw getAbortError(abortSignal);
+      }
       try {
         ({ ref: blobRef } = await storeBlob(videoBuffer, video.mime_type || 'video/mp4', {
           evalId: context?.evaluationId,
@@ -630,9 +707,13 @@ export class GoogleInteractionsProvider implements ApiProvider {
     }
 
     const usage = data.usage;
-    const promptTokens = (usage?.total_input_tokens ?? 0) + (usage?.total_tool_use_tokens ?? 0);
-    const outputTokens = usage?.total_output_tokens ?? 0;
-    const thoughtTokens = usage?.total_reasoning_tokens ?? usage?.total_thought_tokens ?? 0;
+    const promptTokens = usage
+      ? (usage.total_input_tokens ?? 0) + (usage.total_tool_use_tokens ?? 0)
+      : undefined;
+    const outputTokens = usage ? (usage.total_output_tokens ?? 0) : undefined;
+    const thoughtTokens = usage
+      ? (usage.total_reasoning_tokens ?? usage.total_thought_tokens ?? 0)
+      : undefined;
     const audioInputTokens =
       getInteractionModalityTokenCount(usage?.input_tokens_by_modality, ['audio']) +
       getInteractionModalityTokenCount(usage?.tool_use_tokens_by_modality, ['audio']);
@@ -673,30 +754,37 @@ export class GoogleInteractionsProvider implements ApiProvider {
     return {
       output: text || `[Video: ${sanitizedPrompt}](${videoUrl})`,
       cached,
-      tokenUsage: {
-        prompt: promptTokens,
-        completion: outputTokens,
-        total: usage?.total_tokens ?? promptTokens + outputTokens + thoughtTokens,
-        cached: usage?.total_cached_tokens ?? 0,
-        numRequests: 1,
-        ...(thoughtTokens > 0 ? { completionDetails: { reasoning: thoughtTokens } } : {}),
-      },
-      cost: cached
-        ? undefined
-        : calculateGoogleCost(
-            this.modelName,
-            config,
-            promptTokens,
-            outputTokens + thoughtTokens,
-            config.vertexai,
-            audioInputTokens,
-            audioOutputTokens,
-            videoTokens,
-            imageInputTokens,
-            usage?.total_cached_tokens,
-            cachedAudioTokens,
-            cachedImageTokens,
-          ),
+      tokenUsage: usage
+        ? {
+            prompt: promptTokens,
+            completion: outputTokens,
+            total:
+              usage.total_tokens ??
+              (promptTokens ?? 0) + (outputTokens ?? 0) + (thoughtTokens ?? 0),
+            cached: usage.total_cached_tokens ?? 0,
+            numRequests: 1,
+            ...((thoughtTokens ?? 0) > 0
+              ? { completionDetails: { reasoning: thoughtTokens } }
+              : {}),
+          }
+        : { numRequests: 1 },
+      cost:
+        cached || !usage
+          ? undefined
+          : calculateGoogleCost(
+              this.modelName,
+              config,
+              promptTokens ?? 0,
+              (outputTokens ?? 0) + (thoughtTokens ?? 0),
+              config.vertexai,
+              audioInputTokens,
+              audioOutputTokens,
+              videoTokens,
+              imageInputTokens,
+              usage?.total_cached_tokens,
+              cachedAudioTokens,
+              cachedImageTokens,
+            ),
       video: {
         id: data.id,
         blobRef,

--- a/src/providers/google/interactions.ts
+++ b/src/providers/google/interactions.ts
@@ -324,7 +324,7 @@ export class GoogleInteractionsProvider implements ApiProvider {
     } as GoogleProviderConfig;
     if (
       config.vertexai &&
-      (config.previousInteractionId !== undefined ||
+      (Boolean(config.previousInteractionId) ||
         config.passthrough?.previous_interaction_id !== undefined ||
         config.passthrough?.previousInteractionId !== undefined)
     ) {
@@ -710,13 +710,20 @@ export class GoogleInteractionsProvider implements ApiProvider {
       }
       try {
         ({ ref: blobRef } = await storeBlob(videoBuffer, video.mime_type || 'video/mp4', {
+          abortSignal,
           evalId: context?.evaluationId,
           kind: 'video',
           location: 'response.video',
           promptIdx: context?.promptIdx,
           testIdx: context?.testIdx,
         }));
+        if (abortSignal?.aborted) {
+          throw getAbortError(abortSignal);
+        }
       } catch (err) {
+        if (abortSignal?.aborted) {
+          throw getAbortError(abortSignal);
+        }
         return { error: `Failed to store Gemini interaction video: ${String(err)}` };
       }
     }

--- a/src/providers/google/interactions.ts
+++ b/src/providers/google/interactions.ts
@@ -69,6 +69,13 @@ function getAbortError(signal: AbortSignal): Error {
   return error;
 }
 
+function hasUnsupportedSafetySettings(value: unknown): boolean {
+  if (value == null) {
+    return false;
+  }
+  return !Array.isArray(value) || value.length > 0;
+}
+
 async function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
   if (!signal) {
     await sleep(ms);
@@ -274,6 +281,7 @@ export class GoogleInteractionsProvider implements ApiProvider {
   config: GoogleProviderConfig;
   env?: EnvOverrides;
   private providerId?: string;
+  private readonly isVertexProvider: boolean;
 
   constructor(
     modelName: string,
@@ -283,6 +291,7 @@ export class GoogleInteractionsProvider implements ApiProvider {
     this.config = options.config || {};
     this.env = options.env;
     this.providerId = options.id;
+    this.isVertexProvider = this.config.vertexai === true;
   }
 
   id(): string {
@@ -306,10 +315,13 @@ export class GoogleInteractionsProvider implements ApiProvider {
       return { error: 'Prompt is required for Gemini Interactions API' };
     }
 
-    const config = mergeGoogleCompletionOptions(
-      this.config,
-      context?.prompt?.config as Partial<CompletionOptions> | undefined,
-    ) as GoogleProviderConfig;
+    const config = {
+      ...mergeGoogleCompletionOptions(
+        this.config,
+        context?.prompt?.config as Partial<CompletionOptions> | undefined,
+      ),
+      vertexai: this.isVertexProvider,
+    } as GoogleProviderConfig;
     if (
       config.vertexai &&
       (config.previousInteractionId !== undefined ||
@@ -322,9 +334,9 @@ export class GoogleInteractionsProvider implements ApiProvider {
       };
     }
     if (
-      config.safetySettings !== undefined ||
-      config.passthrough?.safetySettings !== undefined ||
-      config.passthrough?.safety_settings !== undefined
+      hasUnsupportedSafetySettings(config.safetySettings) ||
+      hasUnsupportedSafetySettings(config.passthrough?.safetySettings) ||
+      hasUnsupportedSafetySettings(config.passthrough?.safety_settings)
     ) {
       return {
         error:
@@ -387,6 +399,9 @@ export class GoogleInteractionsProvider implements ApiProvider {
           ...config.headers,
         };
       } catch (err) {
+        if (abortSignal?.aborted) {
+          throw getAbortError(abortSignal);
+        }
         return { error: `Gemini Omni Vertex AI authentication error: ${String(err)}` };
       }
     } else {
@@ -413,7 +428,9 @@ export class GoogleInteractionsProvider implements ApiProvider {
       throw getAbortError(abortSignal);
     }
     const unsupportedGenerationFields = new Set([
-      ...(config.vertexai ? [] : ['temperature', 'top_p', 'topP']),
+      'temperature',
+      'top_p',
+      'topP',
       'stop_sequences',
       'stopSequences',
       'negative_prompt',
@@ -428,10 +445,6 @@ export class GoogleInteractionsProvider implements ApiProvider {
       ...(config.maxOutputTokens === undefined
         ? {}
         : { max_output_tokens: config.maxOutputTokens }),
-      ...(config.vertexai && config.temperature !== undefined
-        ? { temperature: config.temperature }
-        : {}),
-      ...(config.vertexai && config.topP !== undefined ? { top_p: config.topP } : {}),
       ...Object.fromEntries(
         Object.entries({
           ...(config.generationConfig || {}),
@@ -453,6 +466,8 @@ export class GoogleInteractionsProvider implements ApiProvider {
         ([field]) =>
           field !== 'generation_config' &&
           field !== 'generationConfig' &&
+          field !== 'safetySettings' &&
+          field !== 'safety_settings' &&
           !unsupportedGenerationFields.has(field),
       ),
     );

--- a/src/providers/google/interactions.ts
+++ b/src/providers/google/interactions.ts
@@ -729,13 +729,23 @@ export class GoogleInteractionsProvider implements ApiProvider {
     }
 
     const usage = data.usage;
-    const promptTokens = usage
-      ? (usage.total_input_tokens ?? 0) + (usage.total_tool_use_tokens ?? 0)
-      : undefined;
-    const outputTokens = usage ? (usage.total_output_tokens ?? 0) : undefined;
-    const thoughtTokens = usage
-      ? (usage.total_reasoning_tokens ?? usage.total_thought_tokens ?? 0)
-      : undefined;
+    // Presence is per field, not per object: an empty or partial `usage` is not a report of
+    // zero. Treating `{}` as truthy turned a billed video generation into 0 tokens and $0.
+    const promptTokens =
+      usage?.total_input_tokens !== undefined || usage?.total_tool_use_tokens !== undefined
+        ? (usage.total_input_tokens ?? 0) + (usage.total_tool_use_tokens ?? 0)
+        : undefined;
+    const outputTokens = usage?.total_output_tokens;
+    const thoughtTokens =
+      usage?.total_reasoning_tokens !== undefined || usage?.total_thought_tokens !== undefined
+        ? (usage.total_reasoning_tokens ?? usage.total_thought_tokens ?? 0)
+        : undefined;
+    const hasReportedUsage =
+      promptTokens !== undefined ||
+      outputTokens !== undefined ||
+      thoughtTokens !== undefined ||
+      usage?.total_tokens !== undefined ||
+      usage?.total_cached_tokens !== undefined;
     const audioInputTokens =
       getInteractionModalityTokenCount(usage?.input_tokens_by_modality, ['audio']) +
       getInteractionModalityTokenCount(usage?.tool_use_tokens_by_modality, ['audio']);
@@ -776,14 +786,14 @@ export class GoogleInteractionsProvider implements ApiProvider {
     return {
       output: text || `[Video: ${sanitizedPrompt}](${videoUrl})`,
       cached,
-      tokenUsage: usage
+      tokenUsage: hasReportedUsage
         ? {
             prompt: promptTokens,
             completion: outputTokens,
             total:
-              usage.total_tokens ??
+              usage?.total_tokens ??
               (promptTokens ?? 0) + (outputTokens ?? 0) + (thoughtTokens ?? 0),
-            cached: usage.total_cached_tokens ?? 0,
+            cached: usage?.total_cached_tokens ?? 0,
             numRequests: 1,
             ...((thoughtTokens ?? 0) > 0
               ? { completionDetails: { reasoning: thoughtTokens } }
@@ -791,7 +801,7 @@ export class GoogleInteractionsProvider implements ApiProvider {
           }
         : { numRequests: 1 },
       cost:
-        cached || !usage
+        cached || !hasReportedUsage
           ? undefined
           : calculateGoogleCost(
               this.modelName,

--- a/src/providers/google/interactions.ts
+++ b/src/providers/google/interactions.ts
@@ -261,6 +261,22 @@ function getInteractionsEndpoint(config: CompletionOptions, env?: EnvOverrides):
   return 'https://generativelanguage.googleapis.com/v1beta/interactions';
 }
 
+/**
+ * Resolves the configured Vertex region, or null when the caller did not pick one.
+ */
+function getConfiguredVertexRegion(
+  config: GoogleProviderConfig,
+  env?: EnvOverrides,
+): string | null {
+  return (
+    config.region ||
+    env?.VERTEX_REGION ||
+    getEnvString('VERTEX_REGION') ||
+    getEnvString('GOOGLE_CLOUD_LOCATION') ||
+    null
+  );
+}
+
 function getVertexInteractionsEndpoint(
   config: GoogleProviderConfig,
   projectId: string,
@@ -385,6 +401,18 @@ export class GoogleInteractionsProvider implements ApiProvider {
         const token = typeof accessToken === 'string' ? accessToken : accessToken?.token;
         if (!token) {
           return { error: 'Gemini Omni on Vertex AI could not obtain an OAuth access token.' };
+        }
+        // The Interactions API accepts locations global, us and eu, but the Omni publisher
+        // model resolves only in global -- us and eu return 404 "Publisher model ... was not
+        // found". Rewriting a configured region to global silently would send prompts and
+        // generated video somewhere the caller did not choose, so say so instead.
+        const configuredRegion = getConfiguredVertexRegion(config, this.env);
+        if (configuredRegion && configuredRegion !== 'global') {
+          logger.warn(
+            `[Google Interactions] Gemini Omni is only served from the 'global' location, so the ` +
+              `configured region '${configuredRegion}' is not used. Prompts and generated video ` +
+              `are sent to the global endpoint.`,
+          );
         }
         endpoint = getVertexInteractionsEndpoint(config, projectId, this.env);
         const { authorization, ...authHeaders } =

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -335,7 +335,7 @@ const PromptMetricsSchema = z.object({
       strategyFailCount: z.record(z.string(), z.number()),
     })
     .optional(),
-  cost: z.number(),
+  cost: z.number().optional(),
 });
 export type PromptMetrics = z.infer<typeof PromptMetricsSchema>;
 
@@ -402,7 +402,7 @@ export interface EvaluateResult {
   namedScores: Record<string, number>;
   cost?: number;
   metadata?: Record<string, any>;
-  tokenUsage?: Required<TokenUsage>;
+  tokenUsage?: TokenUsage;
   /**
    * Eval ID this result belongs to, surfaced when tracing is enabled so consumers
    * can pass it to `/api/traces/evaluation/:evaluationId` without re-deriving it.
@@ -478,7 +478,7 @@ export interface EvaluateStats {
   successes: number;
   failures: number;
   errors: number;
-  tokenUsage: Required<TokenUsage>;
+  tokenUsage: TokenUsage;
   durationMs?: number;
   generationDurationMs?: number;
   evaluationDurationMs?: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -414,7 +414,7 @@ export interface EvaluateResult {
 }
 
 export interface EvaluateTableOutput {
-  cost: number;
+  cost?: number;
   failureReason: ResultFailureReason;
   gradingResult?: GradingResult | null;
   id: string;

--- a/src/util/calculateFilteredMetrics.ts
+++ b/src/util/calculateFilteredMetrics.ts
@@ -131,7 +131,39 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
       SUM(CAST(json_extract(response, '$.tokenUsage.prompt') AS INTEGER)) as prompt_tokens,
       SUM(CAST(json_extract(response, '$.tokenUsage.completion') AS INTEGER)) as completion_tokens,
       SUM(CAST(json_extract(response, '$.tokenUsage.cached') AS INTEGER)) as cached_tokens,
-      COUNT(CASE WHEN json_extract(response, '$.tokenUsage') IS NOT NULL THEN 1 END) as num_requests_with_tokens
+      SUM(
+        CASE
+          WHEN response IS NULL THEN 0
+          WHEN json_extract(response, '$.tokenUsage.numRequests') IS NOT NULL
+            THEN CAST(json_extract(response, '$.tokenUsage.numRequests') AS INTEGER)
+          ELSE 1
+        END
+      ) as num_requests,
+      MAX(
+        CASE
+          WHEN response IS NOT NULL
+            AND COALESCE(
+              CAST(json_extract(response, '$.tokenUsage.numRequests') AS INTEGER),
+              1
+            ) > 0
+            AND json_extract(response, '$.tokenUsage.total') IS NULL
+            AND json_extract(response, '$.tokenUsage.prompt') IS NULL
+            AND json_extract(response, '$.tokenUsage.completion') IS NULL
+            AND json_extract(response, '$.tokenUsage.cached') IS NULL
+          THEN 1
+          ELSE 0
+        END
+      ) as has_unknown_token_usage,
+      MAX(
+        CASE
+          WHEN response IS NOT NULL
+            AND cost IS NULL
+            AND COALESCE(CAST(json_extract(response, '$.cached') AS INTEGER), 0) = 0
+            AND json_extract(response, '$.error') IS NULL
+          THEN 1
+          ELSE 0
+        END
+      ) as has_unknown_cost
     FROM eval_results
     WHERE ${whereSql}
     GROUP BY prompt_idx
@@ -146,12 +178,14 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
     error_count: number;
     total_score: number;
     total_latency: number;
-    total_cost: number;
+    total_cost: number | null;
     total_tokens: number | null;
     prompt_tokens: number | null;
     completion_tokens: number | null;
     cached_tokens: number | null;
-    num_requests_with_tokens: number;
+    num_requests: number;
+    has_unknown_token_usage: number;
+    has_unknown_cost: number;
   }>;
 
   // Populate basic metrics
@@ -168,13 +202,17 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
       testFailCount: row.fail_count || 0,
       testErrorCount: row.error_count || 0,
       totalLatencyMs: row.total_latency || 0,
-      cost: row.total_cost || 0,
+      ...(row.has_unknown_cost ? {} : { cost: row.total_cost ?? 0 }),
       tokenUsage: {
-        total: row.total_tokens || 0,
-        prompt: row.prompt_tokens || 0,
-        completion: row.completion_tokens || 0,
-        cached: row.cached_tokens || 0,
-        numRequests: row.num_requests_with_tokens || 0,
+        ...(row.has_unknown_token_usage
+          ? {}
+          : {
+              total: row.total_tokens ?? 0,
+              prompt: row.prompt_tokens ?? 0,
+              completion: row.completion_tokens ?? 0,
+              cached: row.cached_tokens ?? 0,
+            }),
+        numRequests: row.num_requests || 0,
       },
       namedScores: {},
       namedScoresCount: {},

--- a/src/util/convertEvalResultsToTable.ts
+++ b/src/util/convertEvalResultsToTable.ts
@@ -135,16 +135,17 @@ export function convertResultsToTable(eval_: ResultsFile): EvaluateTable {
     } else {
       resultText = outputTextDisplay;
     }
+    const { cost, ...resultWithoutCost } = result;
 
     row.outputs[result.promptIdx] = {
       id: result.id || `${result.testIdx}-${result.promptIdx}`,
-      ...result,
+      ...resultWithoutCost,
       text: resultText || '',
       prompt: result.prompt.raw,
       provider: result.provider?.label || result.provider?.id || 'unknown provider',
       pass: result.success,
       failureReason: result.failureReason,
-      cost: result.cost || 0,
+      ...(cost === undefined ? {} : { cost }),
       tokenUsage: result.tokenUsage,
       audio: result.response?.audio
         ? {

--- a/src/util/eval/summary.ts
+++ b/src/util/eval/summary.ts
@@ -171,6 +171,11 @@ function getTokenUsageLines(
   const hasEvalTokens =
     (tokenUsage.total || 0) > 0 || (tokenUsage.prompt || 0) + (tokenUsage.completion || 0) > 0;
   const hasGradingTokens = tokenUsage.assertions && (tokenUsage.assertions.total || 0) > 0;
+  const hasUnknownEvalTokens =
+    (tokenUsage.numRequests || 0) > 0 &&
+    tokenUsage.total === undefined &&
+    tokenUsage.prompt === undefined &&
+    tokenUsage.completion === undefined;
 
   if (!hasEvalTokens && !hasGradingTokens) {
     return [];
@@ -190,11 +195,13 @@ function getTokenUsageLines(
     },
   };
 
-  const lines = [
-    `${chalk.bold('Total Tokens:')} ${chalk.white.bold(
-      (evalTokens.total + (tokenUsage.assertions?.total || 0)).toLocaleString(),
-    )}`,
-  ];
+  const lines = hasUnknownEvalTokens
+    ? []
+    : [
+        `${chalk.bold('Total Tokens:')} ${chalk.white.bold(
+          (evalTokens.total + (tokenUsage.assertions?.total || 0)).toLocaleString(),
+        )}`,
+      ];
 
   if (isRedteam && tokenUsage.numRequests) {
     lines.push(

--- a/src/util/exportToFile/index.ts
+++ b/src/util/exportToFile/index.ts
@@ -23,15 +23,16 @@ export function convertEvalResultToTableCell(result: EvalResult): EvaluateTableO
   } else {
     resultText = outputTextDisplay;
   }
+  const { cost, ...resultWithoutCost } = result;
 
   return {
-    ...result,
+    ...resultWithoutCost,
     id: result.id || `${result.testIdx}-${result.promptIdx}`,
     text: resultText || '',
     prompt: result.prompt.raw,
     provider: result.provider?.label || result.provider?.id || 'unknown provider',
     pass: result.success,
-    cost: result.cost || 0,
+    ...(cost === undefined ? {} : { cost }),
     audio: result.response?.audio
       ? {
           id: result.response.audio.id,

--- a/src/util/output.ts
+++ b/src/util/output.ts
@@ -315,7 +315,9 @@ const outputToHtmlReportCell = (output: EvaluateTableOutput) => {
     failureReason: output.failureReason,
     latencyDisplay: Number.isFinite(output.latencyMs) ? `${output.latencyMs.toFixed(0)} ms` : '',
     costDisplay:
-      Number.isFinite(output.cost) && output.cost > 0 ? `$${output.cost.toFixed(6)}` : '',
+      typeof output.cost === 'number' && Number.isFinite(output.cost) && output.cost > 0
+        ? `$${output.cost.toFixed(6)}`
+        : '',
     totalTokensDisplay:
       typeof output.tokenUsage?.total === 'number'
         ? output.tokenUsage.total.toLocaleString('en-US')

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -158,7 +158,7 @@ export function accumulateTokenUsage(
 }
 
 /**
- * Accumulate usage while treating missing token counts on a counted request as unknown.
+ * Accumulate usage while treating a counted request with no reported token counts as unknown.
  *
  * Unlike {@link accumulateTokenUsage}, this helper does not turn an omitted count into zero.
  * Once any counted request has an unknown count, that aggregate count remains unknown.
@@ -181,32 +181,23 @@ export function accumulateTokenUsagePreservingUnknown(
     cached: target.cached,
     total: target.total,
   };
+  const hasReportedTokenCounts =
+    update.prompt !== undefined ||
+    update.completion !== undefined ||
+    update.cached !== undefined ||
+    update.total !== undefined;
 
   accumulateTokenUsage(target, update, incrementRequests);
 
   if (updateRequests > 0) {
     for (const field of ['prompt', 'completion', 'cached', 'total'] as const) {
       const priorCount = priorCounts[field];
-      const updateCount = update[field];
-      if (priorRequests === 0) {
-        if (updateCount === undefined) {
-          delete target[field];
-        } else {
-          target[field] = updateCount;
-        }
-      } else if (priorCount === undefined || updateCount === undefined) {
+      if (!hasReportedTokenCounts || (priorRequests > 0 && priorCount === undefined)) {
         delete target[field];
-      } else {
-        target[field] = priorCount + updateCount;
       }
     }
 
-    if (
-      update.prompt === undefined &&
-      update.completion === undefined &&
-      update.cached === undefined &&
-      update.total === undefined
-    ) {
+    if (!hasReportedTokenCounts) {
       delete target.completionDetails;
     } else if (priorRequests > 0 && priorCompletionDetails === undefined) {
       delete target.completionDetails;

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -189,6 +189,18 @@ export function accumulateTokenUsagePreservingUnknown(
 
   accumulateTokenUsage(target, update, incrementRequests);
 
+  if (updateRequests === 0) {
+    for (const field of ['prompt', 'completion', 'cached', 'total'] as const) {
+      if (priorCounts[field] === undefined) {
+        delete target[field];
+      }
+    }
+    if (priorCompletionDetails === undefined) {
+      delete target.completionDetails;
+    }
+    return;
+  }
+
   if (updateRequests > 0) {
     for (const field of ['prompt', 'completion', 'cached', 'total'] as const) {
       const priorCount = priorCounts[field];

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -158,6 +158,63 @@ export function accumulateTokenUsage(
 }
 
 /**
+ * Accumulate usage while treating missing token counts on a counted request as unknown.
+ *
+ * Unlike {@link accumulateTokenUsage}, this helper does not turn an omitted count into zero.
+ * Once any counted request has an unknown count, that aggregate count remains unknown.
+ */
+export function accumulateTokenUsagePreservingUnknown(
+  target: TokenUsage,
+  update: Partial<TokenUsage> | undefined,
+  incrementRequests = false,
+): void {
+  if (!update) {
+    return;
+  }
+
+  const priorRequests = target.numRequests ?? 0;
+  const updateRequests = update.numRequests ?? (incrementRequests ? 1 : 0);
+  const priorCompletionDetails = target.completionDetails;
+  const priorCounts = {
+    prompt: target.prompt,
+    completion: target.completion,
+    cached: target.cached,
+    total: target.total,
+  };
+
+  accumulateTokenUsage(target, update, incrementRequests);
+
+  if (updateRequests > 0) {
+    for (const field of ['prompt', 'completion', 'cached', 'total'] as const) {
+      const priorCount = priorCounts[field];
+      const updateCount = update[field];
+      if (priorRequests === 0) {
+        if (updateCount === undefined) {
+          delete target[field];
+        } else {
+          target[field] = updateCount;
+        }
+      } else if (priorCount === undefined || updateCount === undefined) {
+        delete target[field];
+      } else {
+        target[field] = priorCount + updateCount;
+      }
+    }
+
+    if (
+      update.prompt === undefined &&
+      update.completion === undefined &&
+      update.cached === undefined &&
+      update.total === undefined
+    ) {
+      delete target.completionDetails;
+    } else if (priorRequests > 0 && priorCompletionDetails === undefined) {
+      delete target.completionDetails;
+    }
+  }
+}
+
+/**
  * Accumulate token usage specifically for assertions.
  * This function operates directly on an assertions object rather than a full TokenUsage object.
  * @param target Assertions object to update
@@ -235,6 +292,34 @@ export function accumulateResponseTokenUsage(
   } else if (response && countAsRequest) {
     // Only increment numRequests if we got a response but no token usage
     target.numRequests = (target.numRequests ?? 0) + 1;
+  }
+}
+
+/**
+ * Response-accounting counterpart to {@link accumulateTokenUsagePreservingUnknown}.
+ */
+export function accumulateResponseTokenUsagePreservingUnknown(
+  target: TokenUsage,
+  response: { tokenUsage?: Partial<TokenUsage> } | undefined,
+  options?: { countAsRequest?: boolean },
+): void {
+  const countAsRequest = options?.countAsRequest ?? true;
+
+  if (response?.tokenUsage) {
+    if (countAsRequest) {
+      accumulateTokenUsagePreservingUnknown(
+        target,
+        response.tokenUsage,
+        response.tokenUsage.numRequests === undefined,
+      );
+    } else {
+      accumulateTokenUsagePreservingUnknown(target, {
+        ...response.tokenUsage,
+        numRequests: undefined,
+      });
+    }
+  } else if (response && countAsRequest) {
+    accumulateTokenUsagePreservingUnknown(target, { numRequests: 1 });
   }
 }
 

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -181,11 +181,17 @@ export function accumulateTokenUsagePreservingUnknown(
     cached: target.cached,
     total: target.total,
   };
-  const hasReportedTokenCounts =
-    update.prompt !== undefined ||
-    update.completion !== undefined ||
-    update.cached !== undefined ||
-    update.total !== undefined;
+  // Presence is tracked per field: a single flag across all four let a partial update
+  // fabricate zeros for the counts it never mentioned (reporting only `prompt` invented
+  // completion/cached/total as 0).
+  const reported = {
+    prompt: update.prompt !== undefined,
+    completion: update.completion !== undefined,
+    cached: update.cached !== undefined,
+    total: update.total !== undefined,
+  };
+  const reportedAnyTokenCount =
+    reported.prompt || reported.completion || reported.cached || reported.total;
 
   accumulateTokenUsage(target, update, incrementRequests);
 
@@ -204,14 +210,14 @@ export function accumulateTokenUsagePreservingUnknown(
   if (updateRequests > 0) {
     for (const field of ['prompt', 'completion', 'cached', 'total'] as const) {
       const priorCount = priorCounts[field];
-      if (!hasReportedTokenCounts || (priorRequests > 0 && priorCount === undefined)) {
+      // A counted request that did not supply this field leaves the aggregate unable to
+      // claim it, whether it reported nothing at all or only some of the four.
+      if (!reported[field] || (priorRequests > 0 && priorCount === undefined)) {
         delete target[field];
       }
     }
 
-    if (!hasReportedTokenCounts) {
-      delete target.completionDetails;
-    } else if (priorRequests > 0 && priorCompletionDetails === undefined) {
+    if (!reportedAnyTokenCount || (priorRequests > 0 && priorCompletionDetails === undefined)) {
       delete target.completionDetails;
     }
   }

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -181,17 +181,11 @@ export function accumulateTokenUsagePreservingUnknown(
     cached: target.cached,
     total: target.total,
   };
-  // Presence is tracked per field: a single flag across all four let a partial update
-  // fabricate zeros for the counts it never mentioned (reporting only `prompt` invented
-  // completion/cached/total as 0).
-  const reported = {
-    prompt: update.prompt !== undefined,
-    completion: update.completion !== undefined,
-    cached: update.cached !== undefined,
-    total: update.total !== undefined,
-  };
-  const reportedAnyTokenCount =
-    reported.prompt || reported.completion || reported.cached || reported.total;
+  const hasReportedTokenCounts =
+    update.prompt !== undefined ||
+    update.completion !== undefined ||
+    update.cached !== undefined ||
+    update.total !== undefined;
 
   accumulateTokenUsage(target, update, incrementRequests);
 
@@ -210,14 +204,14 @@ export function accumulateTokenUsagePreservingUnknown(
   if (updateRequests > 0) {
     for (const field of ['prompt', 'completion', 'cached', 'total'] as const) {
       const priorCount = priorCounts[field];
-      // A counted request that did not supply this field leaves the aggregate unable to
-      // claim it, whether it reported nothing at all or only some of the four.
-      if (!reported[field] || (priorRequests > 0 && priorCount === undefined)) {
+      if (!hasReportedTokenCounts || (priorRequests > 0 && priorCount === undefined)) {
         delete target[field];
       }
     }
 
-    if (!reportedAnyTokenCount || (priorRequests > 0 && priorCompletionDetails === undefined)) {
+    if (!hasReportedTokenCounts) {
+      delete target.completionDetails;
+    } else if (priorRequests > 0 && priorCompletionDetails === undefined) {
       delete target.completionDetails;
     }
   }

--- a/test/blobs/index.test.ts
+++ b/test/blobs/index.test.ts
@@ -1,19 +1,93 @@
 import { randomUUID } from 'node:crypto';
 
 import { eq, inArray } from 'drizzle-orm';
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getShareAuthorizedBlob,
   isBlobAllowedForShare,
   recordBlobReference,
   resetBlobStorageProvider,
   setBlobStorageProvider,
+  storeBlob,
 } from '../../src/blobs';
 import { getDb } from '../../src/database';
 import { blobAssetsTable, blobReferencesTable, evalsTable } from '../../src/database/tables';
 import { runDbMigrations } from '../../src/migrate';
 
 import type { BlobStorageProvider } from '../../src/blobs';
+
+describe('abort-aware blob storage', () => {
+  const evalId = `eval-${randomUUID()}`;
+  const hash = 'f'.repeat(64);
+
+  beforeAll(async () => {
+    await runDbMigrations();
+  });
+
+  afterEach(async () => {
+    resetBlobStorageProvider();
+    const db = await getDb();
+    await db.delete(blobReferencesTable).where(eq(blobReferencesTable.evalId, evalId));
+    await db.delete(blobAssetsTable).where(eq(blobAssetsTable.hash, hash));
+    await db.delete(evalsTable).where(eq(evalsTable.id, evalId));
+  });
+
+  it('deletes a newly stored blob and skips database references when aborted during storage', async () => {
+    const controller = new AbortController();
+    let finishStore: (() => void) | undefined;
+    const deleteByHash = vi.fn().mockResolvedValue(undefined);
+    setBlobStorageProvider({
+      providerId: 'abort-test',
+      store: vi.fn(async () => {
+        await new Promise<void>((resolve) => {
+          finishStore = resolve;
+        });
+        return {
+          ref: {
+            uri: `blob://${hash}`,
+            hash,
+            mimeType: 'video/mp4',
+            provider: 'abort-test',
+            sizeBytes: 5,
+          },
+          deduplicated: false,
+        };
+      }),
+      getByHash: vi.fn(),
+      exists: vi.fn(),
+      deleteByHash,
+      getUrl: vi.fn(),
+    });
+    const db = await getDb();
+    await db.insert(evalsTable).values({ id: evalId, config: {}, results: {} });
+
+    const pendingStore = storeBlob(Buffer.from('video'), 'video/mp4', {
+      abortSignal: controller.signal,
+      evalId,
+      kind: 'video',
+      location: 'response.video',
+    });
+    controller.abort(new Error('cancelled while storing blob'));
+    finishStore?.();
+
+    await expect(pendingStore).rejects.toThrow('cancelled while storing blob');
+    expect(deleteByHash).toHaveBeenCalledWith(hash);
+    await expect(
+      db
+        .select({ id: blobReferencesTable.id })
+        .from(blobReferencesTable)
+        .where(eq(blobReferencesTable.evalId, evalId))
+        .get(),
+    ).resolves.toBeUndefined();
+    await expect(
+      db
+        .select({ hash: blobAssetsTable.hash })
+        .from(blobAssetsTable)
+        .where(eq(blobAssetsTable.hash, hash))
+        .get(),
+    ).resolves.toBeUndefined();
+  });
+});
 
 describe('blob share authorization', () => {
   const evalId = `eval-${randomUUID()}`;

--- a/test/blobs/index.test.ts
+++ b/test/blobs/index.test.ts
@@ -18,6 +18,7 @@ import type { BlobStorageProvider } from '../../src/blobs';
 
 describe('abort-aware blob storage', () => {
   const evalId = `eval-${randomUUID()}`;
+  const otherEvalId = `eval-${randomUUID()}`;
   const hash = 'f'.repeat(64);
 
   beforeAll(async () => {
@@ -27,9 +28,11 @@ describe('abort-aware blob storage', () => {
   afterEach(async () => {
     resetBlobStorageProvider();
     const db = await getDb();
-    await db.delete(blobReferencesTable).where(eq(blobReferencesTable.evalId, evalId));
+    await db
+      .delete(blobReferencesTable)
+      .where(inArray(blobReferencesTable.evalId, [evalId, otherEvalId]));
     await db.delete(blobAssetsTable).where(eq(blobAssetsTable.hash, hash));
-    await db.delete(evalsTable).where(eq(evalsTable.id, evalId));
+    await db.delete(evalsTable).where(inArray(evalsTable.id, [evalId, otherEvalId]));
   });
 
   it('deletes a newly stored blob and skips database references when aborted during storage', async () => {
@@ -86,6 +89,78 @@ describe('abort-aware blob storage', () => {
         .where(eq(blobAssetsTable.hash, hash))
         .get(),
     ).resolves.toBeUndefined();
+  });
+
+  it('keeps a concurrently referenced blob when an original upload is aborted', async () => {
+    const controller = new AbortController();
+    let finishStore: (() => void) | undefined;
+    const deleteByHash = vi.fn().mockResolvedValue(undefined);
+    setBlobStorageProvider({
+      providerId: 'abort-test',
+      store: vi.fn(async () => {
+        await new Promise<void>((resolve) => {
+          finishStore = resolve;
+        });
+        return {
+          ref: {
+            uri: `blob://${hash}`,
+            hash,
+            mimeType: 'video/mp4',
+            provider: 'abort-test',
+            sizeBytes: 5,
+          },
+          deduplicated: false,
+        };
+      }),
+      getByHash: vi.fn(),
+      exists: vi.fn(),
+      deleteByHash,
+      getUrl: vi.fn(),
+    });
+    const db = await getDb();
+    await db.insert(evalsTable).values([
+      { id: evalId, config: {}, results: {} },
+      { id: otherEvalId, config: {}, results: {} },
+    ]);
+
+    const pendingStore = storeBlob(Buffer.from('video'), 'video/mp4', {
+      abortSignal: controller.signal,
+      evalId,
+      kind: 'video',
+      location: 'response.video',
+    });
+    await db.insert(blobAssetsTable).values({
+      hash,
+      mimeType: 'video/mp4',
+      provider: 'abort-test',
+      sizeBytes: 5,
+    });
+    await db.insert(blobReferencesTable).values({
+      id: randomUUID(),
+      blobHash: hash,
+      evalId: otherEvalId,
+      kind: 'video',
+      location: 'response.video',
+    });
+    controller.abort(new Error('cancelled after a concurrent store'));
+    finishStore?.();
+
+    await expect(pendingStore).rejects.toThrow('cancelled after a concurrent store');
+    expect(deleteByHash).not.toHaveBeenCalled();
+    await expect(
+      db
+        .select({ hash: blobAssetsTable.hash })
+        .from(blobAssetsTable)
+        .where(eq(blobAssetsTable.hash, hash))
+        .get(),
+    ).resolves.toEqual({ hash });
+    await expect(
+      db
+        .select({ evalId: blobReferencesTable.evalId })
+        .from(blobReferencesTable)
+        .where(eq(blobReferencesTable.blobHash, hash))
+        .get(),
+    ).resolves.toEqual({ evalId: otherEvalId });
   });
 });
 

--- a/test/evaluator/metrics.test.ts
+++ b/test/evaluator/metrics.test.ts
@@ -4,12 +4,59 @@ import { randomUUID } from 'crypto';
 
 import { expect, it, vi } from 'vitest';
 import { evaluate } from '../../src/evaluator';
+import { runExtensionHook } from '../../src/evaluatorHelpers';
 import Eval from '../../src/models/eval';
 import { type ApiProvider, ResultFailureReason, type TestSuite } from '../../src/types/index';
 import { mockApiProvider, toPrompt } from './helpers';
 import { describeEvaluator } from './lifecycle';
 
 describeEvaluator('evaluator metrics and scoring', () => {
+  it('accumulates prompt cost when concurrent rows finish out of reservation order', async () => {
+    let signalFirstHookEntered: () => void;
+    const firstHookEntered = new Promise<void>((resolve) => {
+      signalFirstHookEntered = resolve;
+    });
+    let releaseFirstHook: () => void;
+    const firstHookCanFinish = new Promise<void>((resolve) => {
+      releaseFirstHook = resolve;
+    });
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('concurrent-cost-provider'),
+      callApi: vi.fn().mockImplementation(async (prompt: string) => {
+        const cost = Number(prompt);
+        if (cost === 0.2) {
+          await firstHookEntered;
+        }
+        return { output: 'Generated output', cost };
+      }),
+    };
+    const testSuite: TestSuite = {
+      extensions: ['file://test-extension.js'],
+      providers: [provider],
+      prompts: [toPrompt('{{cost}}')],
+      tests: [{ vars: { cost: 0.1 } }, { vars: { cost: 0.2 } }],
+    };
+    vi.mocked(runExtensionHook).mockImplementation(async (_extensions, hookName, context) => {
+      if (hookName === 'afterEach' && 'result' in context && context.result?.cost === 0.1) {
+        signalFirstHookEntered();
+        await firstHookCanFinish;
+      }
+      return context;
+    });
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {
+      maxConcurrency: 2,
+      progressCallback: (_completed, _total, _index, _evalStep, metrics) => {
+        if (metrics.cost === 0.2) {
+          releaseFirstHook();
+        }
+      },
+    });
+
+    expect(evalRecord.prompts[0].metrics?.cost).toBeCloseTo(0.3);
+  });
+
   it('evaluator should count named score assertions per metric', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -10,6 +10,50 @@ import { mockApiProvider, mockGradingApiProviderPasses, toPrompt } from './helpe
 import { describeEvaluator } from './lifecycle';
 
 describeEvaluator('evaluator token usage', () => {
+  it('preserves unknown provider usage and cost through persistence and export', async () => {
+    const providerWithoutUsage: ApiProvider = {
+      id: vi.fn().mockReturnValue('provider-without-usage'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Generated output',
+        tokenUsage: { numRequests: 1 },
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [providerWithoutUsage],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+    evalRecord.clearResults();
+    const summary = await evalRecord.toEvaluateSummary();
+    expect(summary.version).toBe(3);
+    if (!('prompts' in summary)) {
+      throw new Error('Expected a persisted v3 evaluation summary');
+    }
+
+    const result = summary.results[0];
+    expect(result.cost).toBeUndefined();
+    expect(result.response?.tokenUsage).toEqual({ numRequests: 1 });
+    expect(result.tokenUsage).toMatchObject({ numRequests: 1 });
+    expect(result.tokenUsage).not.toHaveProperty('prompt');
+    expect(result.tokenUsage).not.toHaveProperty('completion');
+    expect(result.tokenUsage).not.toHaveProperty('cached');
+    expect(result.tokenUsage).not.toHaveProperty('total');
+
+    expect(summary.prompts[0].metrics?.cost).toBeUndefined();
+    expect(summary.prompts[0].metrics?.tokenUsage).not.toHaveProperty('prompt');
+    expect(summary.prompts[0].metrics?.tokenUsage).not.toHaveProperty('completion');
+    expect(summary.prompts[0].metrics?.tokenUsage).not.toHaveProperty('cached');
+    expect(summary.prompts[0].metrics?.tokenUsage).not.toHaveProperty('total');
+    expect(summary.stats.tokenUsage).not.toHaveProperty('prompt');
+    expect(summary.stats.tokenUsage).not.toHaveProperty('completion');
+    expect(summary.stats.tokenUsage).not.toHaveProperty('cached');
+    expect(summary.stats.tokenUsage).not.toHaveProperty('total');
+    expect(JSON.parse(JSON.stringify(summary.prompts[0].metrics))).not.toHaveProperty('cost');
+  });
+
   it('should accumulate token usage correctly', async () => {
     const mockOptions = {
       delay: 0,

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -54,6 +54,35 @@ describeEvaluator('evaluator token usage', () => {
     expect(JSON.parse(JSON.stringify(summary.prompts[0].metrics))).not.toHaveProperty('cost');
   });
 
+  it('treats a successful Promptfoo cache hit as zero incremental cost', async () => {
+    const provider: ApiProvider = {
+      id: vi.fn().mockReturnValue('cache-aware-provider'),
+      callApi: vi.fn().mockImplementation(async (prompt: string) =>
+        prompt === 'fresh'
+          ? {
+              output: 'Fresh output',
+              cost: 0.25,
+              tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+            }
+          : {
+              output: 'Cached output',
+              cached: true,
+              tokenUsage: { numRequests: 0 },
+            },
+      ),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('{{kind}}')],
+      tests: [{ vars: { kind: 'fresh' } }, { vars: { kind: 'cached' } }],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+
+    expect(evalRecord.prompts[0].metrics?.cost).toBe(0.25);
+  });
+
   it('should accumulate token usage correctly', async () => {
     const mockOptions = {
       delay: 0,

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -10,6 +10,31 @@ import { mockApiProvider, mockGradingApiProviderPasses, toPrompt } from './helpe
 import { describeEvaluator } from './lifecycle';
 
 describeEvaluator('evaluator token usage', () => {
+  it('counts a successful response with omitted token usage without inventing counts', async () => {
+    const providerWithoutTokenUsage: ApiProvider = {
+      id: vi.fn().mockReturnValue('provider-without-token-usage'),
+      callApi: vi.fn().mockResolvedValue({ output: 'Generated output' }),
+    };
+    const results = await runEval({
+      conversations: {},
+      delay: 0,
+      isRedteam: false,
+      prompt: toPrompt('Test prompt'),
+      promptIdx: 0,
+      provider: providerWithoutTokenUsage,
+      registers: {},
+      repeatIndex: 0,
+      test: {},
+      testIdx: 0,
+    });
+
+    expect(results[0].tokenUsage).toMatchObject({ numRequests: 1 });
+    expect(results[0].tokenUsage).not.toHaveProperty('prompt');
+    expect(results[0].tokenUsage).not.toHaveProperty('completion');
+    expect(results[0].tokenUsage).not.toHaveProperty('cached');
+    expect(results[0].tokenUsage).not.toHaveProperty('total');
+  });
+
   it('preserves unknown provider usage and cost through persistence and export', async () => {
     const providerWithoutUsage: ApiProvider = {
       id: vi.fn().mockReturnValue('provider-without-usage'),

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -670,6 +670,16 @@ describe('evaluator', () => {
       expect(exportedRow.tokenUsage).toEqual({ numRequests: 1 });
       expect(exportedRow.response?.tokenUsage).toEqual({ numRequests: 1 });
       expect(JSON.parse(JSON.stringify(exportedRow))).not.toHaveProperty('cost');
+
+      const fullTable = await evaluation.getTable();
+      const fullTableOutput = fullTable.body[0].outputs[0];
+      expect(fullTableOutput.cost).toBeUndefined();
+      expect(JSON.parse(JSON.stringify(fullTableOutput))).not.toHaveProperty('cost');
+
+      const pagedTable = await evaluation.getTablePage({ filters: [] });
+      const pagedTableOutput = pagedTable.body[0].outputs[0];
+      expect(pagedTableOutput.cost).toBeUndefined();
+      expect(JSON.parse(JSON.stringify(pagedTableOutput))).not.toHaveProperty('cost');
     });
   });
 
@@ -970,6 +980,37 @@ describe('evaluator', () => {
   });
 
   describe('getStats', () => {
+    it('keeps unknown usage after a later prompt contributes no requests', () => {
+      const eval1 = new Eval({});
+      eval1.prompts = [
+        {
+          raw: 'unknown usage',
+          metrics: {
+            tokenUsage: { numRequests: 1 },
+          },
+        } as any,
+        {
+          raw: 'untouched',
+          metrics: {
+            tokenUsage: {
+              prompt: 0,
+              completion: 0,
+              cached: 0,
+              total: 0,
+              numRequests: 0,
+            },
+          },
+        } as any,
+      ];
+
+      const stats = eval1.getStats();
+      expect(stats.tokenUsage.numRequests).toBe(1);
+      expect(stats.tokenUsage).not.toHaveProperty('prompt');
+      expect(stats.tokenUsage).not.toHaveProperty('completion');
+      expect(stats.tokenUsage).not.toHaveProperty('cached');
+      expect(stats.tokenUsage).not.toHaveProperty('total');
+    });
+
     it('should accumulate assertion token usage correctly', () => {
       const eval1 = new Eval({});
       eval1.prompts = [

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -640,6 +640,37 @@ describe('evaluator', () => {
       expect(exportedRow.metadata).not.toHaveProperty('__promptfoo');
       expect(JSON.stringify(summary)).not.toContain('__promptfoo');
     });
+
+    it('preserves unknown provider usage and cost through persistence and export', async () => {
+      const resultWithUnknownUsage = createEvaluateResult({
+        cost: undefined,
+        gradingResult: null,
+        response: {
+          output: '[Video: generated](blob://video/omni)',
+          tokenUsage: { numRequests: 1 },
+        },
+        tokenUsage: { numRequests: 1 },
+      });
+
+      const evaluation = await Eval.create({ description: 'Unknown usage export coverage' }, [], {
+        results: [resultWithUnknownUsage as unknown as EvalResult],
+      });
+
+      const db = await getDb();
+      const [persistedRow] = await db
+        .select({ cost: evalResultsTable.cost })
+        .from(evalResultsTable)
+        .where(eq(evalResultsTable.evalId, evaluation.id));
+      expect(persistedRow.cost).toBeNull();
+
+      const summary = await evaluation.toEvaluateSummary();
+      expect('results' in summary).toBe(true);
+      const [exportedRow] = (summary as { results: EvaluateResult[] }).results;
+      expect(exportedRow.cost).toBeUndefined();
+      expect(exportedRow.tokenUsage).toEqual({ numRequests: 1 });
+      expect(exportedRow.response?.tokenUsage).toEqual({ numRequests: 1 });
+      expect(JSON.parse(JSON.stringify(exportedRow))).not.toHaveProperty('cost');
+    });
   });
 
   describe('setResults trace linkage', () => {

--- a/test/node/retry.test.ts
+++ b/test/node/retry.test.ts
@@ -266,6 +266,38 @@ describe('retryCommand', () => {
     );
   });
 
+  it('treats cached rows without cost as zero incremental cost during recalculation', async () => {
+    const prompts = [{}] as any[];
+    const evalRecord = createEval({
+      prompts,
+      fetchResultsBatched: vi.fn(async function* () {
+        yield [
+          {
+            id: 'fresh-result',
+            promptIdx: 0,
+            success: true,
+            failureReason: ResultFailureReason.NONE,
+            score: 1,
+            cost: 0.25,
+            response: { output: 'fresh' },
+          },
+          {
+            id: 'cached-result',
+            promptIdx: 0,
+            success: true,
+            failureReason: ResultFailureReason.NONE,
+            score: 1,
+            response: { output: 'cached', cached: true },
+          },
+        ] as any[];
+      }),
+    });
+
+    await recalculatePromptMetrics(evalRecord);
+
+    expect(prompts[0].metrics?.cost).toBe(0.25);
+  });
+
   it('logs and rethrows metric recalculation and persistence failures', async () => {
     const calculationError = new Error('batch unavailable');
     const calculationEval = createEval({

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -815,6 +815,15 @@ describe('GoogleInteractionsProvider', () => {
         aspectRatio: '16:9',
         temperature: 0.2,
         topP: 0.9,
+        generationConfig: {
+          seed: 42,
+          temperature: 0.4,
+          top_p: 0.8,
+        } as any,
+        passthrough: {
+          temperature: 0.6,
+          top_p: 0.7,
+        },
       },
     });
 
@@ -833,7 +842,7 @@ describe('GoogleInteractionsProvider', () => {
           model: 'gemini-omni-flash-preview',
           input: [{ type: 'text', text: 'A city at dusk' }],
           response_format: [{ type: 'video', aspect_ratio: '16:9' }],
-          generation_config: { temperature: 0.2, top_p: 0.9 },
+          generation_config: { seed: 42 },
           background: false,
           stream: false,
         }),
@@ -845,6 +854,29 @@ describe('GoogleInteractionsProvider', () => {
     expect(getRequestHeaders).toHaveBeenCalledWith(
       'https://aiplatform.googleapis.com/v1beta1/projects/configured-project/locations/global/interactions',
     );
+  });
+
+  it('keeps the constructed Vertex route when prompt config sets vertexai false', async () => {
+    const authSpy = vi.spyOn(GoogleAuthManager, 'getOAuthClient');
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: {
+        vertexai: true,
+        projectId: 'configured-project',
+      },
+    });
+
+    const result = await provider.callApi('Make it brighter', {
+      prompt: {
+        config: {
+          vertexai: false,
+          previousInteractionId: 'interaction-0',
+        },
+      },
+    } as any);
+
+    expect(result.error).toContain('does not support previousInteractionId');
+    expect(authSpy).not.toHaveBeenCalled();
+    expect(mockFetchWithCache).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -1011,9 +1043,16 @@ describe('GoogleInteractionsProvider', () => {
   });
 
   it.each([
-    ['top-level safetySettings', { safetySettings: [] }],
-    ['passthrough safetySettings', { passthrough: { safetySettings: [] } }],
-    ['passthrough safety_settings', { passthrough: { safety_settings: [] } }],
+    [
+      'top-level safetySettings',
+      {
+        safetySettings: [
+          { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_LOW_AND_ABOVE' },
+        ],
+      },
+    ],
+    ['passthrough safetySettings', { passthrough: { safetySettings: [{}] } }],
+    ['passthrough safety_settings', { passthrough: { safety_settings: [{}] } }],
   ])('rejects unsupported %s before Vertex auth or network', async (_source, safetyConfig) => {
     const authSpy = vi.spyOn(GoogleAuthManager, 'getOAuthClient');
     const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
@@ -1031,6 +1070,35 @@ describe('GoogleInteractionsProvider', () => {
     );
     expect(authSpy).not.toHaveBeenCalled();
     expect(mockFetchWithCache).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['top-level safetySettings', { safetySettings: [] }],
+    ['passthrough safetySettings', { passthrough: { safetySettings: [] } }],
+    ['passthrough safety_settings', { passthrough: { safety_settings: [] } }],
+  ])('allows and omits empty %s', async (_source, safetyConfig) => {
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
+          },
+        ],
+      },
+      cached: false,
+    } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { apiKey: 'test-key', ...safetyConfig } as any,
+    });
+
+    const result = await provider.callApi('A city at dusk');
+
+    expect(result.error).toBeUndefined();
+    const body = JSON.parse(mockFetchWithCache.mock.calls[0]?.[1]?.body as string);
+    expect(body).not.toHaveProperty('safetySettings');
+    expect(body).not.toHaveProperty('safety_settings');
   });
 
   it.each([
@@ -1153,6 +1221,27 @@ describe('GoogleInteractionsProvider', () => {
       expect.objectContaining({ signal: controller.signal }),
       expect.any(Number),
     );
+    expect(mockStoreBlob).not.toHaveBeenCalled();
+  });
+
+  it('normalizes cancellation that wins a Vertex authentication failure race', async () => {
+    const controller = new AbortController();
+    vi.spyOn(GoogleAuthManager, 'getOAuthClient').mockImplementationOnce(async () => {
+      controller.abort(new Error('cancelled during authentication'));
+      throw new Error('OAuth failed after cancellation');
+    });
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { vertexai: true, projectId: 'configured-project' },
+    });
+
+    await expect(
+      provider.callApi('A city at dusk', undefined, { abortSignal: controller.signal }),
+    ).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'cancelled during authentication',
+    });
+    expect(mockFetchWithCache).not.toHaveBeenCalled();
+    expect(mockFetchWithTimeout).not.toHaveBeenCalled();
     expect(mockStoreBlob).not.toHaveBeenCalled();
   });
 

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -957,6 +957,41 @@ describe('GoogleInteractionsProvider', () => {
     expect(mockFetchWithCache).not.toHaveBeenCalled();
   });
 
+  it('treats an empty top-level Vertex previousInteractionId as absent', async () => {
+    vi.spyOn(GoogleAuthManager, 'getOAuthClient').mockResolvedValueOnce({
+      client: {
+        getAccessToken: vi.fn().mockResolvedValue({ token: 'vertex-token' }),
+        getRequestHeaders: vi.fn().mockResolvedValue(new Headers()),
+      },
+      projectId: 'configured-project',
+    });
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
+          },
+        ],
+      },
+      cached: false,
+    } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: {
+        vertexai: true,
+        projectId: 'configured-project',
+        previousInteractionId: '',
+      },
+    });
+
+    const result = await provider.callApi('A city at dusk');
+
+    expect(result.error).toBeUndefined();
+    const body = JSON.parse(String(mockFetchWithCache.mock.calls[0]?.[1]?.body));
+    expect(body).not.toHaveProperty('previous_interaction_id');
+  });
+
   it('rejects unsupported Vertex Omni follow-ups supplied through passthrough', async () => {
     const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
       config: {
@@ -1222,6 +1257,53 @@ describe('GoogleInteractionsProvider', () => {
       expect.any(Number),
     );
     expect(mockStoreBlob).not.toHaveBeenCalled();
+  });
+
+  it('normalizes cancellation while blob persistence is pending', async () => {
+    const controller = new AbortController();
+    let finishStore: (() => void) | undefined;
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
+          },
+        ],
+      },
+      cached: false,
+    } as any);
+    mockStoreBlob.mockImplementationOnce(async (_data, _mimeType, context) => {
+      await new Promise<void>((resolve) => {
+        finishStore = resolve;
+      });
+      context?.abortSignal?.throwIfAborted();
+      return {
+        ref: { uri: 'blob://video/omni', hash: 'omni', mimeType: 'video/mp4', sizeBytes: 5 },
+        deduplicated: false,
+      } as any;
+    });
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { apiKey: 'test-key' },
+    });
+
+    const pendingCall = provider.callApi('A city at dusk', { evaluationId: 'eval-1' } as any, {
+      abortSignal: controller.signal,
+    });
+    await vi.waitFor(() => expect(mockStoreBlob).toHaveBeenCalledOnce());
+    controller.abort(new Error('cancelled during blob persistence'));
+    finishStore?.();
+
+    await expect(pendingCall).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'cancelled during blob persistence',
+    });
+    expect(mockStoreBlob).toHaveBeenCalledWith(
+      Buffer.from('video'),
+      'video/mp4',
+      expect.objectContaining({ abortSignal: controller.signal, evalId: 'eval-1' }),
+    );
   });
 
   it('normalizes cancellation that wins a Vertex authentication failure race', async () => {

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -68,10 +68,6 @@ describe('GoogleInteractionsProvider', () => {
         aspectRatio: '9:16',
         previousInteractionId: 'interaction-0',
         store: true,
-        safetySettings: [
-          { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_LOW_AND_ABOVE' },
-          { category: 'HARM_CATEGORY_HARASSMENT', probability: 'BLOCK_MEDIUM_AND_ABOVE' },
-        ],
         service_tier: 'priority',
         maxOutputTokens: 2_048,
         generationConfig: {
@@ -117,10 +113,6 @@ describe('GoogleInteractionsProvider', () => {
           response_format: { type: 'video', aspect_ratio: '9:16' },
           previous_interaction_id: 'interaction-0',
           store: true,
-          safety_settings: [
-            { type: 'hate_speech', threshold: 'block_low_and_above' },
-            { type: 'harassment', threshold: 'block_medium_and_above' },
-          ],
           generation_config: {
             max_output_tokens: 2_048,
             thinking_level: 'low',
@@ -199,12 +191,16 @@ describe('GoogleInteractionsProvider', () => {
           role: 'user',
           content: [
             { type: 'text', text: 'Use this reference.' },
+            { type: 'input_text', text: 'Use an establishing shot.' },
             { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,aW1hZ2U=' } },
             { type: 'input_image', image_url: 'https://image.example/reference.png' },
             { type: 'input_audio', input_audio: { data: 'YXVkaW8=', format: 'mp3' } },
           ],
         },
-        { role: 'assistant', content: 'I will create that scene.' },
+        {
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'I will create that scene.' }],
+        },
         { role: 'user', content: 'Add rain.' },
       ]),
     );
@@ -221,6 +217,7 @@ describe('GoogleInteractionsProvider', () => {
         type: 'user_input',
         content: [
           { type: 'text', text: 'Use this reference.' },
+          { type: 'text', text: 'Use an establishing shot.' },
           { type: 'image', mime_type: 'image/jpeg', data: 'aW1hZ2U=' },
           { type: 'image', uri: 'https://image.example/reference.png' },
           { type: 'audio', mime_type: 'audio/mpeg', data: 'YXVkaW8=' },
@@ -368,6 +365,29 @@ describe('GoogleInteractionsProvider', () => {
     expect(result.cost).toBeCloseTo(48.8, 10);
   });
 
+  it('leaves token counts and cost unknown when Interactions omits usage', async () => {
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
+          },
+        ],
+      },
+      cached: false,
+    } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { apiKey: 'test-key' },
+    });
+
+    const result = await provider.callApi('Animate the reference');
+
+    expect(result.tokenUsage).toEqual({ numRequests: 1 });
+    expect(result.cost).toBeUndefined();
+  });
+
   it('returns only the latest Omni turn and stores authenticated URI-delivered video', async () => {
     mockFetchWithCache.mockResolvedValue({
       data: {
@@ -422,6 +442,7 @@ describe('GoogleInteractionsProvider', () => {
   });
 
   it('does not forward Gemini credentials across a video-download redirect', async () => {
+    const controller = new AbortController();
     mockFetchWithCache.mockResolvedValue({
       data: {
         status: 'completed',
@@ -452,7 +473,7 @@ describe('GoogleInteractionsProvider', () => {
       config: { apiKey: 'test-key' },
     });
 
-    await provider.callApi('a city at dusk');
+    await provider.callApi('a city at dusk', undefined, { abortSignal: controller.signal });
 
     expect(mockFetchWithTimeout).toHaveBeenNthCalledWith(
       1,
@@ -460,13 +481,14 @@ describe('GoogleInteractionsProvider', () => {
       expect.objectContaining({
         headers: expect.objectContaining({ 'x-goog-api-key': 'test-key' }),
         redirect: 'manual',
+        signal: controller.signal,
       }),
       expect.any(Number),
     );
     expect(mockFetchWithTimeout).toHaveBeenNthCalledWith(
       2,
       'https://storage.googleapis.com/signed-video',
-      { method: 'GET', redirect: 'manual' },
+      { method: 'GET', redirect: 'manual', signal: controller.signal },
       expect.any(Number),
     );
     expect(mockStoreBlob).toHaveBeenCalledWith(
@@ -579,6 +601,50 @@ describe('GoogleInteractionsProvider', () => {
       'json',
       true,
     );
+  });
+
+  it('does not start an interaction for an already-aborted eval', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled before dispatch'));
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { apiKey: 'test-key' },
+    });
+
+    await expect(
+      provider.callApi('make it rainy', undefined, { abortSignal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError', message: 'cancelled before dispatch' });
+    expect(mockFetchWithCache).not.toHaveBeenCalled();
+    expect(mockFetchWithTimeout).not.toHaveBeenCalled();
+    expect(mockStoreBlob).not.toHaveBeenCalled();
+  });
+
+  it('stops polling immediately when the eval is aborted', async () => {
+    const controller = new AbortController();
+    mockFetchWithCache
+      .mockResolvedValueOnce({
+        data: { id: 'interaction-pending', status: 'in_progress' },
+        cached: false,
+      } as any)
+      .mockResolvedValueOnce({
+        data: { id: 'interaction-pending', status: 'in_progress' },
+        cached: false,
+      } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { apiKey: 'test-key', timeoutMs: 5_000 },
+    });
+
+    const result = provider.callApi('make it rainy', undefined, {
+      abortSignal: controller.signal,
+    });
+    await vi.waitFor(() => expect(mockFetchWithCache).toHaveBeenCalledTimes(2));
+    controller.abort();
+
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+    expect(mockFetchWithCache).toHaveBeenCalledTimes(2);
+    expect(mockFetchWithCache.mock.calls[0]?.[1]).toMatchObject({ signal: controller.signal });
+    expect(mockFetchWithCache.mock.calls[1]?.[1]).toMatchObject({ signal: controller.signal });
+    expect(mockFetchWithTimeout).not.toHaveBeenCalled();
+    expect(mockStoreBlob).not.toHaveBeenCalled();
   });
 
   it('surfaces a failed latest Omni model-output step instead of reusing old video', async () => {
@@ -781,6 +847,69 @@ describe('GoogleInteractionsProvider', () => {
     );
   });
 
+  it.each([
+    ['provider region', { region: 'us-central1' }, {}, 'https://aiplatform.googleapis.com'],
+    ['VERTEX_REGION', {}, { VERTEX_REGION: 'us-central1' }, 'https://aiplatform.googleapis.com'],
+    [
+      'GOOGLE_CLOUD_LOCATION',
+      {},
+      { GOOGLE_CLOUD_LOCATION: 'us-east1' },
+      'https://aiplatform.googleapis.com',
+    ],
+    [
+      'an explicit API base URL',
+      { apiBaseUrl: 'http://127.0.0.1:15500/vertex-proxy' },
+      {},
+      'http://127.0.0.1:15500/vertex-proxy',
+    ],
+    [
+      'an explicit API host',
+      { apiHost: 'vertex-proxy.example' },
+      {},
+      'https://vertex-proxy.example',
+    ],
+    [
+      'VERTEX_API_HOST',
+      {},
+      { VERTEX_API_HOST: 'env-vertex-proxy.example' },
+      'https://env-vertex-proxy.example',
+    ],
+  ])('keeps Vertex Omni on the global endpoint despite %s', async (_source, config, env, host) => {
+    vi.spyOn(GoogleAuthManager, 'getOAuthClient').mockResolvedValueOnce({
+      client: {
+        getAccessToken: vi.fn().mockResolvedValue({ token: 'vertex-token' }),
+        getRequestHeaders: vi.fn().mockResolvedValue(new Headers()),
+      },
+      projectId: 'configured-project',
+    });
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
+          },
+        ],
+      },
+      cached: false,
+    } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { ...config, vertexai: true, projectId: 'configured-project' },
+      env,
+    });
+
+    await provider.callApi('A city at dusk');
+
+    expect(mockFetchWithCache).toHaveBeenCalledWith(
+      `${host}/v1beta1/projects/configured-project/locations/global/interactions`,
+      expect.any(Object),
+      expect.any(Number),
+      'json',
+      true,
+    );
+  });
+
   it('rejects unsupported Vertex Omni follow-up interactions before making a request', async () => {
     const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
       config: {
@@ -826,6 +955,26 @@ describe('GoogleInteractionsProvider', () => {
     expect(mockFetchWithCache).not.toHaveBeenCalled();
   });
 
+  it('rejects a real camelCase Vertex follow-up when the snake-case alias is empty', async () => {
+    const authSpy = vi.spyOn(GoogleAuthManager, 'getOAuthClient');
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: {
+        vertexai: true,
+        projectId: 'configured-project',
+        passthrough: {
+          previous_interaction_id: '',
+          previousInteractionId: 'interaction-0',
+        },
+      },
+    });
+
+    const result = await provider.callApi('Make it brighter');
+
+    expect(result.error).toContain('does not support previousInteractionId');
+    expect(authSpy).not.toHaveBeenCalled();
+    expect(mockFetchWithCache).not.toHaveBeenCalled();
+  });
+
   it('does not reject an AI Studio Omni follow-up supplied through passthrough', async () => {
     // The follow-up guard is Vertex-only; AI Studio supports conversational editing, so
     // the request must proceed past the guard (here it reaches the API-key check).
@@ -859,6 +1008,29 @@ describe('GoogleInteractionsProvider', () => {
       expect(result.error).toContain('does not support tools');
       expect(mockFetchWithCache).not.toHaveBeenCalled();
     }
+  });
+
+  it.each([
+    ['top-level safetySettings', { safetySettings: [] }],
+    ['passthrough safetySettings', { passthrough: { safetySettings: [] } }],
+    ['passthrough safety_settings', { passthrough: { safety_settings: [] } }],
+  ])('rejects unsupported %s before Vertex auth or network', async (_source, safetyConfig) => {
+    const authSpy = vi.spyOn(GoogleAuthManager, 'getOAuthClient');
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: {
+        vertexai: true,
+        projectId: 'configured-project',
+        ...safetyConfig,
+      } as any,
+    });
+
+    const result = await provider.callApi('A city at dusk');
+
+    expect(result.error).toBe(
+      'Gemini Omni Flash does not support custom safety settings through the Interactions API.',
+    );
+    expect(authSpy).not.toHaveBeenCalled();
+    expect(mockFetchWithCache).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -937,6 +1109,51 @@ describe('GoogleInteractionsProvider', () => {
       'video/mp4',
       expect.any(Object),
     );
+  });
+
+  it('does not store a downloaded video after the eval is aborted', async () => {
+    const controller = new AbortController();
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [
+              {
+                type: 'video',
+                mime_type: 'video/mp4',
+                uri: 'https://generativelanguage.googleapis.com/v1beta/files/video:download',
+              },
+            ],
+          },
+        ],
+      },
+      cached: false,
+    } as any);
+    mockFetchWithTimeout.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      arrayBuffer: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return Buffer.from('downloaded video');
+      }),
+    } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { apiKey: 'test-key' },
+    });
+
+    await expect(
+      provider.callApi('A city at dusk', undefined, { abortSignal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(mockFetchWithTimeout).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: controller.signal }),
+      expect.any(Number),
+    );
+    expect(mockStoreBlob).not.toHaveBeenCalled();
   });
 
   it('preserves a configured provider id and supports the legacy PALM API key', async () => {

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -1197,31 +1197,31 @@ describe('GoogleInteractionsProvider', () => {
     expect(body).not.toHaveProperty('safety_settings');
   });
 
-  it.each([{ tools: [] }, { passthrough: { tools: [] } }])(
-    'allows an empty Omni tools list: %j',
-    async (toolConfig) => {
-      mockFetchWithCache.mockResolvedValue({
-        data: {
-          status: 'completed',
-          steps: [
-            {
-              type: 'model_output',
-              content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
-            },
-          ],
-        },
-        cached: false,
-      } as any);
-      const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
-        config: { apiKey: 'test-key', ...toolConfig },
-      });
+  it.each([
+    { tools: [] },
+    { passthrough: { tools: [] } },
+  ])('allows an empty Omni tools list: %j', async (toolConfig) => {
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
+          },
+        ],
+      },
+      cached: false,
+    } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { apiKey: 'test-key', ...toolConfig },
+    });
 
-      const result = await provider.callApi('A city at dusk');
+    const result = await provider.callApi('A city at dusk');
 
-      expect(result.error).toBeUndefined();
-      expect(mockFetchWithCache).toHaveBeenCalledOnce();
-    },
-  );
+    expect(result.error).toBeUndefined();
+    expect(mockFetchWithCache).toHaveBeenCalledOnce();
+  });
 
   it('downloads Vertex Omni gs:// video output using OAuth headers', async () => {
     const video = { type: 'video', mime_type: 'video/mp4', uri: 'gs://video-bucket/out/a.mp4' };
@@ -1498,37 +1498,34 @@ describe('GoogleInteractionsProvider', () => {
       { GOOGLE_API_HOST: 'wrong.example' },
       'http://127.0.0.1:15500/proxy/v1beta/interactions',
     ],
-  ])(
-    'prefers explicit interaction endpoints and preserves HTTP schemes',
-    async (config, env, endpoint) => {
-      mockFetchWithCache.mockResolvedValue({
-        data: {
-          status: 'completed',
-          steps: [
-            {
-              type: 'model_output',
-              content: [{ type: 'video', mime_type: 'video/mp4', uri: 'https://video.example/4' }],
-            },
-          ],
-        },
-        cached: false,
-      } as any);
-      const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
-        config: { ...config, apiKey: 'test-key' },
-        env,
-      });
+  ])('prefers explicit interaction endpoints and preserves HTTP schemes', async (config, env, endpoint) => {
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'video', mime_type: 'video/mp4', uri: 'https://video.example/4' }],
+          },
+        ],
+      },
+      cached: false,
+    } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { ...config, apiKey: 'test-key' },
+      env,
+    });
 
-      await provider.callApi('A city at dusk');
+    await provider.callApi('A city at dusk');
 
-      expect(mockFetchWithCache).toHaveBeenCalledWith(
-        endpoint,
-        expect.any(Object),
-        expect.any(Number),
-        'json',
-        true,
-      );
-    },
-  );
+    expect(mockFetchWithCache).toHaveBeenCalledWith(
+      endpoint,
+      expect.any(Object),
+      expect.any(Number),
+      'json',
+      true,
+    );
+  });
 
   it('returns a timeout error when polling exceeds the configured deadline', async () => {
     mockFetchWithCache.mockResolvedValue({

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -388,6 +388,33 @@ describe('GoogleInteractionsProvider', () => {
     expect(result.cost).toBeUndefined();
   });
 
+  it('treats an empty usage object as unreported rather than zero', async () => {
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
+          },
+        ],
+        // A completed, billed generation that reports no counts. Object truthiness would
+        // turn this into 0 tokens and $0 -- a paid video reported as free.
+        usage: {},
+      },
+      cached: false,
+    } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { apiKey: 'test-key' },
+    });
+
+    const result = await provider.callApi('Animate the reference');
+
+    expect(result.tokenUsage?.prompt).toBeUndefined();
+    expect(result.tokenUsage?.completion).toBeUndefined();
+    expect(result.cost).toBeUndefined();
+  });
+
   it('returns only the latest Omni turn and stores authenticated URI-delivered video', async () => {
     mockFetchWithCache.mockResolvedValue({
       data: {

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { storeBlob } from '../../../src/blobs';
 import { fetchWithCache } from '../../../src/cache';
+import logger from '../../../src/logger';
 import { GoogleAuthManager } from '../../../src/providers/google/auth';
 import { GoogleInteractionsProvider } from '../../../src/providers/google/interactions';
 import { fetchWithTimeout } from '../../../src/util/fetch/index';
@@ -969,6 +970,39 @@ describe('GoogleInteractionsProvider', () => {
     );
   });
 
+  it('warns when a configured Vertex region is dropped for the global-only Omni endpoint', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger);
+    vi.spyOn(GoogleAuthManager, 'getOAuthClient').mockResolvedValueOnce({
+      client: {
+        getAccessToken: vi.fn().mockResolvedValue({ token: 'vertex-token' }),
+        getRequestHeaders: vi.fn().mockResolvedValue(new Headers()),
+      },
+      projectId: 'configured-project',
+    });
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        status: 'completed',
+        steps: [
+          {
+            type: 'model_output',
+            content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
+          },
+        ],
+      },
+      cached: false,
+    } as any);
+    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+      config: { vertexai: true, projectId: 'configured-project', region: 'eu' },
+    });
+
+    await provider.callApi('A city at dusk');
+
+    // The Interactions API accepts global/us/eu, but the Omni publisher model 404s outside
+    // global, so the request has to go global. Silently relocating a caller who asked for eu
+    // is the part worth surfacing.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("region 'eu' is not used"));
+  });
+
   it('rejects unsupported Vertex Omni follow-up interactions before making a request', async () => {
     const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
       config: {
@@ -1163,31 +1197,31 @@ describe('GoogleInteractionsProvider', () => {
     expect(body).not.toHaveProperty('safety_settings');
   });
 
-  it.each([
-    { tools: [] },
-    { passthrough: { tools: [] } },
-  ])('allows an empty Omni tools list: %j', async (toolConfig) => {
-    mockFetchWithCache.mockResolvedValue({
-      data: {
-        status: 'completed',
-        steps: [
-          {
-            type: 'model_output',
-            content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
-          },
-        ],
-      },
-      cached: false,
-    } as any);
-    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
-      config: { apiKey: 'test-key', ...toolConfig },
-    });
+  it.each([{ tools: [] }, { passthrough: { tools: [] } }])(
+    'allows an empty Omni tools list: %j',
+    async (toolConfig) => {
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          status: 'completed',
+          steps: [
+            {
+              type: 'model_output',
+              content: [{ type: 'video', mime_type: 'video/mp4', data: 'dmlkZW8=' }],
+            },
+          ],
+        },
+        cached: false,
+      } as any);
+      const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+        config: { apiKey: 'test-key', ...toolConfig },
+      });
 
-    const result = await provider.callApi('A city at dusk');
+      const result = await provider.callApi('A city at dusk');
 
-    expect(result.error).toBeUndefined();
-    expect(mockFetchWithCache).toHaveBeenCalledOnce();
-  });
+      expect(result.error).toBeUndefined();
+      expect(mockFetchWithCache).toHaveBeenCalledOnce();
+    },
+  );
 
   it('downloads Vertex Omni gs:// video output using OAuth headers', async () => {
     const video = { type: 'video', mime_type: 'video/mp4', uri: 'gs://video-bucket/out/a.mp4' };
@@ -1464,34 +1498,37 @@ describe('GoogleInteractionsProvider', () => {
       { GOOGLE_API_HOST: 'wrong.example' },
       'http://127.0.0.1:15500/proxy/v1beta/interactions',
     ],
-  ])('prefers explicit interaction endpoints and preserves HTTP schemes', async (config, env, endpoint) => {
-    mockFetchWithCache.mockResolvedValue({
-      data: {
-        status: 'completed',
-        steps: [
-          {
-            type: 'model_output',
-            content: [{ type: 'video', mime_type: 'video/mp4', uri: 'https://video.example/4' }],
-          },
-        ],
-      },
-      cached: false,
-    } as any);
-    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
-      config: { ...config, apiKey: 'test-key' },
-      env,
-    });
+  ])(
+    'prefers explicit interaction endpoints and preserves HTTP schemes',
+    async (config, env, endpoint) => {
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          status: 'completed',
+          steps: [
+            {
+              type: 'model_output',
+              content: [{ type: 'video', mime_type: 'video/mp4', uri: 'https://video.example/4' }],
+            },
+          ],
+        },
+        cached: false,
+      } as any);
+      const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
+        config: { ...config, apiKey: 'test-key' },
+        env,
+      });
 
-    await provider.callApi('A city at dusk');
+      await provider.callApi('A city at dusk');
 
-    expect(mockFetchWithCache).toHaveBeenCalledWith(
-      endpoint,
-      expect.any(Object),
-      expect.any(Number),
-      'json',
-      true,
-    );
-  });
+      expect(mockFetchWithCache).toHaveBeenCalledWith(
+        endpoint,
+        expect.any(Object),
+        expect.any(Number),
+        'json',
+        true,
+      );
+    },
+  );
 
   it('returns a timeout error when polling exceeds the configured deadline', async () => {
     mockFetchWithCache.mockResolvedValue({

--- a/test/util/calculateFilteredMetrics.test.ts
+++ b/test/util/calculateFilteredMetrics.test.ts
@@ -199,12 +199,119 @@ describe('calculateFilteredMetrics', () => {
         whereSql: sql`eval_id = ${eval_.id}`,
       });
 
-      expect(metrics[0].tokenUsage).toMatchObject({
-        total: 0,
-        prompt: 0,
-        completion: 0,
+      expect(metrics[0].tokenUsage).toEqual({ numRequests: 1 });
+    });
+
+    it('should preserve unknown usage and cost across filtered and mixed result sets', async () => {
+      const eval_ = await EvalFactory.create({
+        numResults: 0,
+      });
+
+      await eval_.addResult({
+        promptIdx: 0,
+        testIdx: 0,
+        testCase: { vars: {} },
+        promptId: 'known',
+        provider: { id: 'test', label: 'test' },
+        prompt: { raw: 'test', label: 'test' },
+        vars: {},
+        response: {
+          output: 'known',
+          tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+        },
+        error: null,
+        failureReason: ResultFailureReason.NONE,
+        success: true,
+        score: 1,
+        latencyMs: 100,
+        namedScores: {},
+        cost: 0.01,
+        metadata: {},
+      });
+      await eval_.addResult({
+        promptIdx: 0,
+        testIdx: 1,
+        testCase: { vars: {} },
+        promptId: 'unknown',
+        provider: { id: 'test', label: 'test' },
+        prompt: { raw: 'test', label: 'test' },
+        vars: {},
+        response: {
+          output: 'unknown',
+          tokenUsage: { numRequests: 1 },
+        },
+        error: null,
+        failureReason: ResultFailureReason.NONE,
+        success: true,
+        score: 1,
+        latencyMs: 100,
+        namedScores: {},
+        metadata: {},
+      });
+      await eval_.addResult({
+        promptIdx: 0,
+        testIdx: 2,
+        testCase: { vars: {} },
+        promptId: 'cached',
+        provider: { id: 'test', label: 'test' },
+        prompt: { raw: 'test', label: 'test' },
+        vars: {},
+        response: {
+          output: 'cached',
+          cached: true,
+          tokenUsage: { numRequests: 0 },
+        },
+        error: null,
+        failureReason: ResultFailureReason.NONE,
+        success: true,
+        score: 1,
+        latencyMs: 100,
+        namedScores: {},
+        metadata: {},
+      });
+
+      const known = await calculateFilteredMetrics({
+        evalId: eval_.id,
+        numPrompts: 1,
+        whereSql: sql`eval_id = ${eval_.id} AND test_idx = 0`,
+      });
+      expect(known[0].cost).toBe(0.01);
+      expect(known[0].tokenUsage).toMatchObject({
+        total: 10,
+        prompt: 5,
+        completion: 5,
         cached: 0,
-        numRequests: 0,
+        numRequests: 1,
+      });
+
+      const unknown = await calculateFilteredMetrics({
+        evalId: eval_.id,
+        numPrompts: 1,
+        whereSql: sql`eval_id = ${eval_.id} AND test_idx = 1`,
+      });
+      expect(unknown[0].cost).toBeUndefined();
+      expect(unknown[0].tokenUsage).toEqual({ numRequests: 1 });
+
+      const mixed = await calculateFilteredMetrics({
+        evalId: eval_.id,
+        numPrompts: 1,
+        whereSql: sql`eval_id = ${eval_.id} AND test_idx IN (0, 1)`,
+      });
+      expect(mixed[0].cost).toBeUndefined();
+      expect(mixed[0].tokenUsage).toEqual({ numRequests: 2 });
+
+      const knownAndCached = await calculateFilteredMetrics({
+        evalId: eval_.id,
+        numPrompts: 1,
+        whereSql: sql`eval_id = ${eval_.id} AND test_idx IN (0, 2)`,
+      });
+      expect(knownAndCached[0].cost).toBe(0.01);
+      expect(knownAndCached[0].tokenUsage).toMatchObject({
+        total: 10,
+        prompt: 5,
+        completion: 5,
+        cached: 0,
+        numRequests: 1,
       });
     });
   });

--- a/test/util/convertEvalResultsToTable.test.ts
+++ b/test/util/convertEvalResultsToTable.test.ts
@@ -58,7 +58,6 @@ describe('convertResultsToTable', () => {
               prompt: 'test prompt',
               provider: 'Test Provider',
               pass: true,
-              cost: 0,
               success: true,
               response: {
                 output: 'test output',
@@ -88,6 +87,7 @@ describe('convertResultsToTable', () => {
 
     const result = convertResultsToTable(resultsFile);
     expect(result).toEqual(expected);
+    expect(result.body[0].outputs[0]).not.toHaveProperty('cost');
   });
 
   it('should handle error responses', () => {

--- a/test/util/eval/summary.test.ts
+++ b/test/util/eval/summary.test.ts
@@ -237,6 +237,38 @@ describe('generateEvalSummary', () => {
       expect(output).not.toContain('Eval:');
     });
 
+    it('does not present grading tokens as the total when eval token usage is unknown', () => {
+      const params: EvalSummaryParams = {
+        evalId: 'eval-unknown-usage',
+        isRedteam: false,
+        writeToDatabase: false,
+        shareableUrl: null,
+        wantsToShare: false,
+        hasExplicitDisable: false,
+        cloudEnabled: false,
+        tokenUsage: {
+          numRequests: 1,
+          assertions: {
+            total: 500,
+            prompt: 200,
+            completion: 300,
+          },
+        },
+        successes: 1,
+        failures: 0,
+        errors: 0,
+        duration: 1000,
+        maxConcurrency: 1,
+        tracker: mockTracker,
+      };
+
+      const output = stripAnsi(generateEvalSummary(params).join('\n'));
+
+      expect(output).toContain('Grading: 500 (200 prompt, 300 completion)');
+      expect(output).not.toContain('Total Tokens:');
+      expect(output).not.toContain('Eval:');
+    });
+
     it('should display both eval and grading tokens', () => {
       const params: EvalSummaryParams = {
         evalId: 'eval-both',

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -3,7 +3,9 @@ import {
   accumulateGenerationTokenUsage,
   accumulateGradingRequest,
   accumulateResponseTokenUsage,
+  accumulateResponseTokenUsagePreservingUnknown,
   accumulateTokenUsage,
+  accumulateTokenUsagePreservingUnknown,
   createEmptyAssertions,
   createEmptyTokenUsage,
   getErrorTokenUsage,
@@ -305,6 +307,83 @@ describe('tokenUsageUtils', () => {
 
       expect(target.total).toBe(0);
       expect(target.numRequests).toBe(0);
+    });
+  });
+
+  describe('unknown-preserving accumulation', () => {
+    it('omits unknown token counts for a counted response', () => {
+      const target: TokenUsage = createEmptyTokenUsage();
+
+      accumulateResponseTokenUsagePreservingUnknown(target, {
+        tokenUsage: { numRequests: 1 },
+      });
+
+      expect(target).toMatchObject({ numRequests: 1 });
+      expect(target).not.toHaveProperty('prompt');
+      expect(target).not.toHaveProperty('completion');
+      expect(target).not.toHaveProperty('cached');
+      expect(target).not.toHaveProperty('total');
+      expect(target).not.toHaveProperty('completionDetails');
+    });
+
+    it('keeps aggregate counts unknown after a later request reports usage', () => {
+      const target: TokenUsage = createEmptyTokenUsage();
+      accumulateTokenUsagePreservingUnknown(target, { numRequests: 1 });
+
+      accumulateTokenUsagePreservingUnknown(target, {
+        prompt: 6,
+        completion: 4,
+        cached: 0,
+        total: 10,
+        numRequests: 1,
+      });
+
+      expect(target.numRequests).toBe(2);
+      expect(target).not.toHaveProperty('prompt');
+      expect(target).not.toHaveProperty('completion');
+      expect(target).not.toHaveProperty('cached');
+      expect(target).not.toHaveProperty('total');
+    });
+
+    it('retains fully reported usage for the first counted request', () => {
+      const target: TokenUsage = createEmptyTokenUsage();
+
+      accumulateResponseTokenUsagePreservingUnknown(target, {
+        tokenUsage: {
+          prompt: 6,
+          completion: 4,
+          cached: 0,
+          total: 10,
+          numRequests: 1,
+        },
+      });
+
+      expect(target).toMatchObject({
+        prompt: 6,
+        completion: 4,
+        cached: 0,
+        total: 10,
+        numRequests: 1,
+      });
+    });
+
+    it('does not count response-only usage when countAsRequest is false', () => {
+      const target: TokenUsage = createEmptyTokenUsage();
+
+      accumulateResponseTokenUsagePreservingUnknown(
+        target,
+        {
+          tokenUsage: {
+            prompt: 6,
+            completion: 4,
+            total: 10,
+            numRequests: 1,
+          },
+        },
+        { countAsRequest: false },
+      );
+
+      expect(target).toMatchObject({ prompt: 6, completion: 4, total: 10, numRequests: 0 });
     });
   });
 

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -345,6 +345,20 @@ describe('tokenUsageUtils', () => {
       expect(target).not.toHaveProperty('total');
     });
 
+    it('keeps aggregate counts unknown after a zero-request update', () => {
+      const target: TokenUsage = createEmptyTokenUsage();
+      accumulateTokenUsagePreservingUnknown(target, { numRequests: 1 });
+
+      accumulateTokenUsagePreservingUnknown(target, createEmptyTokenUsage());
+
+      expect(target.numRequests).toBe(1);
+      expect(target).not.toHaveProperty('prompt');
+      expect(target).not.toHaveProperty('completion');
+      expect(target).not.toHaveProperty('cached');
+      expect(target).not.toHaveProperty('total');
+      expect(target).not.toHaveProperty('completionDetails');
+    });
+
     it('retains fully reported usage for the first counted request', () => {
       const target: TokenUsage = createEmptyTokenUsage();
 

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -311,19 +311,6 @@ describe('tokenUsageUtils', () => {
   });
 
   describe('unknown-preserving accumulation', () => {
-    it('does not invent zeros for counts a partial report omitted', () => {
-      const target: TokenUsage = createEmptyTokenUsage();
-
-      // mldangelo-oai review-2 item 4: reporting only `prompt` must not assert that
-      // completion/cached/total were zero -- they were never reported at all.
-      accumulateTokenUsagePreservingUnknown(target, { prompt: 6, numRequests: 1 });
-
-      expect(target.prompt).toBe(6);
-      expect(target).not.toHaveProperty('completion');
-      expect(target).not.toHaveProperty('cached');
-      expect(target).not.toHaveProperty('total');
-    });
-
     it('omits unknown token counts for a counted response', () => {
       const target: TokenUsage = createEmptyTokenUsage();
 

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -311,6 +311,19 @@ describe('tokenUsageUtils', () => {
   });
 
   describe('unknown-preserving accumulation', () => {
+    it('does not invent zeros for counts a partial report omitted', () => {
+      const target: TokenUsage = createEmptyTokenUsage();
+
+      // mldangelo-oai review-2 item 4: reporting only `prompt` must not assert that
+      // completion/cached/total were zero -- they were never reported at all.
+      accumulateTokenUsagePreservingUnknown(target, { prompt: 6, numRequests: 1 });
+
+      expect(target.prompt).toBe(6);
+      expect(target).not.toHaveProperty('completion');
+      expect(target).not.toHaveProperty('cached');
+      expect(target).not.toHaveProperty('total');
+    });
+
     it('omits unknown token counts for a counted response', () => {
       const target: TokenUsage = createEmptyTokenUsage();
 


### PR DESCRIPTION
## Summary

Gemini Omni Flash uses Google's long-running Interactions API for video generation. The initial provider integration could route Vertex requests to unsupported regional endpoints, continue paid work after an eval was cancelled, accept unsupported safety options, send incompatible OpenAI-style text blocks, report unknown usage as free, and allow one Vertex follow-up alias to bypass local validation.

This change corrects those behaviors without changing other Google provider paths:

1. Vertex Omni always uses `/locations/global/interactions` and the global default host, regardless of ordinary Vertex region configuration. Explicit API host and proxy overrides remain supported.
2. The provider accepts the evaluator's abort signal and propagates it through interaction creation, polling requests and waits, video downloads and redirects, and the check before blob storage. Aborts retain `AbortError` semantics and stop subsequent network or storage work.
3. Custom safety settings now fail before authentication or network access when supplied as top-level config or through either passthrough alias, because the Interactions API does not support them.
4. OpenAI-style `input_text` and `output_text` blocks are normalized to Interactions text content for user and model messages.
5. Successful responses without a `usage` object retain `numRequests: 1` but leave token counts and cost unknown instead of reporting zeros and `$0`.
6. Vertex follow-up validation checks the top-level ID and both passthrough aliases independently by presence, so a falsy snake-case value cannot mask a real camelCase ID.

The Google provider documentation now states the global Vertex location and unsupported safety-setting constraint.

## Validation

- `source ~/.nvm/nvm.sh && nvm use` — Node 24.18.0 / npm 11.16.0
- `npm ci`
- `npx vitest run test/providers/google/interactions.test.ts test/providers/google/provider.test.ts test/providers/registry.test.ts --sequence.shuffle=false` — 209 passed
- `npx vitest run test/providers/google/interactions.test.ts test/providers/google/provider.test.ts test/providers/registry.test.ts` — 209 passed with randomized ordering
- `npx vitest run test/providers/google/interactions.test.ts --sequence.shuffle=false` — 50 passed after final endpoint-override coverage
- `npm run tsc -- --pretty false`
- `npm run l`
- `npm run f`
- `npm run format:check`
- `git diff --check`
- `PROMPTFOO_DISABLE_REMOTE_GENERATION=true PROMPTFOO_CONFIG_DIR=/private/tmp/promptfoo-interactions-regression-state npm run local -- eval -c /private/tmp/promptfoo-interactions-regression-e2e.yaml --no-cache -o /private/tmp/promptfoo-interactions-regression-output.json` — deterministic loopback Interactions endpoint, 1/1 passed, score 1, no errors; raw provider response contained only `tokenUsage.numRequests: 1` and no cost when usage was absent
