### PR TITLE
fix(providers): avoid duplicate scheduler retries

### DIFF
--- a/src/scheduler/providerRateLimitState.ts
+++ b/src/scheduler/providerRateLimitState.ts
@@ -20,6 +20,16 @@ class RateLimitExhaustedError extends Error {
   }
 }
 
+function shouldRetryResponse(result: unknown, attempt: number, policy: RetryPolicy): boolean {
+  return Boolean(
+    result &&
+      typeof result === 'object' &&
+      'error' in result &&
+      typeof result.error === 'string' &&
+      shouldRetry(attempt, new Error(result.error), false, policy),
+  );
+}
+
 export interface ProviderStateOptions {
   rateLimitKey: string;
   maxConcurrency: number;
@@ -209,6 +219,22 @@ export class ProviderRateLimitState extends EventEmitter {
           throw new RateLimitExhaustedError(
             `Rate limit exceeded for ${this.rateLimitKey} after ${attempt + 1} attempts`,
           );
+        }
+
+        if (shouldRetryResponse(result, attempt, retryPolicy)) {
+          attempt++;
+          this.retriedRequests++;
+          const delay = getRetryDelay(attempt, retryPolicy, retryAfterMs);
+
+          this.emit('request:retrying', {
+            rateLimitKey: this.rateLimitKey,
+            attempt,
+            delayMs: delay,
+            reason: 'error',
+          });
+
+          await this.sleep(delay);
+          continue;
         }
 
         // Success

--- a/src/scheduler/rateLimitRegistry.ts
+++ b/src/scheduler/rateLimitRegistry.ts
@@ -81,7 +81,7 @@ export class RateLimitRegistry extends EventEmitter {
       });
 
     try {
-      const result = await withFetchRetryContext(providerMaxRetries, run);
+      const result = await withFetchRetryContext(providerMaxRetries, run, true);
 
       this.emit('request:completed', {
         rateLimitKey,

--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -20,7 +20,7 @@ import {
   type SystemError,
 } from './errors';
 import { monkeyPatchFetch } from './monkeyPatchFetch';
-import { getFetchRetryContextMaxRetries } from './retryContext';
+import { getFetchRetryContextMaxRetries, isFetchRetryManagedByScheduler } from './retryContext';
 import { stripDecompressionHeaders } from './stripDecompressionHeaders';
 
 import type { FetchOptions } from './types';
@@ -125,6 +125,9 @@ function getOrCreateProxyAgent(proxyUrl: string, tlsOptions: ConnectionOptions):
  * `maxRetries === 0`.
  */
 function resolveTransientRetryDisabled(explicit?: boolean): boolean {
+  if (isFetchRetryManagedByScheduler()) {
+    return true;
+  }
   if (explicit !== undefined) {
     return explicit;
   }
@@ -665,7 +668,9 @@ export async function fetchWithRetries(
   maxRetries?: number,
 ): Promise<Response> {
   const contextMaxRetries = getFetchRetryContextMaxRetries();
-  maxRetries = Math.max(0, maxRetries ?? contextMaxRetries ?? 4);
+  maxRetries = isFetchRetryManagedByScheduler()
+    ? 0
+    : Math.max(0, maxRetries ?? contextMaxRetries ?? 4);
 
   let lastErrorMessage: string | undefined;
   const backoff = getEnvInt('PROMPTFOO_REQUEST_BACKOFF_MS', 5000);

--- a/src/util/fetch/retryContext.ts
+++ b/src/util/fetch/retryContext.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 interface FetchRetryContext {
   maxRetries?: number;
+  schedulerOwnsRetries: boolean;
 }
 
 const fetchRetryContext = new AsyncLocalStorage<FetchRetryContext>();
@@ -16,8 +17,9 @@ const fetchRetryContext = new AsyncLocalStorage<FetchRetryContext>();
 export function withFetchRetryContext<T>(
   maxRetries: number | undefined,
   fn: () => Promise<T>,
+  schedulerOwnsRetries = false,
 ): Promise<T> {
-  return fetchRetryContext.run({ maxRetries }, fn);
+  return fetchRetryContext.run({ maxRetries, schedulerOwnsRetries }, fn);
 }
 
 /**
@@ -25,4 +27,8 @@ export function withFetchRetryContext<T>(
  */
 export function getFetchRetryContextMaxRetries(): number | undefined {
   return fetchRetryContext.getStore()?.maxRetries;
+}
+
+export function isFetchRetryManagedByScheduler(): boolean {
+  return fetchRetryContext.getStore()?.schedulerOwnsRetries ?? false;
 }

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1313,6 +1313,17 @@ describe('fetchWithRetries', () => {
     expect(sleep).toHaveBeenCalledTimes(2);
   });
 
+  it('should leave retries to the scheduler even when the transport requests retries', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    await expect(
+      withFetchRetryContext(2, () => fetchWithRetries('https://example.com', {}, 1000, 2), true),
+    ).rejects.toThrow('Request failed after 0 retries: Error: Network error');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
   it('should make retries+1 total attempts', async () => {
     vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
 
@@ -2396,6 +2407,26 @@ describe('fetchWithProxy transient error retries', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(result).toBe(successResponse);
     expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it('should leave transient retries to the scheduler even when the caller opts in', async () => {
+    const transientResponse = createMockResponse({
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+
+    const mockFetch = vi.fn().mockResolvedValueOnce(transientResponse);
+    global.fetch = mockFetch;
+
+    const result = await withFetchRetryContext(
+      2,
+      () => fetchWithProxy('https://example.com', { disableTransientRetries: false }),
+      true,
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).toBe(transientResponse);
+    expect(sleep).not.toHaveBeenCalled();
   });
 
   it('should retry on 524 A Timeout Occurred (Cloudflare)', async () => {

--- a/test/scheduler/providerRateLimitState.test.ts
+++ b/test/scheduler/providerRateLimitState.test.ts
@@ -344,6 +344,30 @@ describe('ProviderRateLimitState', () => {
   });
 
   describe('executeWithRetry - retry behavior', () => {
+    it('should retry transient errors returned in provider responses', async () => {
+      const callFn = vi
+        .fn()
+        .mockResolvedValueOnce({ error: 'API error 503: Service Unavailable' })
+        .mockResolvedValueOnce({ output: 'success' });
+
+      const promise = state.executeWithRetry('req-1', callFn, {});
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toEqual({ output: 'success' });
+      expect(callFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return the final transient provider response after retries are exhausted', async () => {
+      const response = { error: 'Network error' };
+      const callFn = vi.fn().mockResolvedValue(response);
+
+      const promise = state.executeWithRetry('req-1', callFn, { maxRetriesOverride: 2 });
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toBe(response);
+      expect(callFn).toHaveBeenCalledTimes(3);
+    });
+
     it('should retry on rate limit and eventually succeed', async () => {
       let attempt = 0;
 

--- a/test/scheduler/rateLimitRegistry.behavior.test.ts
+++ b/test/scheduler/rateLimitRegistry.behavior.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RateLimitRegistry } from '../../src/scheduler/rateLimitRegistry';
+import { fetchWithRetries } from '../../src/util/fetch/index';
 import { getFetchRetryContextMaxRetries } from '../../src/util/fetch/retryContext';
 
 import type { ApiProvider } from '../../src/types/providers';
@@ -105,6 +106,56 @@ describe('RateLimitRegistry integration - provider maxRetries', () => {
 
   it('should retry provider maxRetries + 1 total attempts', async () => {
     expect(await runRateLimitedCall(2)).toBe(3);
+  });
+
+  it('should not multiply scheduler retries by transport retries', async () => {
+    const registry = new RateLimitRegistry({ maxConcurrency: 1, queueTimeoutMs: 100 });
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(
+      async () =>
+        new Response('{"error":{"code":"rate_limit_exceeded"}}', {
+          status: 429,
+          headers: { 'content-type': 'application/json', 'retry-after': '0' },
+        }),
+    );
+
+    try {
+      await expect(
+        registry.execute(
+          createProvider(2),
+          () => fetchWithRetries('https://example.com', {}, 1000, 2),
+          { getRetryAfter: () => 0 },
+        ),
+      ).rejects.toThrow('Rate limit exceeded');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      fetchSpy.mockRestore();
+      registry.dispose();
+    }
+  });
+
+  it('should not retry a hard quota response', async () => {
+    const registry = new RateLimitRegistry({ maxConcurrency: 1, queueTimeoutMs: 100 });
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(
+      async () =>
+        new Response('{"error":{"code":"insufficient_quota"}}', {
+          status: 429,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+
+    try {
+      await expect(
+        registry.execute(createProvider(2), () =>
+          fetchWithRetries('https://example.com', {}, 1000, 2),
+        ),
+      ).rejects.toThrow('Quota exceeded');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchSpy.mockRestore();
+      registry.dispose();
+    }
   });
 
   it('should parse numeric string maxRetries values', async () => {


### PR DESCRIPTION
Let the scheduler own provider retries while preserving standalone HTTP retries and hard-quota handling.