### PR TITLE
fix(providers): restore secret-safe WebSocket retries

### DIFF
--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -4,6 +4,7 @@ import WebSocket, { type ClientOptions } from 'ws';
 import cliState from '../cliState';
 import { importModule } from '../esm';
 import logger from '../logger';
+import { isAbortError, isTransientConnectionError } from '../util/fetch/errors';
 import invariant from '../util/invariant';
 import { safeJsonStringify } from '../util/json';
 import { getProcessShim } from '../util/processShim';
@@ -32,6 +33,55 @@ function normalizeWebSocketProtocols(protocols: string | string[] | undefined): 
     .flatMap((value) => value.split(','))
     .map((value) => value.trim())
     .filter(Boolean);
+}
+
+function getSafeWebSocketError(event: WebSocket.ErrorEvent): Error {
+  const sourceError = event.error instanceof Error ? event.error : new Error(event.message);
+  const sourceCode = (sourceError as NodeJS.ErrnoException).code;
+  let safeReason: string | undefined;
+
+  if (!isAbortError(sourceError)) {
+    if (sourceCode === 'ECONNRESET' || sourceCode === 'ECONNREFUSED' || sourceCode === 'EPIPE') {
+      safeReason = sourceCode;
+    } else if (sourceCode === 'EPROTO' && isTransientConnectionError(sourceError)) {
+      safeReason = sourceCode;
+    } else if (sourceCode === undefined) {
+      const status = sourceError.message.match(
+        /^Unexpected server response:\s*(429|502|503|504)\b/i,
+      )?.[1];
+
+      if (status) {
+        safeReason = status;
+      } else {
+        const transientReason = sourceError.message.match(
+          /^(?:(?:read|write|connect)\s+)?(ECONNRESET|ECONNREFUSED|EPROTO)\b|^(socket hang up|(?:SSL routines:\s*)?bad record mac|(?:request\s+)?timeout|network(?: error)?|rate limit|too many requests)\b/i,
+        );
+        const candidate = (transientReason?.[1] ?? transientReason?.[2])
+          ?.toUpperCase()
+          .replace(/^(?:REQUEST\s+|SSL ROUTINES:\s*)/, '');
+
+        if (candidate !== 'EPROTO' || isTransientConnectionError(sourceError)) {
+          safeReason = candidate;
+        }
+      }
+    }
+  }
+
+  const status =
+    safeReason && /^(?:429|502|503|504)$/.test(safeReason) ? Number(safeReason) : undefined;
+  const displayReason = status === undefined ? safeReason : `HTTP ${status}`;
+  const error = new Error(
+    `WebSocket connection failed${displayReason ? ` (${displayReason})` : ''}`,
+  );
+
+  if (safeReason === 'ECONNRESET' || safeReason === 'ECONNREFUSED' || safeReason === 'EPIPE') {
+    (error as NodeJS.ErrnoException).code = safeReason;
+  }
+  if (status !== undefined) {
+    (error as Error & { status: number }).status = status;
+  }
+
+  return error;
 }
 
 interface WebSocketProviderConfig {
@@ -315,11 +365,11 @@ export class WebSocketProvider implements ApiProvider {
         }
       };
 
