### PR TITLE
fix(eval): prevent duplicate scheduler and transport retries

### DIFF
--- a/src/scheduler/providerWrapper.ts
+++ b/src/scheduler/providerWrapper.ts
@@ -5,6 +5,7 @@
  * code paths that bypass the main evaluator.
  */
 
+import { isHttpRateLimitError } from '../util/fetch/errors';
 import { parseRetryAfter } from './headerParser';
 import {
   getProviderResponseHeaders,
@@ -48,6 +49,9 @@ export function createProviderRateLimitOptions(): RateLimitExecuteOptions<Provid
     getHeaders: getProviderResponseHeaders,
     isRateLimited: isProviderResponseRateLimited,
     getRetryAfter: (result: ProviderResponse | undefined, error: Error | undefined) => {
+      if (isHttpRateLimitError(error)) {
+        return error.retryAfterMs;
+      }
       const rawHeaders = getProviderResponseHeaders(result);
       if (rawHeaders) {
         // Normalize header keys to lowercase for consistent access

--- a/src/scheduler/rateLimitRegistry.ts
+++ b/src/scheduler/rateLimitRegistry.ts
@@ -53,9 +53,7 @@ export class RateLimitRegistry extends EventEmitter {
   ): Promise<T> {
     const providerMaxRetries = getProviderMaxRetries(provider);
 
-    // Even when the scheduler is disabled, propagate the retry context so
-    // `fetchWithRetries` picks up the provider's `maxRetries` as its default
-    // and `fetchWithProxy` disables transient retries when `maxRetries: 0`.
+    // Without the scheduler, the transport owns the provider's retry budget.
     if (!this.enabled) {
       return withFetchRetryContext(providerMaxRetries, callFn);
     }
@@ -81,7 +79,7 @@ export class RateLimitRegistry extends EventEmitter {
       });
 
     try {
-      const result = await withFetchRetryContext(providerMaxRetries, run);
+      const result = await withFetchRetryContext(providerMaxRetries, run, 'scheduler');
 
       this.emit('request:completed', {
         rateLimitKey,

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -20,7 +20,7 @@ import {
   type SystemError,
 } from './errors';
 import { monkeyPatchFetch } from './monkeyPatchFetch';
-import { getFetchRetryContextMaxRetries } from './retryContext';
+import { getFetchRetryContextMaxRetries, isFetchRetryManagedByScheduler } from './retryContext';
 import { stripDecompressionHeaders } from './stripDecompressionHeaders';
 
 import type { FetchOptions } from './types';
@@ -119,12 +119,13 @@ function getOrCreateProxyAgent(proxyUrl: string, tlsOptions: ConnectionOptions):
 }
 
 /**
- * Resolve whether to disable transient-error retries. An explicit caller flag
- * always wins (a caller may opt back in even when the provider set
- * `maxRetries: 0`); otherwise we disable only when the retry context carries
- * `maxRetries === 0`.
+ * The scheduler owns retries while active. Otherwise explicit caller options
+ * win, falling back to the provider's `maxRetries: 0` setting.
  */
 function resolveTransientRetryDisabled(explicit?: boolean): boolean {
+  if (isFetchRetryManagedByScheduler()) {
+    return true;
+  }
   if (explicit !== undefined) {
     return explicit;
   }
@@ -665,7 +666,9 @@ export async function fetchWithRetries(
   maxRetries?: number,
 ): Promise<Response> {
   const contextMaxRetries = getFetchRetryContextMaxRetries();
-  maxRetries = Math.max(0, maxRetries ?? contextMaxRetries ?? 4);
+  maxRetries = isFetchRetryManagedByScheduler()
+    ? 0
+    : Math.max(0, maxRetries ?? contextMaxRetries ?? 4);
 
   let lastErrorMessage: string | undefined;
   const backoff = getEnvInt('PROMPTFOO_REQUEST_BACKOFF_MS', 5000);

--- a/src/util/fetch/retryContext.ts
+++ b/src/util/fetch/retryContext.ts
@@ -2,13 +2,14 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 interface FetchRetryContext {
   maxRetries?: number;
+  owner: 'fetch' | 'scheduler';
 }
 
 const fetchRetryContext = new AsyncLocalStorage<FetchRetryContext>();
 
 /**
- * Run `fn` with a fetch retry context so nested `fetchWithRetries` /
- * `fetchWithProxy` calls inherit the provider's configured `maxRetries`.
+ * Run `fn` with a provider retry context. While the scheduler owns retries,
+ * nested transport calls make one attempt instead of retrying independently.
  *
  * When `maxRetries` is `undefined`, the new scope deliberately shadows any
  * outer provider context so providers without an override fall back to defaults.
@@ -16,8 +17,9 @@ const fetchRetryContext = new AsyncLocalStorage<FetchRetryContext>();
 export function withFetchRetryContext<T>(
   maxRetries: number | undefined,
   fn: () => Promise<T>,
+  owner: 'fetch' | 'scheduler' = 'fetch',
 ): Promise<T> {
-  return fetchRetryContext.run({ maxRetries }, fn);
+  return fetchRetryContext.run({ maxRetries, owner }, fn);
 }
 
 /**
@@ -25,4 +27,8 @@ export function withFetchRetryContext<T>(
  */
 export function getFetchRetryContextMaxRetries(): number | undefined {
   return fetchRetryContext.getStore()?.maxRetries;
+}
+
+export function isFetchRetryManagedByScheduler(): boolean {
+  return fetchRetryContext.getStore()?.owner === 'scheduler';
 }

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1313,6 +1313,21 @@ describe('fetchWithRetries', () => {
     expect(sleep).toHaveBeenCalledTimes(2);
   });
 
+  it('should defer explicit transport retries to the active scheduler', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(
+      withFetchRetryContext(
+        2,
+        () => fetchWithRetries('https://example.com', {}, 1000, 2),
+        'scheduler',
+      ),
+    ).rejects.toThrow('Request failed after 0 retries: Error: Network error');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
   it('should make retries+1 total attempts', async () => {
     vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
 
@@ -2396,6 +2411,24 @@ describe('fetchWithProxy transient error retries', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(result).toBe(successResponse);
     expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('should defer explicit transient retries to the active scheduler', async () => {
+    const transientResponse = createMockResponse({
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+    vi.mocked(global.fetch).mockResolvedValueOnce(transientResponse);
+
+    const result = await withFetchRetryContext(
+      2,
+      () => fetchWithProxy('https://example.com', { disableTransientRetries: false }),
+      'scheduler',
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(result).toBe(transientResponse);
+    expect(sleep).not.toHaveBeenCalled();
   });
 
   it('should retry on 524 A Timeout Occurred (Cloudflare)', async () => {

--- a/test/scheduler/providerWrapper.test.ts
+++ b/test/scheduler/providerWrapper.test.ts
@@ -4,6 +4,7 @@ import {
   wrapProvidersWithRateLimiting,
   wrapProviderWithRateLimiting,
 } from '../../src/scheduler/providerWrapper';
+import { HttpRateLimitError } from '../../src/util/fetch/errors';
 import { createMockProvider } from '../factories/provider';
 
 import type { RateLimitRegistry } from '../../src/scheduler/rateLimitRegistry';
@@ -200,6 +201,23 @@ describe('providerWrapper', () => {
       // Headers are normalized to lowercase in getRetryAfter
       const retryAfter = capturedOptions.getRetryAfter(result, undefined);
       expect(retryAfter).toBe(30000); // 30 seconds in ms
+    });
+
+    it('should preserve retry-after metadata from transport rate-limit errors', async () => {
+      let capturedOptions: any;
+      mockExecute.mockImplementation(async (_provider, callFn, options) => {
+        capturedOptions = options;
+        return callFn();
+      });
+
+      await wrapProviderWithRateLimiting(mockProvider, mockRegistry).callApi('test');
+
+      expect(
+        capturedOptions.getRetryAfter(
+          undefined,
+          new HttpRateLimitError({ status: 429, retryAfterMs: 2500 }),
+        ),
+      ).toBe(2500);
     });
 
     it('should ignore non-finite retry-after-ms and fall back to retry-after', async () => {

--- a/test/scheduler/rateLimitRegistry.behavior.test.ts
+++ b/test/scheduler/rateLimitRegistry.behavior.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RateLimitRegistry } from '../../src/scheduler/rateLimitRegistry';
+import { HttpRateLimitError } from '../../src/util/fetch/errors';
+import { fetchWithRetries } from '../../src/util/fetch/index';
 import { getFetchRetryContextMaxRetries } from '../../src/util/fetch/retryContext';
 
 import type { ApiProvider } from '../../src/types/providers';
@@ -39,6 +41,7 @@ describe('RateLimitRegistry integration - provider maxRetries', () => {
   afterEach(() => {
     vi.resetAllMocks();
     vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
   it('should propagate provider maxRetries into the fetch retry context', async () => {
@@ -105,6 +108,89 @@ describe('RateLimitRegistry integration - provider maxRetries', () => {
 
   it('should retry provider maxRetries + 1 total attempts', async () => {
     expect(await runRateLimitedCall(2)).toBe(3);
+  });
+
+  it.each([
+    { providerRetries: 0, explicitTransportRetries: 8, requests: 1 },
+    { providerRetries: 2, explicitTransportRetries: 8, requests: 3 },
+    { providerRetries: undefined, explicitTransportRetries: 8, requests: 4 },
+  ])('should make $requests HTTP requests with provider maxRetries=$providerRetries', async ({
+    providerRetries,
+    explicitTransportRetries,
+    requests,
+  }) => {
+    const fetch = vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ error: { code: 'rate_limit_exceeded' } }), {
+          status: 429,
+          headers: { 'content-type': 'application/json', 'retry-after': '0' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetch);
+    const registry = new RateLimitRegistry({ maxConcurrency: 1, queueTimeoutMs: 100 });
+
+    try {
+      await expect(
+        registry.execute(
+          createProvider(providerRetries),
+          () => fetchWithRetries('https://example.com', {}, 1000, explicitTransportRetries),
+          {
+            isRateLimited: (_result, error) =>
+              error instanceof HttpRateLimitError && error.kind === 'rate_limit',
+            getRetryAfter: (_result, error) =>
+              error instanceof HttpRateLimitError ? error.retryAfterMs : undefined,
+          },
+        ),
+      ).rejects.toThrow('Rate limit exceeded');
+
+      expect(fetch).toHaveBeenCalledTimes(requests);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('should leave transport retries intact when the scheduler is disabled', async () => {
+    vi.stubEnv('PROMPTFOO_DISABLE_ADAPTIVE_SCHEDULER', 'true');
+    vi.stubEnv('PROMPTFOO_REQUEST_BACKOFF_MS', '0');
+    const fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('fetch', fetch);
+    const registry = new RateLimitRegistry({ maxConcurrency: 1, queueTimeoutMs: 100 });
+
+    try {
+      await expect(
+        registry.execute(createProvider(2), () =>
+          fetchWithRetries('https://example.com', {}, 1000),
+        ),
+      ).rejects.toThrow('Request failed after 2 retries');
+
+      expect(fetch).toHaveBeenCalledTimes(3);
+    } finally {
+      registry.dispose();
+    }
+  });
+
+  it('should not retry exhausted quotas in either retry layer', async () => {
+    const fetch = vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ error: { code: 'insufficient_quota' } }), {
+          status: 429,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    vi.stubGlobal('fetch', fetch);
+    const registry = new RateLimitRegistry({ maxConcurrency: 1, queueTimeoutMs: 100 });
+
+    try {
+      await expect(
+        registry.execute(createProvider(2), () =>
+          fetchWithRetries('https://example.com', {}, 1000, 2),
+        ),
+      ).rejects.toThrow('Quota exceeded');
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      registry.dispose();
+    }
   });
 
   it('should parse numeric string maxRetries values', async () => {


### PR DESCRIPTION
Let the active scheduler own provider retry budgets while preserving standalone transport retries, quota fail-fast, and Retry-After handling.