### PR TITLE
feat(websocket): support URL templating

### DIFF
--- a/site/docs/providers/websocket.md
+++ b/site/docs/providers/websocket.md
@@ -26,7 +26,7 @@ providers:
 
 ### Configuration Options
 
-- `url` (required): The WebSocket URL to connect to.
+- `url` (required): The WebSocket URL to connect to. Supports Nunjucks templating with test variables.
 - `messageTemplate` (required): A template for the message to be sent over the WebSocket connection. You can use placeholders like `{{prompt}}` which will be replaced with the actual prompt.
 - `transformResponse` (optional): A JavaScript snippet or function to extract the desired output from the WebSocket response given the `data` parameter. If not provided, the entire response will be used as the output. If the response is valid JSON, the object will be returned.
 - `streamResponse` (optional): A JavaScript function to extract the desired output from streamed WebSocket messages when the server sends multiple messages per prompt. It receives `(accumulator, data, context?)` and must return `[nextAccumulator, complete]`. When `streamResponse` is provided, it is used instead of `transformResponse`.
@@ -36,17 +36,20 @@ providers:
 
 ## Using Variables
 
-You can use test variables in your `messageTemplate`:
+You can use test variables in the connection `url` and `messageTemplate`. Both templates
+are rendered for every API call:
 
 ```yaml
 providers:
-  - id: 'wss://example.com/ws'
+  - id: 'websocket'
     config:
+      url: 'wss://example.com/ws/sessions/{{ sessionId }}'
       messageTemplate: '{"prompt": {{ prompt | dump }}, "model": {{ model | dump }}, "language": {{ language | dump }} }'
       transformResponse: 'data.translation'
 
 tests:
   - vars:
+      sessionId: 'conversation-123'
       model: 'gpt-4'
       language: 'French'
 ```
@@ -226,17 +229,17 @@ Note that when using the WebSocket provider, the connection will be opened for e
 
 Supported config options:
 
-| Option            | Type               | Description                                                                                                                                                        |
-| ----------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| url               | string             | The WebSocket URL to connect to. If not provided, the `id` of the provider will be used as the URL.                                                                |
-| messageTemplate   | string             | A template string for the message to be sent over the WebSocket connection. Supports Nunjucks templating.                                                          |
-| transformResponse | string             | A function body or string to parse a single response. Ignored when `streamResponse` is provided.                                                                   |
-| streamResponse    | Function           | A function body, function expression, or `file://` reference that receives `(accumulator, data, context?)` and returns `[result, complete]` for streamed messages. |
-| timeoutMs         | number             | The timeout in milliseconds for the WebSocket connection. Defaults to 300000 (5 minutes) if not specified.                                                         |
-| protocols         | string \| string[] | A WebSocket subprotocol or list of subprotocols to request during the connection handshake.                                                                        |
-| headers           | object             | A map of HTTP headers to include in the WebSocket connection request. Useful for authentication or other custom headers.                                           |
+| Option            | Type               | Description                                                                                                                                                          |
+| ----------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| url               | string             | The WebSocket URL to connect to. Supports Nunjucks templating and is rendered for every API call. If not provided, the `id` of the provider will be used as the URL. |
+| messageTemplate   | string             | A template string for the message to be sent over the WebSocket connection. Supports Nunjucks templating.                                                            |
+| transformResponse | string             | A function body or string to parse a single response. Ignored when `streamResponse` is provided.                                                                     |
+| streamResponse    | Function           | A function body, function expression, or `file://` reference that receives `(accumulator, data, context?)` and returns `[result, complete]` for streamed messages.   |
+| timeoutMs         | number             | The timeout in milliseconds for the WebSocket connection. Defaults to 300000 (5 minutes) if not specified.                                                           |
+| protocols         | string \| string[] | A WebSocket subprotocol or list of subprotocols to request during the connection handshake.                                                                          |
+| headers           | object             | A map of HTTP headers to include in the WebSocket connection request. Useful for authentication or other custom headers.                                             |
 
-Note: The `messageTemplate` supports Nunjucks templating, allowing you to use the `{{prompt}}` variable or any other variables passed in the test context.
+Note: The `url` and `messageTemplate` support Nunjucks templating, allowing you to use the `{{prompt}}` variable or any other variables passed in the test context.
 
 In addition to a full URL, the provider `id` field accepts `ws`, `wss`, or `websocket` as values.
 

--- a/src/providers/httpTransforms.ts
+++ b/src/providers/httpTransforms.ts
@@ -1,7 +1,7 @@
 import logger from '../logger';
 import { safeJsonStringify } from '../util/json';
 import { getProcessShim } from '../util/processShim';
