### PR TITLE
refactor(eval): remove unused scheduler telemetry

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -3135,33 +3135,6 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
       maxConcurrency: options.maxConcurrency || DEFAULT_MAX_CONCURRENCY,
     });
 
-    // Add debug logging for rate limit events
-    this.rateLimitRegistry.on('ratelimit:hit', (data) => {
-      logger.debug(`[Scheduler] Rate limit hit for ${data.rateLimitKey}`, {
-        retryAfterMs: data.retryAfterMs,
-        resetAt: data.resetAt,
-        concurrencyChange: data.concurrencyChange,
-      });
-    });
-    this.rateLimitRegistry.on('ratelimit:learned', (data) => {
-      logger.debug(`[Scheduler] Learned rate limits for ${data.rateLimitKey}`, {
-        requestLimit: data.requestLimit,
-        tokenLimit: data.tokenLimit,
-      });
-    });
-    this.rateLimitRegistry.on('concurrency:decreased', (data) => {
-      logger.debug(`[Scheduler] Concurrency decreased for ${data.rateLimitKey}`, {
-        previous: data.previous,
-        current: data.current,
-      });
-    });
-    this.rateLimitRegistry.on('concurrency:increased', (data) => {
-      logger.debug(`[Scheduler] Concurrency increased for ${data.rateLimitKey}`, {
-        previous: data.previous,
-        current: data.current,
-      });
-    });
-
     // Share rate limit registry with redteam provider manager
     // This ensures redteam internal providers also benefit from rate limiting
     redteamProviderManager.setRateLimitRegistry(this.rateLimitRegistry);
@@ -4806,25 +4779,6 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
 
         // Clean up Python worker pools to prevent resource leaks
         await providerRegistry.shutdownAll();
-
-        // Log rate limit metrics for debugging before cleanup
-        if (this.rateLimitRegistry) {
-          const metrics = this.rateLimitRegistry.getMetrics();
-          for (const [key, m] of Object.entries(metrics)) {
-            if (m.totalRequests > 0) {
-              logger.debug(`[Scheduler] Final metrics for ${sanitizeProviderIdForLog(key)}`, {
-                totalRequests: m.totalRequests,
-                completedRequests: m.completedRequests,
-                failedRequests: m.failedRequests,
-                rateLimitHits: m.rateLimitHits,
-                retriedRequests: m.retriedRequests,
-                avgLatencyMs: Math.round(m.avgLatencyMs),
-                p50LatencyMs: Math.round(m.p50LatencyMs),
-                p99LatencyMs: Math.round(m.p99LatencyMs),
-              });
-            }
-          }
-        }
 
         // Clean up rate limit registry resources
         this.rateLimitRegistry?.dispose();

