### PR TITLE
fix(providers): preserve WebSocket retries for certificate-like URLs

### DIFF
--- a/src/providers/websocket.ts
+++ b/src/providers/websocket.ts
@@ -46,9 +46,10 @@ function getSafeWebSocketError(event: WebSocket.ErrorEvent): Error {
   }
 
   const isSafeTransportCode = ['ECONNRESET', 'ECONNREFUSED', 'EPIPE'].includes(sourceCode ?? '');
+  const transportErrorMessage = sourceError.message.replace(/\b(?:wss?|https?):\/\/\S+/gi, '');
   const isPermanentProtocolError =
     /wrong version number|self signed|unable to verify|unknown ca|cert|alert protocol version|unsupported protocol/i.test(
-      sourceError.message,
+      transportErrorMessage,
     );
   let safeReason: string | undefined;
 

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -497,6 +497,57 @@ describe('WebSocketProvider', () => {
     }
   });
 
+  it('should retry transient TLS failures when the rendered URL contains certificate text', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const renderedUrl =
+      'ws://certificate-service.invalid/sessions/private-session-123?token=runtime-query-secret';
+    provider = new WebSocketProvider('ws://test.com', {
+      config: {
+        url: 'ws://{{ tenant }}.invalid/sessions/{{ sessionId }}?token={{ token }}',
+        messageTemplate: '{{ prompt }}',
+        timeoutMs: 1000,
+        maxRetries: 1,
+      },
+    });
+    emitWebSocketEvents({
+      type: 'error',
+      error: Object.assign(new Error(`write EPROTO transient TLS failure ${renderedUrl}`), {
+        code: 'EPROTO',
+      }),
+    });
+
+    const registry = new RateLimitRegistry({ maxConcurrency: 1, queueTimeoutMs: 100 });
+    const callApi = vi.fn(() =>
+      provider.callApi('test prompt', {
+        prompt: { raw: 'test prompt', label: 'test prompt' },
+        vars: {
+          tenant: 'certificate-service',
+          sessionId: 'private-session-123',
+          token: 'runtime-query-secret',
+        },
+      }),
+    );
+
+    try {
+      await expect(
+        registry.execute(provider, callApi, {
+          isRateLimited: isProviderResponseRateLimited,
+          getRetryAfter: () => 0,
+        }),
+      ).rejects.toThrow('WebSocket connection failed (EPROTO)');
+      expect(callApi).toHaveBeenCalledTimes(2);
+      expect(Object.values(registry.getMetrics())[0]).toMatchObject({
+        retriedRequests: 1,
+        rateLimitHits: 0,
+        failedRequests: 1,
+      });
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain('certificate-service');
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain('runtime-query-secret');
+    } finally {
+      registry.dispose();
+    }
+  });
+
   it.each([
     new Error('getaddrinfo ENOTFOUND runtime-secret-tenant.invalid'),
     Object.assign(new Error('getaddrinfo ENOTFOUND tenant-429.invalid'), { code: 'ENOTFOUND' }),


### PR DESCRIPTION
## Summary

- Remove rendered WebSocket URLs from transport error messages before classifying permanent TLS failures.
- Preserve retryable `EPROTO` failures when ordinary endpoint names or URL values contain certificate-related text.
- Keep permanent certificate/protocol failures fail-fast and continue redacting rendered URLs, tenant names, session identifiers, and query credentials.
- Add a composed `WebSocketProvider` → `RateLimitRegistry` regression covering retry count, scheduler metrics, safe error text, and log redaction.

## Regression

On current `main`, a transient error such as `write EPROTO transient TLS failure ws://certificate-service.invalid/...` is incorrectly classified as a permanent certificate failure. The scheduler stops after one attempt and exposes only `WebSocket connection failed` instead of retaining the safe, retryable `EPROTO` classification.

The new regression failed before the fix and passes afterward.

## Validation

- `./node_modules/.bin/vitest run test/providers/websocket.test.ts test/scheduler/retryPolicy.test.ts test/scheduler/providerRateLimitState.test.ts test/util/fetch/errors.test.ts` — **191 tests passed**.
- `npm run tsc`.
- `npm run architecture:check`.
- `npm run l` and `npm run f`.
- Real local CLI evaluation against a loopback WebSocket endpoint containing `/certificate-service`: the first upgrade returns HTTP 503, the second succeeds, and the exported result reports one passing assertion with output `recovered-after-retry`.