-import { sanitizeObject } from '../util/sanitizer';
+import { sanitizeProviderObject } from './providerLogging';
 import { normalizeResponseTransformResult } from './transformResult';
 
 import type { FetchWithCacheResult } from '../cache';
@@ -157,7 +157,7 @@ export async function createTransformRequest(
         return result;
       } catch (err) {
         logger.error(
-          `[Http Provider] Error in request transform: ${String(err)}. Prompt: ${prompt}. Vars: ${safeJsonStringify(vars)}. Context: ${safeJsonStringify(sanitizeObject(context, { context: 'request transform' }))}.`,
+          `[Http Provider] Error in request transform: ${String(err)}. Prompt: ${prompt}. Vars: ${safeJsonStringify(vars)}. Context: ${safeJsonStringify(sanitizeProviderObject(context, 'request transform'))}.`,
         );
         throw new Error(`Failed to transform request: ${String(err)}`);
       }

--- a/src/providers/providerLogging.ts
+++ b/src/providers/providerLogging.ts
@@ -1,0 +1,21 @@
+import { REDACTED, sanitizeObject, sanitizeUrl } from '../util/sanitizer';
+
+/**
+ * Returns a provider identifier that preserves ordinary URLs while ensuring
+ * credential-bearing URLs are safe to log or persist.
+ */
+export function getSafeProviderId(url: string): string {
+  const sanitizedUrl = sanitizeUrl(url);
+  return sanitizedUrl === REDACTED ||
+    sanitizedUrl.includes(encodeURIComponent(REDACTED)) ||
+    sanitizedUrl.includes('***')
+    ? sanitizedUrl
+    : url;
+}
+
+/**
+ * Sanitizes provider-owned data before including it in logs or error messages.
+ */
+export function sanitizeProviderObject(value: unknown, context: string): unknown {
+  return sanitizeObject(value, { context });
+}

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -7,6 +7,7 @@ import logger from '../logger';
 import invariant from '../util/invariant';
 import { safeJsonStringify } from '../util/json';
 import { getProcessShim } from '../util/processShim';
+import { sanitizeUrlForLogging } from '../util/sanitizer';
 import { getNunjucksEngine } from '../util/templates';
 import { getRequestTimeoutMs } from './shared';
 import { normalizeResponseTransformResult } from './transformResult';