--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -39,7 +39,6 @@ export {
 export { SlotQueue } from './slotQueue';
 
 export type { ConcurrencyChangeResult } from './adaptiveConcurrency';
-export type { ProviderMetrics } from './providerRateLimitState';
 export type { RateLimitRegistryOptions } from './rateLimitRegistry';
 export type { SlotQueueOptions } from './slotQueue';
 // Shared types

--- a/src/scheduler/providerRateLimitState.ts
+++ b/src/scheduler/providerRateLimitState.ts
@@ -1,5 +1,3 @@
-import { EventEmitter } from 'events';
-
 import {
   AdaptiveConcurrency,
   type ConcurrencyChangeResult,
@@ -26,82 +24,25 @@ export interface ProviderStateOptions {
   minConcurrency: number;
   queueTimeoutMs?: number;
   retryPolicy?: RetryPolicy;
-}
-
-export interface ProviderMetrics {
-  rateLimitKey: string;
-  activeRequests: number;
-  maxConcurrency: number;
-  queueDepth: number;
-  totalRequests: number;
-  completedRequests: number;
-  failedRequests: number;
-  rateLimitHits: number;
-  retriedRequests: number;
-  avgLatencyMs: number;
-  p50LatencyMs: number;
-  p99LatencyMs: number;
-}
-
-/**
- * Circular buffer for latency tracking.
- * O(1) insertions instead of O(n) shift().
- */
-class CircularBuffer {
-  private buffer: number[];
-  private head = 0;
-  private count = 0;
-
-  constructor(private capacity: number) {
-    this.buffer = new Array(capacity);
-  }
-
-  push(value: number): void {
-    this.buffer[this.head] = value;
-    this.head = (this.head + 1) % this.capacity;
-    if (this.count < this.capacity) {
-      this.count++;
-    }
-  }
-
-  toSortedArray(): number[] {
-    const result: number[] = [];
-    for (let i = 0; i < this.count; i++) {
-      const idx = (this.head - this.count + i + this.capacity) % this.capacity;
-      result.push(this.buffer[idx]);
-    }
-    return result.sort((a, b) => a - b);
-  }
-
-  get length(): number {
-    return this.count;
-  }
+  onDebug?: (message: string, context: Record<string, unknown>) => void;
 }
 
 /**
  * Manages rate limit state and retry logic for a single rate limit key.
  */
-export class ProviderRateLimitState extends EventEmitter {
+export class ProviderRateLimitState {
   readonly rateLimitKey: string;
   private slotQueue: SlotQueue;
   private adaptiveConcurrency: AdaptiveConcurrency;
   private retryPolicy: RetryPolicy;
+  private onDebug: ProviderStateOptions['onDebug'];
 
-  // Metrics
-  private totalRequests = 0;
-  private completedRequests = 0;
-  private failedRequests = 0;
-  private rateLimitHits = 0;
-  private retriedRequests = 0;
-  private latencies = new CircularBuffer(100);
-
-  // Track if we've emitted ratelimit:learned for this provider
   private hasLearnedLimits = false;
 
   constructor(options: ProviderStateOptions) {
-    super();
     this.rateLimitKey = options.rateLimitKey;
     this.retryPolicy = options.retryPolicy ?? DEFAULT_RETRY_POLICY;
+    this.onDebug = options.onDebug;
 
     this.adaptiveConcurrency = new AdaptiveConcurrency(
       options.maxConcurrency,
@@ -112,12 +53,6 @@ export class ProviderRateLimitState extends EventEmitter {
       maxConcurrency: options.maxConcurrency,
       minConcurrency: options.minConcurrency,
       queueTimeoutMs: options.queueTimeoutMs,
-      onSlotAcquired: (queueDepth) => {
-        this.emit('slot:acquired', { rateLimitKey: this.rateLimitKey, queueDepth });
-      },
-      onSlotReleased: (queueDepth) => {
-        this.emit('slot:released', { rateLimitKey: this.rateLimitKey, queueDepth });
-      },
     });
   }
 
@@ -139,36 +74,17 @@ export class ProviderRateLimitState extends EventEmitter {
       maxRetriesOverride?: number;
     },
   ): Promise<T> {
-    this.totalRequests++;
     let attempt = 0;
-    let lastError: Error | undefined;
     const retryPolicy =
       options.maxRetriesOverride === undefined
         ? this.retryPolicy
         : { ...this.retryPolicy, maxRetries: options.maxRetriesOverride };
 
     while (true) {
-      // Acquire slot (may wait for rate limit window via queue)
-      // Queue timeout failures are counted as failed requests
-      try {
-        await this.slotQueue.acquire(`${requestId}-${attempt}`);
-      } catch (acquireError) {
-        // Queue timeout or other acquire failures
-        this.failedRequests++;
-        this.emit('queue:timeout', {
-          rateLimitKey: this.rateLimitKey,
-          requestId,
-          error: String(acquireError),
-        });
-        throw acquireError;
-      }
-
-      const startTime = Date.now();
+      await this.slotQueue.acquire(`${requestId}-${attempt}`);
 
       try {
         const result = await callFn();
-        const latencyMs = Date.now() - startTime;
-        this.latencies.push(latencyMs);
 
         // Extract headers and check for rate limit
         const headers = options.getHeaders?.(result);
@@ -189,23 +105,13 @@ export class ProviderRateLimitState extends EventEmitter {
           // Check if we should retry
           if (shouldRetry(attempt, undefined, true, retryPolicy)) {
             attempt++;
-            this.retriedRequests++;
             const delay = getRetryDelay(attempt, retryPolicy, retryAfterMs);
-
-            this.emit('request:retrying', {
-              rateLimitKey: this.rateLimitKey,
-              attempt,
-              delayMs: delay,
-              reason: 'ratelimit',
-            });
 
             await this.sleep(delay);
             continue;
           }
 
-          // Rate limited and no more retries - count as FAILED, throw sentinel error
-          // Using sentinel error to prevent catch block from double-releasing/double-counting
-          this.failedRequests++;
+          // The sentinel prevents the catch block from releasing the same slot twice.
           throw new RateLimitExhaustedError(
             `Rate limit exceeded for ${this.rateLimitKey} after ${attempt + 1} attempts`,
           );
@@ -213,7 +119,6 @@ export class ProviderRateLimitState extends EventEmitter {
 
         // Success
         this.handleSuccess();
-        this.completedRequests++;
         return result;
       } catch (error) {
         // Re-throw sentinel error immediately to prevent double-release/double-count
@@ -221,10 +126,7 @@ export class ProviderRateLimitState extends EventEmitter {
           throw error;
         }
 
-        const latencyMs = Date.now() - startTime;
-        this.latencies.push(latencyMs);
-
-        lastError = error as Error;
+        const lastError = error as Error;
 
         // Release slot
         this.slotQueue.release();
@@ -241,22 +143,13 @@ export class ProviderRateLimitState extends EventEmitter {
         // Check if we should retry
         if (shouldRetry(attempt, lastError, isRateLimited, retryPolicy)) {
           attempt++;
-          this.retriedRequests++;
           const delay = getRetryDelay(attempt, retryPolicy, retryAfterMs);
-
-          this.emit('request:retrying', {
-            rateLimitKey: this.rateLimitKey,
-            attempt,
-            delayMs: delay,
-            reason: isRateLimited ? 'ratelimit' : 'error',
-          });
 
           await this.sleep(delay);
           continue;
         }
 
         // No more retries
-        this.failedRequests++;
         throw lastError;
       }
     }
@@ -272,14 +165,12 @@ export class ProviderRateLimitState extends EventEmitter {
   private updateFromHeaders(headers: Record<string, string>, isRateLimited: boolean): void {
     const parsed = parseRateLimitHeaders(headers);
 
-    // Emit ratelimit:learned only once per provider when we first see limit headers
     if (
       !this.hasLearnedLimits &&
       (parsed.limitRequests !== undefined || parsed.limitTokens !== undefined)
     ) {
       this.hasLearnedLimits = true;
-      this.emit('ratelimit:learned', {
-        rateLimitKey: this.rateLimitKey,
+      this.onDebug?.(`[Scheduler] Learned rate limits for ${this.rateLimitKey}`, {
         requestLimit: parsed.limitRequests,
         tokenLimit: parsed.limitTokens,
       });
@@ -300,13 +191,6 @@ export class ProviderRateLimitState extends EventEmitter {
     const minRatio = Math.min(ratios.requests ?? 1, ratios.tokens ?? 1);
 
     if (minRatio < WARNING_THRESHOLD) {
-      this.emit('ratelimit:warning', {
-        rateLimitKey: this.rateLimitKey,
-        requestRatio: ratios.requests,
-        tokenRatio: ratios.tokens,
-      });
-
-      // Proactive concurrency reduction
       this.applyConcurrencyChange(this.adaptiveConcurrency.recordApproachingLimit(minRatio));
     }
   }
@@ -316,17 +200,12 @@ export class ProviderRateLimitState extends EventEmitter {
    * Delegates to SlotQueue which preserves existing resetAt from headers.
    */
   private handleRateLimit(retryAfterMs?: number): void {
-    this.rateLimitHits++;
-
-    // Pass retryAfterMs to queue (may be undefined)
-    // SlotQueue.markRateLimited preserves existing resetAt from headers if no retryAfter provided
     this.slotQueue.markRateLimited(retryAfterMs);
 
     const change = this.adaptiveConcurrency.recordRateLimit();
     this.applyConcurrencyChange(change);
 
-    this.emit('ratelimit:hit', {
-      rateLimitKey: this.rateLimitKey,
+    this.onDebug?.(`[Scheduler] Rate limit hit for ${this.rateLimitKey}`, {
       retryAfterMs,
       resetAt: this.slotQueue.getResetAt(),
       concurrencyChange: change,
@@ -341,16 +220,15 @@ export class ProviderRateLimitState extends EventEmitter {
   }
 
   /**
-   * Apply concurrency change and emit appropriate event.
+   * Apply and log concurrency changes.
    */
   private applyConcurrencyChange(change: ConcurrencyChangeResult): void {
     if (change.changed) {
       this.slotQueue.setMaxConcurrency(change.current);
-      const eventName =
-        change.reason === 'recovery' ? 'concurrency:increased' : 'concurrency:decreased';
-      this.emit(eventName, {
-        rateLimitKey: this.rateLimitKey,
-        ...change,
+      const direction = change.reason === 'recovery' ? 'increased' : 'decreased';
+      this.onDebug?.(`[Scheduler] Concurrency ${direction} for ${this.rateLimitKey}`, {
+        previous: change.previous,
+        current: change.current,
       });
     }
   }
@@ -371,37 +249,7 @@ export class ProviderRateLimitState extends EventEmitter {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  /**
-   * Get current queue depth without sorting latencies.
-   * Use this for frequent checks instead of getMetrics().
-   */
-  getQueueDepth(): number {
-    return this.slotQueue.getQueueDepth();
-  }
-
-  getMetrics(): ProviderMetrics {
-    const sorted = this.latencies.toSortedArray();
-    const avgLatency = sorted.length > 0 ? sorted.reduce((a, b) => a + b, 0) / sorted.length : 0;
-
-    return {
-      rateLimitKey: this.rateLimitKey,
-      activeRequests: this.slotQueue.getActiveCount(),
-      maxConcurrency: this.slotQueue.getMaxConcurrency(),
-      queueDepth: this.slotQueue.getQueueDepth(),
-      totalRequests: this.totalRequests,
-      completedRequests: this.completedRequests,
-      failedRequests: this.failedRequests,
-      rateLimitHits: this.rateLimitHits,
-      retriedRequests: this.retriedRequests,
-      avgLatencyMs: avgLatency,
-      // Percentiles: for n elements, pX is at index floor((n-1) * X/100)
-      p50LatencyMs: sorted[Math.floor((sorted.length - 1) * 0.5)] ?? 0,
-      p99LatencyMs: sorted[Math.floor((sorted.length - 1) * 0.99)] ?? 0,
-    };
-  }
-
   dispose(): void {
     this.slotQueue.dispose();
-    this.removeAllListeners();
   }
 }

--- a/src/scheduler/rateLimitRegistry.ts
+++ b/src/scheduler/rateLimitRegistry.ts
@@ -1,10 +1,8 @@
-import { EventEmitter } from 'events';
-
 import { getEnvBool, getEnvInt } from '../envars';
 import logger from '../logger';
 import { withFetchRetryContext } from '../util/fetch/retryContext';
 import { sanitizeProviderIdForLog } from '../util/provider';
-import { type ProviderMetrics, ProviderRateLimitState } from './providerRateLimitState';
+import { ProviderRateLimitState } from './providerRateLimitState';
 import { getRateLimitKey } from './rateLimitKey';
 
 import type { ApiProvider } from '../types/providers';
@@ -19,15 +17,15 @@ export interface RateLimitRegistryOptions {
  * Per-eval registry that manages rate limit state for all providers.
  * NOT a singleton - create one per evaluation context.
  */
-export class RateLimitRegistry extends EventEmitter {
+export class RateLimitRegistry {
   private states: Map<string, ProviderRateLimitState> = new Map();
   private maxConcurrency: number;
   private minConcurrency: number;
   private queueTimeoutMs: number;
   private enabled: boolean;
+  private nextRequestId = 0;
 
   constructor(options: RateLimitRegistryOptions) {
-    super();
     this.maxConcurrency = options.maxConcurrency;
     this.minConcurrency = options.minConcurrency ?? getEnvInt('PROMPTFOO_MIN_CONCURRENCY', 1);
     // Queue timeout: 0 means disabled, default is 5 minutes
@@ -63,14 +61,7 @@ export class RateLimitRegistry extends EventEmitter {
     const rateLimitKey = getRateLimitKey(provider);
     const state = this.getOrCreateState(rateLimitKey);
 
-    // Generate unique request ID for metrics/logging
-    const requestId = `${rateLimitKey}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-
-    this.emit('request:started', {
-      rateLimitKey,
-      requestId,
-      queueDepth: state.getQueueDepth(),
-    });
+    const requestId = `${rateLimitKey}-${++this.nextRequestId}`;
 
     const run = () =>
       state.executeWithRetry(requestId, callFn, {
@@ -80,23 +71,7 @@ export class RateLimitRegistry extends EventEmitter {
         maxRetriesOverride: providerMaxRetries,
       });
 
-    try {
-      const result = await withFetchRetryContext(providerMaxRetries, run);
-
-      this.emit('request:completed', {
-        rateLimitKey,
-        requestId,
-      });
-
-      return result;
-    } catch (error) {
-      this.emit('request:failed', {
-        rateLimitKey,
-        requestId,
-        error: String(error),
-      });
-      throw error;
-    }
+    return withFetchRetryContext(providerMaxRetries, run);
   }
 
   /**
@@ -109,31 +84,13 @@ export class RateLimitRegistry extends EventEmitter {
         maxConcurrency: this.maxConcurrency,
         minConcurrency: this.minConcurrency,
         queueTimeoutMs: this.queueTimeoutMs,
+        onDebug: (message, context) => logger.debug(message, context),
       });
-
-      // Forward events
-      state.on('ratelimit:hit', (data) => this.emit('ratelimit:hit', data));
-      state.on('ratelimit:warning', (data) => this.emit('ratelimit:warning', data));
-      state.on('ratelimit:learned', (data) => this.emit('ratelimit:learned', data));
-      state.on('concurrency:increased', (data) => this.emit('concurrency:increased', data));
-      state.on('concurrency:decreased', (data) => this.emit('concurrency:decreased', data));
-      state.on('request:retrying', (data) => this.emit('request:retrying', data));
 
       this.states.set(rateLimitKey, state);
     }
 
     return this.states.get(rateLimitKey)!;
-  }
-
-  /**
-   * Get metrics for all tracked providers.
-   */
-  getMetrics(): Record<string, ProviderMetrics> {
-    const metrics: Record<string, ProviderMetrics> = {};
-    for (const [key, state] of this.states) {
-      metrics[key] = state.getMetrics();
-    }
-    return metrics;
   }
 
   /**
@@ -144,7 +101,6 @@ export class RateLimitRegistry extends EventEmitter {
       state.dispose();
     }
     this.states.clear();
-    this.removeAllListeners();
   }
 }
 

--- a/src/scheduler/slotQueue.ts
+++ b/src/scheduler/slotQueue.ts
@@ -11,8 +11,6 @@ export interface SlotQueueOptions {
   maxConcurrency: number;
   minConcurrency: number;
   queueTimeoutMs?: number; // Optional timeout for queued requests
-  onSlotAcquired?: (queueDepth: number) => void;
-  onSlotReleased?: (queueDepth: number) => void;
 }
 
 const DEFAULT_QUEUE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
@@ -40,15 +38,10 @@ export class SlotQueue {
   private requestLimit: number | null = null;
   private tokenLimit: number | null = null;
 
-  private onSlotAcquired?: (queueDepth: number) => void;
-  private onSlotReleased?: (queueDepth: number) => void;
-
   constructor(options: SlotQueueOptions) {
     this.maxConcurrency = options.maxConcurrency;
     this.minConcurrency = options.minConcurrency;
     this.queueTimeoutMs = options.queueTimeoutMs ?? DEFAULT_QUEUE_TIMEOUT_MS;
-    this.onSlotAcquired = options.onSlotAcquired;
-    this.onSlotReleased = options.onSlotReleased;
   }
 
   /**
@@ -79,7 +72,6 @@ export class SlotQueue {
           clearTimeout(timeoutId);
         }
         this.activeCount++;
-        this.onSlotAcquired?.(this.waiting.length);
         resolve();
       };
 
@@ -112,7 +104,6 @@ export class SlotQueue {
       return;
     }
     this.activeCount--;
-    this.onSlotReleased?.(this.waiting.length);
     this.processQueue();
   }
 

--- a/test/scheduler/providerRateLimitState.test.ts
+++ b/test/scheduler/providerRateLimitState.test.ts
@@ -11,27 +11,29 @@ const FAST_RETRY_POLICY = {
 
 describe('ProviderRateLimitState', () => {
   let state: ProviderRateLimitState;
+  let debug: ReturnType<typeof vi.fn<(message: string, context: Record<string, unknown>) => void>>;
 
   beforeEach(() => {
     vi.useFakeTimers();
+    debug = vi.fn<(message: string, context: Record<string, unknown>) => void>();
     state = new ProviderRateLimitState({
       rateLimitKey: 'test-provider',
       maxConcurrency: 5,
       minConcurrency: 1,
       retryPolicy: FAST_RETRY_POLICY,
+      onDebug: debug,
     });
   });
 
   afterEach(() => {
     state.dispose();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   describe('Constructor', () => {
     it('should initialize with provided options', () => {
-      const metrics = state.getMetrics();
-      expect(metrics.rateLimitKey).toBe('test-provider');
-      expect(metrics.maxConcurrency).toBe(5);
+      expect(state.rateLimitKey).toBe('test-provider');
     });
 
     it('should accept custom retry policy', () => {
@@ -58,22 +60,6 @@ describe('ProviderRateLimitState', () => {
 
       expect(result).toBe('success');
     });
-
-    it('should increment completed requests on success', async () => {
-      await state.executeWithRetry('req-1', async () => 'success', {});
-
-      const metrics = state.getMetrics();
-      expect(metrics.completedRequests).toBe(1);
-      expect(metrics.failedRequests).toBe(0);
-    });
-
-    it('should increment total requests', async () => {
-      await state.executeWithRetry('req-1', async () => 'success', {});
-      await state.executeWithRetry('req-2', async () => 'success', {});
-
-      const metrics = state.getMetrics();
-      expect(metrics.totalRequests).toBe(2);
-    });
   });
 
   describe('executeWithRetry - error handling', () => {
@@ -88,22 +74,6 @@ describe('ProviderRateLimitState', () => {
         ),
       ).rejects.toThrow('Test error');
     });
-
-    it('should increment failed requests on error', async () => {
-      try {
-        await state.executeWithRetry(
-          'req-1',
-          async () => {
-            throw new Error('Test error');
-          },
-          {},
-        );
-      } catch {}
-
-      const metrics = state.getMetrics();
-      expect(metrics.failedRequests).toBe(1);
-      expect(metrics.completedRequests).toBe(0);
-    });
   });
 
   describe('executeWithRetry - rate limit detection', () => {
@@ -116,6 +86,7 @@ describe('ProviderRateLimitState', () => {
         maxConcurrency: 5,
         minConcurrency: 1,
         retryPolicy: { maxRetries: 0, baseDelayMs: 1, maxDelayMs: 1, jitterFactor: 0 },
+        onDebug: debug,
       });
     });
 
@@ -124,67 +95,32 @@ describe('ProviderRateLimitState', () => {
     });
 
     it('should detect rate limit via isRateLimited callback', async () => {
-      const events: any[] = [];
-      noRetryState.on('ratelimit:hit', (data) => events.push(data));
-
-      try {
-        await noRetryState.executeWithRetry('req-1', async () => ({ status: 429 }), {
+      await expect(
+        noRetryState.executeWithRetry('req-1', async () => ({ status: 429 }), {
           isRateLimited: (result) => result?.status === 429,
-        });
-      } catch {}
-
-      expect(events.length).toBeGreaterThan(0);
+        }),
+      ).rejects.toThrow('Rate limit exceeded for test-provider-no-retry after 1 attempts');
     });
 
-    it('should detect rate limit error by message', async () => {
-      const events: any[] = [];
-      noRetryState.on('ratelimit:hit', (data) => events.push(data));
-
-      try {
-        await noRetryState.executeWithRetry(
+    it.each([
+      'Rate limit exceeded',
+      'HTTP 429: Too Many Requests',
+      'Too many requests',
+    ])('detects rate-limit error %s', async (message) => {
+      await expect(
+        noRetryState.executeWithRetry(
           'req-1',
           async () => {
-            throw new Error('Rate limit exceeded');
+            throw new Error(message);
           },
           {},
-        );
-      } catch {}
+        ),
+      ).rejects.toThrow(message);
 
-      expect(events.length).toBeGreaterThan(0);
-    });
-
-    it('should detect 429 error by message', async () => {
-      const events: any[] = [];
-      noRetryState.on('ratelimit:hit', (data) => events.push(data));
-
-      try {
-        await noRetryState.executeWithRetry(
-          'req-1',
-          async () => {
-            throw new Error('HTTP 429: Too Many Requests');
-          },
-          {},
-        );
-      } catch {}
-
-      expect(events.length).toBeGreaterThan(0);
-    });
-
-    it('should detect too many requests error', async () => {
-      const events: any[] = [];
-      noRetryState.on('ratelimit:hit', (data) => events.push(data));
-
-      try {
-        await noRetryState.executeWithRetry(
-          'req-1',
-          async () => {
-            throw new Error('Too many requests');
-          },
-          {},
-        );
-      } catch {}
-
-      expect(events.length).toBeGreaterThan(0);
+      expect(debug).toHaveBeenCalledWith(
+        '[Scheduler] Rate limit hit for test-provider-no-retry',
+        expect.objectContaining({ resetAt: expect.any(Number) }),
+      );
     });
 
     it('should handle error with undefined message gracefully', async () => {
@@ -202,11 +138,6 @@ describe('ProviderRateLimitState', () => {
           {},
         ),
       ).rejects.toBeDefined();
-
-      // The error should be counted as failed, not as a rate limit
-      const metrics = noRetryState.getMetrics();
-      expect(metrics.failedRequests).toBe(1);
-      expect(metrics.rateLimitHits).toBe(0);
     });
 
     it('back-compat: substring matcher detects HttpRateLimitError (rate_limit kind)', async () => {
@@ -216,11 +147,8 @@ describe('ProviderRateLimitState', () => {
       // to contain `429` and a rate-limit token; verify the scheduler still
       // counts these as ratelimit:hit events.
       const { HttpRateLimitError } = await import('../../src/util/fetch/errors');
-      const events: any[] = [];
-      noRetryState.on('ratelimit:hit', (data) => events.push(data));
-
-      try {
-        await noRetryState.executeWithRetry(
+      await expect(
+        noRetryState.executeWithRetry(
           'req-1',
           async () => {
             throw new HttpRateLimitError({
@@ -230,21 +158,19 @@ describe('ProviderRateLimitState', () => {
             });
           },
           {},
-        );
-      } catch {}
+        ),
+      ).rejects.toThrow();
 
-      expect(events.length).toBeGreaterThan(0);
-      const metrics = noRetryState.getMetrics();
-      expect(metrics.rateLimitHits).toBeGreaterThan(0);
+      expect(debug).toHaveBeenCalledWith(
+        '[Scheduler] Rate limit hit for test-provider-no-retry',
+        expect.any(Object),
+      );
     });
 
     it('back-compat: substring matcher detects HttpRateLimitError (quota kind)', async () => {
       const { HttpRateLimitError } = await import('../../src/util/fetch/errors');
-      const events: any[] = [];
-      noRetryState.on('ratelimit:hit', (data) => events.push(data));
-
-      try {
-        await noRetryState.executeWithRetry(
+      await expect(
+        noRetryState.executeWithRetry(
           'req-1',
           async () => {
             throw new HttpRateLimitError({
@@ -253,12 +179,13 @@ describe('ProviderRateLimitState', () => {
             });
           },
           {},
-        );
-      } catch {}
+        ),
+      ).rejects.toThrow();
 
-      expect(events.length).toBeGreaterThan(0);
-      const metrics = noRetryState.getMetrics();
-      expect(metrics.rateLimitHits).toBeGreaterThan(0);
+      expect(debug).toHaveBeenCalledWith(
+        '[Scheduler] Rate limit hit for test-provider-no-retry',
+        expect.any(Object),
+      );
     });
 
     it('result-path: kind=quota in result.metadata short-circuits retry', async () => {
@@ -373,38 +300,7 @@ describe('ProviderRateLimitState', () => {
       expect(result).toBe('success');
     });
 
-    it('should emit retrying event', async () => {
-      const events: any[] = [];
-      state.on('request:retrying', (data) => events.push(data));
-
-      let attempt = 0;
-      const promise = state.executeWithRetry(
-        'req-1',
-        async () => {
-          attempt++;
-          if (attempt < 2) {
-            throw new Error('Rate limit');
-          }
-          return 'success';
-        },
-        {
-          // Use 0 for immediate retry to avoid timing-dependent flakiness
-          // (non-zero values race against slot queue's resetAt timer)
-          getRetryAfter: () => 0,
-        },
-      );
-
-      // Run all timers to completion
-      await vi.runAllTimersAsync();
-
-      await promise;
-
-      expect(events.length).toBe(1);
-      expect(events[0].attempt).toBe(1);
-      expect(events[0].reason).toBe('ratelimit');
-    });
-
-    it('should increment retriedRequests', async () => {
+    it('retries until a subsequent attempt succeeds', async () => {
       let attempt = 0;
       const promise = state.executeWithRetry(
         'req-1',
@@ -427,36 +323,18 @@ describe('ProviderRateLimitState', () => {
 
       await promise;
 
-      const metrics = state.getMetrics();
-      expect(metrics.retriedRequests).toBe(2);
+      expect(attempt).toBe(3);
     });
   });
 
   describe('Header parsing and updates', () => {
-    it('should update state from rate limit headers', async () => {
-      await state.executeWithRetry('req-1', async () => 'success', {
-        getHeaders: () => ({
-          'x-ratelimit-remaining-requests': '50',
-          'x-ratelimit-limit-requests': '100',
-        }),
-      });
-
-      const metrics = state.getMetrics();
-      expect(metrics.completedRequests).toBe(1);
-    });
-
-    it('should emit ratelimit:learned only once per provider', async () => {
-      const events: any[] = [];
-      state.on('ratelimit:learned', (data) => events.push(data));
-
+    it('logs learned rate limits only once per provider', async () => {
       // First request with limit headers
       await state.executeWithRetry('req-1', async () => 'success', {
         getHeaders: () => ({
           'x-ratelimit-limit-requests': '100',
         }),
       });
-
-      expect(events.length).toBe(1);
 
       // Second request with limit headers - should not emit again
       await state.executeWithRetry('req-2', async () => 'success', {
@@ -465,7 +343,10 @@ describe('ProviderRateLimitState', () => {
         }),
       });
 
-      expect(events.length).toBe(1); // Still 1, not 2
+      const learnedLogs = debug.mock.calls.filter(([message]) =>
+        String(message).includes('Learned rate limits'),
+      );
+      expect(learnedLogs).toHaveLength(1);
     });
 
     it('should not call markRateLimited for successful responses with retry-after headers', async () => {
@@ -500,9 +381,6 @@ describe('ProviderRateLimitState', () => {
       });
 
       expect(result).toBe('second-success');
-      const metrics = state2.getMetrics();
-      expect(metrics.completedRequests).toBe(2);
-      expect(metrics.rateLimitHits).toBe(0);
       state2.dispose();
     });
 
@@ -512,10 +390,8 @@ describe('ProviderRateLimitState', () => {
         maxConcurrency: 5,
         minConcurrency: 1,
         retryPolicy: { maxRetries: 0, baseDelayMs: 1, maxDelayMs: 1, jitterFactor: 0 },
+        onDebug: debug,
       });
-
-      const hitEvents: any[] = [];
-      state2.on('ratelimit:hit', (data) => hitEvents.push(data));
 
       // Rate-limited response with retry-after-ms header
       try {
@@ -529,9 +405,10 @@ describe('ProviderRateLimitState', () => {
         // Expected - rate limit exhausted with maxRetries=0
       }
 
-      expect(hitEvents.length).toBe(1);
-      expect(hitEvents[0].retryAfterMs).toBeUndefined(); // getRetryAfter not provided
-      expect(state2.getMetrics().rateLimitHits).toBe(1);
+      expect(debug).toHaveBeenCalledWith(
+        '[Scheduler] Rate limit hit for test-block-on-429',
+        expect.objectContaining({ retryAfterMs: undefined }),
+      );
       state2.dispose();
     });
   });
@@ -544,10 +421,8 @@ describe('ProviderRateLimitState', () => {
         maxConcurrency: 5,
         minConcurrency: 1,
         retryPolicy: { maxRetries: 0, baseDelayMs: 1, maxDelayMs: 1, jitterFactor: 0 },
+        onDebug: debug,
       });
-
-      const events: any[] = [];
-      testState.on('concurrency:decreased', (data) => events.push(data));
 
       try {
         await testState.executeWithRetry(
@@ -564,8 +439,10 @@ describe('ProviderRateLimitState', () => {
 
       testState.dispose();
 
-      expect(events.length).toBe(1);
-      expect(events[0].reason).toBe('ratelimit');
+      expect(debug).toHaveBeenCalledWith(
+        '[Scheduler] Concurrency decreased for test-adaptive-decrease',
+        { previous: 5, current: 2 },
+      );
     });
 
     it('should increase concurrency after sustained success', async () => {
@@ -575,6 +452,7 @@ describe('ProviderRateLimitState', () => {
         maxConcurrency: 5,
         minConcurrency: 1,
         retryPolicy: { maxRetries: 0, baseDelayMs: 1, maxDelayMs: 1, jitterFactor: 0 },
+        onDebug: debug,
       });
 
       // First decrease concurrency via rate limit
@@ -594,9 +472,6 @@ describe('ProviderRateLimitState', () => {
       // Advance past the rate limit reset time to allow subsequent requests
       vi.advanceTimersByTime(10);
 
-      const events: any[] = [];
-      testState.on('concurrency:increased', (data) => events.push(data));
-
       // 5 consecutive successes trigger recovery
       for (let i = 0; i < 5; i++) {
         await testState.executeWithRetry(`req-${i + 2}`, async () => 'success', {});
@@ -604,31 +479,15 @@ describe('ProviderRateLimitState', () => {
 
       testState.dispose();
 
-      expect(events.length).toBe(1);
-      expect(events[0].reason).toBe('recovery');
+      expect(debug).toHaveBeenCalledWith(
+        '[Scheduler] Concurrency increased for test-adaptive-increase',
+        expect.objectContaining({ current: 3 }),
+      );
     });
   });
 
   describe('Proactive throttling', () => {
-    it('should emit warning when approaching limit', async () => {
-      const events: any[] = [];
-      state.on('ratelimit:warning', (data) => events.push(data));
-
-      await state.executeWithRetry('req-1', async () => 'success', {
-        getHeaders: () => ({
-          'x-ratelimit-remaining-requests': '5',
-          'x-ratelimit-limit-requests': '100',
-        }),
-      });
-
-      expect(events.length).toBe(1);
-      expect(events[0].requestRatio).toBe(0.05);
-    });
-
     it('should proactively decrease concurrency when approaching limit', async () => {
-      const events: any[] = [];
-      state.on('concurrency:decreased', (data) => events.push(data));
-
       await state.executeWithRetry('req-1', async () => 'success', {
         getHeaders: () => ({
           'x-ratelimit-remaining-requests': '5',
@@ -636,69 +495,10 @@ describe('ProviderRateLimitState', () => {
         }),
       });
 
-      expect(events.length).toBe(1);
-      expect(events[0].reason).toBe('proactive');
-    });
-  });
-
-  describe('getQueueDepth', () => {
-    it('should return current queue depth', () => {
-      const depth = state.getQueueDepth();
-      expect(depth).toBe(0);
-    });
-  });
-
-  describe('getMetrics', () => {
-    it('should return all metrics', async () => {
-      await state.executeWithRetry('req-1', async () => 'success', {});
-
-      const metrics = state.getMetrics();
-
-      expect(metrics).toMatchObject({
-        rateLimitKey: 'test-provider',
-        activeRequests: 0,
-        maxConcurrency: 5,
-        queueDepth: 0,
-        totalRequests: 1,
-        completedRequests: 1,
-        failedRequests: 0,
-        rateLimitHits: 0,
-        retriedRequests: 0,
+      expect(debug).toHaveBeenCalledWith('[Scheduler] Concurrency decreased for test-provider', {
+        previous: 5,
+        current: 2,
       });
-      expect(typeof metrics.avgLatencyMs).toBe('number');
-      expect(typeof metrics.p50LatencyMs).toBe('number');
-      expect(typeof metrics.p99LatencyMs).toBe('number');
-    });
-  });
-
-  describe('dispose', () => {
-    it('should clean up resources', () => {
-      state.dispose();
-
-      // Should not throw when disposed
-      expect(() => state.getMetrics()).not.toThrow();
-    });
-  });
-
-  describe('Event emission', () => {
-    it('should emit slot:acquired event', async () => {
-      const events: any[] = [];
-      state.on('slot:acquired', (data) => events.push(data));
-
-      await state.executeWithRetry('req-1', async () => 'success', {});
-
-      expect(events.length).toBe(1);
-      expect(events[0].rateLimitKey).toBe('test-provider');
-    });
-
-    it('should emit slot:released event', async () => {
-      const events: any[] = [];
-      state.on('slot:released', (data) => events.push(data));
-
-      await state.executeWithRetry('req-1', async () => 'success', {});
-
-      expect(events.length).toBe(1);
-      expect(events[0].rateLimitKey).toBe('test-provider');
     });
   });
 });

--- a/test/scheduler/rateLimitRegistry.test.ts
+++ b/test/scheduler/rateLimitRegistry.test.ts
@@ -1,63 +1,30 @@
-import { EventEmitter } from 'events';
-
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ApiProvider } from '../../src/types/providers';
 
-// Track constructor calls and instances
 const mockProviderRateLimitStateConstructor = vi.fn();
 const mockGetRateLimitKey = vi.fn();
 const mockGetEnvInt = vi.fn();
 const mockGetEnvBool = vi.fn();
 
-let mockStateToReturn: any = null;
-const mockStateQueue: any[] = [];
+type MockProviderState = {
+  executeWithRetry: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+};
 
-// Mock dependencies before imports
+let defaultState: MockProviderState;
+const queuedStates: MockProviderState[] = [];
+
 vi.mock('../../src/scheduler/providerRateLimitState', () => ({
-  ProviderRateLimitState: class extends EventEmitter {
-    executeWithRetry: any;
-    getMetrics: any;
-    getQueueDepth: any;
-    dispose: any;
+  ProviderRateLimitState: class {
+    executeWithRetry: MockProviderState['executeWithRetry'];
+    dispose: MockProviderState['dispose'];
 
-    constructor(options: any) {
-      super();
+    constructor(options: unknown) {
       mockProviderRateLimitStateConstructor(options);
-
-      // Check if we have a queued mock state
-      const queuedState = mockStateQueue.shift();
-      if (queuedState) {
-        this.executeWithRetry = queuedState.executeWithRetry;
-        this.getMetrics = queuedState.getMetrics;
-        this.getQueueDepth = queuedState.getQueueDepth || vi.fn().mockReturnValue(0);
-        this.dispose = queuedState.dispose;
-      } else if (mockStateToReturn) {
-        // If we have a specific mock state to return, copy its methods
-        this.executeWithRetry = mockStateToReturn.executeWithRetry;
-        this.getMetrics = mockStateToReturn.getMetrics;
-        this.getQueueDepth = mockStateToReturn.getQueueDepth || vi.fn().mockReturnValue(0);
-        this.dispose = mockStateToReturn.dispose;
-      } else {
-        // Default mocks
-        this.executeWithRetry = vi.fn().mockResolvedValue('result');
-        this.getMetrics = vi.fn().mockReturnValue({
-          rateLimitKey: 'test-provider',
-          activeRequests: 0,
-          maxConcurrency: 10,
-          queueDepth: 0,
-          totalRequests: 0,
-          completedRequests: 0,
-          failedRequests: 0,
-          rateLimitHits: 0,
-          retriedRequests: 0,
-          avgLatencyMs: 0,
-          p50LatencyMs: 0,
-          p99LatencyMs: 0,
-        });
-        this.getQueueDepth = vi.fn().mockReturnValue(0);
-        this.dispose = vi.fn();
-      }
+      const state = queuedStates.shift() ?? defaultState;
+      this.executeWithRetry = state.executeWithRetry;
+      this.dispose = state.dispose;
     }
   },
 }));
@@ -73,72 +40,33 @@ vi.mock('../../src/envars', () => ({
 
 vi.mock('../../src/logger', () => ({
   __esModule: true,
-  default: {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  },
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   logRequestResponse: vi.fn(),
 }));
 
-// Import after mocks are set up
 const { RateLimitRegistry, createRateLimitRegistry } = await import(
   '../../src/scheduler/rateLimitRegistry'
 );
 
 describe('RateLimitRegistry', () => {
-  let mockProvider: ApiProvider;
-  let mockState: any;
+  let provider: ApiProvider;
 
   beforeEach(() => {
-    // Reset mocks with mockReset() to clear both call history AND implementations
-    // This ensures test isolation when tests use mockReturnValueOnce
     mockProviderRateLimitStateConstructor.mockReset();
     mockGetRateLimitKey.mockReset();
     mockGetEnvInt.mockReset();
     mockGetEnvBool.mockReset();
-
-    // Clear the queue
-    mockStateQueue.length = 0;
-
-    // Setup mock provider
-    mockProvider = {
+    queuedStates.length = 0;
+    defaultState = {
+      executeWithRetry: vi.fn().mockResolvedValue('result'),
+      dispose: vi.fn(),
+    };
+    provider = {
       id: () => 'test-provider',
       config: {},
       callApi: vi.fn(),
     } as unknown as ApiProvider;
-
-    // Setup mock state
-    mockState = {
-      executeWithRetry: vi.fn().mockResolvedValue('result'),
-      getMetrics: vi.fn().mockReturnValue({
-        rateLimitKey: 'test-provider',
-        activeRequests: 0,
-        maxConcurrency: 10,
-        queueDepth: 0,
-        totalRequests: 0,
-        completedRequests: 0,
-        failedRequests: 0,
-        rateLimitHits: 0,
-        retriedRequests: 0,
-        avgLatencyMs: 0,
-        p50LatencyMs: 0,
-        p99LatencyMs: 0,
-      }),
-      dispose: vi.fn(),
-      emit: vi.fn(),
-      on: vi.fn(),
-      listenerCount: vi.fn().mockReturnValue(1),
-    };
-
-    // Set this as the mock to be returned by the constructor
-    mockStateToReturn = mockState;
-
-    // Mock getRateLimitKey
     mockGetRateLimitKey.mockReturnValue('test-provider');
-
-    // Mock envars with defaults
     mockGetEnvInt.mockReturnValue(1);
     mockGetEnvBool.mockReturnValue(false);
   });
@@ -147,892 +75,199 @@ describe('RateLimitRegistry', () => {
     vi.resetAllMocks();
   });
 
-  describe('createRateLimitRegistry - factory function', () => {
-    it('should create a new RateLimitRegistry instance', () => {
-      const registry = createRateLimitRegistry({ maxConcurrency: 10 });
-      expect(registry).toBeInstanceOf(RateLimitRegistry);
-    });
+  it('creates a registry with the configured concurrency settings', async () => {
+    const registry = createRateLimitRegistry({ maxConcurrency: 10, minConcurrency: 3 });
 
-    it('should pass options to constructor', () => {
-      const registry = createRateLimitRegistry({ maxConcurrency: 20, minConcurrency: 2 });
-      expect(registry).toBeInstanceOf(RateLimitRegistry);
-    });
-  });
+    await registry.execute(provider, vi.fn());
 
-  describe('Constructor - options handling', () => {
-    it('should initialize with maxConcurrency from options', () => {
-      const registry = new RateLimitRegistry({ maxConcurrency: 15 });
-      expect(registry).toBeDefined();
-    });
-
-    it('should use minConcurrency from options if provided', () => {
-      mockGetEnvInt.mockReturnValue(1);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10, minConcurrency: 3 });
-
-      // Execute to trigger state creation
-      const callFn = vi.fn().mockResolvedValue('result');
-      registry.execute(mockProvider, callFn);
-
-      // Check ProviderRateLimitState was created with correct minConcurrency
-      // queueTimeoutMs is 1 because mockGetEnvInt returns 1 for all calls
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        maxConcurrency: 10,
-        minConcurrency: 3,
-        queueTimeoutMs: 1,
-      });
-    });
-
-    it('should use default minConcurrency from env when not provided', () => {
-      mockGetEnvInt.mockReturnValue(2);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      // Execute to trigger state creation
-      const callFn = vi.fn().mockResolvedValue('result');
-      registry.execute(mockProvider, callFn);
-
-      expect(mockGetEnvInt).toHaveBeenCalledWith('PROMPTFOO_MIN_CONCURRENCY', 1);
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        maxConcurrency: 10,
-        minConcurrency: 2,
-        queueTimeoutMs: 2,
-      });
-    });
-
-    it('should enable scheduler by default', async () => {
-      mockGetEnvBool.mockReturnValue(false);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn().mockResolvedValue('result');
-      await registry.execute(mockProvider, callFn);
-
-      // Should create state and use scheduler
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenCalled();
-    });
-
-    it('should disable scheduler when env var is true', async () => {
-      mockGetEnvBool.mockReturnValue(true);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn().mockResolvedValue('result');
-      const result = await registry.execute(mockProvider, callFn);
-
-      expect(mockGetEnvBool).toHaveBeenCalledWith('PROMPTFOO_DISABLE_ADAPTIVE_SCHEDULER', false);
-      expect(callFn).toHaveBeenCalled();
-      expect(mockProviderRateLimitStateConstructor).not.toHaveBeenCalled();
-      expect(result).toBe('result');
+    expect(registry).toBeInstanceOf(RateLimitRegistry);
+    expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledWith({
+      rateLimitKey: 'test-provider',
+      maxConcurrency: 10,
+      minConcurrency: 3,
+      queueTimeoutMs: 1,
+      onDebug: expect.any(Function),
     });
   });
 
-  describe('execute - calls function directly when disabled', () => {
-    it('should bypass rate limiting when disabled', async () => {
-      mockGetEnvBool.mockReturnValue(true);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+  it('uses environment defaults for minimum concurrency and queue timeout', async () => {
+    mockGetEnvInt.mockReturnValue(2);
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
 
-      const callFn = vi.fn().mockResolvedValue('direct-result');
-      const result = await registry.execute(mockProvider, callFn);
+    await registry.execute(provider, vi.fn());
 
-      expect(result).toBe('direct-result');
-      expect(callFn).toHaveBeenCalledTimes(1);
-      expect(mockProviderRateLimitStateConstructor).not.toHaveBeenCalled();
-    });
-
-    it('should propagate errors when disabled', async () => {
-      mockGetEnvBool.mockReturnValue(true);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const error = new Error('Test error');
-      const callFn = vi.fn().mockRejectedValue(error);
-
-      await expect(registry.execute(mockProvider, callFn)).rejects.toThrow('Test error');
+    expect(mockGetEnvInt).toHaveBeenCalledWith('PROMPTFOO_MIN_CONCURRENCY', 1);
+    expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledWith({
+      rateLimitKey: 'test-provider',
+      maxConcurrency: 10,
+      minConcurrency: 2,
+      queueTimeoutMs: 2,
+      onDebug: expect.any(Function),
     });
   });
 
-  describe('execute - wraps calls through ProviderRateLimitState', () => {
-    it('should call executeWithRetry on state', async () => {
-      mockState.executeWithRetry.mockResolvedValue('state-result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+  it('runs calls directly when the adaptive scheduler is disabled', async () => {
+    mockGetEnvBool.mockReturnValue(true);
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+    const call = vi.fn().mockResolvedValue('direct-result');
 
-      const callFn = vi.fn().mockResolvedValue('call-result');
-      const result = await registry.execute(mockProvider, callFn);
+    await expect(registry.execute(provider, call)).resolves.toBe('direct-result');
 
-      expect(mockState.executeWithRetry).toHaveBeenCalledWith(
-        expect.stringContaining('test-provider-'),
-        callFn,
-        {
-          getHeaders: undefined,
-          isRateLimited: undefined,
-          getRetryAfter: undefined,
-          maxRetriesOverride: undefined,
-        },
-      );
-      expect(result).toBe('state-result');
-    });
+    expect(call).toHaveBeenCalledOnce();
+    expect(mockProviderRateLimitStateConstructor).not.toHaveBeenCalled();
+  });
 
-    it('should pass options to executeWithRetry', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+  it('preserves errors when the adaptive scheduler is disabled', async () => {
+    mockGetEnvBool.mockReturnValue(true);
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
 
-      const callFn = vi.fn();
-      const getHeaders = vi.fn();
-      const isRateLimited = vi.fn();
-      const getRetryAfter = vi.fn();
+    await expect(
+      registry.execute(provider, vi.fn().mockRejectedValue(new Error('request failed'))),
+    ).rejects.toThrow('request failed');
+  });
 
-      await registry.execute(mockProvider, callFn, {
-        getHeaders,
-        isRateLimited,
-        getRetryAfter,
-      });
+  it('passes request classification callbacks to the provider state', async () => {
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+    const call = vi.fn();
+    const getHeaders = vi.fn();
+    const isRateLimited = vi.fn();
+    const getRetryAfter = vi.fn();
 
-      expect(mockState.executeWithRetry).toHaveBeenCalledWith(expect.any(String), callFn, {
-        getHeaders,
-        isRateLimited,
-        getRetryAfter,
-        maxRetriesOverride: undefined,
-      });
-    });
+    await registry.execute(provider, call, { getHeaders, isRateLimited, getRetryAfter });
 
-    it.each([
-      [0, 0],
-      [5, 5],
-      ['2', 2],
-    ])('should forward provider config.maxRetries %p as maxRetriesOverride %p', async (input, expected) => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const provider = {
-        ...mockProvider,
-        config: { ...mockProvider.config, maxRetries: input },
-      } as ApiProvider;
-
-      await registry.execute(provider, vi.fn());
-
-      expect(mockState.executeWithRetry).toHaveBeenLastCalledWith(
-        expect.any(String),
-        expect.any(Function),
-        expect.objectContaining({ maxRetriesOverride: expected }),
-      );
-    });
-
-    it.each([
-      ['negative number', -1],
-      ['non-integer number', 2.5],
-      ['non-integer string', '2.5'],
-      // Digit strings that overflow to Infinity / lose precision would cause
-      // unbounded retry loops if accepted — reject them.
-      ['unsafe-integer string', '1' + '0'.repeat(400)],
-      ['above MAX_SAFE_INTEGER', String(Number.MAX_SAFE_INTEGER) + '0'],
-    ])('should warn and forward maxRetriesOverride=undefined for invalid %s (%p)', async (_label, input) => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const logger = (await import('../../src/logger')).default;
-      const warnSpy = vi.mocked(logger.warn);
-      warnSpy.mockClear();
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const provider = {
-        ...mockProvider,
-        config: { ...mockProvider.config, maxRetries: input },
-      } as ApiProvider;
-
-      await registry.execute(provider, vi.fn());
-
-      expect(warnSpy).toHaveBeenCalledWith(
-        '[RateLimit] Ignoring invalid provider.config.maxRetries; expected a non-negative integer.',
-        expect.objectContaining({
-          maxRetries: input,
-          providerId: 'test-provider',
-        }),
-      );
-      expect(mockState.executeWithRetry).toHaveBeenLastCalledWith(
-        expect.any(String),
-        expect.any(Function),
-        expect.objectContaining({ maxRetriesOverride: undefined }),
-      );
-    });
-
-    it('should not warn when provider does not set maxRetries', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const logger = (await import('../../src/logger')).default;
-      const warnSpy = vi.mocked(logger.warn);
-      warnSpy.mockClear();
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      await registry.execute(mockProvider, vi.fn());
-
-      expect(warnSpy).not.toHaveBeenCalled();
-    });
-
-    it('should sanitize URL provider ids in invalid maxRetries warnings', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const logger = (await import('../../src/logger')).default;
-      const warnSpy = vi.mocked(logger.warn);
-      warnSpy.mockClear();
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const provider = {
-        ...mockProvider,
-        id: () => 'https://example.com/api?api_key=secret&model=test',
-        config: { ...mockProvider.config, maxRetries: -1 },
-      } as ApiProvider;
-
-      await registry.execute(provider, vi.fn());
-
-      const [, context] = warnSpy.mock.calls[0];
-      expect(context).toEqual(
-        expect.objectContaining({
-          maxRetries: -1,
-          providerId: expect.stringContaining('api_key=%5BREDACTED%5D'),
-        }),
-      );
-      expect((context as { providerId: string }).providerId).not.toContain('secret');
-    });
-
-    it('should generate unique request IDs', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn();
-      const requestIds: string[] = [];
-
-      // Capture request IDs from executeWithRetry calls
-      mockState.executeWithRetry.mockImplementation(async (requestId: string) => {
-        requestIds.push(requestId);
-        return 'result';
-      });
-
-      await registry.execute(mockProvider, callFn);
-      await registry.execute(mockProvider, callFn);
-
-      expect(requestIds).toHaveLength(2);
-      expect(requestIds[0]).not.toBe(requestIds[1]);
-      expect(requestIds[0]).toMatch(/^test-provider-\d+-[a-z0-9]+$/);
+    expect(defaultState.executeWithRetry).toHaveBeenCalledWith('test-provider-1', call, {
+      getHeaders,
+      isRateLimited,
+      getRetryAfter,
+      maxRetriesOverride: undefined,
     });
   });
 
-  describe('execute - creates new state for new providers', () => {
-    it('should create state on first call', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+  it.each([
+    [0, 0],
+    [5, 5],
+    ['2', 2],
+  ])('preserves the provider retry limit %p', async (configured, expected) => {
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+    const configuredProvider = {
+      ...provider,
+      config: { ...provider.config, maxRetries: configured },
+    } as ApiProvider;
 
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
+    await registry.execute(configuredProvider, vi.fn());
 
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledTimes(1);
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        maxConcurrency: 10,
-        minConcurrency: 1,
-        queueTimeoutMs: 1,
-      });
-    });
-
-    it('should setup event forwarding for new state', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      // Verify state was created with event forwarding capability
-      // Note: Full event forwarding is tested in the "Event forwarding" describe block
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledTimes(1);
-    });
+    expect(defaultState.executeWithRetry).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Function),
+      expect.objectContaining({ maxRetriesOverride: expected }),
+    );
   });
 
-  describe('execute - reuses state for same provider', () => {
-    it('should reuse existing state for same provider', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+  it.each([
+    -1,
+    2.5,
+    '2.5',
+    '1' + '0'.repeat(400),
+    String(Number.MAX_SAFE_INTEGER) + '0',
+  ])('rejects the invalid provider retry limit %p', async (configured) => {
+    const logger = (await import('../../src/logger')).default;
+    const warn = vi.mocked(logger.warn);
+    warn.mockClear();
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+    const configuredProvider = {
+      ...provider,
+      config: { ...provider.config, maxRetries: configured },
+    } as ApiProvider;
 
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-      await registry.execute(mockProvider, callFn);
-      await registry.execute(mockProvider, callFn);
+    await registry.execute(configuredProvider, vi.fn());
 
-      // State should only be created once
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledTimes(1);
-      expect(mockState.executeWithRetry).toHaveBeenCalledTimes(3);
-    });
+    expect(warn).toHaveBeenCalledWith(
+      '[RateLimit] Ignoring invalid provider.config.maxRetries; expected a non-negative integer.',
+      expect.objectContaining({ maxRetries: configured, providerId: 'test-provider' }),
+    );
+    expect(defaultState.executeWithRetry).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Function),
+      expect.objectContaining({ maxRetriesOverride: undefined }),
+    );
   });
 
-  describe('execute - different API keys get different states (via rateLimitKey)', () => {
-    it('should create separate states for different rate limit keys', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
+  it('redacts credentials in invalid retry-limit warnings', async () => {
+    const logger = (await import('../../src/logger')).default;
+    const warn = vi.mocked(logger.warn);
+    warn.mockClear();
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+    const configuredProvider = {
+      ...provider,
+      id: () => 'https://example.com/api?api_key=secret&model=test',
+      config: { maxRetries: -1 },
+    } as ApiProvider;
 
-      const provider1 = { id: () => 'provider-1', config: { apiKey: 'key1' } } as ApiProvider;
-      const provider2 = { id: () => 'provider-2', config: { apiKey: 'key2' } } as ApiProvider;
+    await registry.execute(configuredProvider, vi.fn());
 
-      // Mock different rate limit keys
-      mockGetRateLimitKey
-        .mockReturnValueOnce('provider-1[abc123]')
-        .mockReturnValueOnce('provider-2[def456]');
-
-      // Create mock states for each provider
-      const state1 = {
-        executeWithRetry: vi.fn().mockResolvedValue('result1'),
-        getMetrics: vi.fn().mockReturnValue({ queueDepth: 0 }),
-        dispose: vi.fn(),
-      };
-
-      const state2 = {
-        executeWithRetry: vi.fn().mockResolvedValue('result2'),
-        getMetrics: vi.fn().mockReturnValue({ queueDepth: 0 }),
-        dispose: vi.fn(),
-      };
-
-      // Queue the states to be returned by constructor
-      mockStateQueue.push(state1, state2);
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn();
-      await registry.execute(provider1, callFn);
-      await registry.execute(provider2, callFn);
-
-      // Two different states should be created
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledTimes(2);
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenNthCalledWith(1, {
-        rateLimitKey: 'provider-1[abc123]',
-        maxConcurrency: 10,
-        minConcurrency: 1,
-        queueTimeoutMs: 1,
-      });
-      expect(mockProviderRateLimitStateConstructor).toHaveBeenNthCalledWith(2, {
-        rateLimitKey: 'provider-2[def456]',
-        maxConcurrency: 10,
-        minConcurrency: 1,
-        queueTimeoutMs: 1,
-      });
-    });
+    const [, context] = warn.mock.calls[0];
+    expect(context).toEqual(
+      expect.objectContaining({ providerId: expect.stringContaining('api_key=%5BREDACTED%5D') }),
+    );
+    expect((context as { providerId: string }).providerId).not.toContain('secret');
   });
 
-  describe('Event forwarding', () => {
-    it('should emit request:started event', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+  it('assigns unique, predictable queue identifiers', async () => {
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
 
-      const startedListener = vi.fn();
-      registry.on('request:started', startedListener);
+    await registry.execute(provider, vi.fn());
+    await registry.execute(provider, vi.fn());
 
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(startedListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        requestId: expect.stringContaining('test-provider-'),
-        queueDepth: 0,
-      });
-    });
-
-    it('should emit request:completed event on success', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const completedListener = vi.fn();
-      registry.on('request:completed', completedListener);
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(completedListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        requestId: expect.stringContaining('test-provider-'),
-      });
-    });
-
-    it('should emit request:failed event on error', async () => {
-      const error = new Error('Test failure');
-      mockState.executeWithRetry.mockRejectedValue(error);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const failedListener = vi.fn();
-      registry.on('request:failed', failedListener);
-
-      const callFn = vi.fn();
-      await expect(registry.execute(mockProvider, callFn)).rejects.toThrow('Test failure');
-
-      expect(failedListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        requestId: expect.stringContaining('test-provider-'),
-        error: 'Error: Test failure',
-      });
-    });
-
-    it('should forward ratelimit:hit events from state', async () => {
-      mockState.executeWithRetry.mockImplementation(async function (this: any) {
-        this.emit('ratelimit:hit', {
-          rateLimitKey: 'test-provider',
-          retryAfterMs: 1000,
-          resetAt: Date.now() + 1000,
-          concurrencyChange: { changed: true, previous: 10, current: 5, reason: 'ratelimit' },
-        });
-        return 'result';
-      });
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const hitListener = vi.fn();
-      registry.on('ratelimit:hit', hitListener);
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(hitListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        retryAfterMs: 1000,
-        resetAt: expect.any(Number),
-        concurrencyChange: { changed: true, previous: 10, current: 5, reason: 'ratelimit' },
-      });
-    });
-
-    it('should forward concurrency:decreased events from state', async () => {
-      mockState.executeWithRetry.mockImplementation(async function (this: any) {
-        this.emit('concurrency:decreased', {
-          rateLimitKey: 'test-provider',
-          changed: true,
-          previous: 10,
-          current: 5,
-          reason: 'ratelimit',
-        });
-        return 'result';
-      });
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const decreasedListener = vi.fn();
-      registry.on('concurrency:decreased', decreasedListener);
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(decreasedListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        changed: true,
-        previous: 10,
-        current: 5,
-        reason: 'ratelimit',
-      });
-    });
-
-    it('should forward concurrency:increased events from state', async () => {
-      mockState.executeWithRetry.mockImplementation(async function (this: any) {
-        this.emit('concurrency:increased', {
-          rateLimitKey: 'test-provider',
-          changed: true,
-          previous: 5,
-          current: 8,
-          reason: 'recovery',
-        });
-        return 'result';
-      });
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const increasedListener = vi.fn();
-      registry.on('concurrency:increased', increasedListener);
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(increasedListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        changed: true,
-        previous: 5,
-        current: 8,
-        reason: 'recovery',
-      });
-    });
-
-    it('should forward ratelimit:warning events from state', async () => {
-      mockState.executeWithRetry.mockImplementation(async function (this: any) {
-        this.emit('ratelimit:warning', {
-          rateLimitKey: 'test-provider',
-          requestRatio: 0.05,
-          tokenRatio: 0.08,
-        });
-        return 'result';
-      });
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const warningListener = vi.fn();
-      registry.on('ratelimit:warning', warningListener);
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(warningListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        requestRatio: 0.05,
-        tokenRatio: 0.08,
-      });
-    });
-
-    it('should forward ratelimit:learned events from state', async () => {
-      mockState.executeWithRetry.mockImplementation(async function (this: any) {
-        this.emit('ratelimit:learned', {
-          rateLimitKey: 'test-provider',
-          requestLimit: 100,
-          tokenLimit: 50000,
-        });
-        return 'result';
-      });
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const learnedListener = vi.fn();
-      registry.on('ratelimit:learned', learnedListener);
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(learnedListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        requestLimit: 100,
-        tokenLimit: 50000,
-      });
-    });
-
-    it('should forward request:retrying events from state', async () => {
-      mockState.executeWithRetry.mockImplementation(async function (this: any) {
-        this.emit('request:retrying', {
-          rateLimitKey: 'test-provider',
-          attempt: 1,
-          delayMs: 2000,
-          reason: 'ratelimit',
-        });
-        return 'result';
-      });
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const retryingListener = vi.fn();
-      registry.on('request:retrying', retryingListener);
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(retryingListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        attempt: 1,
-        delayMs: 2000,
-        reason: 'ratelimit',
-      });
-    });
+    expect(defaultState.executeWithRetry.mock.calls.map(([requestId]) => requestId)).toEqual([
+      'test-provider-1',
+      'test-provider-2',
+    ]);
   });
 
-  describe('getMetrics - returns metrics for all providers', () => {
-    it('should return empty metrics when no providers have been used', () => {
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-      const metrics = registry.getMetrics();
+  it('reuses state for repeated requests to the same provider', async () => {
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
 
-      expect(metrics).toEqual({});
-    });
+    await registry.execute(provider, vi.fn());
+    await registry.execute(provider, vi.fn());
 
-    it('should return metrics for single provider', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      vi.mocked(mockState.getMetrics).mockReturnValue({
-        rateLimitKey: 'test-provider',
-        activeRequests: 2,
-        maxConcurrency: 10,
-        queueDepth: 1,
-        totalRequests: 5,
-        completedRequests: 3,
-        failedRequests: 0,
-        rateLimitHits: 1,
-        retriedRequests: 2,
-        avgLatencyMs: 150,
-        p50LatencyMs: 140,
-        p99LatencyMs: 200,
-      });
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      const metrics = registry.getMetrics();
-      expect(metrics).toEqual({
-        'test-provider': {
-          rateLimitKey: 'test-provider',
-          activeRequests: 2,
-          maxConcurrency: 10,
-          queueDepth: 1,
-          totalRequests: 5,
-          completedRequests: 3,
-          failedRequests: 0,
-          rateLimitHits: 1,
-          retriedRequests: 2,
-          avgLatencyMs: 150,
-          p50LatencyMs: 140,
-          p99LatencyMs: 200,
-        },
-      });
-    });
-
-    it('should return metrics for multiple providers', async () => {
-      const provider1 = { id: () => 'provider-1', config: {} } as ApiProvider;
-      const provider2 = { id: () => 'provider-2', config: {} } as ApiProvider;
-
-      // Mock different rate limit keys
-      mockGetRateLimitKey
-        .mockReturnValueOnce('provider-1')
-        .mockReturnValueOnce('provider-2')
-        .mockReturnValue('provider-1'); // For getMetrics calls
-
-      // Create separate mock states
-      const state1 = {
-        executeWithRetry: vi.fn().mockResolvedValue('result1'),
-        getMetrics: vi.fn().mockReturnValue({
-          rateLimitKey: 'provider-1',
-          activeRequests: 1,
-          maxConcurrency: 10,
-          queueDepth: 0,
-          totalRequests: 10,
-          completedRequests: 10,
-          failedRequests: 0,
-          rateLimitHits: 0,
-          retriedRequests: 0,
-          avgLatencyMs: 100,
-          p50LatencyMs: 95,
-          p99LatencyMs: 150,
-        }),
-        dispose: vi.fn(),
-      };
-
-      const state2 = {
-        executeWithRetry: vi.fn().mockResolvedValue('result2'),
-        getMetrics: vi.fn().mockReturnValue({
-          rateLimitKey: 'provider-2',
-          activeRequests: 3,
-          maxConcurrency: 5,
-          queueDepth: 2,
-          totalRequests: 20,
-          completedRequests: 15,
-          failedRequests: 2,
-          rateLimitHits: 3,
-          retriedRequests: 5,
-          avgLatencyMs: 200,
-          p50LatencyMs: 180,
-          p99LatencyMs: 300,
-        }),
-        dispose: vi.fn(),
-      };
-
-      mockStateQueue.push(state1, state2);
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn();
-      await registry.execute(provider1, callFn);
-      await registry.execute(provider2, callFn);
-
-      const metrics = registry.getMetrics();
-      expect(Object.keys(metrics)).toHaveLength(2);
-      expect(metrics['provider-1']).toBeDefined();
-      expect(metrics['provider-2']).toBeDefined();
-      expect(metrics['provider-1'].totalRequests).toBe(10);
-      expect(metrics['provider-2'].totalRequests).toBe(20);
-    });
+    expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledOnce();
+    expect(defaultState.executeWithRetry).toHaveBeenCalledTimes(2);
   });
 
-  describe('dispose - cleans up all states', () => {
-    it('should dispose all states', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+  it('isolates different provider credentials', async () => {
+    const first = { executeWithRetry: vi.fn().mockResolvedValue('first'), dispose: vi.fn() };
+    const second = { executeWithRetry: vi.fn().mockResolvedValue('second'), dispose: vi.fn() };
+    queuedStates.push(first, second);
+    mockGetRateLimitKey
+      .mockReturnValueOnce('provider[first]')
+      .mockReturnValueOnce('provider[second]');
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
 
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
+    await expect(registry.execute(provider, vi.fn())).resolves.toBe('first');
+    await expect(registry.execute(provider, vi.fn())).resolves.toBe('second');
 
-      registry.dispose();
-
-      expect(mockState.dispose).toHaveBeenCalledTimes(1);
-    });
-
-    it('should clear all states map', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(registry.getMetrics()).not.toEqual({});
-
-      registry.dispose();
-
-      expect(registry.getMetrics()).toEqual({});
-    });
-
-    it('should remove all event listeners', async () => {
-      mockState.executeWithRetry.mockResolvedValue('result');
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const listener = vi.fn();
-      registry.on('request:started', listener);
-      registry.on('request:completed', listener);
-
-      const callFn = vi.fn();
-      await registry.execute(mockProvider, callFn);
-
-      expect(registry.listenerCount('request:started')).toBe(1);
-      expect(registry.listenerCount('request:completed')).toBe(1);
-
-      registry.dispose();
-
-      expect(registry.listenerCount('request:started')).toBe(0);
-      expect(registry.listenerCount('request:completed')).toBe(0);
-    });
-
-    it('should dispose multiple states', async () => {
-      const provider1 = { id: () => 'provider-1', config: {} } as ApiProvider;
-      const provider2 = { id: () => 'provider-2', config: {} } as ApiProvider;
-
-      mockGetRateLimitKey.mockReturnValueOnce('provider-1').mockReturnValueOnce('provider-2');
-
-      const state1 = new EventEmitter() as any;
-      state1.executeWithRetry = vi.fn().mockResolvedValue('result');
-      state1.getMetrics = vi.fn().mockReturnValue({ queueDepth: 0 });
-      state1.dispose = vi.fn();
-
-      const state2 = new EventEmitter() as any;
-      state2.executeWithRetry = vi.fn().mockResolvedValue('result');
-      state2.getMetrics = vi.fn().mockReturnValue({ queueDepth: 0 });
-      state2.dispose = vi.fn();
-
-      mockStateQueue.push(state1, state2);
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn();
-      await registry.execute(provider1, callFn);
-      await registry.execute(provider2, callFn);
-
-      registry.dispose();
-
-      expect(state1.dispose).toHaveBeenCalledTimes(1);
-      expect(state2.dispose).toHaveBeenCalledTimes(1);
-    });
+    expect(mockProviderRateLimitStateConstructor).toHaveBeenCalledTimes(2);
   });
 
-  describe('Error handling - propagates errors from callFn', () => {
-    it('should propagate errors from executeWithRetry', async () => {
-      const error = new Error('Execution failed');
-      mockState.executeWithRetry.mockRejectedValue(error);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
+  it('propagates provider execution failures', async () => {
+    defaultState.executeWithRetry.mockRejectedValue(new Error('provider failed'));
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
 
-      const callFn = vi.fn();
-      await expect(registry.execute(mockProvider, callFn)).rejects.toThrow('Execution failed');
-    });
-
-    it('should emit failed event before throwing', async () => {
-      const error = new Error('Test error');
-      mockState.executeWithRetry.mockRejectedValue(error);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const failedListener = vi.fn();
-      registry.on('request:failed', failedListener);
-
-      const callFn = vi.fn();
-
-      try {
-        await registry.execute(mockProvider, callFn);
-      } catch {
-        // Expected
-      }
-
-      expect(failedListener).toHaveBeenCalledWith({
-        rateLimitKey: 'test-provider',
-        requestId: expect.any(String),
-        error: 'Error: Test error',
-      });
-    });
-
-    it('should not emit completed event on error', async () => {
-      const error = new Error('Test error');
-      mockState.executeWithRetry.mockRejectedValue(error);
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const completedListener = vi.fn();
-      registry.on('request:completed', completedListener);
-
-      const callFn = vi.fn();
-
-      try {
-        await registry.execute(mockProvider, callFn);
-      } catch {
-        // Expected
-      }
-
-      expect(completedListener).not.toHaveBeenCalled();
-    });
+    await expect(registry.execute(provider, vi.fn())).rejects.toThrow('provider failed');
   });
 
-  describe('Multi-provider isolation - providers do not interfere', () => {
-    it('should isolate execution between different providers', async () => {
-      const provider1 = { id: () => 'provider-1', config: {} } as ApiProvider;
-      const provider2 = { id: () => 'provider-2', config: {} } as ApiProvider;
+  it('disposes every provider state', async () => {
+    const first = { executeWithRetry: vi.fn().mockResolvedValue('first'), dispose: vi.fn() };
+    const second = { executeWithRetry: vi.fn().mockResolvedValue('second'), dispose: vi.fn() };
+    queuedStates.push(first, second);
+    mockGetRateLimitKey.mockReturnValueOnce('first').mockReturnValueOnce('second');
+    const registry = new RateLimitRegistry({ maxConcurrency: 10 });
 
-      mockGetRateLimitKey
-        .mockReturnValueOnce('provider-1')
-        .mockReturnValueOnce('provider-2')
-        .mockReturnValueOnce('provider-1')
-        .mockReturnValueOnce('provider-2');
+    await registry.execute(provider, vi.fn());
+    await registry.execute(provider, vi.fn());
+    registry.dispose();
 
-      const state1 = new EventEmitter() as any;
-      state1.executeWithRetry = vi.fn().mockResolvedValue('result1');
-      state1.getMetrics = vi.fn().mockReturnValue({ queueDepth: 0 });
-      state1.dispose = vi.fn();
-
-      const state2 = new EventEmitter() as any;
-      state2.executeWithRetry = vi.fn().mockResolvedValue('result2');
-      state2.getMetrics = vi.fn().mockReturnValue({ queueDepth: 0 });
-      state2.dispose = vi.fn();
-
-      mockStateQueue.push(state1, state2);
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn1 = vi.fn();
-      const callFn2 = vi.fn();
-
-      await registry.execute(provider1, callFn1);
-      await registry.execute(provider2, callFn2);
-      await registry.execute(provider1, callFn1);
-      await registry.execute(provider2, callFn2);
-
-      // Each state should be called twice
-      expect(state1.executeWithRetry).toHaveBeenCalledTimes(2);
-      expect(state2.executeWithRetry).toHaveBeenCalledTimes(2);
-    });
-
-    it('should handle errors in one provider without affecting others', async () => {
-      const provider1 = { id: () => 'provider-1', config: {} } as ApiProvider;
-      const provider2 = { id: () => 'provider-2', config: {} } as ApiProvider;
-
-      mockGetRateLimitKey
-        .mockReturnValueOnce('provider-1')
-        .mockReturnValueOnce('provider-2')
-        .mockReturnValueOnce('provider-1');
-
-      const state1 = new EventEmitter() as any;
-      state1.executeWithRetry = vi.fn().mockRejectedValue(new Error('Provider 1 error'));
-      state1.getMetrics = vi.fn().mockReturnValue({ queueDepth: 0 });
-      state1.dispose = vi.fn();
-
-      const state2 = new EventEmitter() as any;
-      state2.executeWithRetry = vi.fn().mockResolvedValue('result2');
-      state2.getMetrics = vi.fn().mockReturnValue({ queueDepth: 0 });
-      state2.dispose = vi.fn();
-
-      mockStateQueue.push(state1, state2);
-
-      const registry = new RateLimitRegistry({ maxConcurrency: 10 });
-
-      const callFn = vi.fn();
-
-      // Provider 1 fails
-      await expect(registry.execute(provider1, callFn)).rejects.toThrow('Provider 1 error');
-
-      // Provider 2 succeeds
-      const result2 = await registry.execute(provider2, callFn);
-      expect(result2).toBe('result2');
-
-      // Provider 1 still fails
-      await expect(registry.execute(provider1, callFn)).rejects.toThrow('Provider 1 error');
-    });
+    expect(first.dispose).toHaveBeenCalledOnce();
+    expect(second.dispose).toHaveBeenCalledOnce();
   });
 });

--- a/test/scheduler/slotQueue.test.ts
+++ b/test/scheduler/slotQueue.test.ts
@@ -128,45 +128,6 @@ describe('SlotQueue', () => {
       expect(queue.getActiveCount()).toBe(3);
       expect(queue.getQueueDepth()).toBe(0);
     });
-
-    it('should call onSlotAcquired callback with queue depth', async () => {
-      const onSlotAcquired = vi.fn();
-      queue = new SlotQueue({
-        maxConcurrency: 2,
-        minConcurrency: 1,
-        onSlotAcquired,
-      });
-
-      await queue.acquire('test-1');
-      expect(onSlotAcquired).toHaveBeenCalledWith(0);
-
-      await queue.acquire('test-2');
-      expect(onSlotAcquired).toHaveBeenCalledWith(0); // No queue yet
-
-      trackAcquire(queue.acquire('test-3')); // This will queue
-      queue.release(); // Process queued request
-
-      await vi.runAllTimersAsync();
-      expect(onSlotAcquired).toHaveBeenCalledWith(0); // Queue depth after test-3 was dequeued
-    });
-
-    it('should call onSlotReleased callback with queue depth', async () => {
-      const onSlotReleased = vi.fn();
-      queue = new SlotQueue({
-        maxConcurrency: 1,
-        minConcurrency: 1,
-        onSlotReleased,
-      });
-
-      await queue.acquire('test-1');
-      trackAcquire(queue.acquire('test-2')); // Queue this
-      trackAcquire(queue.acquire('test-3')); // Queue this too
-      expect(queue.getQueueDepth()).toBe(2);
-
-      queue.release();
-      // Callback is called with queue depth BEFORE processing
-      expect(onSlotReleased).toHaveBeenCalledWith(2);
-    });
   });
 
   describe('acquire - concurrent requests respect maxConcurrency', () => {


### PR DESCRIPTION
Remove unused scheduler metrics and event plumbing while retaining rate-limit and concurrency diagnostics.