### PR TITLE
docs(site): use GPT-5.6 Luna in Langfuse example

### DIFF
--- a/site/docs/integrations/langfuse.md
+++ b/site/docs/integrations/langfuse.md
@@ -79,7 +79,7 @@ prompts:
   - 'langfuse://chat-prompt:2:chat' # Numeric → version 2
 
 providers:
-  - openai:gpt-5.4-mini
+  - openai:responses:gpt-5.6-luna
 
 tests:
   - vars:


### PR DESCRIPTION
## Summary
- Update the Langfuse prompt example to use GPT-5.6 Luna.
- Select the Responses API explicitly with openai:responses:gpt-5.6-luna.

## Validation
- Parsed the embedded YAML and verified the Luna provider.
- Checked the changed documentation with repository-matching Prettier 3.8.1.
- Ran git diff --check.