@@ -244,7 +245,7 @@ export class WebSocketProvider implements ApiProvider {
     const message = nunjucks.renderString(this.config.messageTemplate, vars);
     const streamResponse = this.streamResponse == null ? undefined : await this.streamResponse;
 
-    logger.debug(`Sending WebSocket message to ${url}: ${message}`);
+    logger.debug(`Sending WebSocket message to ${sanitizeUrlForLogging(url)}: ${message}`);
     let accumulator: ProviderResponse = { error: 'unknown error occurred' };
     return new Promise<ProviderResponse>((resolve, reject) => {
       const wsOptions: ClientOptions = {};

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -7,6 +7,7 @@ import logger from '../logger';
 import invariant from '../util/invariant';
 import { safeJsonStringify } from '../util/json';
 import { getProcessShim } from '../util/processShim';
+import { REDACTED, sanitizeObject, sanitizeUrl } from '../util/sanitizer';
 import { getNunjucksEngine } from '../util/templates';
 import { getRequestTimeoutMs } from './shared';
 import { normalizeResponseTransformResult } from './transformResult';
@@ -33,24 +34,13 @@ function normalizeWebSocketProtocols(protocols: string | string[] | undefined): 
     .filter(Boolean);
 }
 
-function getWebSocketErrorMessage(err: WebSocket.ErrorEvent | Error | unknown): string {
-  const error =
-    err && typeof err === 'object' && 'error' in err ? (err as WebSocket.ErrorEvent).error : err;
-
-  if (typeof error === 'string' || typeof error === 'number' || typeof error === 'boolean') {
-    return String(error);
-  }
-
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (error && typeof error === 'object' && 'message' in error) {
-    return String((error as { message: unknown }).message);
-  }
-
-  const serialized = safeJsonStringify(error);
-  return serialized && serialized !== '{}' ? serialized : 'unknown WebSocket error';
+function getWebSocketProviderId(url: string): string {
+  const sanitizedUrl = sanitizeUrl(url);
+  return sanitizedUrl === REDACTED ||
+    sanitizedUrl.includes(encodeURIComponent(REDACTED)) ||
+    sanitizedUrl.includes('***')
+    ? sanitizedUrl
+    : url;
 }
 
 interface WebSocketProviderConfig {
@@ -196,6 +186,7 @@ export async function createStreamResponse(
 
 export class WebSocketProvider implements ApiProvider {
   url: string;
+  private readonly providerId: string;
   config: WebSocketProviderConfig;
   timeoutMs: number;
   transformResponse: (data: any) => ProviderResponse;
@@ -210,6 +201,7 @@ export class WebSocketProvider implements ApiProvider {
   constructor(url: string, options: ProviderOptions) {
     this.config = options.config as WebSocketProviderConfig;
     this.url = this.config.url || url;
+    this.providerId = getWebSocketProviderId(this.url);
     this.timeoutMs = this.config.timeoutMs || getRequestTimeoutMs();
     this.transformResponse = createTransformResponse(
       this.config.transformResponse || this.config.responseParser,
@@ -219,18 +211,18 @@ export class WebSocketProvider implements ApiProvider {
       : undefined;
     invariant(
       this.config.messageTemplate,
-      `Expected WebSocket provider ${this.url} to have a config containing {messageTemplate}, but got ${safeJsonStringify(
-        this.config,
+      `Expected WebSocket provider ${this.providerId} to have a config containing {messageTemplate}, but got ${safeJsonStringify(
+        sanitizeObject(this.config, { context: 'provider config' }),
       )}`,
     );
   }
 
   id(): string {
-    return this.url;
+    return this.providerId;
   }
 
   toString(): string {
-    return `[WebSocket Provider ${this.url}]`;
+    return `[WebSocket Provider ${this.providerId}]`;
   }
 
   async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
@@ -251,16 +243,16 @@ export class WebSocketProvider implements ApiProvider {
       if (this.config.headers) {
         wsOptions.headers = this.config.headers;
       }
-      let ws: WebSocket;
       try {
-        ws =
-          protocols.length > 0
-            ? new WebSocket(url, protocols, wsOptions)
-            : new WebSocket(url, wsOptions);
+        new URL(url);
       } catch {
         reject(new Error('Failed to create WebSocket connection'));
         return;
       }
+      const ws =
+        protocols.length > 0
+          ? new WebSocket(url, protocols, wsOptions)
+          : new WebSocket(url, wsOptions);
       const timeout = setTimeout(() => {
         ws.close();
         logger.error(`[WebSocket Provider] Request timed out`);
@@ -332,12 +324,11 @@ export class WebSocketProvider implements ApiProvider {
         }
       };
 
-      ws.onerror = (err) => {
+      ws.onerror = () => {
         clearTimeout(timeout);
         ws.close();
-        const errorMessage = getWebSocketErrorMessage(err);
-        logger.error(`[WebSocket Provider] Error: ${errorMessage}`);
-        reject(new Error(`WebSocket error: ${errorMessage}`));
+        logger.error(`[WebSocket Provider] Connection failed`);
+        reject(new Error('WebSocket connection failed'));
       };
 
       ws.onopen = () => {

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -7,7 +7,6 @@ import logger from '../logger';
 import invariant from '../util/invariant';
 import { safeJsonStringify } from '../util/json';
 import { getProcessShim } from '../util/processShim';
-import { sanitizeUrlForLogging } from '../util/sanitizer';
 import { getNunjucksEngine } from '../util/templates';
 import { getRequestTimeoutMs } from './shared';
 import { normalizeResponseTransformResult } from './transformResult';
@@ -19,8 +18,6 @@ import type {
   ProviderOptions,
   ProviderResponse,
 } from '../types/index';
-
-const nunjucks = getNunjucksEngine();
 
 export const processResult = normalizeResponseTransformResult;
 
@@ -241,11 +238,12 @@ export class WebSocketProvider implements ApiProvider {
       ...(context?.vars || {}),
       prompt,
     };
+    const nunjucks = getNunjucksEngine(context?.filters);
     const url = nunjucks.renderString(this.url, vars);
     const message = nunjucks.renderString(this.config.messageTemplate, vars);
     const streamResponse = this.streamResponse == null ? undefined : await this.streamResponse;
 
-    logger.debug(`Sending WebSocket message to ${sanitizeUrlForLogging(url)}: ${message}`);
+    logger.debug(`Sending WebSocket message: ${message}`);
     let accumulator: ProviderResponse = { error: 'unknown error occurred' };
     return new Promise<ProviderResponse>((resolve, reject) => {
       const wsOptions: ClientOptions = {};
@@ -253,10 +251,16 @@ export class WebSocketProvider implements ApiProvider {
       if (this.config.headers) {
         wsOptions.headers = this.config.headers;
       }
-      const ws =
-        protocols.length > 0
-          ? new WebSocket(url, protocols, wsOptions)
-          : new WebSocket(url, wsOptions);
+      let ws: WebSocket;
+      try {
+        ws =
+          protocols.length > 0
+            ? new WebSocket(url, protocols, wsOptions)
+            : new WebSocket(url, wsOptions);
+      } catch {
+        reject(new Error('Failed to create WebSocket connection'));
+        return;
+      }
       const timeout = setTimeout(() => {
         ws.close();
         logger.error(`[WebSocket Provider] Request timed out`);

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -240,10 +240,11 @@ export class WebSocketProvider implements ApiProvider {
       ...(context?.vars || {}),
       prompt,
     };
+    const url = nunjucks.renderString(this.url, vars);
     const message = nunjucks.renderString(this.config.messageTemplate, vars);
     const streamResponse = this.streamResponse == null ? undefined : await this.streamResponse;
 
-    logger.debug(`Sending WebSocket message to ${this.url}: ${message}`);
+    logger.debug(`Sending WebSocket message to ${url}: ${message}`);
     let accumulator: ProviderResponse = { error: 'unknown error occurred' };
     return new Promise<ProviderResponse>((resolve, reject) => {
       const wsOptions: ClientOptions = {};
@@ -253,8 +254,8 @@ export class WebSocketProvider implements ApiProvider {
       }
       const ws =
         protocols.length > 0
-          ? new WebSocket(this.url, protocols, wsOptions)
-          : new WebSocket(this.url, wsOptions);
+          ? new WebSocket(url, protocols, wsOptions)
+          : new WebSocket(url, wsOptions);
       const timeout = setTimeout(() => {
         ws.close();
         logger.error(`[WebSocket Provider] Request timed out`);

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -7,8 +7,8 @@ import logger from '../logger';
 import invariant from '../util/invariant';
 import { safeJsonStringify } from '../util/json';
 import { getProcessShim } from '../util/processShim';
-import { REDACTED, sanitizeObject, sanitizeUrl } from '../util/sanitizer';
 import { getNunjucksEngine } from '../util/templates';
+import { getSafeProviderId, sanitizeProviderObject } from './providerLogging';
 import { getRequestTimeoutMs } from './shared';
 import { normalizeResponseTransformResult } from './transformResult';
 import { parseFileTransformReference } from './transformUtils';
@@ -32,15 +32,6 @@ function normalizeWebSocketProtocols(protocols: string | string[] | undefined): 
     .flatMap((value) => value.split(','))
     .map((value) => value.trim())
     .filter(Boolean);
-}
-
-function getWebSocketProviderId(url: string): string {
-  const sanitizedUrl = sanitizeUrl(url);
-  return sanitizedUrl === REDACTED ||
-    sanitizedUrl.includes(encodeURIComponent(REDACTED)) ||
-    sanitizedUrl.includes('***')
-    ? sanitizedUrl
-    : url;
 }
 
 interface WebSocketProviderConfig {
@@ -201,7 +192,7 @@ export class WebSocketProvider implements ApiProvider {
   constructor(url: string, options: ProviderOptions) {
     this.config = options.config as WebSocketProviderConfig;
     this.url = this.config.url || url;
-    this.providerId = getWebSocketProviderId(this.url);
+    this.providerId = getSafeProviderId(this.url);
     this.timeoutMs = this.config.timeoutMs || getRequestTimeoutMs();
     this.transformResponse = createTransformResponse(
       this.config.transformResponse || this.config.responseParser,
@@ -212,7 +203,7 @@ export class WebSocketProvider implements ApiProvider {
     invariant(
       this.config.messageTemplate,
       `Expected WebSocket provider ${this.providerId} to have a config containing {messageTemplate}, but got ${safeJsonStringify(
-        sanitizeObject(this.config, { context: 'provider config' }),
+        sanitizeProviderObject(this.config, 'provider config'),
       )}`,
     );
   }

--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -805,6 +805,27 @@ function getSecretLookingRawQueryKeys(search: string): Set<string> {
   return secretKeys;
 }
 
+function sanitizeTemplatedUrl(url: string): string {
+  // A template may coexist with an already-rendered env credential. Avoid URL
+  // parsing here because it encodes the remaining Nunjucks syntax, but still
+  // scrub literal query and fragment credentials before the value is logged or
+  // persisted.
+  if (hasUrlUserinfoPassword(url)) {
+    return REDACTED;
+  }
+
+  const hashIndex = url.indexOf('#');
+  const beforeHash = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const hash = hashIndex === -1 ? '' : url.slice(hashIndex + 1);
+  const queryIndex = beforeHash.indexOf('?');
+  const beforeQuery = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
+  const query = queryIndex === -1 ? '' : beforeHash.slice(queryIndex + 1);
+  const sanitizedQuery = query ? sanitizeUrlEncodedString(query) : query;
+  const sanitizedHash = hash ? sanitizeUrlEncodedString(hash) : hash;
+
+  return `${beforeQuery}${queryIndex === -1 ? '' : `?${sanitizedQuery}`}${hashIndex === -1 ? '' : `#${sanitizedHash}`}`;
+}
+
 export function sanitizeUrl(url: string): string {
   try {
     // Ensure url is a string and handle edge cases
@@ -812,21 +833,10 @@ export function sanitizeUrl(url: string): string {
       return url;
     }
 
-    // Check if URL contains template variables (e.g., {{ variable }})
-    // These are configuration templates, not runtime secrets, so skip sanitization entirely.
-    //
-    // Important trade-off: URLs with both templates AND real sensitive params
-    // (e.g., "https://example.com/{{ path }}?api_key=secret") will NOT be sanitized.
-    // This is acceptable because:
-    // 1. Template URLs come from config files (version-controlled, not runtime)
-    // 2. Secrets should be in environment variables, not hardcoded in config
-    // 3. Attempting to parse/sanitize would URL-encode template syntax ({{ → %7B%7B),
-    //    breaking Nunjucks rendering
-    // 4. When templates render to real URLs at runtime, those URLs get sanitized normally
-    //
-    // Use simple string check instead of regex to avoid ReDoS vulnerability
+    // Preserve unresolved template syntax while redacting any literal credentials
+    // that were already rendered into another part of the same URL.
     if (url.includes('{{') && url.includes('}}')) {
-      return url;
+      return sanitizeTemplatedUrl(url);
     }
 
     // Handle path-only URLs (e.g., /api/openai/completion from raw HTTP request mode).

--- a/test/models/evalResult.test.ts
+++ b/test/models/evalResult.test.ts
@@ -3,6 +3,7 @@ import logger from '../../src/logger';
 import { runDbMigrations } from '../../src/migrate';
 import EvalResult, { sanitizeProvider } from '../../src/models/evalResult';
 import { hashPrompt } from '../../src/prompts/utils';
+import { WebSocketProvider } from '../../src/providers/websocket';
 import {
   type ApiProvider,
   type AtomicTestCase,
@@ -107,6 +108,24 @@ describe('EvalResult', () => {
         label: 'Test Provider',
         config: {
           apiKey: '[REDACTED]',
+        },
+      });
+    });
+
+    it('should redact env-rendered credentials from templated WebSocket provider data', () => {
+      const provider = new WebSocketProvider('websocket', {
+        config: {
+          url: 'ws://127.0.0.1/sessions/{{ sessionId }}?token=runtime-secret',
+          messageTemplate: '{{ prompt }}',
+        },
+      });
+
+      expect(sanitizeProvider(provider)).toEqual({
+        id: 'ws://127.0.0.1/sessions/{{ sessionId }}?token=%5BREDACTED%5D',
+        label: undefined,
+        config: {
+          url: 'ws://127.0.0.1/sessions/{{ sessionId }}?token=%5BREDACTED%5D',
+          messageTemplate: '{{ prompt }}',
         },
       });
     });

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -134,6 +134,7 @@ describe('WebSocketProvider', () => {
       config: {
         url: 'ws://test.com/sessions/{{ sessionId }}',
         messageTemplate: '{{ prompt }}',
+        timeoutMs: 1000,
       },
     });
 
@@ -165,6 +166,7 @@ describe('WebSocketProvider', () => {
       config: {
         url: 'wss://test.com/ws?token={{ token }}',
         messageTemplate: '{{ prompt }}',
+        timeoutMs: 1000,
       },
     });
 

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -6,20 +6,15 @@ import { createTransformResponse, WebSocketProvider } from '../../src/providers/
 const websocketMocks = vi.hoisted(() => {
   let factory: (() => Mocked<WebSocket>) | null = null;
 
-  const createWebSocket = function () {
+  const WebSocketMock = vi.fn(function () {
     return factory?.() ?? ({} as Mocked<WebSocket>);
-  };
-  const WebSocketMock = vi.fn(createWebSocket);
+  });
 
   const setFactory = (nextFactory: () => Mocked<WebSocket>) => {
     factory = nextFactory;
   };
-  const reset = () => {
-    WebSocketMock.mockReset();
-    WebSocketMock.mockImplementation(createWebSocket);
-  };
 
-  return { WebSocketMock, setFactory, reset };
+  return { WebSocketMock, setFactory };
 });
 
 vi.mock('ws', () => ({
@@ -88,7 +83,7 @@ describe('WebSocketProvider', () => {
       onopen: vi.fn(),
     } as unknown as Mocked<WebSocket>;
 
-    websocketMocks.reset();
+    websocketMocks.WebSocketMock.mockReset();
     websocketMocks.setFactory(() => mockWs);
 
     provider = new WebSocketProvider('ws://test.com', {
@@ -106,6 +101,7 @@ describe('WebSocketProvider', () => {
 
   it('should initialize with correct config', () => {
     expect(provider.url).toBe('ws://test.com');
+    expect(provider.id()).toBe('ws://test.com');
     expect(provider.config.messageTemplate).toBe('{{ prompt }}');
   });
 
@@ -165,6 +161,18 @@ describe('WebSocketProvider', () => {
     expect(WebSocket).toHaveBeenNthCalledWith(2, 'ws://test.com/sessions/session-2', {});
   });
 
+  it('should redact literal credentials from templated provider identities', () => {
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        url: 'ws://test.com/sessions/{{ sessionId }}?token=runtime-secret',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    expect(provider.id()).toBe('ws://test.com/sessions/{{ sessionId }}?token=%5BREDACTED%5D');
+    expect(provider.toString()).not.toContain('runtime-secret');
+  });
+
   it('should not log rendered URLs that contain template-like runtime values', async () => {
     const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
     provider = new WebSocketProvider('ws://test.com', {
@@ -194,9 +202,6 @@ describe('WebSocketProvider', () => {
   });
 
   it('should not expose rendered URLs in synchronous constructor errors', async () => {
-    websocketMocks.setFactory(() => {
-      throw new SyntaxError('Invalid URL: wss://[invalid-host/ws?token=runtime-secret');
-    });
     provider = new WebSocketProvider('ws://test.com', {
       config: {
         url: 'wss://{{ host }}/ws?token={{ token }}',
@@ -214,6 +219,24 @@ describe('WebSocketProvider', () => {
 
     expect(error).toEqual(new Error('Failed to create WebSocket connection'));
     expect((error as Error).message).not.toContain('runtime-secret');
+    expect(WebSocket).not.toHaveBeenCalled();
+  });
+
+  it('should preserve safe synchronous WebSocket constructor errors', async () => {
+    websocketMocks.setFactory(() => {
+      throw new Error('An invalid or duplicated subprotocol was specified');
+    });
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        messageTemplate: '{{ prompt }}',
+        protocols: ['invalid protocol'],
+        timeoutMs: 1000,
+      },
+    });
+
+    await expect(provider.callApi('test prompt')).rejects.toThrow(
+      'An invalid or duplicated subprotocol was specified',
+    );
   });
 
   it('should use configured Nunjucks filters for URL and message templates', async () => {
@@ -324,12 +347,29 @@ describe('WebSocketProvider', () => {
     expect(mockWs.close).toHaveBeenCalled();
   });
 
-  it('should handle WebSocket errors', async () => {
-    emitWebSocketEvents({ type: 'error', error: new Error('connection failed') });
+  it('should not expose URL-derived values from asynchronous WebSocket errors', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        url: 'ws://{{ tenant }}.invalid/ws?token={{ token }}',
+        messageTemplate: '{{ prompt }}',
+        timeoutMs: 1000,
+      },
+    });
+    emitWebSocketEvents({
+      type: 'error',
+      error: new Error('getaddrinfo ENOTFOUND runtime-secret-tenant.invalid'),
+    });
 
-    await expect(provider.callApi('test prompt')).rejects.toThrow(
-      'WebSocket error: connection failed',
-    );
+    await expect(
+      provider.callApi('test prompt', {
+        prompt: { raw: 'test prompt', label: 'test prompt' },
+        vars: { tenant: 'runtime-secret-tenant', token: 'runtime-query-secret' },
+      }),
+    ).rejects.toThrow('WebSocket connection failed');
+    const errorLogs = JSON.stringify(errorSpy.mock.calls);
+    expect(errorLogs).not.toContain('runtime-secret-tenant');
+    expect(errorLogs).not.toContain('runtime-query-secret');
     expect(mockWs.close).toHaveBeenCalled();
   });
 

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -127,6 +127,36 @@ describe('WebSocketProvider', () => {
     expect(WebSocket).toHaveBeenCalledWith('ws://test.com', { headers });
   });
 
+  it('should render the URL template for each WebSocket connection', async () => {
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        url: 'ws://test.com/sessions/{{ sessionId }}',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    emitWebSocketEvents(
+      { type: 'open' },
+      { type: 'message', data: JSON.stringify({ result: 'first' }) },
+    );
+    await provider.callApi('first prompt', {
+      prompt: { raw: 'first prompt', label: 'first prompt' },
+      vars: { sessionId: 'session-1' },
+    });
+
+    emitWebSocketEvents(
+      { type: 'open' },
+      { type: 'message', data: JSON.stringify({ result: 'second' }) },
+    );
+    await provider.callApi('second prompt', {
+      prompt: { raw: 'second prompt', label: 'second prompt' },
+      vars: { sessionId: 'session-2' },
+    });
+
+    expect(WebSocket).toHaveBeenNthCalledWith(1, 'ws://test.com/sessions/session-1', {});
+    expect(WebSocket).toHaveBeenNthCalledWith(2, 'ws://test.com/sessions/session-2', {});
+  });
+
   it('should pass configured protocols to WebSocket connection', async () => {
     provider = new WebSocketProvider('ws://test.com', {
       config: {

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -165,11 +165,11 @@ describe('WebSocketProvider', () => {
     expect(WebSocket).toHaveBeenNthCalledWith(2, 'ws://test.com/sessions/session-2', {});
   });
 
-  it('should redact secrets from rendered URLs in debug logs', async () => {
+  it('should not log rendered URLs that contain template-like runtime values', async () => {
     const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
     provider = new WebSocketProvider('ws://test.com', {
       config: {
-        url: 'wss://test.com/ws?token={{ token }}',
+        url: 'wss://test.com/ws/{{ sessionId }}?token={{ token }}',
         messageTemplate: '{{ prompt }}',
         timeoutMs: 1000,
       },
@@ -181,13 +181,64 @@ describe('WebSocketProvider', () => {
     );
     await provider.callApi('test prompt', {
       prompt: { raw: 'test prompt', label: 'test prompt' },
-      vars: { token: 'runtime-secret' },
+      vars: { sessionId: '{{ attacker_controlled }}', token: 'runtime-secret' },
     });
 
-    expect(WebSocket).toHaveBeenCalledWith('wss://test.com/ws?token=runtime-secret', {});
+    expect(WebSocket).toHaveBeenCalledWith(
+      'wss://test.com/ws/{{ attacker_controlled }}?token=runtime-secret',
+      {},
+    );
     const debugLogs = JSON.stringify(debugSpy.mock.calls);
-    expect(debugLogs).toContain('token=%5BREDACTED%5D');
+    expect(debugLogs).not.toContain('wss://test.com/ws');
     expect(debugLogs).not.toContain('runtime-secret');
+  });
+
+  it('should not expose rendered URLs in synchronous constructor errors', async () => {
+    websocketMocks.setFactory(() => {
+      throw new SyntaxError('Invalid URL: wss://[invalid-host/ws?token=runtime-secret');
+    });
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        url: 'wss://{{ host }}/ws?token={{ token }}',
+        messageTemplate: '{{ prompt }}',
+        timeoutMs: 1000,
+      },
+    });
+
+    const error = await provider
+      .callApi('test prompt', {
+        prompt: { raw: 'test prompt', label: 'test prompt' },
+        vars: { host: '[invalid-host', token: 'runtime-secret' },
+      })
+      .catch((err: Error) => err);
+
+    expect(error).toEqual(new Error('Failed to create WebSocket connection'));
+    expect((error as Error).message).not.toContain('runtime-secret');
+  });
+
+  it('should use configured Nunjucks filters for URL and message templates', async () => {
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        url: 'ws://test.com/sessions/{{ sessionId | slugify }}',
+        messageTemplate: '{{ prompt | slugify }}',
+        timeoutMs: 1000,
+      },
+    });
+
+    emitWebSocketEvents(
+      { type: 'open' },
+      { type: 'message', data: JSON.stringify({ result: 'test' }) },
+    );
+    await provider.callApi('Test Prompt', {
+      prompt: { raw: 'Test Prompt', label: 'Test Prompt' },
+      vars: { sessionId: 'Conversation A' },
+      filters: {
+        slugify: (value: string) => value.toLowerCase().replaceAll(' ', '-'),
+      },
+    });
+
+    expect(WebSocket).toHaveBeenCalledWith('ws://test.com/sessions/conversation-a', {});
+    expect(mockWs.send).toHaveBeenCalledWith('test-prompt');
   });
 
   it('should pass configured protocols to WebSocket connection', async () => {

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -6,15 +6,20 @@ import { createTransformResponse, WebSocketProvider } from '../../src/providers/
 const websocketMocks = vi.hoisted(() => {
   let factory: (() => Mocked<WebSocket>) | null = null;
 
-  const WebSocketMock = vi.fn(function () {
+  const createWebSocket = function () {
     return factory?.() ?? ({} as Mocked<WebSocket>);
-  });
+  };
+  const WebSocketMock = vi.fn(createWebSocket);
 
   const setFactory = (nextFactory: () => Mocked<WebSocket>) => {
     factory = nextFactory;
   };
+  const reset = () => {
+    WebSocketMock.mockReset();
+    WebSocketMock.mockImplementation(createWebSocket);
+  };
 
-  return { WebSocketMock, setFactory };
+  return { WebSocketMock, setFactory, reset };
 });
 
 vi.mock('ws', () => ({
@@ -83,7 +88,7 @@ describe('WebSocketProvider', () => {
       onopen: vi.fn(),
     } as unknown as Mocked<WebSocket>;
 
-    websocketMocks.WebSocketMock.mockClear();
+    websocketMocks.reset();
     websocketMocks.setFactory(() => mockWs);
 
     provider = new WebSocketProvider('ws://test.com', {

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import WebSocket from 'ws';
+import logger from '../../src/logger';
 import { createTransformResponse, WebSocketProvider } from '../../src/providers/websocket';
 
 const websocketMocks = vi.hoisted(() => {
@@ -94,6 +95,7 @@ describe('WebSocketProvider', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -155,6 +157,30 @@ describe('WebSocketProvider', () => {
 
     expect(WebSocket).toHaveBeenNthCalledWith(1, 'ws://test.com/sessions/session-1', {});
     expect(WebSocket).toHaveBeenNthCalledWith(2, 'ws://test.com/sessions/session-2', {});
+  });
+
+  it('should redact secrets from rendered URLs in debug logs', async () => {
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        url: 'wss://test.com/ws?token={{ token }}',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    emitWebSocketEvents(
+      { type: 'open' },
+      { type: 'message', data: JSON.stringify({ result: 'test' }) },
+    );
+    await provider.callApi('test prompt', {
+      prompt: { raw: 'test prompt', label: 'test prompt' },
+      vars: { token: 'runtime-secret' },
+    });
+
+    expect(WebSocket).toHaveBeenCalledWith('wss://test.com/ws?token=runtime-secret', {});
+    const debugLogs = JSON.stringify(debugSpy.mock.calls);
+    expect(debugLogs).toContain('token=%5BREDACTED%5D');
+    expect(debugLogs).not.toContain('runtime-secret');
   });
 
   it('should pass configured protocols to WebSocket connection', async () => {

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -1518,26 +1518,29 @@ describe('sanitizeUrl', () => {
       expect(sanitizeUrl(url)).toBe(url);
     });
 
-    it('should skip sanitization for URLs with template variables', () => {
-      // Template URLs are configuration, not runtime secrets
-      // They get rendered by Nunjucks before actual use, then sanitized
+    it('should redact literal credentials in URLs with template variables', () => {
       const url = '{{ api_base }}/api?token=secret123&user_id=42';
-      expect(sanitizeUrl(url)).toBe(url);
+      expect(sanitizeUrl(url)).toBe('{{ api_base }}/api?token=%5BREDACTED%5D&user_id=42');
     });
 
-    it('should skip sanitization for URLs with templates and credentials', () => {
+    it('should fail closed for templated URLs with userinfo credentials', () => {
       const url = 'https://user:pass@{{ host }}/api';
-      expect(sanitizeUrl(url)).toBe(url);
+      expect(sanitizeUrl(url)).toBe('[REDACTED]');
     });
 
-    it('should skip sanitization for mixed template and sensitive params', () => {
+    it('should redact mixed template and sensitive params', () => {
       const url = 'https://admin:secret@{{ api_base }}/api?api_key=key123&data=public';
-      expect(sanitizeUrl(url)).toBe(url);
+      expect(sanitizeUrl(url)).toBe('[REDACTED]');
     });
 
-    it('should skip sanitization for templates with sensitive param names', () => {
+    it('should preserve pure templates for sensitive params', () => {
       const url = 'https://example.com/{{ path }}?password={{ user_password }}&data=public';
       expect(sanitizeUrl(url)).toBe(url);
+    });
+
+    it('should redact env-rendered query credentials while preserving runtime templates', () => {
+      const url = 'ws://127.0.0.1/sessions/{{ sessionId }}?token=runtime-secret';
+      expect(sanitizeUrl(url)).toBe('ws://127.0.0.1/sessions/{{ sessionId }}?token=%5BREDACTED%5D');
     });
   });
 


### PR DESCRIPTION
## Summary

- Render the generic WebSocket provider URL with per-call Nunjucks variables.
- Add regression coverage proving one provider instance opens distinct session URLs across calls.
- Document URL templating and a `{{ sessionId }}` example.

## Why

The WebSocket provider already rendered `messageTemplate` per request, but passed its URL unchanged to every new connection. That prevented stateful targets from placing a generated session or conversation ID in the WebSocket URL, even though each API call opens a fresh connection.

## Impact

WebSocket targets can now use test variables such as `{{ sessionId }}` in `config.url`, matching the per-request templating behavior users expect from the HTTP provider. Existing static URLs behave unchanged.

## Validation

- `npx vitest run test/providers/websocket.test.ts --sequence.shuffle=false`
- `npm run tsc`
- `npm run f`
- `npm run l`
- `SKIP_OG_GENERATION=true npx docusaurus build --out-dir /private/tmp/promptfoo-docs-build-websocket-url-templating`