### PR TITLE
fix(openrouter): avoid crash on empty choices array

### DIFF
--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -180,6 +180,12 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
       };
     }
 
+    if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+      return {
+        error: `Malformed response data: ${JSON.stringify(data)}`,
+      };
+    }
+
     // Process the response with special handling for Gemini
     const message: any = data.choices[0].message;
     const finishReason = normalizeFinishReason(data.choices[0].finish_reason);

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -142,9 +142,10 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
     let status: number;
     let statusText: string;
     let cached = false;
+    let deleteFromCache: (() => Promise<void>) | undefined;
 
     try {
-      ({ data, cached, status, statusText } =
+      ({ data, cached, status, statusText, deleteFromCache } =
         await fetchWithCache<OpenRouterChatCompletionResponse>(
           `${this.getApiUrl()}/chat/completions`,
           {
@@ -181,6 +182,12 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
     }
 
     if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+      // fetchWithCache only skips caching for non-2xx responses and bodies carrying an
+      // `error` key, so this 200 has already been written to the cache. OpenRouter emits
+      // this shape when an upstream provider fails, which is transient — leaving it
+      // cached would pin the failure for every later run of the same prompt. Evict it so
+      // the next call retries, matching OpenAiChatCompletionProvider's behavior.
+      await deleteFromCache?.();
       return {
         error: `Malformed response data: ${JSON.stringify(data)}`,
       };

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -166,6 +166,32 @@ describe('OpenRouter', () => {
       }
     });
 
+    it('returns a graceful error instead of crashing on an empty choices array', async () => {
+      const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'default-test-key' });
+
+      try {
+        const provider = new OpenRouterProvider('google/gemini-2.5-pro', {});
+
+        const response = new Response(
+          JSON.stringify({
+            choices: [],
+            usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
+          }),
+          {
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        );
+        mockedFetchWithRetries.mockResolvedValueOnce(response);
+
+        const result = await provider.callApi('Test prompt');
+        expect(result.error).toContain('Malformed response data');
+      } finally {
+        restoreEnv();
+      }
+    });
+
     it('should preserve a trailing slash on the configured apiBaseUrl as-is', async () => {
       const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
 

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearCache } from '../../src/cache';
+import { clearCache, disableCache, enableCache, isCacheEnabled } from '../../src/cache';
 import { OpenRouterProvider } from '../../src/providers/openrouter';
 import * as fetchModule from '../../src/util/fetch/index';
 import { mockProcessEnv } from '../util/utils';
@@ -272,6 +272,45 @@ describe('OpenRouter', () => {
           expect(result.error).toContain(JSON.stringify(body));
           expect(result.output).toBeUndefined();
         } finally {
+          restoreEnv();
+        }
+      });
+
+      it('evicts the cached malformed response so the next call retries', async () => {
+        const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'default-test-key' });
+        const cacheWasEnabled = isCacheEnabled();
+        enableCache();
+
+        try {
+          const provider = new OpenRouterProvider('google/gemini-2.5-pro', {});
+
+          // An upstream provider behind OpenRouter fails and returns a cacheable 200
+          // with no usable choice.
+          mockedFetchWithRetries.mockResolvedValueOnce(okJson({ choices: [], usage }));
+          const failed = await provider.callApi('Test prompt');
+          expect(failed.error).toContain('Malformed response data');
+
+          // Upstream has recovered. Without eviction the malformed body would still be
+          // cached under the same key and this call would never reach the network.
+          mockedFetchWithRetries.mockResolvedValueOnce(
+            okJson({
+              choices: [{ message: { content: 'recovered' }, finish_reason: 'stop' }],
+              usage: { total_tokens: 9, prompt_tokens: 5, completion_tokens: 4 },
+            }),
+          );
+          const recovered = await provider.callApi('Test prompt');
+
+          expect(recovered.error).toBeUndefined();
+          expect(recovered.output).toBe('recovered');
+          expect(mockedFetchWithRetries).toHaveBeenCalledTimes(2);
+        } finally {
+          if (!cacheWasEnabled) {
+            disableCache();
+          }
+          // The file-level afterEach uses clearAllMocks, which does not drain queued
+          // mockResolvedValueOnce values. Reset here so a failure in this test cannot
+          // leak an unconsumed response into whichever test runs next.
+          mockedFetchWithRetries.mockReset();
           restoreEnv();
         }
       });

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -166,32 +166,6 @@ describe('OpenRouter', () => {
       }
     });
 
