### PR TITLE
refactor(webui): replace react query with shared health polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18376,34 +18376,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.99.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
-      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.99.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
-      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.99.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
     "node_modules/@tanstack/react-table": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
@@ -45203,7 +45175,6 @@
         "@storybook/addon-docs": "^10.4.0",
         "@storybook/react-vite": "^10.4.0",
         "@tailwindcss/postcss": "^4.2.2",
-        "@tanstack/react-query": "^5.91.0",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/table-core": "^8.21.3",
         "@testing-library/dom": "^10.4.1",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -28,7 +28,6 @@
     "@storybook/addon-docs": "^10.4.0",
     "@storybook/react-vite": "^10.4.0",
     "@tailwindcss/postcss": "^4.2.2",
-    "@tanstack/react-query": "^5.91.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/table-core": "^8.21.3",
     "@testing-library/dom": "^10.4.1",

--- a/src/app/src/App.tsx
+++ b/src/app/src/App.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   createBrowserRouter,
   createRoutesFromElements,
@@ -128,16 +127,12 @@ const router = createBrowserRouter(
   { basename },
 );
 
-const queryClient = new QueryClient();
-
 function App() {
   return (
     <TooltipProvider delayDuration={300} skipDelayDuration={0}>
       <ToastProvider>
         <EvalHistoryProvider>
-          <QueryClientProvider client={queryClient}>
-            <RouterProvider router={router} />
-          </QueryClientProvider>
+          <RouterProvider router={router} />
         </EvalHistoryProvider>
       </ToastProvider>
     </TooltipProvider>

--- a/src/app/src/components/ApiSettingsModal.test.tsx
+++ b/src/app/src/components/ApiSettingsModal.test.tsx
@@ -1,11 +1,10 @@
-import { type ApiHealthResult, useApiHealth } from '@app/hooks/useApiHealth';
+import { type ApiHealthQueryResult, useApiHealth } from '@app/hooks/useApiHealth';
 import useApiConfig from '@app/stores/apiConfig';
 import { renderWithProviders } from '@app/utils/testutils';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ApiSettingsModal from './ApiSettingsModal';
-import type { DefinedUseQueryResult } from '@tanstack/react-query';
 
 vi.mock('@app/hooks/useApiHealth', () => ({
   useApiHealth: vi.fn(),
@@ -28,7 +27,7 @@ describe('ApiSettingsModal', () => {
       data: { status: 'unknown', message: '' },
       refetch: mockCheckHealth,
       isLoading: false,
-    } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+    } as unknown as ApiHealthQueryResult);
 
     vi.mocked(useApiConfig).mockReturnValue({
       apiBaseUrl: 'https://api.example.com',
@@ -78,7 +77,7 @@ describe('ApiSettingsModal', () => {
       data: { status: 'loading', message: '' },
       refetch: mockCheckHealth,
       isLoading: true,
-    } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+    } as unknown as ApiHealthQueryResult);
 
     renderWithProviders(<ApiSettingsModal open={true} onClose={mockOnClose} />);
     expect(screen.getByText('Checking connection...')).toBeInTheDocument();
@@ -89,7 +88,7 @@ describe('ApiSettingsModal', () => {
       data: { status: 'connected', message: 'Cloud API is healthy' },
       refetch: mockCheckHealth,
       isLoading: false,
-    } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+    } as unknown as ApiHealthQueryResult);
 
     renderWithProviders(<ApiSettingsModal open={true} onClose={mockOnClose} />);
     expect(screen.getByText('Connected to promptfoo API')).toBeInTheDocument();
@@ -101,7 +100,7 @@ describe('ApiSettingsModal', () => {
       data: { status: 'blocked', message: 'Failed to connect' },
       refetch: mockCheckHealth,
       isLoading: false,
-    } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+    } as unknown as ApiHealthQueryResult);
 
     renderWithProviders(<ApiSettingsModal open={true} onClose={mockOnClose} />);
     expect(screen.getByText('Cannot connect to promptfoo API')).toBeInTheDocument();
@@ -113,7 +112,7 @@ describe('ApiSettingsModal', () => {
       data: { status: 'disabled', message: 'Remote generation is disabled' },
       refetch: mockCheckHealth,
       isLoading: false,
-    } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+    } as unknown as ApiHealthQueryResult);
 
     renderWithProviders(<ApiSettingsModal open={true} onClose={mockOnClose} />);
     const elements = screen.getAllByText('Remote generation is disabled');
@@ -145,7 +144,7 @@ describe('ApiSettingsModal', () => {
       data: { status: 'loading', message: '' },
       refetch: mockCheckHealth,
       isLoading: true,
-    } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+    } as unknown as ApiHealthQueryResult);
 
     renderWithProviders(<ApiSettingsModal open={true} onClose={mockOnClose} />);
 

--- a/src/app/src/components/ApiSettingsModal.test.tsx
+++ b/src/app/src/components/ApiSettingsModal.test.tsx
@@ -74,7 +74,7 @@ describe('ApiSettingsModal', () => {
 
   it('shows loading state during health check', () => {
     vi.mocked(useApiHealth).mockReturnValue({
-      data: { status: 'loading', message: '' },
+      data: { status: 'unknown', message: '' },
       refetch: mockCheckHealth,
       isLoading: true,
     } as unknown as ApiHealthQueryResult);
@@ -139,21 +139,27 @@ describe('ApiSettingsModal', () => {
     });
   });
 
-  it('disables form controls during health check', () => {
+  it('keeps API settings editable while a health check is pending', async () => {
+    const user = userEvent.setup();
+    mockCheckHealth.mockReturnValueOnce(new Promise(() => {}));
     vi.mocked(useApiHealth).mockReturnValue({
-      data: { status: 'loading', message: '' },
+      data: { status: 'connected', message: '' },
       refetch: mockCheckHealth,
       isLoading: true,
     } as unknown as ApiHealthQueryResult);
 
     renderWithProviders(<ApiSettingsModal open={true} onClose={mockOnClose} />);
 
-    expect(screen.getByLabelText('API Base URL')).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
-    // Find the Close button in the footer (not the dialog X button)
+    const input = screen.getByLabelText('API Base URL');
+    expect(input).toBeEnabled();
+    await user.clear(input);
+    await user.type(input, 'https://working.example.com');
+    expect(input).toHaveValue('https://working.example.com');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    expect(screen.getByLabelText('Check connection')).toBeDisabled();
     const closeButtons = screen.getAllByRole('button', { name: 'Close' });
     const footerCloseButton = closeButtons.find((btn) => btn.textContent === 'Close');
-    expect(footerCloseButton).toBeDisabled();
+    expect(footerCloseButton).toBeEnabled();
   });
 
   it('shows refresh button and handles click', async () => {

--- a/src/app/src/components/ApiSettingsModal.tsx
+++ b/src/app/src/components/ApiSettingsModal.tsx
@@ -88,8 +88,6 @@ export default function ApiSettingsModal<T extends { open: boolean; onClose: () 
     }
   };
 
-  const isFormDisabled = isChecking || isSaving;
-
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent className="max-w-sm">
@@ -138,7 +136,7 @@ export default function ApiSettingsModal<T extends { open: boolean; onClose: () 
                 id="api-base-url"
                 value={tempApiBaseUrl}
                 onChange={handleApiBaseUrlChange}
-                disabled={isFormDisabled}
+                disabled={isSaving}
                 placeholder="Enter API base URL"
               />
               <p className="text-xs text-muted-foreground">
@@ -149,10 +147,10 @@ export default function ApiSettingsModal<T extends { open: boolean; onClose: () 
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={isFormDisabled}>
+          <Button variant="outline" onClick={onClose} disabled={isSaving}>
             Close
           </Button>
-          <Button onClick={handleSave} disabled={isFormDisabled}>
+          <Button onClick={handleSave} disabled={isSaving}>
             {isSaving && <Spinner size="sm" className="mr-2" />}
             Save
           </Button>

--- a/src/app/src/components/Navigation.test.tsx
+++ b/src/app/src/components/Navigation.test.tsx
@@ -1,7 +1,6 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
 import { MODEL_AUDIT_ROUTES, REDTEAM_ROUTES, ROUTES } from '@app/constants/routes';
 import { mockMatchMedia, restoreBrowserMocks } from '@app/tests/browserMocks';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -12,34 +11,16 @@ const LEGACY_MODEL_AUDIT_HISTORY_ROUTE = `${MODEL_AUDIT_ROUTES.ROOT}/history`;
 
 // Helper function to render Navigation with all required providers
 const renderNavigation = (routerProps: { initialEntries?: string[] } = {}) => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
   return render(
     <TooltipProvider delayDuration={0}>
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter {...routerProps}>
-          <Navigation />
-        </MemoryRouter>
-      </QueryClientProvider>
+      <MemoryRouter {...routerProps}>
+        <Navigation />
+      </MemoryRouter>
     </TooltipProvider>,
   );
 };
 
 const renderWithModal = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
   const Modal = () => (
     <div
       data-testid="modal"
@@ -59,12 +40,10 @@ const renderWithModal = () => {
 
   return render(
     <TooltipProvider delayDuration={0}>
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <Navigation />
-          <Modal />
-        </MemoryRouter>
-      </QueryClientProvider>
+      <MemoryRouter>
+        <Navigation />
+        <Modal />
+      </MemoryRouter>
     </TooltipProvider>,
   );
 };

--- a/src/app/src/hooks/useApiHealth.test.tsx
+++ b/src/app/src/hooks/useApiHealth.test.tsx
@@ -5,12 +5,14 @@ import {
   rejectCallApi,
   resetCallApiMock,
 } from '@app/tests/apiMocks';
+import { getApiBaseUrl } from '@app/utils/api';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useApiHealth, useApiHealthStore } from './useApiHealth';
+import { type ApiHealthResult, useApiHealth, useApiHealthStore } from './useApiHealth';
 
 vi.mock('@app/utils/api', () => ({
   callApi: vi.fn(),
+  getApiBaseUrl: vi.fn(() => 'https://old.example.com'),
   fetchUserEmail: vi.fn(() => Promise.resolve('test@example.com')),
   fetchUserId: vi.fn(() => Promise.resolve('test-user-id')),
   updateEvalAuthor: vi.fn(() => Promise.resolve({})),
@@ -19,6 +21,7 @@ vi.mock('@app/utils/api', () => ({
 describe('useApiHealth', () => {
   beforeEach(() => {
     resetCallApiMock();
+    vi.mocked(getApiBaseUrl).mockReturnValue('https://old.example.com');
     useApiHealthStore.setState({
       data: { status: 'unknown', message: '' },
       isLoading: false,
@@ -27,6 +30,7 @@ describe('useApiHealth', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     vi.resetAllMocks();
   });
 
@@ -145,6 +149,125 @@ describe('useApiHealth', () => {
     });
 
     expect(getCallApiMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps background polling from showing a loading state', async () => {
+    vi.useFakeTimers();
+    let resolveRequest!: (response: Response) => void;
+    getCallApiMock().mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useApiHealth());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      resolveRequest(createMockResponse({ status: 'OK', message: 'Connected' }));
+      await Promise.resolve();
+    });
+
+    expect(result.current.data.status).toBe('connected');
+  });
+
+  it('pauses hidden-tab polling and refreshes when the page becomes visible', async () => {
+    vi.useFakeTimers();
+    let visibility: DocumentVisibilityState = 'hidden';
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibility);
+    mockCallApiResponse({ status: 'OK', message: 'Connected' });
+
+    renderHook(() => useApiHealth());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(getCallApiMock()).not.toHaveBeenCalled();
+
+    visibility = 'visible';
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await Promise.resolve();
+    });
+
+    expect(getCallApiMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes immediately when the connection comes back online', async () => {
+    mockCallApiResponse({ status: 'OK', message: 'Connected' });
+    renderHook(() => useApiHealth());
+
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+      await Promise.resolve();
+    });
+
+    expect(getCallApiMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks a newly configured API even when the previous request is still pending', async () => {
+    let resolveOldRequest!: (response: Response) => void;
+    getCallApiMock()
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveOldRequest = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(createMockResponse({ status: 'OK', message: 'New API connected' }));
+
+    const { result } = renderHook(() => useApiHealth());
+    let oldRequest!: Promise<ApiHealthResult>;
+
+    act(() => {
+      oldRequest = result.current.refetch();
+    });
+
+    vi.mocked(getApiBaseUrl).mockReturnValue('https://new.example.com');
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(getCallApiMock()).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toEqual({ status: 'connected', message: 'New API connected' });
+
+    await act(async () => {
+      resolveOldRequest(createMockResponse({ status: 'ERROR', message: 'Old API failed' }));
+      await oldRequest;
+    });
+
+    expect(result.current.data).toEqual({ status: 'connected', message: 'New API connected' });
+  });
+
+  it('refreshes stale cached health as soon as a subscriber remounts', async () => {
+    vi.useFakeTimers();
+    mockCallApiResponse({ status: 'OK', message: 'Connected' });
+
+    const first = renderHook(() => useApiHealth());
+
+    await act(async () => {
+      await first.result.current.refetch();
+    });
+
+    first.unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2001);
+    });
+
+    await act(async () => {
+      renderHook(() => useApiHealth());
+      await Promise.resolve();
+    });
+
+    expect(getCallApiMock()).toHaveBeenCalledTimes(2);
   });
 
   it('updates the status when a later response changes', async () => {

--- a/src/app/src/hooks/useApiHealth.test.tsx
+++ b/src/app/src/hooks/useApiHealth.test.tsx
@@ -5,6 +5,7 @@ import {
   rejectCallApi,
   resetCallApiMock,
 } from '@app/tests/apiMocks';
+import { restoreTestTimers, useTestTimers } from '@app/tests/timers';
 import { getApiBaseUrl } from '@app/utils/api';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -29,7 +30,7 @@ describe('useApiHealth', () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
+    restoreTestTimers();
     vi.restoreAllMocks();
     vi.resetAllMocks();
   });
@@ -129,14 +130,14 @@ describe('useApiHealth', () => {
   });
 
   it('uses one shared polling interval and stops polling after unmount', async () => {
-    vi.useFakeTimers();
+    const timers = useTestTimers();
     mockCallApiResponse({ status: 'OK', message: 'Connected' });
 
     const first = renderHook(() => useApiHealth());
     const second = renderHook(() => useApiHealth());
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await timers.advanceByAsync(3000);
     });
 
     expect(getCallApiMock()).toHaveBeenCalledTimes(1);
@@ -145,14 +146,14 @@ describe('useApiHealth', () => {
     second.unmount();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await timers.advanceByAsync(3000);
     });
 
     expect(getCallApiMock()).toHaveBeenCalledTimes(1);
   });
 
   it('keeps background polling from showing a loading state', async () => {
-    vi.useFakeTimers();
+    const timers = useTestTimers();
     let resolveRequest!: (response: Response) => void;
     getCallApiMock().mockReturnValue(
       new Promise<Response>((resolve) => {
@@ -163,7 +164,7 @@ describe('useApiHealth', () => {
     const { result } = renderHook(() => useApiHealth());
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await timers.advanceByAsync(3000);
     });
 
     expect(result.current.isLoading).toBe(false);
@@ -177,7 +178,7 @@ describe('useApiHealth', () => {
   });
 
   it('pauses hidden-tab polling and refreshes when the page becomes visible', async () => {
-    vi.useFakeTimers();
+    const timers = useTestTimers();
     let visibility: DocumentVisibilityState = 'hidden';
     vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibility);
     mockCallApiResponse({ status: 'OK', message: 'Connected' });
@@ -185,7 +186,7 @@ describe('useApiHealth', () => {
     renderHook(() => useApiHealth());
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(3000);
+      await timers.advanceByAsync(3000);
     });
 
     expect(getCallApiMock()).not.toHaveBeenCalled();
@@ -247,7 +248,7 @@ describe('useApiHealth', () => {
   });
 
   it('refreshes stale cached health as soon as a subscriber remounts', async () => {
-    vi.useFakeTimers();
+    const timers = useTestTimers();
     mockCallApiResponse({ status: 'OK', message: 'Connected' });
 
     const first = renderHook(() => useApiHealth());
@@ -259,7 +260,7 @@ describe('useApiHealth', () => {
     first.unmount();
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2001);
+      await timers.advanceByAsync(2001);
     });
 
     await act(async () => {

--- a/src/app/src/hooks/useApiHealth.test.tsx
+++ b/src/app/src/hooks/useApiHealth.test.tsx
@@ -201,9 +201,19 @@ describe('useApiHealth', () => {
     expect(getCallApiMock()).toHaveBeenCalledTimes(1);
   });
 
-  it('refreshes immediately when the connection comes back online', async () => {
+  it('pauses offline polling and refreshes when the connection comes back', async () => {
+    const timers = useTestTimers();
+    let isOnline = false;
+    vi.spyOn(navigator, 'onLine', 'get').mockImplementation(() => isOnline);
     mockCallApiResponse({ status: 'OK', message: 'Connected' });
     renderHook(() => useApiHealth());
+
+    await act(async () => {
+      await timers.advanceByAsync(3000);
+    });
+
+    expect(getCallApiMock()).not.toHaveBeenCalled();
+    isOnline = true;
 
     await act(async () => {
       window.dispatchEvent(new Event('online'));

--- a/src/app/src/hooks/useApiHealth.test.tsx
+++ b/src/app/src/hooks/useApiHealth.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   createMockResponse,
   getCallApiMock,
@@ -7,12 +5,10 @@ import {
   rejectCallApi,
   resetCallApiMock,
 } from '@app/tests/apiMocks';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useApiHealth } from './useApiHealth';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useApiHealth, useApiHealthStore } from './useApiHealth';
 
-// Mock the API call
 vi.mock('@app/utils/api', () => ({
   callApi: vi.fn(),
   fetchUserEmail: vi.fn(() => Promise.resolve('test@example.com')),
@@ -21,161 +17,150 @@ vi.mock('@app/utils/api', () => ({
 }));
 
 describe('useApiHealth', () => {
-  let queryClient: QueryClient;
-
   beforeEach(() => {
     resetCallApiMock();
-    queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          retry: false,
-          gcTime: 0,
-          refetchInterval: false, // Disable auto-refetch for tests
-        },
-      },
+    useApiHealthStore.setState({
+      data: { status: 'unknown', message: '' },
+      isLoading: false,
     });
   });
 
-  const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  );
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetAllMocks();
+  });
 
   it('initializes with unknown status', () => {
-    const { result } = renderHook(() => useApiHealth(), { wrapper });
-    expect(result.current.data.status).toBe('unknown');
-    expect(result.current.data.message).toBe('');
+    const { result } = renderHook(() => useApiHealth());
+
+    expect(result.current.data).toEqual({ status: 'unknown', message: '' });
     expect(result.current.isLoading).toBe(false);
   });
 
-  it('handles successful health check', async () => {
-    mockCallApiResponse({ status: 'OK', message: 'Cloud API is healthy' });
+  it.each([
+    ['OK', 'connected'],
+    ['ERROR', 'blocked'],
+    ['DISABLED', 'disabled'],
+  ] as const)('maps %s responses to %s', async (responseStatus, expectedStatus) => {
+    mockCallApiResponse({ status: responseStatus, message: 'Health check result' });
 
-    const { result } = renderHook(() => useApiHealth(), { wrapper });
+    const { result } = renderHook(() => useApiHealth());
 
-    // Trigger a refetch since initialData prevents automatic fetching
-    result.current.refetch();
-
-    await waitFor(() => {
-      expect(result.current.data.status).toBe('connected');
+    await act(async () => {
+      await result.current.refetch();
     });
 
-    expect(result.current.data.message).toBe('Cloud API is healthy');
-    expect(result.current.isLoading).toBe(false);
-  });
-
-  it('handles failed health check', async () => {
-    mockCallApiResponse({ status: 'ERROR', message: 'API is not accessible' });
-
-    const { result } = renderHook(() => useApiHealth(), { wrapper });
-
-    // Trigger a refetch since initialData prevents automatic fetching
-    result.current.refetch();
-
-    await waitFor(() => {
-      expect(result.current.data.status).toBe('blocked');
+    expect(result.current.data).toEqual({
+      status: expectedStatus,
+      message: 'Health check result',
     });
-
-    expect(result.current.data.message).toBe('API is not accessible');
     expect(result.current.isLoading).toBe(false);
   });
 
-  it('handles network errors', async () => {
+  it('reports network failures without throwing', async () => {
     rejectCallApi(new Error('Network error'));
 
-    const { result } = renderHook(() => useApiHealth(), { wrapper });
+    const { result } = renderHook(() => useApiHealth());
 
-    // Trigger a refetch since initialData prevents automatic fetching
-    result.current.refetch();
-
-    await waitFor(() => {
-      expect(result.current.data.status).toBe('blocked');
+    await act(async () => {
+      await result.current.refetch();
     });
 
-    expect(result.current.data.message).toBe('Network error: Unable to check API health');
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toEqual({
+      status: 'blocked',
+      message: 'Network error: Unable to check API health',
+    });
   });
 
-  it('handles disabled status from API', async () => {
-    mockCallApiResponse({ status: 'DISABLED', message: 'Remote generation is disabled' });
+  it('updates the loading state while a request is pending', async () => {
+    let resolveRequest!: (response: Response) => void;
+    getCallApiMock().mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
 
-    const { result } = renderHook(() => useApiHealth(), { wrapper });
+    const { result } = renderHook(() => useApiHealth());
+    let request!: Promise<unknown>;
 
-    // Trigger a refetch since initialData prevents automatic fetching
-    result.current.refetch();
-
-    await waitFor(() => {
-      expect(result.current.data.status).toBe('disabled');
+    act(() => {
+      request = result.current.refetch();
     });
 
-    expect(result.current.data.message).toBe('Remote generation is disabled');
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      resolveRequest(createMockResponse({ status: 'OK', message: 'Connected' }));
+      await request;
+    });
+
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.data.status).toBe('connected');
   });
 
-  it('updates status when API response changes', async () => {
-    // First call succeeds
+  it('shares an in-flight request across consumers', async () => {
+    let resolveRequest!: (response: Response) => void;
+    getCallApiMock().mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveRequest = resolve;
+      }),
+    );
+
+    const first = renderHook(() => useApiHealth());
+    const second = renderHook(() => useApiHealth());
+
+    await act(async () => {
+      const firstRequest = first.result.current.refetch();
+      const secondRequest = second.result.current.refetch();
+
+      expect(firstRequest).toBe(secondRequest);
+      expect(getCallApiMock()).toHaveBeenCalledTimes(1);
+
+      resolveRequest(createMockResponse({ status: 'OK', message: 'Connected' }));
+      await Promise.all([firstRequest, secondRequest]);
+    });
+
+    expect(first.result.current.data.status).toBe('connected');
+    expect(second.result.current.data.status).toBe('connected');
+  });
+
+  it('uses one shared polling interval and stops polling after unmount', async () => {
+    vi.useFakeTimers();
+    mockCallApiResponse({ status: 'OK', message: 'Connected' });
+
+    const first = renderHook(() => useApiHealth());
+    const second = renderHook(() => useApiHealth());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(getCallApiMock()).toHaveBeenCalledTimes(1);
+
+    first.unmount();
+    second.unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    expect(getCallApiMock()).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates the status when a later response changes', async () => {
     getCallApiMock()
-      .mockResolvedValueOnce(createMockResponse({ status: 'OK', message: 'Cloud API is healthy' }))
-      .mockResolvedValueOnce(
-        createMockResponse({ status: 'ERROR', message: 'API is not accessible' }),
-      );
+      .mockResolvedValueOnce(createMockResponse({ status: 'OK', message: 'Connected' }))
+      .mockResolvedValueOnce(createMockResponse({ status: 'ERROR', message: 'Unavailable' }));
 
-    const { result } = renderHook(() => useApiHealth(), { wrapper });
+    const { result } = renderHook(() => useApiHealth());
 
-    // Trigger initial refetch
-    result.current.refetch();
+    await act(async () => {
+      await result.current.refetch();
+      await result.current.refetch();
+    });
 
     await waitFor(() => {
-      expect(result.current.data.status).toBe('connected');
-    });
-
-    await result.current.refetch();
-
-    await waitFor(() => {
-      expect(result.current.data.status).toBe('blocked');
-    });
-  });
-
-  it('shows loading state transitions correctly', async () => {
-    // Start with a slow response
-    let resolvePromise: (value: Response) => void;
-    const slowPromise = new Promise<Response>((resolve) => {
-      resolvePromise = resolve;
-    });
-
-    getCallApiMock().mockReturnValue(slowPromise);
-
-    const { result } = renderHook(() => useApiHealth(), { wrapper });
-
-    // Initial state should be unknown and not loading
-    expect(result.current.data.status).toBe('unknown');
-    expect(result.current.isLoading).toBe(false);
-
-    // Trigger refetch - this starts the loading state
-    const refetchPromise = result.current.refetch();
-
-    // Immediately check if loading (synchronously, right after calling refetch)
-    // Note: Due to React Query's internal batching, isLoading might not be true yet
-    // So we wait for it to become true
-    await waitFor(
-      () => {
-        expect(result.current.isLoading).toBe(true);
-      },
-      { timeout: 100 },
-    ).catch(() => {
-      // If we can't catch the loading state, that's okay - it may be too fast
-      // The important thing is that the query eventually completes
-    });
-
-    // Resolve the promise
-    resolvePromise!(createMockResponse({ status: 'OK', message: 'test' }));
-
-    // Wait for the refetch to complete
-    await refetchPromise;
-
-    // Wait for the state to update after the promise resolves
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.data.status).toBe('connected');
+      expect(result.current.data).toEqual({ status: 'blocked', message: 'Unavailable' });
     });
   });
 });

--- a/src/app/src/hooks/useApiHealth.tsx
+++ b/src/app/src/hooks/useApiHealth.tsx
@@ -1,45 +1,82 @@
+import { useEffect } from 'react';
+
 import { callApi } from '@app/utils/api';
-import { useQuery } from '@tanstack/react-query';
+import { create } from 'zustand';
 
 export type ApiHealthStatus = 'unknown' | 'connected' | 'blocked' | 'disabled';
 
-interface HealthResponse {
-  status: string;
+export interface ApiHealthResult {
+  status: ApiHealthStatus;
   message: string;
 }
 
-export type ApiHealthResult = {
-  status: ApiHealthStatus;
-  message: string;
-};
+export interface ApiHealthQueryResult {
+  data: ApiHealthResult;
+  isLoading: boolean;
+  refetch: () => Promise<ApiHealthResult>;
+}
 
-/**
- * Checks the health of the connection to Promptfoo Cloud.
- */
-export function useApiHealth() {
-  return useQuery<ApiHealthResult, Error>({
-    queryKey: ['apiHealth'],
-    queryFn: async () => {
-      try {
-        const response = await callApi('/remote-health', { cache: 'no-store' });
-        const { status, message } = (await response.json()) as HealthResponse;
-        return {
+let pendingRequest: Promise<ApiHealthResult> | undefined;
+let subscriberCount = 0;
+let pollingInterval: ReturnType<typeof setInterval> | undefined;
+
+export const useApiHealthStore = create<ApiHealthQueryResult>((set) => ({
+  data: { status: 'unknown', message: '' },
+  isLoading: false,
+  refetch: () => {
+    if (pendingRequest !== undefined) {
+      return pendingRequest;
+    }
+
+    set({ isLoading: true });
+    pendingRequest = callApi('/remote-health', { cache: 'no-store' })
+      .then((response) => response.json())
+      .then(
+        ({ status, message }: { status: string; message: string }): ApiHealthResult => ({
           status: status === 'DISABLED' ? 'disabled' : status === 'OK' ? 'connected' : 'blocked',
           message,
-        };
-      } catch {
-        return {
+        }),
+      )
+      .catch(
+        (): ApiHealthResult => ({
           status: 'blocked',
           message: 'Network error: Unable to check API health',
-        };
+        }),
+      )
+      .then((data) => {
+        set({ data });
+        return data;
+      })
+      .finally(() => {
+        pendingRequest = undefined;
+        set({ isLoading: false });
+      });
+
+    return pendingRequest;
+  },
+}));
+
+export function useApiHealth(): ApiHealthQueryResult {
+  const { data, isLoading, refetch } = useApiHealthStore();
+
+  useEffect(() => {
+    subscriberCount++;
+
+    if (subscriberCount === 1) {
+      pollingInterval = setInterval(() => {
+        void refetch();
+      }, 3000);
+    }
+
+    return () => {
+      subscriberCount--;
+
+      if (subscriberCount === 0) {
+        clearInterval(pollingInterval);
+        pollingInterval = undefined;
       }
-    },
-    refetchInterval: 3000, // Poll every 3 seconds
-    retry: false, // Failed queries will not be retried until the next poll
-    staleTime: 2000, // Data is fresh for 2 seconds
-    initialData: {
-      status: 'unknown',
-      message: '',
-    },
-  });
+    };
+  }, [refetch]);
+
+  return { data, isLoading, refetch };
 }

--- a/src/app/src/hooks/useApiHealth.tsx
+++ b/src/app/src/hooks/useApiHealth.tsx
@@ -70,7 +70,7 @@ function refreshHealth(background = false): Promise<ApiHealthResult> {
 }
 
 function refreshVisiblePage(): void {
-  if (document.visibilityState !== 'hidden') {
+  if (document.visibilityState !== 'hidden' && navigator.onLine) {
     void refreshHealth(true);
   }
 }

--- a/src/app/src/hooks/useApiHealth.tsx
+++ b/src/app/src/hooks/useApiHealth.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { callApi } from '@app/utils/api';
+import { callApi, getApiBaseUrl } from '@app/utils/api';
 import { create } from 'zustand';
 
 export type ApiHealthStatus = 'unknown' | 'connected' | 'blocked' | 'disabled';
@@ -16,44 +16,69 @@ export interface ApiHealthQueryResult {
   refetch: () => Promise<ApiHealthResult>;
 }
 
-let pendingRequest: Promise<ApiHealthResult> | undefined;
+let pendingRequest:
+  | { apiBaseUrl: string; promise: Promise<ApiHealthResult>; requestId: number }
+  | undefined;
 let subscriberCount = 0;
 let pollingInterval: ReturnType<typeof setInterval> | undefined;
+let latestRequestId = 0;
+let lastUpdatedAt = 0;
 
-export const useApiHealthStore = create<ApiHealthQueryResult>((set) => ({
+function refreshHealth(background = false): Promise<ApiHealthResult> {
+  const apiBaseUrl = getApiBaseUrl();
+
+  if (pendingRequest?.apiBaseUrl === apiBaseUrl) {
+    return pendingRequest.promise;
+  }
+
+  const requestId = ++latestRequestId;
+
+  if (!background) {
+    useApiHealthStore.setState({ isLoading: true });
+  }
+
+  const promise = callApi('/remote-health', { cache: 'no-store' })
+    .then((response) => response.json())
+    .then(
+      ({ status, message }: { status: string; message: string }): ApiHealthResult => ({
+        status: status === 'DISABLED' ? 'disabled' : status === 'OK' ? 'connected' : 'blocked',
+        message,
+      }),
+    )
+    .catch(
+      (): ApiHealthResult => ({
+        status: 'blocked',
+        message: 'Network error: Unable to check API health',
+      }),
+    )
+    .then((data) => {
+      if (requestId === latestRequestId) {
+        lastUpdatedAt = Date.now();
+        useApiHealthStore.setState({ data });
+      }
+      return data;
+    })
+    .finally(() => {
+      if (pendingRequest?.requestId === requestId) {
+        pendingRequest = undefined;
+        useApiHealthStore.setState({ isLoading: false });
+      }
+    });
+
+  pendingRequest = { apiBaseUrl, promise, requestId };
+  return promise;
+}
+
+function refreshVisiblePage(): void {
+  if (document.visibilityState !== 'hidden') {
+    void refreshHealth(true);
+  }
+}
+
+export const useApiHealthStore = create<ApiHealthQueryResult>(() => ({
   data: { status: 'unknown', message: '' },
   isLoading: false,
-  refetch: () => {
-    if (pendingRequest !== undefined) {
-      return pendingRequest;
-    }
-
-    set({ isLoading: true });
-    pendingRequest = callApi('/remote-health', { cache: 'no-store' })
-      .then((response) => response.json())
-      .then(
-        ({ status, message }: { status: string; message: string }): ApiHealthResult => ({
-          status: status === 'DISABLED' ? 'disabled' : status === 'OK' ? 'connected' : 'blocked',
-          message,
-        }),
-      )
-      .catch(
-        (): ApiHealthResult => ({
-          status: 'blocked',
-          message: 'Network error: Unable to check API health',
-        }),
-      )
-      .then((data) => {
-        set({ data });
-        return data;
-      })
-      .finally(() => {
-        pendingRequest = undefined;
-        set({ isLoading: false });
-      });
-
-    return pendingRequest;
-  },
+  refetch: () => refreshHealth(),
 }));
 
 export function useApiHealth(): ApiHealthQueryResult {
@@ -63,9 +88,17 @@ export function useApiHealth(): ApiHealthQueryResult {
     subscriberCount++;
 
     if (subscriberCount === 1) {
-      pollingInterval = setInterval(() => {
-        void refetch();
-      }, 3000);
+      if (
+        useApiHealthStore.getState().data.status !== 'unknown' &&
+        Date.now() - lastUpdatedAt >= 2000
+      ) {
+        refreshVisiblePage();
+      }
+
+      pollingInterval = setInterval(refreshVisiblePage, 3000);
+      document.addEventListener('visibilitychange', refreshVisiblePage);
+      window.addEventListener('focus', refreshVisiblePage);
+      window.addEventListener('online', refreshVisiblePage);
     }
 
     return () => {
@@ -74,9 +107,12 @@ export function useApiHealth(): ApiHealthQueryResult {
       if (subscriberCount === 0) {
         clearInterval(pollingInterval);
         pollingInterval = undefined;
+        document.removeEventListener('visibilitychange', refreshVisiblePage);
+        window.removeEventListener('focus', refreshVisiblePage);
+        window.removeEventListener('online', refreshVisiblePage);
       }
     };
-  }, [refetch]);
+  }, []);
 
   return { data, isLoading, refetch };
 }

--- a/src/app/src/pages/launcher/page.test.tsx
+++ b/src/app/src/pages/launcher/page.test.tsx
@@ -1,5 +1,5 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
-import { type ApiHealthResult, useApiHealth } from '@app/hooks/useApiHealth';
+import { type ApiHealthQueryResult, useApiHealth } from '@app/hooks/useApiHealth';
 import {
   mockMatchMedia as installMatchMedia,
   mockBrowserProperty,
@@ -11,7 +11,6 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import LauncherPage from './page';
-import type { DefinedUseQueryResult } from '@tanstack/react-query';
 import type { Mock } from 'vitest';
 
 const mockFetch = vi.fn();
@@ -39,7 +38,7 @@ vi.mock('@app/hooks/useApiHealth', () => ({
     data: { status: 'unknown', message: null },
     refetch: vi.fn(),
     isLoading: false,
-  } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>),
+  } as unknown as ApiHealthQueryResult),
 }));
 
 describe('LauncherPage', () => {
@@ -161,7 +160,7 @@ describe('LauncherPage', () => {
       data: { status: 'unknown', message: null },
       refetch: checkHealthMock,
       isLoading: false,
-    } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+    } as unknown as ApiHealthQueryResult);
 
     renderLauncher();
 

--- a/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.test.tsx
@@ -8,8 +8,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { useRecentlyUsedPlugins, useRedTeamConfig } from '../hooks/useRedTeamConfig';
 import Plugins from './Plugins';
-import type { ApiHealthResult } from '@app/hooks/useApiHealth';
-import type { DefinedUseQueryResult } from '@tanstack/react-query';
+import type { ApiHealthQueryResult } from '@app/hooks/useApiHealth';
 
 vi.mock('../hooks/useRedTeamConfig', async () => {
   const actual = await vi.importActual('../hooks/useRedTeamConfig');
@@ -36,7 +35,7 @@ vi.mock('@app/hooks/useApiHealth', () => ({
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      }) as unknown as DefinedUseQueryResult<ApiHealthResult, Error>,
+      }) as unknown as ApiHealthQueryResult,
   ),
 }));
 

--- a/src/app/src/pages/redteam/setup/components/Plugins.unit.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Plugins.unit.test.tsx
@@ -8,8 +8,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { useRecentlyUsedPlugins, useRedTeamConfig } from '../hooks/useRedTeamConfig';
 import Plugins from './Plugins';
-import type { ApiHealthResult } from '@app/hooks/useApiHealth';
-import type { DefinedUseQueryResult } from '@tanstack/react-query';
+import type { ApiHealthQueryResult } from '@app/hooks/useApiHealth';
 
 import type { Config } from '../types';
 
@@ -37,7 +36,7 @@ vi.mock('@app/hooks/useApiHealth', () => ({
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      }) as unknown as DefinedUseQueryResult<ApiHealthResult, Error>,
+      }) as unknown as ApiHealthQueryResult,
   ),
 }));
 

--- a/src/app/src/pages/redteam/setup/components/PluginsTab.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/PluginsTab.test.tsx
@@ -38,8 +38,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { useRecentlyUsedPlugins, useRedTeamConfig } from '../hooks/useRedTeamConfig';
 import PluginsTab from './PluginsTab';
 import { DOMAIN_SPECIFIC_PLUGINS } from './verticalSuites';
-import type { ApiHealthResult } from '@app/hooks/useApiHealth';
-import type { DefinedUseQueryResult } from '@tanstack/react-query';
+import type { ApiHealthQueryResult } from '@app/hooks/useApiHealth';
 
 import type { LocalPluginConfig } from '../types';
 
@@ -70,7 +69,7 @@ vi.mock('@app/hooks/useApiHealth', () => ({
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      }) as unknown as DefinedUseQueryResult<ApiHealthResult, Error>,
+      }) as unknown as ApiHealthQueryResult,
   ),
 }));
 

--- a/src/app/src/pages/redteam/setup/components/Purpose.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Purpose.test.tsx
@@ -1,11 +1,10 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
-import { type ApiHealthResult, useApiHealth } from '@app/hooks/useApiHealth';
+import { type ApiHealthQueryResult, useApiHealth } from '@app/hooks/useApiHealth';
 import { callApi } from '@app/utils/api';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Purpose from './Purpose';
-import type { DefinedUseQueryResult } from '@tanstack/react-query';
 
 const mockUpdateApplicationDefinition = vi.fn();
 const mockUpdateConfig = vi.fn();
@@ -32,7 +31,7 @@ const connectedApiHealth = {
   data: { status: 'connected', message: null },
   refetch: mockCheckHealth,
   isLoading: false,
-} as unknown as DefinedUseQueryResult<ApiHealthResult, Error>;
+} as unknown as ApiHealthQueryResult;
 
 vi.mock('@app/utils/api', () => ({
   callApi: vi.fn(),
@@ -299,7 +298,7 @@ describe('Purpose Component', () => {
         data: { status: 'blocked', message: 'Network error: Unable to check API health' },
         refetch: mockCheckHealth,
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       rerender(
         <TooltipProvider>

--- a/src/app/src/pages/redteam/setup/components/Review.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.test.tsx
@@ -1,6 +1,6 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
 import { EvalHistoryProvider } from '@app/contexts/EvalHistoryContext';
-import { type ApiHealthResult, useApiHealth } from '@app/hooks/useApiHealth';
+import { type ApiHealthQueryResult, useApiHealth } from '@app/hooks/useApiHealth';
 import { useEmailVerification } from '@app/hooks/useEmailVerification';
 import { useRedteamJobStore } from '@app/stores/redteamJobStore';
 import { restoreTestTimers, type TestTimers, useTestTimers } from '@app/tests/timers';
@@ -9,7 +9,6 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Review from './Review';
-import type { DefinedUseQueryResult } from '@tanstack/react-query';
 
 // Helper to render with required providers
 let rerenderWithProviders: (ui: React.ReactElement) => void;
@@ -83,7 +82,7 @@ vi.mocked(useApiHealth).mockReturnValue({
   data: { status: 'connected', message: null },
   refetch: vi.fn(),
   isLoading: false,
-} as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+} as unknown as ApiHealthQueryResult);
 
 vi.mock('@app/pages/eval-creator/components/YamlEditor', () => ({
   default: ({ initialYaml }: { initialYaml: string }) => (
@@ -263,7 +262,7 @@ describe('Review Component', () => {
       data: { status: 'connected', message: null },
       refetch: vi.fn(),
       isLoading: false,
-    } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+    } as unknown as ApiHealthQueryResult);
 
     // Reset the job store mock
     vi.mocked(useRedteamJobStore).mockReturnValue({
@@ -564,7 +563,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -585,7 +584,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -604,7 +603,7 @@ Application Details:
         data: { status: 'blocked', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -623,7 +622,7 @@ Application Details:
         data: { status: 'disabled', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -642,7 +641,7 @@ Application Details:
         data: { status: 'unknown', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -661,7 +660,7 @@ Application Details:
         data: { status: 'loading', message: null },
         refetch: vi.fn(),
         isLoading: true,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -680,7 +679,7 @@ Application Details:
         data: { status: 'blocked', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -704,7 +703,7 @@ Application Details:
         data: { status: 'blocked', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -727,7 +726,7 @@ Application Details:
         data: { status: 'disabled', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -748,7 +747,7 @@ Application Details:
         data: { status: 'unknown', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -767,7 +766,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -788,7 +787,7 @@ Application Details:
         data: { status: 'loading', message: null },
         refetch: vi.fn(),
         isLoading: true,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -809,7 +808,7 @@ Application Details:
         data: { status: 'disabled', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -833,7 +832,7 @@ Application Details:
         data: { status: 'unknown', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -855,7 +854,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -883,7 +882,7 @@ Application Details:
         data: { status: 'loading', message: null },
         refetch: vi.fn(),
         isLoading: true,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -918,7 +917,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       // Mock successful job status check and run API calls
       vi.mocked(callApi).mockImplementation(async (url: string, _options?: any) => {
@@ -950,7 +949,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       // Mock email verification to proceed
       vi.mocked(useEmailVerification).mockReturnValue({
@@ -987,7 +986,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       // Mock email verification to proceed
       vi.mocked(useEmailVerification).mockReturnValue({
@@ -1020,7 +1019,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       // Mock email verification to proceed
       vi.mocked(useEmailVerification).mockReturnValue({
@@ -1054,7 +1053,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       // Mock email verification to proceed
       vi.mocked(useEmailVerification).mockReturnValue({
@@ -1096,7 +1095,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       // Mock email verification to proceed
       vi.mocked(useEmailVerification).mockReturnValue({
@@ -1123,7 +1122,7 @@ Application Details:
         data: { status: 'blocked', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       rerenderWithProviders(
         <Review
@@ -1150,7 +1149,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -1168,7 +1167,7 @@ Application Details:
         data: { status: 'blocked', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       rerenderWithProviders(
         <Review
@@ -1186,7 +1185,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       rerenderWithProviders(
         <Review
@@ -1205,7 +1204,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -1224,7 +1223,7 @@ Application Details:
         data: { status: 'blocked', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       rerenderWithProviders(
         <Review
@@ -1246,7 +1245,7 @@ Application Details:
         data: { status: 'disabled', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       rerenderWithProviders(
         <Review
@@ -1268,7 +1267,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       rerenderWithProviders(
         <Review
@@ -1289,7 +1288,7 @@ Application Details:
         data: { status: 'blocked', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       renderWithProviders(
         <Review
@@ -1309,7 +1308,7 @@ Application Details:
         data: { status: 'disabled', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       rerenderWithProviders(
         <Review
@@ -1327,7 +1326,7 @@ Application Details:
         data: { status: 'unknown', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
 
       rerenderWithProviders(
         <Review
@@ -1352,7 +1351,7 @@ Application Details:
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      } as unknown as DefinedUseQueryResult<ApiHealthResult, Error>);
+      } as unknown as ApiHealthQueryResult);
     });
 
     it('should check for running job on mount', async () => {

--- a/src/app/src/pages/redteam/setup/components/Review.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Review.test.tsx
@@ -657,7 +657,7 @@ Application Details:
 
     it('should enable the Run Now button when API status is loading', () => {
       vi.mocked(useApiHealth).mockReturnValue({
-        data: { status: 'loading', message: null },
+        data: { status: 'connected', message: '' },
         refetch: vi.fn(),
         isLoading: true,
       } as unknown as ApiHealthQueryResult);
@@ -784,7 +784,7 @@ Application Details:
 
     it('should not display warning alert when API is loading', () => {
       vi.mocked(useApiHealth).mockReturnValue({
-        data: { status: 'loading', message: null },
+        data: { status: 'connected', message: '' },
         refetch: vi.fn(),
         isLoading: true,
       } as unknown as ApiHealthQueryResult);
@@ -879,7 +879,7 @@ Application Details:
 
     it('should not show tooltip when API is loading', async () => {
       vi.mocked(useApiHealth).mockReturnValue({
-        data: { status: 'loading', message: null },
+        data: { status: 'connected', message: '' },
         refetch: vi.fn(),
         isLoading: true,
       } as unknown as ApiHealthQueryResult);

--- a/src/app/src/pages/redteam/setup/components/Strategies.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Strategies.test.tsx
@@ -3,7 +3,6 @@ import { useApiHealth } from '@app/hooks/useApiHealth';
 import { useTelemetry } from '@app/hooks/useTelemetry';
 import { useToast } from '@app/hooks/useToast';
 import { MULTI_MODAL_STRATEGIES } from '@promptfoo/redteam/constants';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
@@ -12,13 +11,9 @@ import { useRedTeamConfig } from '../hooks/useRedTeamConfig';
 import Strategies from './Strategies';
 
 const renderWithProviders = (ui: React.ReactElement) => {
-  const queryClient = new QueryClient();
-
   return render(
     <MemoryRouter>
-      <QueryClientProvider client={queryClient}>
-        <TooltipProvider>{ui}</TooltipProvider>
-      </QueryClientProvider>
+      <TooltipProvider>{ui}</TooltipProvider>
     </MemoryRouter>,
   );
 };

--- a/src/app/src/pages/redteam/setup/components/Targets/CustomPoliciesSection.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/CustomPoliciesSection.test.tsx
@@ -7,8 +7,7 @@ import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { useRedTeamConfig } from '../../hooks/useRedTeamConfig';
 import { TestCaseGenerationProvider } from '../TestCaseGenerationProvider';
 import { CustomPoliciesSection } from './CustomPoliciesSection';
-import type { ApiHealthResult } from '@app/hooks/useApiHealth';
-import type { DefinedUseQueryResult } from '@tanstack/react-query';
+import type { ApiHealthQueryResult } from '@app/hooks/useApiHealth';
 
 vi.mock('../../hooks/useRedTeamConfig');
 vi.mock('@app/hooks/useTelemetry', () => ({
@@ -24,7 +23,7 @@ vi.mock('@app/hooks/useApiHealth', () => ({
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      }) as unknown as DefinedUseQueryResult<ApiHealthResult, Error>,
+      }) as unknown as ApiHealthQueryResult,
   ),
 }));
 

--- a/src/app/src/pages/redteam/setup/components/TestCaseDialog.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/TestCaseDialog.test.tsx
@@ -3,8 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { TestCaseDialog, TestCaseGenerateButton } from './TestCaseDialog';
-import type { ApiHealthResult } from '@app/hooks/useApiHealth';
-import type { DefinedUseQueryResult } from '@tanstack/react-query';
+import type { ApiHealthQueryResult } from '@app/hooks/useApiHealth';
 
 // Helper to render with TooltipProvider
 const renderWithTooltipProvider = (ui: React.ReactElement) => {
@@ -21,7 +20,7 @@ vi.mock('@app/hooks/useApiHealth', () => ({
         data: { status: 'connected', message: null },
         refetch: vi.fn(),
         isLoading: false,
-      }) as unknown as DefinedUseQueryResult<ApiHealthResult, Error>,
+      }) as unknown as ApiHealthQueryResult,
   ),
 }));
 

--- a/src/app/src/pages/redteam/setup/components/strategies/StrategyItem.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/strategies/StrategyItem.test.tsx
@@ -1,5 +1,4 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -45,14 +44,6 @@ describe('StrategyItem', () => {
     description: 'Test description',
   };
 
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
   const renderStrategyItem = (props: any) => {
     const redTeamConfig = {
       description: 'Test config',
@@ -67,13 +58,11 @@ describe('StrategyItem', () => {
     };
 
     return render(
-      <QueryClientProvider client={queryClient}>
-        <TooltipProvider>
-          <TestCaseGenerationProvider redTeamConfig={redTeamConfig as any}>
-            <StrategyItem {...props} />
-          </TestCaseGenerationProvider>
-        </TooltipProvider>
-      </QueryClientProvider>,
+      <TooltipProvider>
+        <TestCaseGenerationProvider redTeamConfig={redTeamConfig as any}>
+          <StrategyItem {...props} />
+        </TestCaseGenerationProvider>
+      </TooltipProvider>,
     );
   };
 
@@ -122,20 +111,18 @@ describe('StrategyItem', () => {
       };
 
       rerender(
-        <QueryClientProvider client={queryClient}>
-          <TooltipProvider>
-            <TestCaseGenerationProvider redTeamConfig={redTeamConfig as any}>
-              <StrategyItem
-                isDisabled={false}
-                isRemoteGenerationDisabled={false}
-                strategy={baseStrategy}
-                isSelected={true}
-                onToggle={mockOnToggle}
-                onConfigClick={mockOnConfigClick}
-              />
-            </TestCaseGenerationProvider>
-          </TooltipProvider>
-        </QueryClientProvider>,
+        <TooltipProvider>
+          <TestCaseGenerationProvider redTeamConfig={redTeamConfig as any}>
+            <StrategyItem
+              isDisabled={false}
+              isRemoteGenerationDisabled={false}
+              strategy={baseStrategy}
+              isSelected={true}
+              onToggle={mockOnToggle}
+              onConfigClick={mockOnConfigClick}
+            />
+          </TestCaseGenerationProvider>
+        </TooltipProvider>,
       );
 
       expect(card).toHaveAttribute('aria-pressed', 'true');
@@ -346,20 +333,18 @@ describe('StrategyItem', () => {
       };
 
       render(
-        <QueryClientProvider client={queryClient}>
-          <TooltipProvider>
-            <TestCaseGenerationProvider redTeamConfig={redTeamConfig as any}>
-              <StrategyItem
-                isDisabled={false}
-                isRemoteGenerationDisabled={false}
-                strategy={hydraStrategy}
-                isSelected={true}
-                onToggle={mockOnToggle}
-                onConfigClick={mockOnConfigClick}
-              />
-            </TestCaseGenerationProvider>
-          </TooltipProvider>
-        </QueryClientProvider>,
+        <TooltipProvider>
+          <TestCaseGenerationProvider redTeamConfig={redTeamConfig as any}>
+            <StrategyItem
+              isDisabled={false}
+              isRemoteGenerationDisabled={false}
+              strategy={hydraStrategy}
+              isSelected={true}
+              onToggle={mockOnToggle}
+              onConfigClick={mockOnConfigClick}
+            />
+          </TestCaseGenerationProvider>
+        </TooltipProvider>,
       );
 
       // Should have test case generation button + settings button

--- a/src/app/src/utils/testutils.tsx
+++ b/src/app/src/utils/testutils.tsx
@@ -1,5 +1,4 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RenderOptions, render } from '@testing-library/react';
 
 export interface ProviderOptions {
@@ -9,14 +8,6 @@ export interface ProviderOptions {
 const Providers =
   (options?: ProviderOptions) =>
   ({ children }: { children: React.ReactNode }) => {
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          retry: false,
-        },
-      },
-    });
-
     // Set data-theme attribute for Tailwind dark mode
     if (options?.darkMode) {
       document.documentElement.setAttribute('data-theme', 'dark');
@@ -24,11 +15,7 @@ const Providers =
       document.documentElement.removeAttribute('data-theme');
     }
 
-    return (
-      <QueryClientProvider client={queryClient}>
-        <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
-      </QueryClientProvider>
-    );
+    return <TooltipProvider delayDuration={0}>{children}</TooltipProvider>;
   };
 
 export const renderWithProviders = (


### PR DESCRIPTION
Use a shared Zustand health check instead of loading React Query across the application.