### PR TITLE
fix(websocket): preserve safe distinct provider identities

### DIFF
--- a/site/docs/providers/websocket.md
+++ b/site/docs/providers/websocket.md
@@ -26,7 +26,7 @@ providers:
 
 ### Configuration Options
 
-- `url` (required): The WebSocket URL to connect to. Supports Nunjucks templating with test variables.
+- `url` (optional): The WebSocket URL to connect to. Supports Nunjucks templating with test variables. Required unless the provider `id` is a full `ws://` or `wss://` URL.
 - `messageTemplate` (required): A template for the message to be sent over the WebSocket connection. You can use placeholders like `{{prompt}}` which will be replaced with the actual prompt.
 - `transformResponse` (optional): A JavaScript snippet or function to extract the desired output from the WebSocket response given the `data` parameter. If not provided, the entire response will be used as the output. If the response is valid JSON, the object will be returned.
 - `streamResponse` (optional): A JavaScript function to extract the desired output from streamed WebSocket messages when the server sends multiple messages per prompt. It receives `(accumulator, data, context?)` and must return `[nextAccumulator, complete]`. When `streamResponse` is provided, it is used instead of `transformResponse`.
@@ -53,6 +53,8 @@ tests:
       model: 'gpt-4'
       language: 'French'
 ```
+
+When multiple WebSocket provider URLs differ only by credentials, give each provider a unique, non-secret `label` so result columns, provider references, and rate-limit state stay distinct.
 
 ## Parsing the Response
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -2047,9 +2047,7 @@ function buildCompletedPrompts(testSuite: TestSuite, store: EvaluationStore): Co
     invariant(
       !existingProvider ||
         existingProvider === provider ||
-        (!isWebSocketProvider(existingProvider) &&
-          !isWebSocketProvider(provider) &&
-          existingProvider.id() !== providerId),
+        (!isWebSocketProvider(existingProvider) && !isWebSocketProvider(provider)),
       `Duplicate provider identity "${providerKey}". Configure a unique, non-secret label or provider ID for each distinct provider.`,
     );
     providersByIdentity.set(providerKey, provider);
@@ -2080,7 +2078,10 @@ function buildCompletedPrompts(testSuite: TestSuite, store: EvaluationStore): Co
 
 function isWebSocketProvider(provider: ApiProvider): boolean {
   const url = (provider as ApiProvider & { url?: unknown }).url;
-  return typeof url === 'string' && /^wss?:\/\//i.test(url);
+  return (
+    typeof url === 'string' &&
+    (/^wss?:\/\//i.test(url) || typeof provider.config?.messageTemplate === 'string')
+  );
 }
 
 function buildPromptIndexMap(prompts: CompletedPrompt[]) {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -2038,10 +2038,23 @@ function buildExistingPromptsMap(store: EvaluationStore) {
 function buildCompletedPrompts(testSuite: TestSuite, store: EvaluationStore): CompletedPrompt[] {
   const prompts: CompletedPrompt[] = [];
   const existingPromptsMap = buildExistingPromptsMap(store);
+  const providersByIdentity = new Map<string, ApiProvider>();
 
   for (const provider of testSuite.providers) {
+    const providerId = provider.id();
+    const providerKey = provider.label || providerId;
+    const existingProvider = providersByIdentity.get(providerKey);
+    invariant(
+      !existingProvider ||
+        existingProvider === provider ||
+        (!isWebSocketProvider(existingProvider) &&
+          !isWebSocketProvider(provider) &&
+          existingProvider.id() !== providerId),
+      `Duplicate provider identity "${providerKey}". Configure a unique, non-secret label or provider ID for each distinct provider.`,
+    );
+    providersByIdentity.set(providerKey, provider);
+
     for (const prompt of testSuite.prompts) {
-      const providerKey = provider.label || provider.id();
       if (!isAllowedPrompt(prompt, testSuite.providerPromptMap?.[providerKey])) {
         continue;
       }
@@ -2063,6 +2076,11 @@ function buildCompletedPrompts(testSuite: TestSuite, store: EvaluationStore): Co
   }
 
   return prompts;
+}
+
+function isWebSocketProvider(provider: ApiProvider): boolean {
+  const url = (provider as ApiProvider & { url?: unknown }).url;
+  return typeof url === 'string' && /^wss?:\/\//i.test(url);
 }
 
 function buildPromptIndexMap(prompts: CompletedPrompt[]) {

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -126,7 +126,11 @@ export function sanitizeProvider(
         }),
       };
     }
-  } catch {}
+  } catch (error) {
+    if (isApiProvider(provider)) {
+      throw error;
+    }
+  }
   return JSON.parse(safeJsonStringify(provider) as string);
 }
 

--- a/src/providers/providerLogging.ts
+++ b/src/providers/providerLogging.ts
@@ -1,10 +1,50 @@
-import { REDACTED, sanitizeObject, sanitizeUrl } from '../util/sanitizer';
+import {
+  looksLikeCredentialPathSegment,
+  looksLikeSecret,
+  REDACTED,
+  sanitizeObject,
+  sanitizeUrl,
+  sanitizeUrlEncodedString,
+} from '../util/sanitizer';
 
 /**
  * Returns a provider identifier that preserves ordinary URLs while ensuring
  * credential-bearing URLs are safe to log or persist.
  */
 export function getSafeProviderId(url: string): string {
+  if (!url.includes('://') && !url.startsWith('/')) {
+    let decodedUrl = url;
+    try {
+      decodedUrl = decodeURIComponent(url);
+    } catch {}
+    if (looksLikeSecret(url) || looksLikeSecret(decodedUrl)) {
+      return REDACTED;
+    }
+
+    for (const part of decodedUrl.split(/[\s{}/?&#;]+/)) {
+      const candidate = part.replace(/^[-_.:]+/, '');
+      const value = candidate.includes('=')
+        ? candidate.slice(candidate.indexOf('=') + 1)
+        : candidate;
+      const embeddedCredential =
+        /(?:^|[^a-z0-9])((?:token|key|secret|credential|auth)[-_][a-z0-9._]{8,})/i.exec(
+          candidate,
+        )?.[1];
+      if (
+        looksLikeSecret(candidate) ||
+        looksLikeSecret(value) ||
+        (embeddedCredential && looksLikeCredentialPathSegment(embeddedCredential)) ||
+        /(?:^|[^a-z0-9])sk-(?:proj-|ant-)?[a-z0-9_-]{20,}/i.test(candidate) ||
+        looksLikeCredentialPathSegment(value) ||
+        sanitizeUrlEncodedString(candidate) !== candidate
+      ) {
+        return REDACTED;
+      }
+    }
+
+    return url;
+  }
+
   const sanitizedUrl = sanitizeUrl(url);
   return sanitizedUrl === REDACTED ||
     sanitizedUrl.includes(encodeURIComponent(REDACTED)) ||

--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -178,6 +178,8 @@ export async function createStreamResponse(
 export class WebSocketProvider implements ApiProvider {
   url: string;
   private readonly providerId: string;
+  private readonly useLabelAsIdentity: boolean;
+  label?: string;
   config: WebSocketProviderConfig;
   timeoutMs: number;
   transformResponse: (data: any) => ProviderResponse;
@@ -192,7 +194,19 @@ export class WebSocketProvider implements ApiProvider {
   constructor(url: string, options: ProviderOptions) {
     this.config = options.config as WebSocketProviderConfig;
     this.url = this.config.url || url;
-    this.providerId = getSafeProviderId(this.url);
+    this.label = options.label;
+    const explicitProviderId =
+      options.id && options.id !== url && !['websocket', 'ws', 'wss'].includes(options.id)
+        ? options.id
+        : undefined;
+    if (explicitProviderId) {
+      invariant(
+        getSafeProviderId(explicitProviderId) === explicitProviderId,
+        'WebSocket provider IDs must not contain credentials. Configure a non-secret provider ID.',
+      );
+    }
+    this.providerId = explicitProviderId ?? getSafeProviderId(this.url);
+    this.useLabelAsIdentity = !explicitProviderId && this.providerId !== this.url;
     this.timeoutMs = this.config.timeoutMs || getRequestTimeoutMs();
     this.transformResponse = createTransformResponse(
       this.config.transformResponse || this.config.responseParser,
@@ -209,11 +223,21 @@ export class WebSocketProvider implements ApiProvider {
   }
 
   id(): string {
+    if (this.label) {
+      invariant(
+        getSafeProviderId(this.label) === this.label,
+        'WebSocket provider labels must not contain credentials. Configure a non-secret label.',
+      );
+      if (this.useLabelAsIdentity) {
+        return this.label;
+      }
+    }
+
     return this.providerId;
   }
 
   toString(): string {
-    return `[WebSocket Provider ${this.providerId}]`;
+    return `[WebSocket Provider ${this.id()}]`;
   }
 
   async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {

--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -18,28 +18,70 @@ const SENSITIVE_URL_PARAM_NAMES =
 const OPAQUE_CREDENTIAL_PATH_SEGMENT =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32,}|(?:token|key|secret|credential|auth)[-_][a-z0-9._-]{8,}|eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)$/i;
 
+export function looksLikeCredentialPathSegment(value: string): boolean {
+  if (/^eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+$/.test(value)) {
+    return true;
+  }
+
+  const match = /^(?:token|key|secret|credential|auth)[-_]([a-z0-9._]{8,})$/i.exec(value);
+  if (!match) {
+    return false;
+  }
+
+  const suffix = match[1];
+  return (
+    /\d/.test(suffix) ||
+    (/[a-z]/.test(suffix) && /[A-Z]/.test(suffix)) ||
+    /^[a-f]{12,}$/i.test(suffix) ||
+    new Set(suffix.toLowerCase()).size >= 13
+  );
+}
+
+function findUrlDelimiterOutsideTemplates(
+  value: string,
+  delimiters: string,
+  startIndex = 0,
+): number {
+  for (let index = startIndex; index < value.length; index++) {
+    const closingTag = value.startsWith('{{', index)
+      ? '}}'
+      : value.startsWith('{%', index)
+        ? '%}'
+        : value.startsWith('{#', index)
+          ? '#}'
+          : undefined;
+    if (closingTag) {
+      const tagEnd = value.indexOf(closingTag, index + 2);
+      if (tagEnd !== -1) {
+        index = tagEnd + 1;
+        continue;
+      }
+      return -1;
+    }
+
+    if (delimiters.includes(value[index])) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
 /**
- * Whether a `scheme://user:pass@host` userinfo password is present. Implemented
+ * Whether a `scheme://user@host` or `scheme://user:pass@host` credential is present. Implemented
  * with plain string scans rather than a regex to avoid polynomial backtracking
  * on adversarial input (e.g. `://:::::…`).
  */
