### PR TITLE
fix(assertions): default RAG assertion thresholds to 0.5

### DIFF
--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -176,10 +176,10 @@ See [Model-graded evals](/docs/configuration/expected-outputs/model-graded), [cl
 | [moderation](/docs/configuration/expected-outputs/moderation)                                        | Check output against safety policies and include provider-reported usage metrics |
 | [llm-rubric](/docs/configuration/expected-outputs/model-graded)                                      | LLM output matches a given rubric, using a Language Model to grade output        |
 | [g-eval](/docs/configuration/expected-outputs/model-graded/g-eval)                                   | Chain-of-thought evaluation based on custom criteria using the G-Eval framework  |
-| [answer-relevance](/docs/configuration/expected-outputs/model-graded)                                | Ensure that LLM output is related to original query                              |
-| [context-faithfulness](/docs/configuration/expected-outputs/model-graded)                            | Ensure that LLM output uses the context                                          |
-| [context-recall](/docs/configuration/expected-outputs/model-graded)                                  | Ensure that ground truth appears in context                                      |
-| [context-relevance](/docs/configuration/expected-outputs/model-graded)                               | Ensure that context is relevant to original query                                |
+| [answer-relevance](/docs/configuration/expected-outputs/model-graded)                                | Ensure that LLM output is related to original query (default threshold 0.5)      |
+| [context-faithfulness](/docs/configuration/expected-outputs/model-graded)                            | Ensure that LLM output uses the context (default threshold 0.5)                  |
+| [context-recall](/docs/configuration/expected-outputs/model-graded)                                  | Ensure that ground truth appears in context (default threshold 0.5)              |
+| [context-relevance](/docs/configuration/expected-outputs/model-graded)                               | Ensure that context is relevant to original query (default threshold 0.5)        |
 | [conversation-relevance](/docs/configuration/expected-outputs/model-graded)                          | Ensure that responses remain relevant throughout a conversation                  |
 | [trajectory:goal-success](/docs/configuration/expected-outputs/model-graded/#trajectorygoal-success) | Use an LLM judge to decide whether the traced agent run achieved its goal        |
 | [factuality](/docs/configuration/expected-outputs/model-graded)                                      | LLM output adheres to the given facts, using Factuality method from OpenAI eval  |

--- a/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
@@ -17,6 +17,8 @@ assert:
     threshold: 0.7 # Score between 0 and 1
 ```
 
+If `threshold` is omitted, it defaults to `0.5`.
+
 ### How it works
 
 The answer relevance checker:

--- a/site/docs/configuration/expected-outputs/model-graded/context-faithfulness.md
+++ b/site/docs/configuration/expected-outputs/model-graded/context-faithfulness.md
@@ -27,11 +27,11 @@ assert:
     threshold: 0.9 # Require 90% of claims to be supported
 ```
 
-### Required fields
+### Fields
 
-- `query` - User's question (in test vars)
-- `context` - Reference text (in vars or via `contextTransform`)
-- `threshold` - Minimum score 0-1 (default: 0)
+- `query` - Required. User's question (in test vars)
+- `context` - Required. Reference text (in vars or via `contextTransform`)
+- `threshold` - Optional. Minimum score 0-1 (default: 0.5)
 
 ### Full example
 

--- a/site/docs/configuration/expected-outputs/model-graded/context-recall.md
+++ b/site/docs/configuration/expected-outputs/model-graded/context-recall.md
@@ -28,11 +28,12 @@ assert:
     threshold: 1.0 # Context must support entire answer
 ```
 
-### Required fields
+### Fields
 
-- `value` - Expected answer/ground truth
-- `context` - Retrieved text (in vars or via `contextTransform`)
-- `threshold` - Minimum score 0-1 (default: 0)
+- `value` - Required. Expected answer/ground truth
+- `context` - Optional. Retrieved text (in vars or via `contextTransform`). If omitted,
+  `context-recall` uses the prompt as context.
+- `threshold` - Optional. Minimum score 0-1 (default: 0.5)
 
 ### Full example
 

--- a/site/docs/configuration/expected-outputs/model-graded/context-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/context-relevance.md
@@ -31,11 +31,11 @@ assert:
     threshold: 0.3 # At least 30% should be essential
 ```
 
-### Required fields
+### Fields
 
-- `query` - User's question (in test vars)
-- `context` - Retrieved text (in vars or via `contextTransform`)
-- `threshold` - Minimum score 0-1 (default: 0)
+- `query` - Required. User's question (in test vars)
+- `context` - Required. Retrieved text (in vars or via `contextTransform`)
+- `threshold` - Optional. Minimum score 0-1 (default: 0.5)
 
 ### Full example
 

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -15,7 +15,7 @@ Output-based:
 - [`model-graded-closedqa`](/docs/configuration/expected-outputs/model-graded/model-graded-closedqa) - Checks if LLM answers meet specific requirements using OpenAI's public evals prompts.
 - [`factuality`](/docs/configuration/expected-outputs/model-graded/factuality) - Evaluates factual consistency between LLM output and a reference statement. Uses OpenAI's public evals prompt to determine if the output is factually consistent with the reference.
 - [`g-eval`](/docs/configuration/expected-outputs/model-graded/g-eval) - Uses chain-of-thought prompting to evaluate outputs against custom criteria following the G-Eval framework.
-- [`answer-relevance`](/docs/configuration/expected-outputs/model-graded/answer-relevance) - Evaluates whether LLM output is directly related to the original query.
+- [`answer-relevance`](/docs/configuration/expected-outputs/model-graded/answer-relevance) - Evaluates whether LLM output is directly related to the original query. Defaults to threshold `0.5`.
 - [`similar`](/docs/configuration/expected-outputs/similar) - Checks semantic similarity between output and expected value using embedding models.
 - [`pi`](/docs/configuration/expected-outputs/model-graded/pi) - Alternative scoring approach using a dedicated evaluation model to score inputs/outputs against criteria.
 - [`classifier`](/docs/configuration/expected-outputs/classifier) - Runs LLM output through HuggingFace text classifiers for detection of tone, bias, toxicity, and other properties. See [classifier grading docs](/docs/configuration/expected-outputs/classifier).
@@ -25,9 +25,9 @@ Output-based:
 
 Context-based:
 
-- [`context-recall`](/docs/configuration/expected-outputs/model-graded/context-recall) - ensure that ground truth appears in context
-- [`context-relevance`](/docs/configuration/expected-outputs/model-graded/context-relevance) - ensure that context is relevant to original query
-- [`context-faithfulness`](/docs/configuration/expected-outputs/model-graded/context-faithfulness) - ensure that LLM output is supported by context
+- [`context-recall`](/docs/configuration/expected-outputs/model-graded/context-recall) - ensure that ground truth appears in context. Defaults to threshold `0.5`.
+- [`context-relevance`](/docs/configuration/expected-outputs/model-graded/context-relevance) - ensure that context is relevant to original query. Defaults to threshold `0.5`.
+- [`context-faithfulness`](/docs/configuration/expected-outputs/model-graded/context-faithfulness) - ensure that LLM output is supported by context. Defaults to threshold `0.5`.
 
 Conversational:
 
@@ -532,7 +532,7 @@ contextTransform: 'JSON.stringify(output, null, 2)'
 
 ### Examples
 
-Context-based metrics require a `query` and context. You must also set the `threshold` property on your test (all scores are normalized between 0 and 1).
+Context-based metrics require a `query` and context. Scores are normalized between 0 and 1; when `threshold` is omitted, `answer-relevance`, `context-recall`, `context-relevance`, and `context-faithfulness` default to `0.5`.
 
 Here's an example config using statically-defined (`test.vars.context`) context:
 
@@ -678,6 +678,10 @@ Model-graded assertions like `llm-rubric` determine PASS/FAIL using two mechanis
 2. **With threshold**: PASS requires both `pass === true` AND `score >= threshold`
 
 This means a result like `{"pass": true, "score": 0}` will pass without a threshold, but fail with `threshold: 1`.
+
+Assertions with built-in thresholds, such as `answer-relevance`, `context-recall`,
+`context-relevance`, and `context-faithfulness`, default to `0.5` when `threshold` is
+omitted.
 
 **Common issue**: Tests show PASS even when scores are low
 

--- a/src/assertions/answerRelevance.ts
+++ b/src/assertions/answerRelevance.ts
@@ -1,5 +1,6 @@
 import { matchesAnswerRelevance } from '../matchers/rag';
 import invariant from '../util/invariant';
+import { DEFAULT_RAG_ASSERTION_THRESHOLD } from './ragDefaults';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 
@@ -22,7 +23,7 @@ export const handleAnswerRelevance = async ({
     ...(await matchesAnswerRelevance(
       input,
       output,
-      assertion.threshold ?? 0,
+      assertion.threshold ?? DEFAULT_RAG_ASSERTION_THRESHOLD,
       test.options,
       providerCallContext,
     )),

--- a/src/assertions/contextFaithfulness.ts
+++ b/src/assertions/contextFaithfulness.ts
@@ -1,6 +1,7 @@
 import { matchesContextFaithfulness } from '../matchers/rag';
 import invariant from '../util/invariant';
 import { resolveContext } from './contextUtils';
+import { DEFAULT_RAG_ASSERTION_THRESHOLD } from './ragDefaults';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 
@@ -47,7 +48,7 @@ export async function handleContextFaithfulness({
       test.vars.query,
       output,
       context,
-      assertion.threshold ?? 0,
+      assertion.threshold ?? DEFAULT_RAG_ASSERTION_THRESHOLD,
       test.options,
       test.vars,
       providerCallContext,

--- a/src/assertions/contextRecall.ts
+++ b/src/assertions/contextRecall.ts
@@ -1,6 +1,7 @@
 import { matchesContextRecall } from '../matchers/rag';
 import invariant from '../util/invariant';
 import { resolveContext } from './contextUtils';
+import { DEFAULT_RAG_ASSERTION_THRESHOLD } from './ragDefaults';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 
@@ -35,7 +36,7 @@ export const handleContextRecall = async ({
   const result = await matchesContextRecall(
     context, // context parameter (used as {{context}} in prompt)
     renderedValue, // ground truth parameter (used as {{groundTruth}} in prompt)
-    (assertion.threshold as number) ?? 0,
+    (assertion.threshold as number) ?? DEFAULT_RAG_ASSERTION_THRESHOLD,
     test.options,
     test.vars,
     providerCallContext,

--- a/src/assertions/contextRelevance.ts
+++ b/src/assertions/contextRelevance.ts
@@ -1,6 +1,7 @@
 import { matchesContextRelevance } from '../matchers/rag';
 import invariant from '../util/invariant';
 import { resolveContext } from './contextUtils';
+import { DEFAULT_RAG_ASSERTION_THRESHOLD } from './ragDefaults';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 
@@ -40,7 +41,7 @@ export const handleContextRelevance = async ({
   const result = await matchesContextRelevance(
     test.vars.query,
     context,
-    (assertion.threshold as number) ?? 0,
+    (assertion.threshold as number) ?? DEFAULT_RAG_ASSERTION_THRESHOLD,
     test.options,
     providerCallContext,
   );

--- a/src/assertions/ragDefaults.ts
+++ b/src/assertions/ragDefaults.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_RAG_ASSERTION_THRESHOLD = 0.5;

--- a/test/assertions/answerRelevance.test.ts
+++ b/test/assertions/answerRelevance.test.ts
@@ -162,7 +162,7 @@ describe('handleAnswerRelevance', () => {
     ).rejects.toThrow('answer-relevance assertion type must have a prompt');
   });
 
-  it('should use default threshold of 0 if not specified', async () => {
+  it('should use default threshold of 0.5 if not specified', async () => {
     const mockMatchesAnswerRelevance = vi.mocked(matchesAnswerRelevance);
     mockMatchesAnswerRelevance.mockResolvedValue({
       pass: true,
@@ -193,7 +193,7 @@ describe('handleAnswerRelevance', () => {
     expect(mockMatchesAnswerRelevance).toHaveBeenCalledWith(
       'test prompt',
       'test output',
-      0,
+      0.5,
       {},
       undefined,
     );

--- a/test/assertions/contextFaithfulness.test.ts
+++ b/test/assertions/contextFaithfulness.test.ts
@@ -269,7 +269,7 @@ describe('handleContextFaithfulness', () => {
       'test query',
       'raw',
       'from-transform',
-      0,
+      0.5,
       {},
       expect.any(Object),
       undefined,

--- a/test/assertions/contextRecall.test.ts
+++ b/test/assertions/contextRecall.test.ts
@@ -127,7 +127,7 @@ describe('handleContextRecall', () => {
     );
   });
 
-  it('should use default threshold of 0 when not provided', async () => {
+  it('should use default threshold of 0.5 when not provided', async () => {
     const mockResult = { pass: true, score: 1, reason: 'Perfect match' };
     mockMatchesContextRecall.mockResolvedValue(mockResult);
     vi.mocked(contextUtils.resolveContext).mockResolvedValue('test context');
@@ -162,7 +162,7 @@ describe('handleContextRecall', () => {
     expect(mockMatchesContextRecall).toHaveBeenCalledWith(
       'test context',
       'test value',
-      0,
+      0.5,
       {},
       { context: 'test context' },
       undefined,
@@ -212,7 +212,7 @@ describe('handleContextRecall', () => {
     expect(mockMatchesContextRecall).toHaveBeenCalledWith(
       'test prompt',
       'test output',
-      0,
+      0.5,
       {},
       {},
       undefined,
@@ -259,7 +259,7 @@ describe('handleContextRecall', () => {
       'prompt',
       {},
     );
-    expect(mockMatchesContextRecall).toHaveBeenCalledWith('ctx', 'val', 0, {}, {}, undefined);
+    expect(mockMatchesContextRecall).toHaveBeenCalledWith('ctx', 'val', 0.5, {}, {}, undefined);
   });
 
   it('should throw error when renderedValue is not a string', async () => {

--- a/test/assertions/contextRelevance.test.ts
+++ b/test/assertions/contextRelevance.test.ts
@@ -158,7 +158,7 @@ describe('handleContextRelevance', () => {
     );
   });
 
-  it('should use default threshold of 0 when not provided', async () => {
+  it('should use default threshold of 0.5 when not provided', async () => {
     const mockResult = { pass: true, score: 1, reason: 'Perfect relevance' };
     vi.mocked(matchesContextRelevance).mockResolvedValue(mockResult);
     vi.mocked(contextUtils.resolveContext).mockResolvedValue('test context');
@@ -193,7 +193,7 @@ describe('handleContextRelevance', () => {
     expect(matchesContextRelevance).toHaveBeenCalledWith(
       'test query',
       'test context',
-      0,
+      0.5,
       {},
       undefined,
     );
@@ -296,7 +296,7 @@ describe('handleContextRelevance', () => {
       undefined,
       { output: 'out', tokenUsage: {} },
     );
-    expect(matchesContextRelevance).toHaveBeenCalledWith('q', 'cx', 0, {}, undefined);
+    expect(matchesContextRelevance).toHaveBeenCalledWith('q', 'cx', 0.5, {}, undefined);
     expect(result.metadata).toEqual({
       context: 'cx',
     });


### PR DESCRIPTION
## Summary

`answer-relevance`, `context-faithfulness`, `context-recall`, and `context-relevance` all defaulted `threshold` to `0` when it was omitted, so the assertion passed for *any* score — including `0.0`. They were silently always-green unless you happened to set a threshold.

This defaults them to **0.5**, shared through a single constant rather than four inline literals:

- New `src/assertions/ragDefaults.ts` exports `DEFAULT_RAG_ASSERTION_THRESHOLD = 0.5` and an `applyRagInverse()` helper, so the `not-*` variants invert `pass` and `score` consistently and skip inversion on grader failures (a transport error should not become a pass).
- All four assertions wired to it.
- Docs updated: the four model-graded pages plus the two index pages previously documented `default: 0`.

Fixes #9910.
Fixes #9848.

## Why 0.5

`src/external/assertions/deepeval.ts` already uses `DEFAULT_THRESHOLD = 0.5` for a model-graded assertion, so 0.5 matches existing in-repo precedent. The doc *examples* on these pages suggest different numbers (`0.3` on context-relevance, `0.7` on answer-relevance, `1.0` on context-recall), so they are not a consistent signal for a single default — and a lower default breaks fewer existing evals.

**This is a behavior change.** Evals that pass today with an omitted threshold and a low grader score will start failing. That is the bug being fixed, but it warrants a release note.

## Credit

Five contributors independently identified and fixed this. This PR was chosen as the one to land because it is the only one that covers all four assertions and shares the default through a named constant instead of scattering literals. Please preserve their attribution when squashing:

```
Co-authored-by: Varshith Puli <pulivarshit@gmail.com>
Co-authored-by: Anas Khan <83116240+anxkhn@users.noreply.github.com>
Co-authored-by: JSap0914 <JSap0914@users.noreply.github.com>
Co-authored-by: Abhinav Prakash <abhinavprakash616@gmail.com>
```

After analysing all four against this one:

- **#10494** (Varshith-Kali) and **#9907** (anxkhn) are **not** duplicates. This PR's `applyRagInverse()` skips inversion on grader failures by checking `metadata.graderError`, but the RAG matchers return an *untagged* `fail()` on a grading-provider error, so that guard never fires. Those two PRs fix `src/matchers/rag.ts` — which this PR does not touch — for `context-recall`/`context-relevance` and `context-faithfulness` respectively. They should land right after this one.
- **#9911** (JSap0914) and **#10567** (AbhiPra24) genuinely reduce to nothing once this lands; their residual test cases are strict subsets of cases here. Closing them with the co-authorship above is the right outcome.

**Known gap worth a follow-up:** all four RAG matchers use the untagged `fail()` today. #10494 fixes two and #9907 fixes one, which leaves `answer-relevance` still able to invert a grading-provider outage into a pass.

## Testing

CI is green on the merged branch. Locally: `tsc --noEmit` clean, `architecture:check` passes, `knip` clean, Biome clean, and the four `test/assertions/context*|answerRelevance` suites pass against the 0.5 default.