-    it('returns a graceful error instead of crashing on an empty choices array', async () => {
-      const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'default-test-key' });
-
-      try {
-        const provider = new OpenRouterProvider('google/gemini-2.5-pro', {});
-
-        const response = new Response(
-          JSON.stringify({
-            choices: [],
-            usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
-          }),
-          {
-            status: 200,
-            statusText: 'OK',
-            headers: new Headers({ 'Content-Type': 'application/json' }),
-          },
-        );
-        mockedFetchWithRetries.mockResolvedValueOnce(response);
-
-        const result = await provider.callApi('Test prompt');
-        expect(result.error).toContain('Malformed response data');
-      } finally {
-        restoreEnv();
-      }
-    });
-
     it('should preserve a trailing slash on the configured apiBaseUrl as-is', async () => {
       const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
 
@@ -261,6 +235,46 @@ describe('OpenRouter', () => {
       } finally {
         restoreEnv();
       }
+    });
+
+    describe('Malformed response handling', () => {
+      const usage = { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 };
+
+      const okJson = (body: unknown) =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        });
+
+      // OpenRouter fronts many upstream providers, so a 200 can arrive without a usable
+      // choice when one of them fails. Each of these shapes used to throw a TypeError
+      // out of callApi instead of returning a result.
+      const malformedBodies: [string, Record<string, unknown>][] = [
+        ['an empty choices array', { choices: [], usage }],
+        ['no choices field at all', { usage }],
+        ['a choice with no message', { choices: [{ finish_reason: 'stop' }], usage }],
+      ];
+
+      it.each(
+        malformedBodies,
+      )('returns a graceful error instead of crashing on %s', async (_label, body) => {
+        const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'default-test-key' });
+
+        try {
+          const provider = new OpenRouterProvider('google/gemini-2.5-pro', {});
+          mockedFetchWithRetries.mockResolvedValueOnce(okJson(body));
+
+          const result = await provider.callApi('Test prompt');
+
+          expect(result.error).toContain('Malformed response data');
+          // Echo the body back so the failure is diagnosable from the eval output.
+          expect(result.error).toContain(JSON.stringify(body));
+          expect(result.output).toBeUndefined();
+        } finally {
+          restoreEnv();
+        }
+      });
     });
 
     describe('Thinking tokens handling', () => {


### PR DESCRIPTION
## Summary

`OpenRouterProvider` reads `data.choices[0].message` directly after the `data.error` check. An empty `choices: []` array, or a degenerate 200 response with no `choices` field, makes `data.choices[0]` undefined, so `.message` throws a `TypeError`. That path is not wrapped in a try/catch, so it propagates out of `callApi` as an unhandled crash instead of a usable result.

This adds the same `Malformed response data` guard the other OpenAI-compatible providers here already use (e.g. Mistral, AI21), so an empty or missing `choices` returns a clear error rather than crashing.

## Test

Added a regression test in `test/providers/openrouter.test.ts`: a 200 response with `choices: []` now returns a `Malformed response data` error instead of throwing. The full OpenRouter suite passes (35 tests) locally.

---

## Maintainer follow-up

Two commits pushed on top of the original fix during review. The diagnosis above is
correct — `withGenAISpan` re-throws (`src/tracing/genaiTracer.ts:263`), so the
`TypeError` does escape `callApi` — and copying Mistral's guard rather than AI21's was
the right call, since AI21's variant also requires `message.content` and would reject
OpenRouter's valid tool-call responses.

### `fix(openrouter): evict malformed responses from the cache`

Returning an error was not sufficient on its own. `fetchWithCache` skips caching only
for non-2xx responses and bodies carrying an `error` key (`src/cache.ts:727-758`), so a
200 with an empty `choices` array is **already written to the cache** before the guard
runs. Without eviction the failure was pinned: every later run of the same prompt
replayed the cached body and never reached OpenRouter again, leaving `--no-cache` or
deleting `~/.promptfoo/cache` as the only recovery.

That matters because this shape is transient — it is what OpenRouter returns when an
upstream provider fails — so pinning it defeats the point of degrading gracefully.

`OpenAiChatCompletionProvider` already handles this: it wraps the same
`choices[0].message` access in try/catch (`openai/chat.ts:612`) and calls
`deleteFromCache()` before returning (`:873`). The override had dropped that, so this
takes `deleteFromCache` from `fetchWithCache` and calls it on the malformed path.

Verified end to end: feeding a malformed body followed by a valid one for the same
prompt reached the network twice and recovered. Before the change the second call was
served from cache and returned the same error.

### `test(openrouter): cover every malformed-response shape`

The guard has three clauses but only `choices: []` was exercised. The malformed-response
cases now live in their own suite, parametrized over all three shapes. Each throws a
distinct `TypeError` without the guard, confirming every clause is load-bearing:

| Body | Error without the guard |
| --- | --- |
| `{ choices: [], usage }` | `Cannot read properties of undefined (reading 'message')` |
| `{ usage }` | `Cannot read properties of undefined (reading '0')` |
| `{ choices: [{ finish_reason: 'stop' }], usage }` | `Cannot read properties of undefined (reading 'function_call')` |

The suite is 38 tests and green; `tsc` and `lint:src` are clean.

### Deliberately left alone

- **`tokenUsage` is still dropped on this path**, even though `usage` is often present in
  the malformed body. Every sibling provider and the parent's own catch behave the same
  way, so changing it here would be an inconsistency in the other direction.
- **No `metadata.http`.** The parent attaches it, but `openrouter.ts` attaches metadata on
  no error path today; adding it to one would be arbitrary.
- **The `executeOpenRouterCall` complexity warning** (37 vs. max 30) predates this PR.