-function hasUrlUserinfoPassword(url: string): boolean {
+function hasUrlUserinfo(url: string): boolean {
   const schemeIndex = url.indexOf('://');
   if (schemeIndex === -1) {
     return false;
   }
   const authorityStart = schemeIndex + 3;
-  let authorityEnd = url.length;
-  for (let i = authorityStart; i < url.length; i++) {
-    const char = url[i];
-    if (char === '/' || char === '?' || char === '#') {
-      authorityEnd = i;
-      break;
-    }
-  }
+  const authorityDelimiter = findUrlDelimiterOutsideTemplates(url, '/?#', authorityStart);
+  const authorityEnd = authorityDelimiter === -1 ? url.length : authorityDelimiter;
   const authority = url.slice(authorityStart, authorityEnd);
-  const atIndex = authority.indexOf('@');
-  return atIndex !== -1 && authority.slice(0, atIndex).includes(':');
+  return findUrlDelimiterOutsideTemplates(authority, '@') !== -1;
 }
 
 /**
@@ -83,7 +125,7 @@ function hasSecretFormSegment(text: string): boolean {
  * sanitizeObject for any field literally named `url` and would otherwise be
  * destroyed in persisted eval results.
  *
- * Detection is structural — a `user:pass@` userinfo password, a whole value that
+ * Detection is structural — URL userinfo, a whole value that
  * looks like a secret, or a `key=value` form segment that carries one. We do NOT
  * fail closed on a bare credential keyword appearing anywhere in the string:
  * substring-matching `token`/`secret`/`sig`/etc. redacts benign values such as
@@ -93,7 +135,7 @@ function hasSecretFormSegment(text: string): boolean {
  * by `hasSecretFormSegment`, which normalizes keys like `api_key` before matching).
  */
 function unparseableUrlMightLeakSecret(url: string): boolean {
-  return hasUrlUserinfoPassword(url) || looksLikeSecret(url.trim()) || hasSecretFormSegment(url);
+  return hasUrlUserinfo(url) || looksLikeSecret(url.trim()) || hasSecretFormSegment(url);
 }
 
 /**
@@ -570,6 +612,38 @@ function redactNestedJsonValue(decoded: string | undefined): string | null {
 // Matches one `{{ ... }}` Nunjucks placeholder. `[^{}]*` excludes braces so it
 // cannot backtrack against the closing `}}` (linear, no ReDoS).
 const NUNJUCKS_PLACEHOLDER = /\{\{[^{}]*\}\}/g;
+const NUNJUCKS_TEMPLATE_TOKEN = /(\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\}|\{#[\s\S]*?#\})/g;
+
+function isNunjucksTemplateToken(value: string): boolean {
+  return (
+    (value.startsWith('{{') && value.endsWith('}}')) ||
+    (value.startsWith('{%') && value.endsWith('%}')) ||
+    (value.startsWith('{#') && value.endsWith('#}'))
+  );
+}
+
+function hasUnterminatedNunjucksTag(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const closingTag = value.startsWith('{{', index)
+      ? '}}'
+      : value.startsWith('{%', index)
+        ? '%}'
+        : value.startsWith('{#', index)
+          ? '#}'
+          : undefined;
+    if (!closingTag) {
+      continue;
+    }
+
+    const tagEnd = value.indexOf(closingTag, index + 2);
+    if (tagEnd === -1) {
+      return true;
+    }
+    index = tagEnd + 1;
+  }
+
+  return false;
+}
 
 // A value that is entirely Nunjucks placeholders (e.g. `{{password}}`) with no
 // literal content is a config template, not a runtime secret. A value that merely
@@ -805,25 +879,125 @@ function getSecretLookingRawQueryKeys(search: string): Set<string> {
   return secretKeys;
 }
 
+function sanitizeTemplatedUrlComponent(component: string): string {
+  let sanitized = '';
+  let pairStart = 0;
+
+  while (pairStart < component.length) {
+    const separator = findUrlDelimiterOutsideTemplates(component, '&;', pairStart);
+    const pairEnd = separator === -1 ? component.length : separator;
+    const pair = component.slice(pairStart, pairEnd);
+    const equalsIndex = findUrlDelimiterOutsideTemplates(pair, '=');
+
+    if (equalsIndex === -1) {
+      sanitized += pair;
+    } else {
+      const rawKey = pair.slice(0, equalsIndex);
+      const literalKey = rawKey
+        .split(NUNJUCKS_TEMPLATE_TOKEN)
+        .filter((part) => !isNunjucksTemplateToken(part))
+        .join('');
+      const sanitizedValue = pair
+        .slice(equalsIndex + 1)
+        .split(NUNJUCKS_TEMPLATE_TOKEN)
+        .map((part) => {
+          if (!part || isNunjucksTemplateToken(part)) {
+            return part;
+          }
+
+          if (!literalKey && looksLikeSecret(part.replace(/^[-_.]+/, ''))) {
+            return encodeURIComponent(REDACTED);
+          }
+
+          const sanitizedPair = sanitizeUrlEncodedString(`${literalKey}=${part}`);
+          return sanitizedPair.slice(literalKey.length + 1);
+        })
+        .join('');
+      sanitized += `${rawKey}=${sanitizedValue}`;
+    }
+
+    if (separator === -1) {
+      break;
+    }
+    sanitized += component[separator];
+    pairStart = separator + 1;
+  }
+
+  return sanitized;
+}
+
 function sanitizeTemplatedUrl(url: string): string {
   // A template may coexist with an already-rendered env credential. Avoid URL
   // parsing here because it encodes the remaining Nunjucks syntax, but still
   // scrub literal query and fragment credentials before the value is logged or
   // persisted.
-  if (hasUrlUserinfoPassword(url)) {
+  if (hasUnterminatedNunjucksTag(url) || hasUrlUserinfo(url)) {
     return REDACTED;
   }
 
-  const hashIndex = url.indexOf('#');
+  const templateTokens = url.match(NUNJUCKS_TEMPLATE_TOKEN) || [];
+  if (
+    templateTokens.some((token) =>
+      token.split(/[\s"'=,()/?:&#;]+/).some((part) => {
+        let decoded = part;
+        try {
+          decoded = decodeURIComponent(part);
+        } catch {}
+
+        return decoded.split(/[\s/?:&#;]+/).some((value) => {
+          const candidate = value.replace(/^[-_.]+/, '');
+          return looksLikeCredentialPathSegment(candidate) || looksLikeSecret(candidate);
+        });
+      }),
+    )
+  ) {
+    return REDACTED;
+  }
+
+  const hashIndex = findUrlDelimiterOutsideTemplates(url, '#');
   const beforeHash = hashIndex === -1 ? url : url.slice(0, hashIndex);
   const hash = hashIndex === -1 ? '' : url.slice(hashIndex + 1);
-  const queryIndex = beforeHash.indexOf('?');
+  const queryIndex = findUrlDelimiterOutsideTemplates(beforeHash, '?');
   const beforeQuery = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
   const query = queryIndex === -1 ? '' : beforeHash.slice(queryIndex + 1);
-  const sanitizedQuery = query ? sanitizeUrlEncodedString(query) : query;
-  const sanitizedHash = hash ? sanitizeUrlEncodedString(hash) : hash;
+  const sanitizedQuery = query ? sanitizeTemplatedUrlComponent(query) : query;
+  const sanitizedHash = hash ? sanitizeTemplatedUrlComponent(hash) : hash;
 
-  return `${beforeQuery}${queryIndex === -1 ? '' : `?${sanitizedQuery}`}${hashIndex === -1 ? '' : `#${sanitizedHash}`}`;
+  const schemeIndex = beforeQuery.indexOf('://');
+  const pathStart = findUrlDelimiterOutsideTemplates(
+    beforeQuery,
+    '/',
+    schemeIndex === -1 ? 0 : schemeIndex + 3,
+  );
+  const sanitizedBeforeQuery =
+    pathStart === -1
+      ? beforeQuery
+      : beforeQuery.slice(0, pathStart) +
+        beforeQuery
+          .slice(pathStart)
+          .split(NUNJUCKS_TEMPLATE_TOKEN)
+          .map((part) => {
+            if (!part || isNunjucksTemplateToken(part)) {
+              return part;
+            }
+
+            return part
+              .split('/')
+              .map((segment) => {
+                let decoded = segment;
+                try {
+                  decoded = decodeURIComponent(segment);
+                } catch {}
+                const candidate = decoded.replace(/^[-_.]+/, '');
+                return looksLikeCredentialPathSegment(candidate) || looksLikeSecret(candidate)
+                  ? encodeURIComponent(REDACTED)
+                  : segment;
+              })
+              .join('/');
+          })
+          .join('');
+
+  return `${sanitizedBeforeQuery}${queryIndex === -1 ? '' : `?${sanitizedQuery}`}${hashIndex === -1 ? '' : `#${sanitizedHash}`}`;
 }
 
 export function sanitizeUrl(url: string): string {
@@ -835,7 +1009,11 @@ export function sanitizeUrl(url: string): string {
 
     // Preserve unresolved template syntax while redacting any literal credentials
     // that were already rendered into another part of the same URL.
-    if (url.includes('{{') && url.includes('}}')) {
+    if (
+      (url.includes('{{') && url.includes('}}')) ||
+      (url.includes('{%') && url.includes('%}')) ||
+      (url.includes('{#') && url.includes('#}'))
+    ) {
       return sanitizeTemplatedUrl(url);
     }
 

--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -612,7 +612,6 @@ function redactNestedJsonValue(decoded: string | undefined): string | null {
 // Matches one `{{ ... }}` Nunjucks placeholder. `[^{}]*` excludes braces so it
 // cannot backtrack against the closing `}}` (linear, no ReDoS).
 const NUNJUCKS_PLACEHOLDER = /\{\{[^{}]*\}\}/g;
-const NUNJUCKS_TEMPLATE_TOKEN = /(\{\{[\s\S]*?\}\}|\{%[\s\S]*?%\}|\{#[\s\S]*?#\})/g;
 
 function isNunjucksTemplateToken(value: string): boolean {
   return (
@@ -620,6 +619,36 @@ function isNunjucksTemplateToken(value: string): boolean {
     (value.startsWith('{%') && value.endsWith('%}')) ||
     (value.startsWith('{#') && value.endsWith('#}'))
   );
+}
+
+function splitNunjucksTemplateTokens(value: string): string[] {
+  const parts: string[] = [];
+  let literalStart = 0;
+
+  for (let index = 0; index < value.length; index++) {
+    const closingTag = value.startsWith('{{', index)
+      ? '}}'
+      : value.startsWith('{%', index)
+        ? '%}'
+        : value.startsWith('{#', index)
+          ? '#}'
+          : undefined;
+    if (!closingTag) {
+      continue;
+    }
+
+    const tagEnd = value.indexOf(closingTag, index + 2);
+    if (tagEnd === -1) {
+      break;
+    }
+
+    parts.push(value.slice(literalStart, index), value.slice(index, tagEnd + 2));
+    index = tagEnd + 1;
+    literalStart = index + 1;
+  }
+
+  parts.push(value.slice(literalStart));
+  return parts;
 }
 
 function hasUnterminatedNunjucksTag(value: string): boolean {
@@ -893,13 +922,10 @@ function sanitizeTemplatedUrlComponent(component: string): string {
       sanitized += pair;
     } else {
       const rawKey = pair.slice(0, equalsIndex);
-      const literalKey = rawKey
-        .split(NUNJUCKS_TEMPLATE_TOKEN)
+      const literalKey = splitNunjucksTemplateTokens(rawKey)
         .filter((part) => !isNunjucksTemplateToken(part))
         .join('');
-      const sanitizedValue = pair
-        .slice(equalsIndex + 1)
-        .split(NUNJUCKS_TEMPLATE_TOKEN)
+      const sanitizedValue = splitNunjucksTemplateTokens(pair.slice(equalsIndex + 1))
         .map((part) => {
           if (!part || isNunjucksTemplateToken(part)) {
             return part;
@@ -935,7 +961,7 @@ function sanitizeTemplatedUrl(url: string): string {
     return REDACTED;
   }
 
-  const templateTokens = url.match(NUNJUCKS_TEMPLATE_TOKEN) || [];
+  const templateTokens = splitNunjucksTemplateTokens(url).filter(isNunjucksTemplateToken);
   if (
     templateTokens.some((token) =>
       token.split(/[\s"'=,()/?:&#;]+/).some((part) => {
@@ -973,9 +999,7 @@ function sanitizeTemplatedUrl(url: string): string {
     pathStart === -1
       ? beforeQuery
       : beforeQuery.slice(0, pathStart) +
-        beforeQuery
-          .slice(pathStart)
-          .split(NUNJUCKS_TEMPLATE_TOKEN)
+        splitNunjucksTemplateTokens(beforeQuery.slice(pathStart))
           .map((part) => {
             if (!part || isNunjucksTemplateToken(part)) {
               return part;

--- a/test/evaluator/routing.test.ts
+++ b/test/evaluator/routing.test.ts
@@ -5,11 +5,199 @@ import { randomUUID } from 'crypto';
 import { expect, it, vi } from 'vitest';
 import { evaluate } from '../../src/evaluator';
 import Eval from '../../src/models/eval';
+import { WebSocketProvider } from '../../src/providers/websocket';
+import { createRateLimitRegistry, wrapProviderWithRateLimiting } from '../../src/scheduler';
 import { type ApiProvider, type TestSuite } from '../../src/types/index';
 import { mockApiProvider, toPrompt } from './helpers';
 import { describeEvaluator } from './lifecycle';
 
 describeEvaluator('evaluator prompt and provider routing', () => {
+  it('keeps credential-distinguished WebSocket providers in separate result columns', async () => {
+    const providerA = new WebSocketProvider('websocket', {
+      label: 'Account A',
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-a',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const providerB = new WebSocketProvider('websocket', {
+      label: 'Account B',
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-b',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    vi.spyOn(providerA, 'callApi').mockResolvedValue({ output: 'from-a' });
+    vi.spyOn(providerB, 'callApi').mockResolvedValue({ output: 'from-b' });
+    const testSuite: TestSuite = {
+      providers: [providerA, providerB],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, {});
+
+    const summary = await evalRecord.toEvaluateSummary();
+    const results = summary.results.sort((a, b) => a.promptIdx - b.promptIdx);
+    expect(
+      results.map(({ promptIdx, provider, response }) => ({
+        promptIdx,
+        providerId: provider.id,
+        output: response?.output,
+      })),
+    ).toEqual([
+      { promptIdx: 0, providerId: 'Account A', output: 'from-a' },
+      { promptIdx: 1, providerId: 'Account B', output: 'from-b' },
+    ]);
+    expect(
+      evalRecord.prompts.map(({ provider, metrics }) => ({
+        provider,
+        testPassCount: metrics?.testPassCount,
+      })),
+    ).toEqual([
+      { provider: 'Account A', testPassCount: 1 },
+      { provider: 'Account B', testPassCount: 1 },
+    ]);
+    expect(JSON.stringify(summary)).not.toContain('credential-a');
+    expect(JSON.stringify(summary)).not.toContain('credential-b');
+  });
+
+  it('rejects distinct WebSocket providers whose credentials redact to the same identity', async () => {
+    const providerA = new WebSocketProvider('websocket', {
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-a',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const providerB = new WebSocketProvider('websocket', {
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-b',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const callA = vi.spyOn(providerA, 'callApi');
+    const callB = vi.spyOn(providerB, 'callApi');
+    const testSuite: TestSuite = {
+      providers: [providerA, providerB],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await expect(evaluate(testSuite, evalRecord, {})).rejects.toThrow(
+      'Configure a unique, non-secret label or provider ID',
+    );
+    expect(callA).not.toHaveBeenCalled();
+    expect(callB).not.toHaveBeenCalled();
+  });
+
+  it('rejects credential-redacted WebSocket identity collisions after rate-limit wrapping', async () => {
+    const providerA = new WebSocketProvider('websocket', {
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-a',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const providerB = new WebSocketProvider('websocket', {
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-b',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const registry = createRateLimitRegistry({ maxConcurrency: 1 });
+    const testSuite: TestSuite = {
+      providers: [
+        wrapProviderWithRateLimiting(providerA, registry),
+        wrapProviderWithRateLimiting(providerB, registry),
+      ],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await expect(evaluate(testSuite, evalRecord, {})).rejects.toThrow(
+      'Configure a unique, non-secret label or provider ID',
+    );
+  });
+
+  it('rejects distinct WebSocket providers with the same label and different provider IDs', async () => {
+    const providerA = new WebSocketProvider('websocket', {
+      id: 'account-a',
+      label: 'Shared Account',
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-a',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const providerB = new WebSocketProvider('websocket', {
+      id: 'account-b',
+      label: 'Shared Account',
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-b',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const testSuite: TestSuite = {
+      providers: [providerA, providerB],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await expect(evaluate(testSuite, evalRecord, {})).rejects.toThrow(
+      'Configure a unique, non-secret label or provider ID',
+    );
+  });
+
+  it('rejects WebSocket provider ID and label collisions before results can be misattributed', async () => {
+    const providerA = new WebSocketProvider('websocket', {
+      id: 'account-a',
+      label: 'shared',
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-a',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const providerB = new WebSocketProvider('websocket', {
+      id: 'shared',
+      config: {
+        url: 'ws://127.0.0.1/ws?token=credential-b',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const testSuite: TestSuite = {
+      providers: [providerA, providerB],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await expect(evaluate(testSuite, evalRecord, {})).rejects.toThrow(
+      'Configure a unique, non-secret label or provider ID',
+    );
+  });
+
+  it('rejects unsafe WebSocket labels before persisting prompt metadata', async () => {
+    const provider = new WebSocketProvider('ws://127.0.0.1/ws', {
+      label: 'account-a?token=runtime-secret',
+      config: {
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await expect(evaluate(testSuite, evalRecord, {})).rejects.toThrow(
+      'WebSocket provider labels must not contain credentials',
+    );
+    expect(JSON.stringify(evalRecord.prompts)).not.toContain('runtime-secret');
+  });
+
   it('evaluate with providerPromptMap', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider],

--- a/test/evaluator/routing.test.ts
+++ b/test/evaluator/routing.test.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import { expect, it, vi } from 'vitest';
 import { evaluate } from '../../src/evaluator';
 import Eval from '../../src/models/eval';
+import { EchoProvider } from '../../src/providers/echo';
 import { WebSocketProvider } from '../../src/providers/websocket';
 import { createRateLimitRegistry, wrapProviderWithRateLimiting } from '../../src/scheduler';
 import { type ApiProvider, type TestSuite } from '../../src/types/index';
@@ -12,6 +13,23 @@ import { mockApiProvider, toPrompt } from './helpers';
 import { describeEvaluator } from './lifecycle';
 
 describeEvaluator('evaluator prompt and provider routing', () => {
+  it('preserves existing duplicate identities for non-WebSocket providers', async () => {
+    const testSuite: TestSuite = {
+      providers: [
+        new EchoProvider(),
+        new EchoProvider(),
+        new EchoProvider({ config: { label: 'test' } }),
+      ],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, {});
+
+    expect((await evalRecord.toEvaluateSummary()).stats.successes).toBe(3);
+  });
+
   it('keeps credential-distinguished WebSocket providers in separate result columns', async () => {
     const providerA = new WebSocketProvider('websocket', {
       label: 'Account A',
@@ -102,6 +120,35 @@ describeEvaluator('evaluator prompt and provider routing', () => {
     const providerB = new WebSocketProvider('websocket', {
       config: {
         url: 'ws://127.0.0.1/ws?token=credential-b',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const registry = createRateLimitRegistry({ maxConcurrency: 1 });
+    const testSuite: TestSuite = {
+      providers: [
+        wrapProviderWithRateLimiting(providerA, registry),
+        wrapProviderWithRateLimiting(providerB, registry),
+      ],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await expect(evaluate(testSuite, evalRecord, {})).rejects.toThrow(
+      'Configure a unique, non-secret label or provider ID',
+    );
+  });
+
+  it('rejects wrapped WebSocket identity collisions when the protocol is templated', async () => {
+    const providerA = new WebSocketProvider('websocket', {
+      config: {
+        url: '{{ protocol }}://127.0.0.1/ws?token=credential-a',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+    const providerB = new WebSocketProvider('websocket', {
+      config: {
+        url: '{{ protocol }}://127.0.0.1/ws?token=credential-b',
         messageTemplate: '{{ prompt }}',
       },
     });

--- a/test/models/evalResult.test.ts
+++ b/test/models/evalResult.test.ts
@@ -129,6 +129,78 @@ describe('EvalResult', () => {
         },
       });
     });
+
+    it.each([
+      {
+        name: 'username-only userinfo',
+        url: 'wss://runtime-secret@host/{{ sessionId }}',
+        sanitizedUrl: '[REDACTED]',
+      },
+      {
+        name: 'a literal path credential',
+        url: 'wss://host/sk-1234567890abcdefghijklmnopqrstuv/{{ sessionId }}',
+        sanitizedUrl: 'wss://host/%5BREDACTED%5D/{{ sessionId }}',
+      },
+      {
+        name: 'a credential beside a path template',
+        url: 'wss://host/sk-1234567890abcdefghijklmnopqrstuv-{{ sessionId }}',
+        sanitizedUrl: 'wss://host/%5BREDACTED%5D{{ sessionId }}',
+      },
+      {
+        name: 'an opaque lowercase path credential',
+        url: 'wss://host/token-abcdefghijklmnop/{{ sessionId }}',
+        sanitizedUrl: 'wss://host/%5BREDACTED%5D/{{ sessionId }}',
+      },
+      {
+        name: 'conditional Nunjucks tags',
+        url: 'wss://host/ws{% if token %}?token=runtime-secret{% endif %}',
+        sanitizedUrl: 'wss://host/ws{% if token %}?token=%5BREDACTED%5D{% endif %}',
+      },
+      {
+        name: 'a conditional query credential',
+        url: 'wss://host/ws?token={% if enabled %}runtime-secret{% endif %}',
+        sanitizedUrl: 'wss://host/ws?token={% if enabled %}%5BREDACTED%5D{% endif %}',
+      },
+      {
+        name: 'URL delimiters inside a conditional expression',
+        url: 'wss://host/ws{% if "?#" in token %}?token=runtime-secret{% endif %}',
+        sanitizedUrl: 'wss://host/ws{% if "?#" in token %}?token=%5BREDACTED%5D{% endif %}',
+      },
+    ])('should persist a faithful, secret-free WebSocket provider for $name', ({
+      url,
+      sanitizedUrl,
+    }) => {
+      const provider = new WebSocketProvider('websocket', {
+        config: {
+          url,
+          messageTemplate: '{{ prompt }}',
+        },
+      });
+
+      expect(sanitizeProvider(provider)).toEqual({
+        id: sanitizedUrl,
+        label: undefined,
+        config: {
+          url: sanitizedUrl,
+          messageTemplate: '{{ prompt }}',
+        },
+      });
+    });
+
+    it('should reject unsafe WebSocket labels without falling back to raw provider serialization', () => {
+      const provider = new WebSocketProvider('websocket', {
+        label: 'token=label-secret',
+        config: {
+          url: 'wss://host/ws?token=url-secret',
+          messageTemplate: '{{ prompt }}',
+          headers: { Authorization: 'Bearer header-secret' },
+        },
+      });
+
+      expect(() => sanitizeProvider(provider)).toThrow(
+        'WebSocket provider labels must not contain credentials',
+      );
+    });
   });
 
   describe('createFromEvaluateResult', () => {

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -173,6 +173,146 @@ describe('WebSocketProvider', () => {
     expect(provider.toString()).not.toContain('runtime-secret');
   });
 
+  it('should use an explicit non-secret provider ID instead of a credential-bearing URL', () => {
+    provider = new WebSocketProvider('websocket', {
+      id: 'account-a',
+      config: {
+        url: 'ws://test.com/ws?token=runtime-secret',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    expect(provider.id()).toBe('account-a');
+    expect(provider.toString()).toBe('[WebSocket Provider account-a]');
+  });
+
+  it.each([
+    'sk-1234567890abcdefghijklmnopqrstuv',
+    'token-abcd1234efgh5678',
+    'token-abcdefghijklmnop',
+    'token-deadbeefdeadbeef',
+    'token=runtime-secret',
+    'account-a?token=runtime-secret',
+    'account-a?public=ok#token=runtime-secret',
+    'account/token/sk-1234567890abcdefghijklmnopqrstuv',
+    '{{ sessionId }}-sk-1234567890abcdefghijklmnopqrstuv',
+    'sk%2D1234567890abcdefghijklmnopqrstuv',
+    'token%2Dabcd1234efgh5678',
+    'token%2Dabcdefghijklmnop',
+    'api_key%3Druntime-secret',
+    'Bearer%20ABCDEFGHIJKLMNOPQRSTUVWX',
+    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.signedvalue123',
+    'account?cursor=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.signedvalue123',
+  ])('should reject credentials in the explicitly configured provider ID %s', (id) => {
+    expect(
+      () =>
+        new WebSocketProvider('websocket', {
+          id,
+          config: {
+            url: 'wss://host/ws',
+            messageTemplate: '{{ prompt }}',
+          },
+        }),
+    ).toThrow('WebSocket provider IDs must not contain credentials');
+  });
+
+  it('should distinguish a redacted WebSocket identity with its explicit non-secret label', () => {
+    provider = new WebSocketProvider('websocket', {
+      label: 'Account A',
+      config: {
+        url: 'ws://test.com/ws?token=runtime-secret',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    expect(provider.id()).toBe('Account A');
+    expect(provider.toString()).toBe('[WebSocket Provider Account A]');
+  });
+
+  it.each([
+    'account-a?token=runtime-secret',
+    'token-abcd1234efgh5678',
+    'token-abcdefghijklmnop',
+    'token-deadbeefdeadbeef',
+    '{{ sessionId }}-sk-1234567890abcdefghijklmnopqrstuv',
+    'sk%2D1234567890abcdefghijklmnopqrstuv',
+    'account?cursor=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.signedvalue123',
+  ])('should reject credentials in provider labels %s', (label) => {
+    provider = new WebSocketProvider('ws://test.com/ws', {
+      label,
+      config: {
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    expect(() => provider.id()).toThrow('WebSocket provider labels must not contain credentials');
+  });
+
+  it.each([
+    'auth-service-target',
+    'token-budget-model',
+    'key-management-service',
+    'secret-shopping-agent',
+    'credential-rotation-test',
+    'token-classification',
+    'token-tokenization',
+    'auth-authentication',
+    'auth-authorization',
+    'credential-verification',
+    'key-infrastructure',
+    'secret-configuration',
+    'token-conversation',
+    'token-misconfiguration',
+    'auth-misconfiguration',
+    'credential-misconfiguration',
+    'token-reproducibility',
+  ])('should preserve ordinary non-secret provider labels such as %s', (label) => {
+    provider = new WebSocketProvider('ws://test.com/ws', {
+      label,
+      config: {
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    expect(provider.id()).toBe('ws://test.com/ws');
+    expect(provider.label).toBe(label);
+  });
+
+  it('should preserve the ordinary WebSocket URL identity when a display label is set', () => {
+    provider = new WebSocketProvider('ws://test.com/ws', {
+      label: 'Account A',
+      config: {
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    expect(provider.id()).toBe('ws://test.com/ws');
+  });
+
+  it('should keep username-only credentials out of templated identities', () => {
+    provider = new WebSocketProvider('websocket', {
+      config: {
+        url: 'wss://runtime-secret@host/{{ sessionId }}',
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    expect(provider.id()).toBe('[REDACTED]');
+    expect(provider.toString()).not.toContain('runtime-secret');
+  });
+
+  it('should preserve Nunjucks control tags in provider identities', () => {
+    const url = 'wss://host/ws{% if token %}?token={{ token }}{% endif %}';
+    provider = new WebSocketProvider('websocket', {
+      config: {
+        url,
+        messageTemplate: '{{ prompt }}',
+      },
+    });
+
+    expect(provider.id()).toBe(url);
+  });
+
   it('should not log rendered URLs that contain template-like runtime values', async () => {
     const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
     provider = new WebSocketProvider('ws://test.com', {

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -1528,6 +1528,166 @@ describe('sanitizeUrl', () => {
       expect(sanitizeUrl(url)).toBe('[REDACTED]');
     });
 
+    it('should fail closed for username-only credentials in templated URLs', () => {
+      expect(sanitizeUrl('wss://runtime-secret@host/{{ sessionId }}')).toBe('[REDACTED]');
+    });
+
+    it('should recognize userinfo after URL delimiters inside Nunjucks expressions', () => {
+      const url = 'wss://{% if "x/y?z#q" %}runtime-secret@host{% endif %}/{{ sessionId }}';
+
+      expect(sanitizeUrl(url)).toBe('[REDACTED]');
+    });
+
+    it('should redact secret-shaped literal path segments while preserving runtime templates', () => {
+      const url = 'wss://host/sk-1234567890abcdefghijklmnopqrstuv/{{ sessionId }}';
+
+      expect(sanitizeUrl(url)).toBe('wss://host/%5BREDACTED%5D/{{ sessionId }}');
+    });
+
+    it.each([
+      {
+        value: 'sk-1234567890abcdefghijklmnopqrstuv-{{ sessionId }}',
+        sanitized: '%5BREDACTED%5D{{ sessionId }}',
+      },
+      {
+        value: '{{ sessionId }}-sk-1234567890abcdefghijklmnopqrstuv',
+        sanitized: '{{ sessionId }}%5BREDACTED%5D',
+      },
+      {
+        value: 'token-abcd1234efgh5678{% if active %}-{{ sessionId }}{% endif %}',
+        sanitized: '%5BREDACTED%5D{% if active %}-{{ sessionId }}{% endif %}',
+      },
+      {
+        value: 'token-abcdefghijklmnop{% if active %}-{{ sessionId }}{% endif %}',
+        sanitized: '%5BREDACTED%5D{% if active %}-{{ sessionId }}{% endif %}',
+      },
+      {
+        value: 'token-deadbeefdeadbeef',
+        sanitized: '%5BREDACTED%5D',
+      },
+      {
+        value: 'sk-1234567890abcdefghijklmnopqrstuv%ZZ',
+        sanitized: '%5BREDACTED%5D',
+      },
+      {
+        value: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.signedvalue123',
+        sanitized: '%5BREDACTED%5D',
+      },
+      {
+        value: '{% if "x/y" in path %}sk-1234567890abcdefghijklmnopqrstuv{% endif %}',
+        sanitized: '{% if "x/y" in path %}%5BREDACTED%5D{% endif %}',
+      },
+      {
+        value: '{# a/b #}sk-1234567890abcdefghijklmnopqrstuv',
+        sanitized: '{# a/b #}%5BREDACTED%5D',
+      },
+    ])('should redact credentials beside template tags in path segment $value', ({
+      value,
+      sanitized,
+    }) => {
+      expect(sanitizeUrl(`wss://host/${value}/{{ action }}`)).toBe(
+        `wss://host/${sanitized}/{{ action }}`,
+      );
+    });
+
+    it('should preserve legitimate UUID resource IDs in templated URLs', () => {
+      const url =
+        'wss://host/projects/550e8400-e29b-41d4-a716-446655440000/sessions/{{ sessionId }}';
+
+      expect(sanitizeUrl(url)).toBe(url);
+    });
+
+    it.each([
+      'auth-service-target',
+      'token-budget-model',
+      'key-management-service',
+      'secret-shopping-agent',
+      'credential-rotation-test',
+      'token-classification',
+      'token-tokenization',
+      'auth-authentication',
+      'auth-authorization',
+      'credential-verification',
+      'key-infrastructure',
+      'secret-configuration',
+      'token-conversation',
+      'token-misconfiguration',
+      'auth-misconfiguration',
+      'credential-misconfiguration',
+      'token-reproducibility',
+    ])('should preserve ordinary hyphenated URL path names such as %s', (segment) => {
+      const url = `wss://host/${segment}/{{ sessionId }}`;
+
+      expect(sanitizeUrl(url)).toBe(url);
+    });
+
+    it('should preserve Nunjucks control tags around templated credential values', () => {
+      const url = 'wss://host/ws{% if token %}?token={{ token }}{% endif %}';
+
+      expect(sanitizeUrl(url)).toBe(url);
+    });
+
+    it('should redact literal credentials without removing their closing Nunjucks control tags', () => {
+      const url = 'wss://host/ws{% if token %}?token=runtime-secret{% endif %}';
+
+      expect(sanitizeUrl(url)).toBe('wss://host/ws{% if token %}?token=%5BREDACTED%5D{% endif %}');
+    });
+
+    it('should redact conditional credential values while preserving all Nunjucks control tags', () => {
+      const url =
+        'wss://host/ws?token={% if enabled %}runtime-secret{% endif %}&session={{ sessionId }}';
+
+      expect(sanitizeUrl(url)).toBe(
+        'wss://host/ws?token={% if enabled %}%5BREDACTED%5D{% endif %}&session={{ sessionId }}',
+      );
+    });
+
+    it('should redact conditional fragment credentials while preserving Nunjucks control tags', () => {
+      const url = 'wss://host/ws#access_token={% if enabled %}runtime-secret{% endif %}';
+
+      expect(sanitizeUrl(url)).toBe(
+        'wss://host/ws#access_token={% if enabled %}%5BREDACTED%5D{% endif %}',
+      );
+    });
+
+    it('should ignore URL delimiters inside Nunjucks expressions', () => {
+      const url = 'wss://host/ws{% if "?#" in token %}?token=runtime-secret{% endif %}';
+
+      expect(sanitizeUrl(url)).toBe(
+        'wss://host/ws{% if "?#" in token %}?token=%5BREDACTED%5D{% endif %}',
+      );
+    });
+
+    it('should preserve Nunjucks comments while redacting literal query credentials', () => {
+      const url = 'wss://host/ws{# ? comment #}?token=runtime-secret';
+
+      expect(sanitizeUrl(url)).toBe('wss://host/ws{# ? comment #}?token=%5BREDACTED%5D');
+    });
+
+    it('should redact secret-looking values under a wholly templated query key', () => {
+      const url = 'wss://host/ws?{{ key }}=sk-1234567890abcdefghijklmnopqrstuv';
+
+      expect(sanitizeUrl(url)).toBe('wss://host/ws?{{ key }}=%5BREDACTED%5D');
+    });
+
+    it.each([
+      '{% set token = "sk-1234567890abcdefghijklmnopqrstuv" %}{{ token }}',
+      '{{ "sk-1234567890abcdefghijklmnopqrstuv" }}',
+      '{# sk-1234567890abcdefghijklmnopqrstuv #}{{ sessionId }}',
+      '{{ "prefix/sk-1234567890abcdefghijklmnopqrstuv" }}',
+      '{% set token = "sk%2D1234567890abcdefghijklmnopqrstuv" %}{{ token }}',
+      '{{ "Bearer%20sk%2D1234567890abcdefghijklmnopqrstuv" }}',
+      '{{ "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTYifQ.signedvalue123" }}',
+    ])('should fail closed when a Nunjucks tag contains a literal credential', (template) => {
+      expect(sanitizeUrl(`wss://host/ws/${template}`)).toBe('[REDACTED]');
+    });
+
+    it('should fail closed for malformed template tags beside runtime interpolation', () => {
+      const malformed = `{%${'{%'.repeat(1000)}{{ sessionId }}`;
+
+      expect(sanitizeUrl(`wss://host/ws?value=${malformed}`)).toBe('[REDACTED]');
+    });
+
     it('should redact mixed template and sensitive params', () => {
       const url = 'https://admin:secret@{{ api_base }}/api?api_key=key123&data=public';
       expect(sanitizeUrl(url)).toBe('[REDACTED]');

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -1688,6 +1688,17 @@ describe('sanitizeUrl', () => {
       expect(sanitizeUrl(`wss://host/ws?value=${malformed}`)).toBe('[REDACTED]');
     });
 
+    it.each([
+      '{{',
+      '{%',
+      '{#',
+    ])('should fail closed for repeated unterminated %s template tags without backtracking', (openingTag) => {
+      const validTag = openingTag === '{{' ? '{% if active %}' : '{{ sessionId }}';
+      const malformed = `${openingTag.repeat(10_000)}${validTag}`;
+
+      expect(sanitizeUrl(`wss://host/ws?value=${malformed}`)).toBe('[REDACTED]');
+    });
+
     it('should redact mixed template and sensitive params', () => {
       const url = 'https://admin:secret@{{ api_base }}/api?api_key=key123&data=public';
       expect(sanitizeUrl(url)).toBe('[REDACTED]');


### PR DESCRIPTION
## Summary
- WebSocket targets can include credentials in their connection URLs. Redacting those URLs before using them as provider IDs caused separately authenticated targets to collapse into the same eval column, while partially templated URLs could still leak credentials or lose valid Nunjucks control tags.
- Preserve ordinary WebSocket URL identities and existing resume/grouping behavior, use explicit non-secret provider IDs or labels when authenticated URLs would otherwise collide, and reject ambiguous direct or rate-limit-wrapped targets before results are persisted.
- Keep provider IDs, logs, exported results, and persisted configuration free of username-only credentials, conditional query/fragment values, credential-shaped path segments, encoded secrets, and JWTs while preserving complete Nunjucks syntax, UUID resource IDs, and ordinary descriptive labels/routes.
- Fail closed when provider sanitization encounters an unsafe identity, and document when WebSocket URLs and unique non-secret labels are required.

## Validation
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci` under Node 24.18.0 / npm 11.16.0.
- `npm run tsc`.
- `npm run l` and `npm run f`; both pass with the existing upstream warning on the unchanged WebSocket message-handler complexity.
- `./node_modules/.bin/vitest run test/evaluator test/providers/websocket.test.ts test/providers/registry.test.ts test/providers.test.ts test/util/sanitizer.test.ts test/models/evalResult.test.ts test/scheduler`: **43 files, 1,412 tests passed**.
- Deterministic local loopback: `npm run local -- eval -c /private/tmp/promptfoo-websocket-identity-qa.yaml --no-cache --max-concurrency 2 -o /private/tmp/promptfoo-websocket-identity-results.json` produced separate `Account A`/`Account B` columns, outputs `from-a`/`from-b`, `promptIdx` values 0/1, one passing metric per column, and no raw credentials in the exported JSON.
- Three independent read-only contract, runtime/security, and simplification/documentation reviews completed with no remaining actionable findings.