### PR TITLE
ci(release): advance release-please drift floor

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-v-in-tag": false,
   "include-v-in-release-name": false,
   "commit-batch-size": 1,
-  "last-release-sha": "8be17c32d44b17f4ddbd618fcaca87769e674abc",
+  "last-release-sha": "af7ec0b5f1072685a919015faf5799cc0886d71e",
   "separate-pull-requests": true,
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

- advance release-please's static history floor to the current code-scan-action 0.1.8 release commit
- restore the scheduled drift guard after it crossed the 250-commit threshold on main

## Why this SHA

The guard requires the oldest current package release boundary. Root promptfoo is currently at 0.121.19 (1ede17a), while code-scan-action is at 0.1.8 (af7ec0b), so af7ec0b is the safe floor and preserves unreleased commits for both packages.

## Verification

- reproduced the failure boundary: old floor 8be17c3 is 253 commits behind current main
- verified new floor af7ec0b is reachable and 249 commits behind current main (<= 250)
- jq empty release-please-config.json
- git diff --check

Note: focused Vitest startup was blocked by this worktree's incomplete local dependency tree (vitest/config missing), so the workflow's exact guard logic was validated directly.