-      ws.onerror = () => {
+      ws.onerror = (event) => {
         clearTimeout(timeout);
         ws.close();
         logger.error(`[WebSocket Provider] Connection failed`);
-        reject(new Error('WebSocket connection failed'));
+        reject(getSafeWebSocketError(event));
       };
 
       ws.onopen = () => {

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -4,7 +4,6 @@ import WebSocket, { type ClientOptions } from 'ws';
 import cliState from '../cliState';
 import { importModule } from '../esm';
 import logger from '../logger';
-import { isAbortError, isTransientConnectionError } from '../util/fetch/errors';
 import invariant from '../util/invariant';
 import { safeJsonStringify } from '../util/json';
 import { getProcessShim } from '../util/processShim';
@@ -38,12 +37,15 @@ function normalizeWebSocketProtocols(protocols: string | string[] | undefined): 
 function getSafeWebSocketError(event: WebSocket.ErrorEvent): Error {
   const sourceError = event.error instanceof Error ? event.error : new Error(event.message);
   const sourceCode = (sourceError as NodeJS.ErrnoException).code;
+  const isAbortError = sourceError.name === 'AbortError' || sourceError.name === 'AbortException';
+  const isPermanentProtocolError =
+    /wrong version number|self signed|unable to verify|unknown ca|cert/i.test(sourceError.message);
   let safeReason: string | undefined;
 
-  if (!isAbortError(sourceError)) {
+  if (!isAbortError) {
     if (sourceCode === 'ECONNRESET' || sourceCode === 'ECONNREFUSED' || sourceCode === 'EPIPE') {
       safeReason = sourceCode;
-    } else if (sourceCode === 'EPROTO' && isTransientConnectionError(sourceError)) {
+    } else if (sourceCode === 'EPROTO' && !isPermanentProtocolError) {
       safeReason = sourceCode;
     } else if (sourceCode === undefined) {
       const status = sourceError.message.match(
@@ -60,7 +62,7 @@ function getSafeWebSocketError(event: WebSocket.ErrorEvent): Error {
           ?.toUpperCase()
           .replace(/^(?:REQUEST\s+|SSL ROUTINES:\s*)/, '');
 
-        if (candidate !== 'EPROTO' || isTransientConnectionError(sourceError)) {
+        if (candidate !== 'EPROTO' || !isPermanentProtocolError) {
           safeReason = candidate;
         }
       }

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -37,34 +37,44 @@ function normalizeWebSocketProtocols(protocols: string | string[] | undefined): 
 function getSafeWebSocketError(event: WebSocket.ErrorEvent): Error {
   const sourceError = event.error instanceof Error ? event.error : new Error(event.message);
   const sourceCode = (sourceError as NodeJS.ErrnoException).code;
-  const isAbortError = sourceError.name === 'AbortError' || sourceError.name === 'AbortException';
+  const isAbortError = ['AbortError', 'AbortException'].includes(sourceError.name);
+
+  if (isAbortError) {
+    const error = new Error('WebSocket connection failed');
+    error.name = sourceError.name;
+    return error;
+  }
+
+  const isSafeTransportCode = ['ECONNRESET', 'ECONNREFUSED', 'EPIPE'].includes(sourceCode ?? '');
   const isPermanentProtocolError =
-    /wrong version number|self signed|unable to verify|unknown ca|cert/i.test(sourceError.message);
+    /wrong version number|self signed|unable to verify|unknown ca|cert|alert protocol version|unsupported protocol/i.test(
+      sourceError.message,
+    );
   let safeReason: string | undefined;
 
-  if (!isAbortError) {
-    if (sourceCode === 'ECONNRESET' || sourceCode === 'ECONNREFUSED' || sourceCode === 'EPIPE') {
-      safeReason = sourceCode;
-    } else if (sourceCode === 'EPROTO' && !isPermanentProtocolError) {
-      safeReason = sourceCode;
-    } else if (sourceCode === undefined) {
-      const status = sourceError.message.match(
-        /^Unexpected server response:\s*(429|502|503|504)\b/i,
-      )?.[1];
+  if (isSafeTransportCode) {
+    safeReason = sourceCode;
+  } else if (sourceCode === 'ETIMEDOUT') {
+    safeReason = 'TIMEOUT';
+  } else if (sourceCode === 'EPROTO' && !isPermanentProtocolError) {
+    safeReason = sourceCode;
+  } else if (sourceCode === undefined) {
+    const status = sourceError.message.match(
+      /^Unexpected server response:\s*(429|502|503|504)\b/i,
+    )?.[1];
 
-      if (status) {
-        safeReason = status;
-      } else {
-        const transientReason = sourceError.message.match(
-          /^(?:(?:read|write|connect)\s+)?(ECONNRESET|ECONNREFUSED|EPROTO)\b|^(socket hang up|(?:SSL routines:\s*)?bad record mac|(?:request\s+)?timeout|network(?: error)?|rate limit|too many requests)\b/i,
-        );
-        const candidate = (transientReason?.[1] ?? transientReason?.[2])
-          ?.toUpperCase()
-          .replace(/^(?:REQUEST\s+|SSL ROUTINES:\s*)/, '');
+    if (status) {
+      safeReason = status;
+    } else {
+      const transientReason = sourceError.message.match(
+        /^(?:(?:read|write|connect)\s+)?(ECONNRESET|ECONNREFUSED|EPROTO)\b|^(socket hang up|(?:SSL routines:\s*)?bad record mac|(?:request\s+)?timeout|network(?: error)?|rate limit|too many requests)\b/i,
+      );
+      const candidate = (transientReason?.[1] ?? transientReason?.[2])
+        ?.toUpperCase()
+        .replace(/^(?:REQUEST\s+|SSL ROUTINES:\s*)/, '');
 
-        if (candidate !== 'EPROTO' || !isPermanentProtocolError) {
-          safeReason = candidate;
-        }
+      if (candidate !== 'EPROTO' || !isPermanentProtocolError) {
+        safeReason = candidate;
       }
     }
   }
@@ -76,8 +86,10 @@ function getSafeWebSocketError(event: WebSocket.ErrorEvent): Error {
     `WebSocket connection failed${displayReason ? ` (${displayReason})` : ''}`,
   );
 
-  if (safeReason === 'ECONNRESET' || safeReason === 'ECONNREFUSED' || safeReason === 'EPIPE') {
-    (error as NodeJS.ErrnoException).code = safeReason;
+  if (isSafeTransportCode) {
+    (error as NodeJS.ErrnoException).code = sourceCode;
+  } else if (safeReason === 'TIMEOUT' && sourceCode === 'ETIMEDOUT') {
+    (error as NodeJS.ErrnoException).code = sourceCode;
   }
   if (status !== undefined) {
     (error as Error & { status: number }).status = status;

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, type Mocked, vi } from 'vi
 import WebSocket from 'ws';
 import logger from '../../src/logger';
 import { createTransformResponse, WebSocketProvider } from '../../src/providers/websocket';
+import { RateLimitRegistry } from '../../src/scheduler/rateLimitRegistry';
+import { isProviderResponseRateLimited } from '../../src/scheduler/types';
 
 const websocketMocks = vi.hoisted(() => {
   let factory: (() => Mocked<WebSocket>) | null = null;
@@ -371,6 +373,201 @@ describe('WebSocketProvider', () => {
     expect(errorLogs).not.toContain('runtime-secret-tenant');
     expect(errorLogs).not.toContain('runtime-query-secret');
     expect(mockWs.close).toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      description: 'HTTP 429 handshake responses',
+      createError: (url: string) => new Error(`Unexpected server response: 429 ${url}`),
+      expectedMessage: 'WebSocket connection failed (HTTP 429)',
+      expectedRateLimitHits: 3,
+    },
+    {
+      description: 'connection resets',
+      createError: (url: string) =>
+        Object.assign(new Error(`read ECONNRESET ${url}`), { code: 'ECONNRESET' }),
+      expectedMessage: 'WebSocket connection failed (ECONNRESET)',
+      expectedRateLimitHits: 0,
+    },
+    {
+      description: 'refused connections',
+      createError: (url: string) =>
+        Object.assign(new Error(`connect ECONNREFUSED ${url}`), { code: 'ECONNREFUSED' }),
+      expectedMessage: 'WebSocket connection failed (ECONNREFUSED)',
+      expectedRateLimitHits: 0,
+    },
+    {
+      description: 'broken pipes',
+      createError: (url: string) =>
+        Object.assign(new Error(`write EPIPE ${url}`), { code: 'EPIPE' }),
+      expectedMessage: 'WebSocket connection failed (EPIPE)',
+      expectedRateLimitHits: 0,
+    },
+    {
+      description: 'request timeouts',
+      createError: (url: string) => new Error(`request timeout after 1000ms ${url}`),
+      expectedMessage: 'WebSocket connection failed (TIMEOUT)',
+      expectedRateLimitHits: 0,
+    },
+    {
+      description: 'socket hang-ups',
+      createError: (url: string) => new Error(`socket hang up ${url}`),
+      expectedMessage: 'WebSocket connection failed (SOCKET HANG UP)',
+      expectedRateLimitHits: 0,
+    },
+    {
+      description: 'transient TLS record failures',
+      createError: (url: string) => new Error(`SSL routines: bad record mac ${url}`),
+      expectedMessage: 'WebSocket connection failed (BAD RECORD MAC)',
+      expectedRateLimitHits: 0,
+    },
+    {
+      description: 'retryable TLS protocol failures',
+      createError: (url: string) =>
+        Object.assign(new Error(`write EPROTO transient TLS failure ${url}`), { code: 'EPROTO' }),
+      expectedMessage: 'WebSocket connection failed (EPROTO)',
+      expectedRateLimitHits: 0,
+    },
+  ])('should retry $description without exposing rendered WebSocket URL values', async ({
+    createError,
+    expectedMessage,
+    expectedRateLimitHits,
+  }) => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const renderedUrl =
+      'ws://runtime-secret-tenant.invalid/sessions/private-session-123?token=runtime-query-secret';
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        url: 'ws://{{ tenant }}.invalid/sessions/{{ sessionId }}?token={{ token }}',
+        messageTemplate: '{{ prompt }}',
+        timeoutMs: 1000,
+        maxRetries: 2,
+      },
+    });
+    emitWebSocketEvents({ type: 'error', error: createError(renderedUrl) });
+
+    const registry = new RateLimitRegistry({ maxConcurrency: 1, queueTimeoutMs: 100 });
+    const callApi = vi.fn(() =>
+      provider.callApi('test prompt', {
+        prompt: { raw: 'test prompt', label: 'test prompt' },
+        vars: {
+          tenant: 'runtime-secret-tenant',
+          sessionId: 'private-session-123',
+          token: 'runtime-query-secret',
+        },
+      }),
+    );
+
+    try {
+      const error = await registry
+        .execute(provider, callApi, {
+          isRateLimited: isProviderResponseRateLimited,
+          getRetryAfter: () => 0,
+        })
+        .catch((caughtError: Error) => caughtError);
+
+      if (!(error instanceof Error)) {
+        throw new Error('Expected the WebSocket provider call to fail');
+      }
+      expect(callApi).toHaveBeenCalledTimes(3);
+      expect(error.message).toBe(expectedMessage);
+      expect(Object.values(registry.getMetrics())[0]).toMatchObject({
+        retriedRequests: 2,
+        rateLimitHits: expectedRateLimitHits,
+        failedRequests: 1,
+      });
+
+      const observableError = JSON.stringify({
+        message: error.message,
+        logs: errorSpy.mock.calls,
+        metrics: registry.getMetrics(),
+      });
+      expect(observableError).not.toContain('runtime-secret-tenant');
+      expect(observableError).not.toContain('private-session-123');
+      expect(observableError).not.toContain('runtime-query-secret');
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it.each([
+    new Error('getaddrinfo ENOTFOUND runtime-secret-tenant.invalid'),
+    Object.assign(new Error('getaddrinfo ENOTFOUND tenant-429.invalid'), { code: 'ENOTFOUND' }),
+    Object.assign(new Error('getaddrinfo ENOTFOUND tenant-503.invalid'), { code: 'ENOTFOUND' }),
+    Object.assign(new Error('getaddrinfo ENOTFOUND tenant-network.invalid'), { code: 'ENOTFOUND' }),
+    Object.assign(new Error('getaddrinfo ENOTFOUND tenant-ECONNRESET.invalid'), {
+      code: 'ENOTFOUND',
+    }),
+    new Error('getaddrinfo ENOTFOUND tenant-ECONNRESET.invalid'),
+    new Error('Unexpected server response: 401'),
+    new Error('Unexpected server response: 401 ws://tenant-429.invalid?token=503'),
+    new Error('Unexpected server response: 401 ws://tenant-ECONNRESET.invalid'),
+    Object.assign(new Error('self signed certificate for runtime-secret-tenant.invalid'), {
+      code: 'DEPTH_ZERO_SELF_SIGNED_CERT',
+    }),
+    Object.assign(new Error('self signed certificate for tenant-network.invalid'), {
+      code: 'DEPTH_ZERO_SELF_SIGNED_CERT',
+    }),
+    Object.assign(new Error('Host: timeout.invalid. is not in the certificate'), {
+      code: 'ERR_TLS_CERT_ALTNAME_INVALID',
+    }),
+    Object.assign(new Error('write EPROTO wrong version number runtime-secret-tenant.invalid'), {
+      code: 'EPROTO',
+    }),
+    Object.assign(new Error('request aborted for runtime-secret-tenant.invalid'), {
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+    }),
+    Object.assign(new Error('request aborted for tenant-network.invalid'), {
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+    }),
+    Object.assign(new Error('The operation was aborted after timeout'), {
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+    }),
+    Object.assign(new Error('The operation was aborted after ECONNRESET'), {
+      name: 'AbortError',
+      code: 'ABORT_ERR',
+    }),
+  ])('should not retry permanent or cancelled WebSocket errors: $message', async (sourceError) => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        url: 'ws://{{ tenant }}.invalid/ws?token={{ token }}',
+        messageTemplate: '{{ prompt }}',
+        timeoutMs: 1000,
+        maxRetries: 2,
+      },
+    });
+    emitWebSocketEvents({ type: 'error', error: sourceError });
+
+    const registry = new RateLimitRegistry({ maxConcurrency: 1, queueTimeoutMs: 100 });
+    const callApi = vi.fn(() =>
+      provider.callApi('test prompt', {
+        prompt: { raw: 'test prompt', label: 'test prompt' },
+        vars: { tenant: 'runtime-secret-tenant', token: 'runtime-query-secret' },
+      }),
+    );
+
+    try {
+      await expect(
+        registry.execute(provider, callApi, {
+          isRateLimited: isProviderResponseRateLimited,
+          getRetryAfter: () => 0,
+        }),
+      ).rejects.toThrow('WebSocket connection failed');
+      expect(callApi).toHaveBeenCalledOnce();
+      expect(Object.values(registry.getMetrics())[0]).toMatchObject({
+        retriedRequests: 0,
+        rateLimitHits: 0,
+        failedRequests: 1,
+      });
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain('runtime-secret-tenant');
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain('runtime-query-secret');
+    } finally {
+      registry.dispose();
+    }
   });
 
   it('should handle timeout', async () => {

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -410,6 +410,13 @@ describe('WebSocketProvider', () => {
       expectedRateLimitHits: 0,
     },
     {
+      description: 'coded socket timeouts',
+      createError: (url: string) =>
+        Object.assign(new Error(`connect ETIMEDOUT ${url}`), { code: 'ETIMEDOUT' }),
+      expectedMessage: 'WebSocket connection failed (TIMEOUT)',
+      expectedRateLimitHits: 0,
+    },
+    {
       description: 'socket hang-ups',
       createError: (url: string) => new Error(`socket hang up ${url}`),
       expectedMessage: 'WebSocket connection failed (SOCKET HANG UP)',
@@ -514,6 +521,8 @@ describe('WebSocketProvider', () => {
     Object.assign(new Error('write EPROTO wrong version number runtime-secret-tenant.invalid'), {
       code: 'EPROTO',
     }),
+    Object.assign(new Error('write EPROTO tlsv1 alert protocol version'), { code: 'EPROTO' }),
+    Object.assign(new Error('write EPROTO unsupported protocol'), { code: 'EPROTO' }),
     Object.assign(new Error('request aborted for runtime-secret-tenant.invalid'), {
       name: 'AbortError',
       code: 'ABORT_ERR',
@@ -528,6 +537,10 @@ describe('WebSocketProvider', () => {
     }),
     Object.assign(new Error('The operation was aborted after ECONNRESET'), {
       name: 'AbortError',
+      code: 'ABORT_ERR',
+    }),
+    Object.assign(new Error('The operation was aborted after timeout'), {
+      name: 'AbortException',
       code: 'ABORT_ERR',
     }),
   ])('should not retry permanent or cancelled WebSocket errors: $message', async (sourceError) => {
@@ -551,12 +564,22 @@ describe('WebSocketProvider', () => {
     );
 
     try {
-      await expect(
-        registry.execute(provider, callApi, {
+      const error = await registry
+        .execute(provider, callApi, {
           isRateLimited: isProviderResponseRateLimited,
           getRetryAfter: () => 0,
-        }),
-      ).rejects.toThrow('WebSocket connection failed');
+        })
+        .catch((caughtError: Error) => caughtError);
+
+      if (!(error instanceof Error)) {
+        throw new Error('Expected the WebSocket provider call to fail');
+      }
+      expect(error.message).toBe('WebSocket connection failed');
+      expect(error.name).toBe(
+        sourceError.name === 'AbortError' || sourceError.name === 'AbortException'
+          ? sourceError.name
+          : 'Error',
+      );
       expect(callApi).toHaveBeenCalledOnce();
       expect(Object.values(registry.getMetrics())[0]).toMatchObject({
         retriedRequests: 0,


### PR DESCRIPTION
## Summary

Promptfoo's WebSocket provider opens a fresh connection for each evaluation call. The recent URL-templating change correctly stopped asynchronous connection errors from exposing rendered hostnames, session IDs, and query credentials, but replacing every underlying failure with `WebSocket connection failed` also removed the HTTP status and transport signals that Promptfoo's evaluator scheduler uses to retry transient failures.

- Preserve only trusted, secret-safe WebSocket handshake statuses and transport classifications, including HTTP 429/502/503/504, `ECONNRESET`, `ECONNREFUSED`, `EPIPE`, `ETIMEDOUT`, safe `EPROTO`, socket hang-ups, and transient TLS record failures.
- Keep rendered URLs, hostnames, session IDs, query credentials, and raw error causes out of provider errors and logs.
- Continue failing immediately for permanent DNS, authentication, TLS/configuration, and cancellation errors, including protocol-version mismatches and adversarial hostnames containing retry-looking strings such as `429`, `network`, or `ECONNRESET`; preserve `AbortError` and `AbortException` identities without leaking their raw messages.
- Add composed `WebSocketProvider` → `RateLimitRegistry` regressions that assert configured retry counts, rate-limit metrics, secret redaction, and permanent/cancellation behavior together.

## Why

WebSocket-backed evaluations pass through `RateLimitRegistry`, so discarding safe error classification made transient network failures and HTTP 429 handshake responses stop after a single attempt instead of honoring configured retries and backoff. This restores the existing scheduler contract without reintroducing the URL-derived credential exposure addressed by #10171.

## Validation

- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci` with Node `24.18.0` and npm `11.16.0`.
- `npx vitest run test/providers/websocket.test.ts test/scheduler test/providers/http.test.ts test/providers/providerLogging.test.ts test/util/fetch/errors.test.ts test/util/sanitizer.test.ts test/models/evalResult.test.ts` — **725 tests passed across 14 files**.
- `npm run tsc`.
- `npm run architecture:check`.
- `npm run l && npm run f`; both changed files were actually processed.
- Real local `npm run local -- eval -c <loopback-config> --no-cache --no-write --no-share --no-table -o <results.json>` against an HTTP-upgrade server: an initial 429 recovers on attempt two; repeated 429s stop after the configured retry and export only `WebSocket connection failed (HTTP 429)`.
- Three independent read-only review passes covered contract/security breakage, runtime/test quality, and simplification/documentation; confirmed findings were fixed and revalidated.
