### PR TITLE
fix(webui): accept templated websocket provider URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45193,7 +45193,8 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-virtual": "^3.13.22",
-        "lightningcss": "^1.32.0"
+        "lightningcss": "^1.32.0",
+        "nunjucks": "^3.2.4"
       },
       "devDependencies": {
         "@babel/core": "^7.29.6",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -95,6 +95,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-virtual": "^3.13.22",
-    "lightningcss": "^1.32.0"
+    "lightningcss": "^1.32.0",
+    "nunjucks": "^3.2.4"
   }
 }

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
@@ -4,6 +4,7 @@ import AddProviderDialog from '@app/pages/eval-creator/components/AddProviderDia
 import { renderWithProviders } from '@app/utils/testutils';
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nunjucks from 'nunjucks';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ProviderConfigEditor from './ProviderConfigEditor';
 import ProviderEditor from './ProviderEditor';
@@ -144,6 +145,7 @@ describe('ProviderConfigEditor', () => {
       ['an authority template', 'wss://{{ host }}/ws'],
       ['a port template', 'wss://example.com:{{ port }}/ws'],
       ['a scheme template', '{{ protocol }}://example.com/ws'],
+      ['a constant filtered WebSocket scheme', '{{ "WS" | lower }}://example.com/ws'],
       ['a partial scheme template', 'w{{ protocolSuffix }}://example.com/ws'],
       ['a case-insensitive partial scheme template', 'W{{ protocolSuffix }}://example.com/ws'],
       ['a whole-URL template', '{{ websocketUrl }}'],
@@ -218,6 +220,9 @@ describe('ProviderConfigEditor', () => {
       ['an HTTP URL', 'https://example.com/ws'],
       ['an HTTP URL with a templated host', 'https://{{ host }}/ws'],
       ['an incompatible templated scheme', 'http{{ suffix }}://example.com/ws'],
+      ['a constant filtered HTTP scheme', '{{ "http" | lower }}://example.com/ws'],
+      ['a constant filtered HTTPS scheme', '{{ "https" | upper }}://example.com/ws'],
+      ['a constant default-filtered HTTP scheme', '{{ "http" | default("ws") }}://example.com/ws'],
       [
         'a static scheme containing the internal placeholder',
         '__promptfoo_template__://example.com/ws',
@@ -281,6 +286,32 @@ describe('ProviderConfigEditor', () => {
       expect(validateFn!()).toBe(false);
       expect(setError).toHaveBeenCalledWith('Valid WebSocket URL is required');
       expect(onValidate).toHaveBeenCalledWith(false);
+    });
+
+    it('should validate a static WebSocket URL without using the Nunjucks parser', () => {
+      const parser = (
+        nunjucks as typeof nunjucks & { parser: { parse: (template: string) => unknown } }
+      ).parser;
+      const parse = vi.spyOn(parser, 'parse');
+      let validateFn: (() => boolean) | null = null;
+
+      renderWithProviders(
+        <ProviderConfigEditor
+          provider={{
+            id: 'websocket',
+            config: { url: 'wss://example.com/ws', messageTemplate: '{{ prompt }}' },
+          }}
+          setProvider={vi.fn()}
+          onValidationRequest={(validator) => {
+            validateFn = validator;
+          }}
+          providerType="websocket"
+        />,
+      );
+
+      expect(validateFn!()).toBe(true);
+      expect(parse).not.toHaveBeenCalled();
+      parse.mockRestore();
     });
 
     it.each([

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 
+import AddProviderDialog from '@app/pages/eval-creator/components/AddProviderDialog';
 import { renderWithProviders } from '@app/utils/testutils';
 import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ProviderConfigEditor from './ProviderConfigEditor';
+import ProviderEditor from './ProviderEditor';
 
 import type { ProviderOptions } from '../../types';
 
@@ -15,10 +18,31 @@ vi.mock('./HttpEndpointConfiguration', () => ({
   default: () => <div data-testid="http-config" />,
 }));
 vi.mock('./WebSocketEndpointConfiguration', () => ({
-  default: () => <div data-testid="ws-config" />,
+  default: ({
+    selectedTarget,
+    updateWebSocketTarget,
+    urlError,
+  }: {
+    selectedTarget: ProviderOptions;
+    updateWebSocketTarget: (field: string, value: unknown) => void;
+    urlError: string | null;
+  }) => (
+    <div data-testid="ws-config">
+      <label htmlFor="websocket-url">WebSocket URL</label>
+      <input
+        id="websocket-url"
+        value={selectedTarget.config.url}
+        onChange={(event) => updateWebSocketTarget('url', event.target.value)}
+      />
+      {urlError && <div>{urlError}</div>}
+    </div>
+  ),
 }));
 vi.mock('./CustomTargetConfiguration', () => ({
   default: () => <div data-testid="custom-config" />,
+}));
+vi.mock('./ProviderTypeSelector', () => ({
+  default: () => <div data-testid="provider-type-selector" />,
 }));
 vi.mock('./A2AEndpointConfiguration', async () => {
   const React = await vi.importActual<typeof import('react')>('react');
@@ -112,6 +136,211 @@ describe('ProviderConfigEditor', () => {
       expect(isValid).toBe(true);
       expect(mockSetError).toHaveBeenCalledWith(null);
       expect(mockOnValidate).toHaveBeenCalledWith(true);
+    });
+
+    it.each([
+      ['a static URL', 'wss://example.com/ws'],
+      ['a path template', 'wss://example.com/{{ path }}'],
+      ['an authority template', 'wss://{{ host }}/ws'],
+      ['a port template', 'wss://example.com:{{ port }}/ws'],
+      ['a scheme template', '{{ protocol }}://example.com/ws'],
+      ['a partial scheme template', 'w{{ protocolSuffix }}://example.com/ws'],
+      ['a case-insensitive partial scheme template', 'W{{ protocolSuffix }}://example.com/ws'],
+      ['a whole-URL template', '{{ websocketUrl }}'],
+      ['a filtered scheme prefix', '{{ protocol | default("ws://") }}example.com/ws'],
+      ['a conditional scheme', '{% if secure %}wss{% else %}ws{% endif %}://example.com/ws'],
+      [
+        'a whitespace-trimmed conditional scheme',
+        '{%- if secure -%}wss{%- else -%}ws{%- endif -%}://example.com/ws',
+      ],
+      [
+        'a modulo conditional scheme',
+        '{% if value % 2 == 0 %}ws{% else %}wss{% endif %}://example.com/ws',
+      ],
+      [
+        'a quoted-percent conditional scheme',
+        '{% if value == "100%" %}ws{% else %}wss{% endif %}://example.com/ws',
+      ],
+      [
+        'an implicit empty conditional branch',
+        '{% if useHttp %}http{% endif %}ws://example.com/ws',
+      ],
+      [
+        'a nested conditional scheme',
+        '{% if outer %}{% if inner %}wss{% else %}ws{% endif %}{% else %}ws{% endif %}://example.com/ws',
+      ],
+      ['an IPv6 authority template', 'ws://[{{ address }}]:{{ port }}/ws'],
+      [
+        'an IPv6-or-DNS conditional authority',
+        'ws://{% if ipv6 %}[::1]{% else %}example.com{% endif %}/ws',
+      ],
+      [
+        'a conditional host and port',
+        'ws://{% if usePort %}example.com:1234{% else %}example.com{% endif %}/ws',
+      ],
+      [
+        'authority control-flow templates',
+        'wss://{% if tenant %}{{ tenant }}{% else %}default{% endif %}.example.com/ws',
+      ],
+      ['literal raw-template path content', 'wss://example.com/{% raw %}{{ host }}{% endraw %}'],
+    ])('should accept a WebSocket provider with %s', (_description, url) => {
+      const setError = vi.fn();
+      const onValidate = vi.fn();
+      let validateFn: (() => boolean) | null = null;
+
+      renderWithProviders(
+        <ProviderConfigEditor
+          provider={{ id: 'websocket', config: { url, messageTemplate: '{{ prompt }}' } }}
+          setProvider={vi.fn()}
+          setError={setError}
+          onValidate={onValidate}
+          onValidationRequest={(validator) => {
+            validateFn = validator;
+          }}
+          providerType="websocket"
+        />,
+      );
+
+      expect(validateFn!()).toBe(true);
+      expect(setError).toHaveBeenCalledWith(null);
+      expect(onValidate).toHaveBeenCalledWith(true);
+    });
+
+    it.each([
+      ['an HTTP URL', 'https://example.com/ws'],
+      ['an HTTP URL with a templated host', 'https://{{ host }}/ws'],
+      ['an incompatible templated scheme', 'http{{ suffix }}://example.com/ws'],
+      [
+        'a static scheme containing the internal placeholder',
+        '__promptfoo_template__://example.com/ws',
+      ],
+      [
+        'a static partial scheme containing the internal placeholder',
+        'w__promptfoo_template__://example.com/ws',
+      ],
+      [
+        'an exclusively non-WebSocket conditional scheme',
+        '{% if secure %}https{% else %}http{% endif %}://example.com/ws',
+      ],
+      ['a malformed static URL', 'wss://[invalid-host/ws'],
+      ['a scheme template without an authority', '{{ protocol }}://'],
+      ['an incomplete template', 'wss://{{ host }/ws'],
+      ['an incomplete expression in a path', 'wss://example.com/{{ host }'],
+      ['an empty template expression', 'wss://example.com/{{ }}'],
+      ['an incomplete template filter', 'wss://example.com/{{ host | }}'],
+      ['an unterminated conditional', 'wss://example.com/{% if secure %}/ws'],
+      ['an unterminated whitespace-trimmed conditional', 'wss://{%- if secure -%}example.com/ws'],
+      [
+        'an unterminated nested conditional',
+        '{% if outer %}{% if inner %}wss{% else %}ws{% endif %}://example.com/ws',
+      ],
+      ['literal raw-template host content', 'wss://{% raw %}{{ host }}{% endraw %}/ws'],
+      ['an unfinished comment', 'wss://example.com/{# unfinished'],
+      [
+        'many conditional branches under an invalid static scheme',
+        `https://example.com/${'{% if condition %}x{% else %}y{% endif %}'.repeat(20)}`,
+      ],
+      [
+        'too many incompatible conditional scheme branches',
+        `${'{% if condition %}x{% else %}y{% endif %}'.repeat(20)}://example.com/ws`,
+      ],
+    ])('should reject a WebSocket provider with %s', (_description, url) => {
+      const setError = vi.fn();
+      const onValidate = vi.fn();
+      let validateFn: (() => boolean) | null = null;
+
+      renderWithProviders(
+        <ProviderConfigEditor
+          provider={{ id: 'websocket', config: { url, messageTemplate: '{{ prompt }}' } }}
+          setProvider={vi.fn()}
+          setError={setError}
+          onValidate={onValidate}
+          onValidationRequest={(validator) => {
+            validateFn = validator;
+          }}
+          providerType="websocket"
+        />,
+      );
+
+      expect(validateFn!()).toBe(false);
+      expect(setError).toHaveBeenCalledWith('Valid WebSocket URL is required');
+      expect(onValidate).toHaveBeenCalledWith(false);
+    });
+
+    it.each([
+      ['an authority template', 'wss://{{ host }}/ws'],
+      ['a conditional scheme', '{% if secure %}wss{% else %}ws{% endif %}://example.com/ws'],
+    ])('should continue from the actual red-team Next button with %s', async (_description, url) => {
+      const user = userEvent.setup();
+      const onNext = vi.fn();
+
+      function WebSocketEditorHarness() {
+        const [provider, setProvider] = React.useState<ProviderOptions>({
+          id: 'websocket',
+          label: 'WebSocket target',
+          config: { url: 'wss://example.com/ws', messageTemplate: '{{ prompt }}' },
+        });
+
+        return (
+          <ProviderEditor
+            provider={provider}
+            setProvider={setProvider}
+            onActionButtonClick={onNext}
+            opts={{ disableNameField: true }}
+          />
+        );
+      }
+
+      renderWithProviders(<WebSocketEditorHarness />);
+
+      const urlInput = screen.getByRole('textbox', { name: 'WebSocket URL' });
+      await user.clear(urlInput);
+      await user.paste(url);
+
+      expect(urlInput).toHaveValue(url);
+      expect(
+        screen.queryByText('Please enter a valid WebSocket URL (ws:// or wss://)'),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['an authority template', 'wss://{{ host }}/ws'],
+      ['a whole-URL template', '{{ websocketUrl }}'],
+    ])('should save %s through the actual eval provider dialog', async (_description, url) => {
+      const user = userEvent.setup();
+      const onSave = vi.fn();
+
+      renderWithProviders(
+        <AddProviderDialog
+          open
+          initialProvider={{
+            id: 'websocket',
+            label: 'WebSocket target',
+            config: { url: 'wss://example.com/ws', messageTemplate: '{{ prompt }}' },
+          }}
+          onSave={onSave}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const urlInput = screen.getByRole('textbox', { name: 'WebSocket URL' });
+      await user.clear(urlInput);
+      await user.paste(url);
+
+      expect(
+        screen.queryByText('Please enter a valid WebSocket URL (ws:// or wss://)'),
+      ).not.toBeInTheDocument();
+      const saveButton = screen.getByRole('button', { name: 'Save Changes' });
+      expect(saveButton).toBeEnabled();
+      await user.click(saveButton);
+
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ config: expect.objectContaining({ url }) }),
+      );
     });
 
     it('should return false from validate() when provider ID contains only whitespace characters for foundation model providers', () => {

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
@@ -154,6 +154,10 @@ describe('ProviderConfigEditor', () => {
         '{%- if secure -%}wss{%- else -%}ws{%- endif -%}://example.com/ws',
       ],
       [
+        'a whitespace-trimmed conditional scheme with surrounding spaces',
+        '{%- if secure -%} wss {%- else -%} ws {%- endif -%}://example.com/ws',
+      ],
+      [
         'a modulo conditional scheme',
         '{% if value % 2 == 0 %}ws{% else %}wss{% endif %}://example.com/ws',
       ],
@@ -183,6 +187,10 @@ describe('ProviderConfigEditor', () => {
         'wss://{% if tenant %}{{ tenant }}{% else %}default{% endif %}.example.com/ws',
       ],
       ['literal raw-template path content', 'wss://example.com/{% raw %}{{ host }}{% endraw %}'],
+      [
+        'a long literal containing the previous collision marker',
+        `wss://example.com/__promptfoo_template__${'_'.repeat(4_096)}/{{ path }}`,
+      ],
     ])('should accept a WebSocket provider with %s', (_description, url) => {
       const setError = vi.fn();
       const onValidate = vi.fn();
@@ -224,10 +232,18 @@ describe('ProviderConfigEditor', () => {
       ],
       ['a malformed static URL', 'wss://[invalid-host/ws'],
       ['a scheme template without an authority', '{{ protocol }}://'],
+      ['a standalone host expression', '{{ host }}'],
+      ['a host expression without a WebSocket scheme', '{{ host }}/ws'],
+      ['a filtered host expression without a WebSocket scheme', '{{ host | lower }}/ws'],
       ['an incomplete template', 'wss://{{ host }/ws'],
       ['an incomplete expression in a path', 'wss://example.com/{{ host }'],
       ['an empty template expression', 'wss://example.com/{{ }}'],
       ['an incomplete template filter', 'wss://example.com/{{ host | }}'],
+      ['a syntactically invalid template expression', 'wss://{{ host + }}/ws'],
+      ['a syntactically invalid block tag', 'wss://example.com/{% for %}'],
+      ['an unsupported loop block', '{% for prefix in prefixes %}ws{% endfor %}://example.com/ws'],
+      ['an unsupported set block', '{% set protocol = "ws" %}{{ protocol }}://example.com/ws'],
+      ['an unsupported include block', '{% include "scheme.njk" %}://example.com/ws'],
       ['an unterminated conditional', 'wss://example.com/{% if secure %}/ws'],
       ['an unterminated whitespace-trimmed conditional', 'wss://{%- if secure -%}example.com/ws'],
       [
@@ -270,6 +286,10 @@ describe('ProviderConfigEditor', () => {
     it.each([
       ['an authority template', 'wss://{{ host }}/ws'],
       ['a conditional scheme', '{% if secure %}wss{% else %}ws{% endif %}://example.com/ws'],
+      [
+        'a whitespace-trimmed conditional scheme with surrounding spaces',
+        '{%- if secure -%} wss {%- else -%} ws {%- endif -%}://example.com/ws',
+      ],
     ])('should continue from the actual red-team Next button with %s', async (_description, url) => {
       const user = userEvent.setup();
       const onNext = vi.fn();
@@ -310,6 +330,10 @@ describe('ProviderConfigEditor', () => {
     it.each([
       ['an authority template', 'wss://{{ host }}/ws'],
       ['a whole-URL template', '{{ websocketUrl }}'],
+      [
+        'a whitespace-trimmed conditional scheme with surrounding spaces',
+        '{%- if secure -%} wss {%- else -%} ws {%- endif -%}://example.com/ws',
+      ],
     ])('should save %s through the actual eval provider dialog', async (_description, url) => {
       const user = userEvent.setup();
       const onSave = vi.fn();

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
@@ -146,10 +146,23 @@ describe('ProviderConfigEditor', () => {
       ['a port template', 'wss://example.com:{{ port }}/ws'],
       ['a scheme template', '{{ protocol }}://example.com/ws'],
       ['a constant filtered WebSocket scheme', '{{ "WS" | lower }}://example.com/ws'],
+      [
+        'a boolean-valued constant filter operand',
+        '{{ false | default("ws", true) }}://example.com/ws',
+      ],
+      ['a numeric constant filter operand', '{{ 0 | default("wss", true) }}://example.com/ws'],
       ['a partial scheme template', 'w{{ protocolSuffix }}://example.com/ws'],
       ['a case-insensitive partial scheme template', 'W{{ protocolSuffix }}://example.com/ws'],
       ['a whole-URL template', '{{ websocketUrl }}'],
+      [
+        'a whole-URL template followed by a callback URL',
+        '{{ websocketUrl }}?callback=https://example.com',
+      ],
       ['a filtered scheme prefix', '{{ protocol | default("ws://") }}example.com/ws'],
+      [
+        'many non-branching query-value templates',
+        `wss://example.com/?${Array.from({ length: 32 }, (_, index) => `p${index}={{ v${index} }}`).join('&')}`,
+      ],
       ['a conditional scheme', '{% if secure %}wss{% else %}ws{% endif %}://example.com/ws'],
       [
         'a whitespace-trimmed conditional scheme',
@@ -240,6 +253,7 @@ describe('ProviderConfigEditor', () => {
       ['a standalone host expression', '{{ host }}'],
       ['a host expression without a WebSocket scheme', '{{ host }}/ws'],
       ['a filtered host expression without a WebSocket scheme', '{{ host | lower }}/ws'],
+      ['a host expression followed by a callback URL', '{{ host }}?callback=https://example.com'],
       ['an incomplete template', 'wss://{{ host }/ws'],
       ['an incomplete expression in a path', 'wss://example.com/{{ host }'],
       ['an empty template expression', 'wss://example.com/{{ }}'],
@@ -318,6 +332,10 @@ describe('ProviderConfigEditor', () => {
       ['an authority template', 'wss://{{ host }}/ws'],
       ['a conditional scheme', '{% if secure %}wss{% else %}ws{% endif %}://example.com/ws'],
       [
+        'a whole-URL template followed by a callback URL',
+        '{{ websocketUrl }}?callback=https://example.com',
+      ],
+      [
         'a whitespace-trimmed conditional scheme with surrounding spaces',
         '{%- if secure -%} wss {%- else -%} ws {%- endif -%}://example.com/ws',
       ],
@@ -361,6 +379,10 @@ describe('ProviderConfigEditor', () => {
     it.each([
       ['an authority template', 'wss://{{ host }}/ws'],
       ['a whole-URL template', '{{ websocketUrl }}'],
+      [
+        'a whole-URL template followed by a callback URL',
+        '{{ websocketUrl }}?callback=https://example.com',
+      ],
       [
         'a whitespace-trimmed conditional scheme with surrounding spaces',
         '{%- if secure -%} wss {%- else -%} ws {%- endif -%}://example.com/ws',

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import AddProviderDialog from '@app/pages/eval-creator/components/AddProviderDialog';
+import { useStore as useEvalConfigStore } from '@app/stores/evalConfig';
 import { renderWithProviders } from '@app/utils/testutils';
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -146,6 +147,9 @@ describe('ProviderConfigEditor', () => {
       ['a port template', 'wss://example.com:{{ port }}/ws'],
       ['a scheme template', '{{ protocol }}://example.com/ws'],
       ['a constant filtered WebSocket scheme', '{{ "WS" | lower }}://example.com/ws'],
+      ['a deterministic concatenated WebSocket scheme', '{{ "w" ~ "s" }}://example.com/ws'],
+      ['a separator supplied by a scheme expression', 'ws{{ separator }}example.com/ws'],
+      ['a partial scheme and separator expression', 'w{{ suffix }}example.com/ws'],
       [
         'a boolean-valued constant filter operand',
         '{{ false | default("ws", true) }}://example.com/ws',
@@ -236,6 +240,11 @@ describe('ProviderConfigEditor', () => {
       ['a constant filtered HTTP scheme', '{{ "http" | lower }}://example.com/ws'],
       ['a constant filtered HTTPS scheme', '{{ "https" | upper }}://example.com/ws'],
       ['a constant default-filtered HTTP scheme', '{{ "http" | default("ws") }}://example.com/ws'],
+      ['a deterministic concatenated HTTP scheme', '{{ "ht" ~ "tp" }}://example.com/ws'],
+      ['a static fragment identifier', 'wss://example.com/ws#debug'],
+      ['a templated fragment identifier', '{{ protocol }}://example.com/ws#debug'],
+      ['a templated host with a fragment identifier', 'wss://{{ host }}/ws#debug'],
+      ['many nonmatching scheme expressions', `${'{{ x }}'.repeat(128)}x://example.com/ws`],
       [
         'a static scheme containing the internal placeholder',
         '__promptfoo_template__://example.com/ws',
@@ -326,6 +335,37 @@ describe('ProviderConfigEditor', () => {
       expect(validateFn!()).toBe(true);
       expect(parse).not.toHaveBeenCalled();
       parse.mockRestore();
+    });
+
+    it('should not fold a built-in filter that the evaluation configuration overrides', () => {
+      useEvalConfigStore
+        .getState()
+        .updateConfig({ nunjucksFilters: { lower: 'file://filters.js' } });
+      let validateFn: (() => boolean) | null = null;
+
+      try {
+        renderWithProviders(
+          <ProviderConfigEditor
+            provider={{
+              id: 'websocket',
+              config: {
+                url: '{{ "HTTP" | lower }}://example.com/ws',
+                messageTemplate: '{{ prompt }}',
+              },
+            }}
+            setProvider={vi.fn()}
+            onValidationRequest={(validator) => {
+              validateFn = validator;
+            }}
+            providerType="websocket"
+            mode="eval"
+          />,
+        );
+
+        expect(validateFn!()).toBe(true);
+      } finally {
+        useEvalConfigStore.getState().reset();
+      }
     });
 
     it.each([

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
@@ -41,6 +41,22 @@ const shouldRemoveMcpConfig = (
 const containsNunjucksTemplate = (value: string): boolean =>
   /{{[\s\S]*}}|{%[\s\S]*%}|{#[\s\S]*#}/.test(value);
 
+const replaceNunjucksTemplates = (value: string, placeholder: string): string =>
+  value.replace(/{{[\s\S]*?}}|{%[\s\S]*?%}|{#[\s\S]*?#}/g, (template, offset, source) => {
+    if (template.startsWith('{#') || template.startsWith('{%')) {
+      return '';
+    }
+
+    const before = source.slice(0, offset);
+    const after = source.slice(offset + template.length);
+    return before.endsWith('[') && after.startsWith(']') ? '::1' : placeholder;
+  });
+
+const getNunjucksConditionalBranches = (value: string): string[] => {
+  const branches = value.split(/{%-?\s*(?:else|elif\b(?:(?!%})[\s\S])*)\s*-?%}/);
+  return /{%-?\s*else\s*-?%}/.test(value) ? branches : [...branches, ''];
+};
+
 function ProviderConfigEditor({
   provider,
   setProvider,
@@ -65,15 +81,92 @@ function ProviderConfigEditor({
   const [extensionErrors, setExtensionErrors] = useState(false);
   const [a2aAdvancedConfigError, setA2AAdvancedConfigError] = useState<string | null>(null);
 
-  const validateUrl = useCallback((url: string, type: 'http' | 'websocket' = 'http'): boolean => {
+  const validateUrl = useCallback(function validateUrl(
+    url: string,
+    type: 'http' | 'websocket' = 'http',
+    budget: { remaining: number } = { remaining: 64 },
+  ): boolean {
     try {
-      const parsedUrl = new URL(url);
       if (type === 'http') {
-        return ['http:', 'https:'].includes(parsedUrl.protocol);
-      } else if (type === 'websocket') {
-        return ['ws:', 'wss:'].includes(parsedUrl.protocol);
+        return ['http:', 'https:'].includes(new URL(url).protocol);
       }
-      return false;
+
+      if (--budget.remaining < 0) {
+        return false;
+      }
+
+      const fixedProtocol = url.match(/^([a-z][a-z\d+.-]*):\/\//i);
+      if (fixedProtocol && !/^wss?$/i.test(fixedProtocol[1])) {
+        return false;
+      }
+
+      if (/{{\s*(?:}}|[\s\S]*?\|\s*}})|{%-?\s*(?:if|elif)\s*-?%}/.test(url)) {
+        return false;
+      }
+
+      const rawBlock = url.match(/{%-?\s*raw\s*-?%}([\s\S]*?){%-?\s*endraw\s*-?%}/);
+      if (rawBlock) {
+        const literal = rawBlock[1].replace(/[{}]/g, (character) => encodeURIComponent(character));
+        return validateUrl(url.replace(rawBlock[0], literal), type, budget);
+      }
+
+      const conditional = url.match(
+        /{%-?\s*if\b(?:(?!%})[\s\S])*%}((?:(?!{%-?\s*if\b)[\s\S])*?){%-?\s*endif\s*-?%}/,
+      );
+      if (conditional) {
+        return getNunjucksConditionalBranches(conditional[1]).some((branch) =>
+          validateUrl(url.replace(conditional[0], branch), type, budget),
+        );
+      }
+
+      if (/{%-?\s*(?:if|elif|else|endif|raw|endraw)\b/.test(url)) {
+        return false;
+      }
+
+      let templatePlaceholder = '__promptfoo_template__';
+      while (url.includes(templatePlaceholder)) {
+        templatePlaceholder += '_';
+      }
+      let urlToValidate = replaceNunjucksTemplates(url, templatePlaceholder);
+
+      if (/{{|}}|{%|%}|{#|#}/.test(urlToValidate)) {
+        return false;
+      }
+
+      const schemeSeparatorIndex = urlToValidate.indexOf('://');
+
+      if (schemeSeparatorIndex === -1 && urlToValidate.includes(templatePlaceholder)) {
+        return ['ws://', 'ws://1'].some((replacement) =>
+          validateUrl(
+            urlToValidate
+              .replace(templatePlaceholder, replacement)
+              .split(templatePlaceholder)
+              .join('1'),
+            type,
+            budget,
+          ),
+        );
+      }
+
+      const scheme = urlToValidate.slice(0, schemeSeparatorIndex);
+      if (schemeSeparatorIndex !== -1 && scheme.includes(templatePlaceholder)) {
+        const schemePattern = scheme
+          .split(templatePlaceholder)
+          .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .join('.*');
+        const protocol = ['ws', 'wss'].find((value) =>
+          new RegExp(`^${schemePattern}$`, 'i').test(value),
+        );
+
+        if (!protocol) {
+          return false;
+        }
+
+        urlToValidate = `${protocol}${urlToValidate.slice(schemeSeparatorIndex)}`;
+      }
+
+      const parsedUrl = new URL(urlToValidate.split(templatePlaceholder).join('1'));
+      return ['ws:', 'wss:'].includes(parsedUrl.protocol);
     } catch {
       return false;
     }

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
@@ -49,6 +49,7 @@ type NunjucksAstNode = {
   body?: NunjucksAstNode;
   else_?: NunjucksAstNode;
   args?: NunjucksAstNode;
+  name?: NunjucksAstNode;
 };
 
 type NunjucksUrlCandidate = {
@@ -57,6 +58,36 @@ type NunjucksUrlCandidate = {
 };
 
 const TEMPLATE_PLACEHOLDER = '\0';
+
+const getConstantNunjucksExpression = (node: NunjucksAstNode): string | undefined => {
+  if (node.typename === 'Literal') {
+    return String(node.value ?? '');
+  }
+
+  if (node.typename !== 'Filter' || typeof node.name?.value !== 'string') {
+    return undefined;
+  }
+
+  const values: string[] = [];
+  for (const argument of node.args?.children ?? []) {
+    const value = getConstantNunjucksExpression(argument);
+    if (value === undefined) {
+      return undefined;
+    }
+    values.push(value);
+  }
+
+  try {
+    const value = new nunjucks.Environment(null, { autoescape: false }).getFilter(node.name.value)(
+      ...values,
+    );
+    return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+      ? String(value)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 const getNunjucksUrlCandidates = (
   node: NunjucksAstNode,
@@ -109,6 +140,11 @@ const getNunjucksUrlCandidates = (
     return null;
   }
 
+  const constantExpression = getConstantNunjucksExpression(node);
+  if (constantExpression !== undefined) {
+    return [{ value: constantExpression, expressions: [] }];
+  }
+
   return [{ value: TEMPLATE_PLACEHOLDER, expressions: [node] }];
 };
 
@@ -159,6 +195,10 @@ function ProviderConfigEditor({
 
       if (url.includes(TEMPLATE_PLACEHOLDER)) {
         return false;
+      }
+
+      if (!/{{|{%|{#/.test(url)) {
+        return ['ws:', 'wss:'].includes(new URL(url).protocol);
       }
 
       const fixedProtocol = url.match(/^([a-z][a-z\d+.-]*):\/\//i);

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import nunjucks from 'nunjucks';
 import { useRedTeamConfig } from '../../hooks/useRedTeamConfig';
 import A2AEndpointConfiguration from './A2AEndpointConfiguration';
 import AgentFrameworkConfiguration from './AgentFrameworkConfiguration';
@@ -41,20 +42,86 @@ const shouldRemoveMcpConfig = (
 const containsNunjucksTemplate = (value: string): boolean =>
   /{{[\s\S]*}}|{%[\s\S]*%}|{#[\s\S]*#}/.test(value);
 
-const replaceNunjucksTemplates = (value: string, placeholder: string): string =>
-  value.replace(/{{[\s\S]*?}}|{%[\s\S]*?%}|{#[\s\S]*?#}/g, (template, offset, source) => {
-    if (template.startsWith('{#') || template.startsWith('{%')) {
-      return '';
+type NunjucksAstNode = {
+  typename: string;
+  value?: unknown;
+  children?: NunjucksAstNode[];
+  body?: NunjucksAstNode;
+  else_?: NunjucksAstNode;
+  args?: NunjucksAstNode;
+};
+
+type NunjucksUrlCandidate = {
+  value: string;
+  expressions: NunjucksAstNode[];
+};
+
+const TEMPLATE_PLACEHOLDER = '\0';
+
+const getNunjucksUrlCandidates = (
+  node: NunjucksAstNode,
+  budget: { remaining: number },
+  isOutputExpression = false,
+): NunjucksUrlCandidate[] | null => {
+  if (--budget.remaining < 0) {
+    return null;
+  }
+
+  if (node.typename === 'TemplateData' || node.typename === 'Literal') {
+    return [{ value: String(node.value ?? ''), expressions: [] }];
+  }
+
+  if (node.typename === 'If') {
+    const truthyCandidates = node.body ? getNunjucksUrlCandidates(node.body, budget) : null;
+    const falsyCandidates = node.else_
+      ? getNunjucksUrlCandidates(node.else_, budget)
+      : [{ value: '', expressions: [] }];
+    return truthyCandidates && falsyCandidates ? [...truthyCandidates, ...falsyCandidates] : null;
+  }
+
+  if (node.typename === 'Root' || node.typename === 'NodeList' || node.typename === 'Output') {
+    let candidates: NunjucksUrlCandidate[] = [{ value: '', expressions: [] }];
+
+    for (const child of node.children ?? []) {
+      const nextCandidates = getNunjucksUrlCandidates(child, budget, node.typename === 'Output');
+      if (!nextCandidates) {
+        return null;
+      }
+
+      const combinations = candidates.flatMap((candidate) =>
+        nextCandidates.map((nextCandidate) => ({
+          value: candidate.value + nextCandidate.value,
+          expressions: [...candidate.expressions, ...nextCandidate.expressions],
+        })),
+      );
+
+      budget.remaining -= combinations.length;
+      if (budget.remaining < 0) {
+        return null;
+      }
+      candidates = combinations;
     }
 
-    const before = source.slice(0, offset);
-    const after = source.slice(offset + template.length);
-    return before.endsWith('[') && after.startsWith(']') ? '::1' : placeholder;
-  });
+    return candidates;
+  }
 
-const getNunjucksConditionalBranches = (value: string): string[] => {
-  const branches = value.split(/{%-?\s*(?:else|elif\b(?:(?!%})[\s\S])*)\s*-?%}/);
-  return /{%-?\s*else\s*-?%}/.test(value) ? branches : [...branches, ''];
+  if (!isOutputExpression) {
+    return null;
+  }
+
+  return [{ value: TEMPLATE_PLACEHOLDER, expressions: [node] }];
+};
+
+const getExpressionSymbol = (node?: NunjucksAstNode): string | undefined => {
+  if (!node) {
+    return undefined;
+  }
+
+  if (node.typename === 'Symbol' && typeof node.value === 'string') {
+    return node.value;
+  }
+
+  return node.typename === 'Filter' ? getExpressionSymbol(node.args?.children?.[0]) : undefined;
 };
 
 function ProviderConfigEditor({
@@ -84,14 +151,13 @@ function ProviderConfigEditor({
   const validateUrl = useCallback(function validateUrl(
     url: string,
     type: 'http' | 'websocket' = 'http',
-    budget: { remaining: number } = { remaining: 64 },
   ): boolean {
     try {
       if (type === 'http') {
         return ['http:', 'https:'].includes(new URL(url).protocol);
       }
 
-      if (--budget.remaining < 0) {
+      if (url.includes(TEMPLATE_PLACEHOLDER)) {
         return false;
       }
 
@@ -100,73 +166,79 @@ function ProviderConfigEditor({
         return false;
       }
 
-      if (/{{\s*(?:}}|[\s\S]*?\|\s*}})|{%-?\s*(?:if|elif)\s*-?%}/.test(url)) {
+      const parser = (
+        nunjucks as typeof nunjucks & {
+          parser?: { parse: (template: string) => NunjucksAstNode };
+        }
+      ).parser;
+      if (!parser) {
         return false;
       }
 
-      const rawBlock = url.match(/{%-?\s*raw\s*-?%}([\s\S]*?){%-?\s*endraw\s*-?%}/);
-      if (rawBlock) {
-        const literal = rawBlock[1].replace(/[{}]/g, (character) => encodeURIComponent(character));
-        return validateUrl(url.replace(rawBlock[0], literal), type, budget);
-      }
-
-      const conditional = url.match(
-        /{%-?\s*if\b(?:(?!%})[\s\S])*%}((?:(?!{%-?\s*if\b)[\s\S])*?){%-?\s*endif\s*-?%}/,
-      );
-      if (conditional) {
-        return getNunjucksConditionalBranches(conditional[1]).some((branch) =>
-          validateUrl(url.replace(conditional[0], branch), type, budget),
-        );
-      }
-
-      if (/{%-?\s*(?:if|elif|else|endif|raw|endraw)\b/.test(url)) {
+      const candidates = getNunjucksUrlCandidates(parser.parse(url), { remaining: 128 });
+      if (!candidates) {
         return false;
       }
 
-      let templatePlaceholder = '__promptfoo_template__';
-      while (url.includes(templatePlaceholder)) {
-        templatePlaceholder += '_';
-      }
-      let urlToValidate = replaceNunjucksTemplates(url, templatePlaceholder);
+      return candidates.some((candidate) => {
+        let urlToValidate = candidate.value;
+        const schemeSeparatorIndex = urlToValidate.indexOf('://');
 
-      if (/{{|}}|{%|%}|{#|#}/.test(urlToValidate)) {
-        return false;
-      }
+        if (schemeSeparatorIndex === -1 && urlToValidate.includes(TEMPLATE_PLACEHOLDER)) {
+          const expressionSymbol = getExpressionSymbol(candidate.expressions[0]);
+          if (
+            urlToValidate.startsWith(TEMPLATE_PLACEHOLDER) &&
+            expressionSymbol &&
+            /^(?:host(?:name)?|domain|port)$/i.test(expressionSymbol)
+          ) {
+            return false;
+          }
 
-      const schemeSeparatorIndex = urlToValidate.indexOf('://');
-
-      if (schemeSeparatorIndex === -1 && urlToValidate.includes(templatePlaceholder)) {
-        return ['ws://', 'ws://1'].some((replacement) =>
-          validateUrl(
-            urlToValidate
-              .replace(templatePlaceholder, replacement)
-              .split(templatePlaceholder)
-              .join('1'),
-            type,
-            budget,
-          ),
-        );
-      }
-
-      const scheme = urlToValidate.slice(0, schemeSeparatorIndex);
-      if (schemeSeparatorIndex !== -1 && scheme.includes(templatePlaceholder)) {
-        const schemePattern = scheme
-          .split(templatePlaceholder)
-          .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-          .join('.*');
-        const protocol = ['ws', 'wss'].find((value) =>
-          new RegExp(`^${schemePattern}$`, 'i').test(value),
-        );
-
-        if (!protocol) {
-          return false;
+          return ['ws://', 'ws://1'].some((replacement) => {
+            try {
+              const parsedUrl = new URL(
+                urlToValidate
+                  .replace(TEMPLATE_PLACEHOLDER, replacement)
+                  .split(TEMPLATE_PLACEHOLDER)
+                  .join('1'),
+              );
+              return ['ws:', 'wss:'].includes(parsedUrl.protocol);
+            } catch {
+              return false;
+            }
+          });
         }
 
-        urlToValidate = `${protocol}${urlToValidate.slice(schemeSeparatorIndex)}`;
-      }
+        const scheme = urlToValidate.slice(0, schemeSeparatorIndex);
+        if (schemeSeparatorIndex !== -1 && scheme.includes(TEMPLATE_PLACEHOLDER)) {
+          const schemePattern = scheme
+            .split(TEMPLATE_PLACEHOLDER)
+            .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+            .join('.*');
+          const protocol = ['ws', 'wss'].find((value) =>
+            new RegExp(`^${schemePattern}$`, 'i').test(value),
+          );
 
-      const parsedUrl = new URL(urlToValidate.split(templatePlaceholder).join('1'));
-      return ['ws:', 'wss:'].includes(parsedUrl.protocol);
+          if (!protocol) {
+            return false;
+          }
+
+          urlToValidate = `${protocol}${urlToValidate.slice(schemeSeparatorIndex)}`;
+        }
+
+        try {
+          const parsedUrl = new URL(
+            urlToValidate
+              .split(`[${TEMPLATE_PLACEHOLDER}]`)
+              .join('[::1]')
+              .split(TEMPLATE_PLACEHOLDER)
+              .join('1'),
+          );
+          return ['ws:', 'wss:'].includes(parsedUrl.protocol);
+        } catch {
+          return false;
+        }
+      });
     } catch {
       return false;
     }

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { useStore as useEvalConfigStore } from '@app/stores/evalConfig';
 import nunjucks from 'nunjucks';
 import { useRedTeamConfig } from '../../hooks/useRedTeamConfig';
 import A2AEndpointConfiguration from './A2AEndpointConfiguration';
@@ -50,6 +51,10 @@ type NunjucksAstNode = {
   else_?: NunjucksAstNode;
   args?: NunjucksAstNode;
   name?: NunjucksAstNode;
+  left?: NunjucksAstNode;
+  right?: NunjucksAstNode;
+  target?: NunjucksAstNode;
+  cond?: NunjucksAstNode;
 };
 
 type NunjucksUrlCandidate = {
@@ -60,10 +65,24 @@ type NunjucksUrlCandidate = {
 type NunjucksConstantValue = string | number | boolean | null;
 
 const TEMPLATE_PLACEHOLDER = '\0';
+const SCHEME_TEMPLATE_REPLACEMENTS = ['ws://', 'wss://'].flatMap((protocol) => [
+  `${protocol}1`,
+  ...Array.from({ length: protocol.length + 1 }, (_, index) => protocol.slice(index)),
+]);
 let nunjucksFilterEnvironment: nunjucks.Environment | undefined;
+
+const isValidWebSocketUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return ['ws:', 'wss:'].includes(url.protocol) && !url.hash;
+  } catch {
+    return false;
+  }
+};
 
 const getConstantNunjucksExpression = (
   node: NunjucksAstNode,
+  overriddenFilters: ReadonlySet<string>,
 ): NunjucksConstantValue | undefined => {
   if (node.typename === 'Literal') {
     return node.value === null ||
@@ -74,13 +93,33 @@ const getConstantNunjucksExpression = (
       : undefined;
   }
 
-  if (node.typename !== 'Filter' || typeof node.name?.value !== 'string') {
+  if (node.typename === 'Concat' || node.typename === 'Add') {
+    if (!node.left || !node.right) {
+      return undefined;
+    }
+
+    const left = getConstantNunjucksExpression(node.left, overriddenFilters);
+    const right = getConstantNunjucksExpression(node.right, overriddenFilters);
+    if (left === undefined || right === undefined) {
+      return undefined;
+    }
+
+    return node.typename === 'Add' && typeof left === 'number' && typeof right === 'number'
+      ? left + right
+      : `${left ?? ''}${right ?? ''}`;
+  }
+
+  if (
+    node.typename !== 'Filter' ||
+    typeof node.name?.value !== 'string' ||
+    overriddenFilters.has(node.name.value)
+  ) {
     return undefined;
   }
 
   const values: NunjucksConstantValue[] = [];
   for (const argument of node.args?.children ?? []) {
-    const value = getConstantNunjucksExpression(argument);
+    const value = getConstantNunjucksExpression(argument, overriddenFilters);
     if (value === undefined) {
       return undefined;
     }
@@ -104,6 +143,7 @@ const getConstantNunjucksExpression = (
 const getNunjucksUrlCandidates = (
   node: NunjucksAstNode,
   budget: { remaining: number },
+  overriddenFilters: ReadonlySet<string>,
   isOutputExpression = false,
 ): NunjucksUrlCandidate[] | null => {
   if (node.typename === 'TemplateData' || node.typename === 'Literal') {
@@ -111,9 +151,11 @@ const getNunjucksUrlCandidates = (
   }
 
   if (node.typename === 'If') {
-    const truthyCandidates = node.body ? getNunjucksUrlCandidates(node.body, budget) : null;
+    const truthyCandidates = node.body
+      ? getNunjucksUrlCandidates(node.body, budget, overriddenFilters)
+      : null;
     const falsyCandidates = node.else_
-      ? getNunjucksUrlCandidates(node.else_, budget)
+      ? getNunjucksUrlCandidates(node.else_, budget, overriddenFilters)
       : [{ value: '', expressions: [] }];
     if (!truthyCandidates || !falsyCandidates) {
       return null;
@@ -128,7 +170,12 @@ const getNunjucksUrlCandidates = (
     let candidates: NunjucksUrlCandidate[] = [{ value: '', expressions: [] }];
 
     for (const child of node.children ?? []) {
-      const nextCandidates = getNunjucksUrlCandidates(child, budget, node.typename === 'Output');
+      const nextCandidates = getNunjucksUrlCandidates(
+        child,
+        budget,
+        overriddenFilters,
+        node.typename === 'Output',
+      );
       if (!nextCandidates) {
         return null;
       }
@@ -154,7 +201,7 @@ const getNunjucksUrlCandidates = (
     return null;
   }
 
-  const constantExpression = getConstantNunjucksExpression(node);
+  const constantExpression = getConstantNunjucksExpression(node, overriddenFilters);
   if (constantExpression !== undefined) {
     return [{ value: String(constantExpression ?? ''), expressions: [] }];
   }
@@ -172,6 +219,56 @@ const getExpressionSymbol = (node?: NunjucksAstNode): string | undefined => {
   }
 
   return node.typename === 'Filter' ? getExpressionSymbol(node.args?.children?.[0]) : undefined;
+};
+
+const matchesTemplatedScheme = (scheme: string, protocol: string): boolean => {
+  const parts = scheme.toLowerCase().split(TEMPLATE_PLACEHOLDER);
+  const normalizedProtocol = protocol.toLowerCase();
+  let offset = 0;
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index];
+
+    if (index === 0) {
+      if (!normalizedProtocol.startsWith(part)) {
+        return false;
+      }
+      offset = part.length;
+      continue;
+    }
+
+    if (index === parts.length - 1) {
+      return normalizedProtocol.slice(offset).endsWith(part);
+    }
+
+    const nextOffset = normalizedProtocol.indexOf(part, offset);
+    if (nextOffset === -1) {
+      return false;
+    }
+    offset = nextOffset + part.length;
+  }
+
+  return offset === normalizedProtocol.length;
+};
+
+const isValidSchemePrefixCandidate = (candidate: NunjucksUrlCandidate): boolean => {
+  const expressionSymbol = getExpressionSymbol(candidate.expressions[0]);
+  if (
+    candidate.value.startsWith(TEMPLATE_PLACEHOLDER) &&
+    expressionSymbol &&
+    /^(?:host(?:name)?|domain|port)$/i.test(expressionSymbol)
+  ) {
+    return false;
+  }
+
+  return SCHEME_TEMPLATE_REPLACEMENTS.some((replacement) =>
+    isValidWebSocketUrl(
+      candidate.value
+        .replace(TEMPLATE_PLACEHOLDER, replacement)
+        .split(TEMPLATE_PLACEHOLDER)
+        .join('1'),
+    ),
+  );
 };
 
 function ProviderConfigEditor({
@@ -198,114 +295,91 @@ function ProviderConfigEditor({
   const [extensionErrors, setExtensionErrors] = useState(false);
   const [a2aAdvancedConfigError, setA2AAdvancedConfigError] = useState<string | null>(null);
 
-  const validateUrl = useCallback(function validateUrl(
-    url: string,
-    type: 'http' | 'websocket' = 'http',
-  ): boolean {
-    try {
-      if (type === 'http') {
-        return ['http:', 'https:'].includes(new URL(url).protocol);
-      }
-
-      if (url.includes(TEMPLATE_PLACEHOLDER)) {
-        return false;
-      }
-
-      if (!/{{|{%|{#/.test(url)) {
-        return ['ws:', 'wss:'].includes(new URL(url).protocol);
-      }
-
-      const fixedProtocol = url.match(/^([a-z][a-z\d+.-]*):\/\//i);
-      if (fixedProtocol && !/^wss?$/i.test(fixedProtocol[1])) {
-        return false;
-      }
-
-      const parser = (
-        nunjucks as typeof nunjucks & {
-          parser?: { parse: (template: string) => NunjucksAstNode };
-        }
-      ).parser;
-      if (!parser) {
-        return false;
-      }
-
-      const candidates = getNunjucksUrlCandidates(parser.parse(url), { remaining: 128 });
-      if (!candidates) {
-        return false;
-      }
-
-      return candidates.some((candidate) => {
-        let urlToValidate = candidate.value;
-        let schemeSeparatorIndex = urlToValidate.indexOf('://');
-        if (urlToValidate.startsWith(TEMPLATE_PLACEHOLDER)) {
-          const suffixBoundary = urlToValidate.slice(TEMPLATE_PLACEHOLDER.length).search(/[/?#]/);
-          if (
-            suffixBoundary !== -1 &&
-            TEMPLATE_PLACEHOLDER.length + suffixBoundary < schemeSeparatorIndex
-          ) {
-            schemeSeparatorIndex = -1;
-          }
+  const validateUrl = useCallback(
+    function validateUrl(url: string, type: 'http' | 'websocket' = 'http'): boolean {
+      try {
+        if (type === 'http') {
+          return ['http:', 'https:'].includes(new URL(url).protocol);
         }
 
-        if (schemeSeparatorIndex === -1 && urlToValidate.includes(TEMPLATE_PLACEHOLDER)) {
-          const expressionSymbol = getExpressionSymbol(candidate.expressions[0]);
-          if (
-            urlToValidate.startsWith(TEMPLATE_PLACEHOLDER) &&
-            expressionSymbol &&
-            /^(?:host(?:name)?|domain|port)$/i.test(expressionSymbol)
-          ) {
-            return false;
+        if (url.includes(TEMPLATE_PLACEHOLDER)) {
+          return false;
+        }
+
+        if (!/{{|{%|{#/.test(url)) {
+          return isValidWebSocketUrl(url);
+        }
+
+        const fixedProtocol = url.match(/^([a-z][a-z\d+.-]*):\/\//i);
+        if (fixedProtocol && !/^wss?$/i.test(fixedProtocol[1])) {
+          return false;
+        }
+
+        const parser = (
+          nunjucks as typeof nunjucks & {
+            parser?: { parse: (template: string) => NunjucksAstNode };
+          }
+        ).parser;
+        if (!parser) {
+          return false;
+        }
+
+        const configuredFilters = isRedTeam
+          ? (useRedTeamConfig.getState().config as { nunjucksFilters?: Record<string, unknown> })
+              .nunjucksFilters
+          : useEvalConfigStore.getState().config.nunjucksFilters;
+        const overriddenFilters = new Set(Object.keys(configuredFilters ?? {}));
+        const candidates = getNunjucksUrlCandidates(
+          parser.parse(url),
+          { remaining: 128 },
+          overriddenFilters,
+        );
+        if (!candidates) {
+          return false;
+        }
+
+        return candidates.some((candidate) => {
+          let urlToValidate = candidate.value;
+          let schemeSeparatorIndex = urlToValidate.indexOf('://');
+          if (urlToValidate.startsWith(TEMPLATE_PLACEHOLDER)) {
+            const suffixBoundary = urlToValidate.slice(TEMPLATE_PLACEHOLDER.length).search(/[/?#]/);
+            if (
+              suffixBoundary !== -1 &&
+              TEMPLATE_PLACEHOLDER.length + suffixBoundary < schemeSeparatorIndex
+            ) {
+              schemeSeparatorIndex = -1;
+            }
           }
 
-          return ['ws://', 'ws://1'].some((replacement) => {
-            try {
-              const parsedUrl = new URL(
-                urlToValidate
-                  .replace(TEMPLATE_PLACEHOLDER, replacement)
-                  .split(TEMPLATE_PLACEHOLDER)
-                  .join('1'),
-              );
-              return ['ws:', 'wss:'].includes(parsedUrl.protocol);
-            } catch {
+          if (schemeSeparatorIndex === -1 && urlToValidate.includes(TEMPLATE_PLACEHOLDER)) {
+            return isValidSchemePrefixCandidate(candidate);
+          }
+
+          const scheme = urlToValidate.slice(0, schemeSeparatorIndex);
+          if (schemeSeparatorIndex !== -1 && scheme.includes(TEMPLATE_PLACEHOLDER)) {
+            const protocol = ['ws', 'wss'].find((value) => matchesTemplatedScheme(scheme, value));
+
+            if (!protocol) {
               return false;
             }
-          });
-        }
 
-        const scheme = urlToValidate.slice(0, schemeSeparatorIndex);
-        if (schemeSeparatorIndex !== -1 && scheme.includes(TEMPLATE_PLACEHOLDER)) {
-          const schemePattern = scheme
-            .split(TEMPLATE_PLACEHOLDER)
-            .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-            .join('.*');
-          const protocol = ['ws', 'wss'].find((value) =>
-            new RegExp(`^${schemePattern}$`, 'i').test(value),
-          );
-
-          if (!protocol) {
-            return false;
+            urlToValidate = `${protocol}${urlToValidate.slice(schemeSeparatorIndex)}`;
           }
 
-          urlToValidate = `${protocol}${urlToValidate.slice(schemeSeparatorIndex)}`;
-        }
-
-        try {
-          const parsedUrl = new URL(
+          return isValidWebSocketUrl(
             urlToValidate
               .split(`[${TEMPLATE_PLACEHOLDER}]`)
               .join('[::1]')
               .split(TEMPLATE_PLACEHOLDER)
               .join('1'),
           );
-          return ['ws:', 'wss:'].includes(parsedUrl.protocol);
-        } catch {
-          return false;
-        }
-      });
-    } catch {
-      return false;
-    }
-  }, []);
+        });
+      } catch {
+        return false;
+      }
+    },
+    [isRedTeam],
+  );
 
   const getA2AShorthandUrl = useCallback((id?: string): string | undefined => {
     if (!id?.startsWith('a2a:')) {

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
@@ -57,18 +57,28 @@ type NunjucksUrlCandidate = {
   expressions: NunjucksAstNode[];
 };
 
-const TEMPLATE_PLACEHOLDER = '\0';
+type NunjucksConstantValue = string | number | boolean | null;
 
-const getConstantNunjucksExpression = (node: NunjucksAstNode): string | undefined => {
+const TEMPLATE_PLACEHOLDER = '\0';
+let nunjucksFilterEnvironment: nunjucks.Environment | undefined;
+
+const getConstantNunjucksExpression = (
+  node: NunjucksAstNode,
+): NunjucksConstantValue | undefined => {
   if (node.typename === 'Literal') {
-    return String(node.value ?? '');
+    return node.value === null ||
+      typeof node.value === 'string' ||
+      typeof node.value === 'number' ||
+      typeof node.value === 'boolean'
+      ? node.value
+      : undefined;
   }
 
   if (node.typename !== 'Filter' || typeof node.name?.value !== 'string') {
     return undefined;
   }
 
-  const values: string[] = [];
+  const values: NunjucksConstantValue[] = [];
   for (const argument of node.args?.children ?? []) {
     const value = getConstantNunjucksExpression(argument);
     if (value === undefined) {
@@ -78,11 +88,13 @@ const getConstantNunjucksExpression = (node: NunjucksAstNode): string | undefine
   }
 
   try {
-    const value = new nunjucks.Environment(null, { autoescape: false }).getFilter(node.name.value)(
-      ...values,
-    );
-    return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
-      ? String(value)
+    nunjucksFilterEnvironment ??= new nunjucks.Environment([], { autoescape: false });
+    const value = nunjucksFilterEnvironment.getFilter(node.name.value)(...values);
+    return value === null ||
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+      ? value
       : undefined;
   } catch {
     return undefined;
@@ -94,10 +106,6 @@ const getNunjucksUrlCandidates = (
   budget: { remaining: number },
   isOutputExpression = false,
 ): NunjucksUrlCandidate[] | null => {
-  if (--budget.remaining < 0) {
-    return null;
-  }
-
   if (node.typename === 'TemplateData' || node.typename === 'Literal') {
     return [{ value: String(node.value ?? ''), expressions: [] }];
   }
@@ -107,7 +115,13 @@ const getNunjucksUrlCandidates = (
     const falsyCandidates = node.else_
       ? getNunjucksUrlCandidates(node.else_, budget)
       : [{ value: '', expressions: [] }];
-    return truthyCandidates && falsyCandidates ? [...truthyCandidates, ...falsyCandidates] : null;
+    if (!truthyCandidates || !falsyCandidates) {
+      return null;
+    }
+
+    const candidates = [...truthyCandidates, ...falsyCandidates];
+    budget.remaining -= candidates.length - 1;
+    return budget.remaining < 0 ? null : candidates;
   }
 
   if (node.typename === 'Root' || node.typename === 'NodeList' || node.typename === 'Output') {
@@ -126,7 +140,7 @@ const getNunjucksUrlCandidates = (
         })),
       );
 
-      budget.remaining -= combinations.length;
+      budget.remaining -= combinations.length - candidates.length;
       if (budget.remaining < 0) {
         return null;
       }
@@ -142,7 +156,7 @@ const getNunjucksUrlCandidates = (
 
   const constantExpression = getConstantNunjucksExpression(node);
   if (constantExpression !== undefined) {
-    return [{ value: constantExpression, expressions: [] }];
+    return [{ value: String(constantExpression ?? ''), expressions: [] }];
   }
 
   return [{ value: TEMPLATE_PLACEHOLDER, expressions: [node] }];
@@ -222,7 +236,16 @@ function ProviderConfigEditor({
 
       return candidates.some((candidate) => {
         let urlToValidate = candidate.value;
-        const schemeSeparatorIndex = urlToValidate.indexOf('://');
+        let schemeSeparatorIndex = urlToValidate.indexOf('://');
+        if (urlToValidate.startsWith(TEMPLATE_PLACEHOLDER)) {
+          const suffixBoundary = urlToValidate.slice(TEMPLATE_PLACEHOLDER.length).search(/[/?#]/);
+          if (
+            suffixBoundary !== -1 &&
+            TEMPLATE_PLACEHOLDER.length + suffixBoundary < schemeSeparatorIndex
+          ) {
+            schemeSeparatorIndex = -1;
+          }
+        }
 
         if (schemeSeparatorIndex === -1 && urlToValidate.includes(TEMPLATE_PLACEHOLDER)) {
           const expressionSymbol = getExpressionSymbol(candidate.expressions[0]);

--- a/test/providers/websocket.loopback.test.ts
+++ b/test/providers/websocket.loopback.test.ts
@@ -22,6 +22,8 @@ describe('WebSocketProvider URL templates over loopback', () => {
   it.each([
     ['an authority template', 'ws://{{ host }}/ws'],
     ['scheme and port templates', '{{ protocol }}://127.0.0.1:{{ port }}/ws'],
+    ['a separator supplied by a scheme expression', 'ws{{ separator }}127.0.0.1:{{ port }}/ws'],
+    ['a partial scheme and separator expression', 'w{{ suffix }}127.0.0.1:{{ port }}/ws'],
     ['a whole-URL template', '{{ websocketUrl }}'],
     [
       'a whole-URL template followed by a callback URL',
@@ -31,6 +33,7 @@ describe('WebSocketProvider URL templates over loopback', () => {
       'a boolean-valued constant filter operand',
       '{{ false | default("ws", true) }}://127.0.0.1:{{ port }}/ws',
     ],
+    ['an overridden built-in scheme filter', '{{ "HTTP" | lower }}://127.0.0.1:{{ port }}/ws'],
     ['a conditional scheme', '{% if secure %}wss{% else %}ws{% endif %}://127.0.0.1:{{ port }}/ws'],
     [
       'a whitespace-trimmed conditional scheme',
@@ -80,8 +83,11 @@ describe('WebSocketProvider URL templates over loopback', () => {
         secure: false,
         useHttp: false,
         value: 2,
+        separator: '://',
+        suffix: 's://',
         port,
       },
+      filters: url.includes('"HTTP" | lower') ? { lower: () => 'ws' } : undefined,
     });
 
     expect(requestPath).toBe(

--- a/test/providers/websocket.loopback.test.ts
+++ b/test/providers/websocket.loopback.test.ts
@@ -23,6 +23,14 @@ describe('WebSocketProvider URL templates over loopback', () => {
     ['an authority template', 'ws://{{ host }}/ws'],
     ['scheme and port templates', '{{ protocol }}://127.0.0.1:{{ port }}/ws'],
     ['a whole-URL template', '{{ websocketUrl }}'],
+    [
+      'a whole-URL template followed by a callback URL',
+      '{{ websocketUrl }}?callback=https://example.com',
+    ],
+    [
+      'a boolean-valued constant filter operand',
+      '{{ false | default("ws", true) }}://127.0.0.1:{{ port }}/ws',
+    ],
     ['a conditional scheme', '{% if secure %}wss{% else %}ws{% endif %}://127.0.0.1:{{ port }}/ws'],
     [
       'a whitespace-trimmed conditional scheme',
@@ -76,7 +84,9 @@ describe('WebSocketProvider URL templates over loopback', () => {
       },
     });
 
-    expect(requestPath).toBe('/ws');
+    expect(requestPath).toBe(
+      url.includes('?callback=') ? '/ws?callback=https://example.com' : '/ws',
+    );
     expect(result).toEqual({ output: 'loopback:hello' });
   });
 });

--- a/test/providers/websocket.loopback.test.ts
+++ b/test/providers/websocket.loopback.test.ts
@@ -29,6 +29,10 @@ describe('WebSocketProvider URL templates over loopback', () => {
       '{%- if secure -%}wss{%- else -%}ws{%- endif -%}://127.0.0.1:{{ port }}/ws',
     ],
     [
+      'a whitespace-trimmed conditional scheme with surrounding spaces',
+      '{%- if secure -%} wss {%- else -%} ws {%- endif -%}://127.0.0.1:{{ port }}/ws',
+    ],
+    [
       'a modulo conditional scheme',
       '{% if value % 2 == 0 %}ws{% else %}wss{% endif %}://127.0.0.1:{{ port }}/ws',
     ],

--- a/test/providers/websocket.loopback.test.ts
+++ b/test/providers/websocket.loopback.test.ts
@@ -1,0 +1,78 @@
+import { once } from 'node:events';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { WebSocketServer } from 'ws';
+import { WebSocketProvider } from '../../src/providers/websocket';
+
+describe('WebSocketProvider URL templates over loopback', () => {
+  let server: WebSocketServer | undefined;
+
+  afterEach(async () => {
+    if (!server) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => (error ? reject(error) : resolve()));
+    });
+    server = undefined;
+  });
+
+  it.each([
+    ['an authority template', 'ws://{{ host }}/ws'],
+    ['scheme and port templates', '{{ protocol }}://127.0.0.1:{{ port }}/ws'],
+    ['a whole-URL template', '{{ websocketUrl }}'],
+    ['a conditional scheme', '{% if secure %}wss{% else %}ws{% endif %}://127.0.0.1:{{ port }}/ws'],
+    [
+      'a whitespace-trimmed conditional scheme',
+      '{%- if secure -%}wss{%- else -%}ws{%- endif -%}://127.0.0.1:{{ port }}/ws',
+    ],
+    [
+      'a modulo conditional scheme',
+      '{% if value % 2 == 0 %}ws{% else %}wss{% endif %}://127.0.0.1:{{ port }}/ws',
+    ],
+    [
+      'an implicit empty conditional branch',
+      '{% if useHttp %}http{% endif %}ws://127.0.0.1:{{ port }}/ws',
+    ],
+    ['a filtered scheme prefix', '{{ protocolPrefix | default("ws://") }}127.0.0.1:{{ port }}/ws'],
+  ])('opens a real WebSocket connection from %s', async (_description, url) => {
+    server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    await once(server, 'listening');
+
+    const { port } = server.address() as AddressInfo;
+    let requestPath: string | undefined;
+
+    server.on('connection', (socket, request) => {
+      requestPath = request.url;
+      socket.once('message', (message) => {
+        socket.send(`loopback:${message.toString()}`);
+      });
+    });
+
+    const provider = new WebSocketProvider('websocket', {
+      config: {
+        url,
+        messageTemplate: '{{ prompt }}',
+        timeoutMs: 1000,
+      },
+    });
+
+    const result = await provider.callApi('hello', {
+      prompt: { raw: 'hello', label: 'hello' },
+      vars: {
+        host: `127.0.0.1:${port}`,
+        protocol: 'ws',
+        websocketUrl: `ws://127.0.0.1:${port}/ws`,
+        secure: false,
+        useHttp: false,
+        value: 2,
+        port,
+      },
+    });
+
+    expect(requestPath).toBe('/ws');
+    expect(result).toEqual({ output: 'loopback:hello' });
+  });
+});


### PR DESCRIPTION
## Summary
WebSocket providers render Nunjucks URL templates for every evaluation, but the shared evaluation and red-team target editor rejected valid templates before users could save or continue. This restores parity between the Web UI and the existing backend provider without changing HTTP or A2A validation.

- Accept templated WebSocket schemes, complete URLs, hosts, ports, paths, IPv6 authorities, conditionals, filters, and standard Nunjucks whitespace-control syntax.
- Preserve WebSocket-only protocol checks; reject malformed templates, invalid static protocols, internal-placeholder collisions, and unbounded conditional expansion.
- Exercise the actual red-team Next action and evaluation Save dialog, plus real local WebSocket connections for supported URL-template shapes.

## Validation
- PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci on Node 24.18.0 and npm 11.16.0.
- npm run test:app -- src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx src/pages/redteam/setup/components/Targets/WebSocketEndpointConfiguration.test.tsx src/pages/redteam/setup/components/Targets/ProviderEditor.test.tsx src/pages/redteam/setup/components/Targets/TargetConfiguration.test.tsx src/pages/redteam/setup/components/Targets/index.test.tsx src/pages/eval-creator/components/AddProviderDialog.test.tsx --run: 159 tests passed.
- npm exec -- vitest run test/providers/websocket.test.ts test/providers/websocket.loopback.test.ts: 37 tests passed.
- npm run tsc and npm --prefix src/app run tsc -- --build --noEmit --incremental.
- npm run l and npm run f; targeted Biome checks processed all three changed files.
- Real local CLI evaluation with templated scheme and authority: exported result passed with score 1, no errors, expected request path, and expected WebSocket response.
- Three independent read-only contract, runtime, and simplification review passes found no remaining actionable issues.

## Context
The backend URL-templating support landed in #10171, but its shared Web UI validation did not recognize the same URL forms.