### PR TITLE
fix(eval): avoid prompt index collisions for duplicate providers

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -2066,9 +2066,12 @@ function buildCompletedPrompts(testSuite: TestSuite, store: EvaluationStore): Co
 }
 
 function buildPromptIndexMap(prompts: CompletedPrompt[]) {
-  const promptIndexMap = new Map<string, number>();
+  const promptIndexMap = new Map<string, number[]>();
   for (let i = 0; i < prompts.length; i++) {
-    promptIndexMap.set(`${prompts[i].provider}:${prompts[i].id}`, i);
+    const key = `${prompts[i].provider}:${prompts[i].id}`;
+    const promptIndices = promptIndexMap.get(key) ?? [];
+    promptIndices.push(i);
+    promptIndexMap.set(key, promptIndices);
   }
   return promptIndexMap;
 }
@@ -2256,7 +2259,7 @@ async function buildRunEvalOptions({
   conversations: EvalConversations;
   evalId: string;
   options: InternalEvaluateOptions;
-  promptIndexMap: Map<string, number>;
+  promptIndexMap: Map<string, number[]>;
   providerAbortSignal?: AbortSignal;
   rateLimitRegistry?: RateLimitRegistryRef;
   registers: EvalRegisters;
@@ -2383,7 +2386,7 @@ function appendRunEvalOptionsForTestCase({
   nextTestIdx: number;
   options: InternalEvaluateOptions;
   promptIdCache: Map<Prompt, string>;
-  promptIndexMap: Map<string, number>;
+  promptIndexMap: Map<string, number[]>;
   providerAbortSignal?: AbortSignal;
   rateLimitRegistry?: RateLimitRegistryRef;
   registers: EvalRegisters;
@@ -2456,7 +2459,7 @@ function appendRunEvalOptionsForVars({
   evalId: string;
   options: InternalEvaluateOptions;
   promptIdCache: Map<Prompt, string>;
-  promptIndexMap: Map<string, number>;
+  promptIndexMap: Map<string, number[]>;
   promptPrefix: string;
   promptSuffix: string;
   providerAbortSignal?: AbortSignal;
@@ -2469,7 +2472,12 @@ function appendRunEvalOptionsForVars({
   testSuite: TestSuite;
   vars: Vars | undefined;
 }) {
+  const providerOccurrenceCounts = new Map<string, number>();
   for (const provider of testSuite.providers) {
+    const providerKey = provider.label || provider.id();
+    const providerOccurrenceIndex = providerOccurrenceCounts.get(providerKey) ?? 0;
+    providerOccurrenceCounts.set(providerKey, providerOccurrenceIndex + 1);
+
     if (!isProviderAllowed(provider, testCase.providers)) {
       continue;
     }
@@ -2483,6 +2491,8 @@ function appendRunEvalOptionsForVars({
       promptPrefix,
       promptSuffix,
       provider,
+      providerKey,
+      providerOccurrenceIndex,
       providerAbortSignal,
       rateLimitRegistry,
       registers,
@@ -2506,6 +2516,8 @@ function appendRunEvalOptionsForProvider({
   promptPrefix,
   promptSuffix,
   provider,
+  providerKey,
+  providerOccurrenceIndex,
   providerAbortSignal,
   rateLimitRegistry,
   registers,
@@ -2521,10 +2533,12 @@ function appendRunEvalOptionsForProvider({
   evalId: string;
   options: InternalEvaluateOptions;
   promptIdCache: Map<Prompt, string>;
-  promptIndexMap: Map<string, number>;
+  promptIndexMap: Map<string, number[]>;
   promptPrefix: string;
   promptSuffix: string;
   provider: ApiProvider;
+  providerKey: string;
+  providerOccurrenceIndex: number;
   providerAbortSignal?: AbortSignal;
   rateLimitRegistry?: RateLimitRegistryRef;
   registers: EvalRegisters;
@@ -2535,13 +2549,13 @@ function appendRunEvalOptionsForProvider({
   testSuite: TestSuite;
   vars: Vars | undefined;
 }) {
-  const providerKey = provider.label || provider.id();
   for (const prompt of testSuite.prompts) {
     if (!shouldRunPromptForTest(prompt, providerKey, testCase, testSuite)) {
       continue;
     }
 
-    const promptIdx = promptIndexMap.get(`${providerKey}:${promptIdCache.get(prompt)!}`);
+    const promptIndices = promptIndexMap.get(`${providerKey}:${promptIdCache.get(prompt)!}`);
+    const promptIdx = promptIndices?.[providerOccurrenceIndex];
     if (promptIdx === undefined) {
       logger.warn(
         `Could not find prompt index for ${providerKey}:${promptIdCache.get(prompt)}, skipping`,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -82,6 +82,7 @@ import { accumulateNamedMetric, backfillNamedScoreWeights } from './util/namedMe
 import { filterFiniteScores } from './util/numeric';
 import { isPromptAllowed } from './util/promptMatching';
 import {
+  getProviderIdentifier,
   isAnthropicProvider,
   isGoogleProvider,
   isOpenAiProvider,
@@ -2035,13 +2036,38 @@ function buildExistingPromptsMap(store: EvaluationStore) {
   return existingPromptsMap;
 }
 
-function buildCompletedPrompts(testSuite: TestSuite, store: EvaluationStore): CompletedPrompt[] {
+/**
+ * The results-table columns owned by one provider, in table order. `promptIdx` is the
+ * column's position in the table, which is how results are addressed everywhere else.
+ */
+type ProviderColumns = {
+  provider: ApiProvider;
+  columns: { promptIdx: number; prompt: Prompt }[];
+};
+
+/**
+ * Builds the results-table columns, one per (provider, prompt) pair, and returns them
+ * both flattened (for the table header) and grouped by provider (for scheduling work).
+ *
+ * Callers must derive a result's column from `columns` rather than looking one up by
+ * `providerKey:promptId`, because neither component is unique: two providers can share
+ * a label (or resolve to the same id), and two prompts can share a label, which is what
+ * `generateIdFromPrompt` hashes. Resolving by identity collapses duplicates into a
+ * single column and silently drops the other columns' results.
+ */
+function buildCompletedPrompts(
+  testSuite: TestSuite,
+  store: EvaluationStore,
+): { prompts: CompletedPrompt[]; columnsByProvider: ProviderColumns[] } {
   const prompts: CompletedPrompt[] = [];
+  const columnsByProvider: ProviderColumns[] = [];
   const existingPromptsMap = buildExistingPromptsMap(store);
 
   for (const provider of testSuite.providers) {
+    const providerKey = getProviderIdentifier(provider);
+    const columns: ProviderColumns['columns'] = [];
+
     for (const prompt of testSuite.prompts) {
-      const providerKey = provider.label || provider.id();
       if (!isAllowedPrompt(prompt, testSuite.providerPromptMap?.[providerKey])) {
         continue;
       }
@@ -2052,28 +2078,26 @@ function buildCompletedPrompts(testSuite: TestSuite, store: EvaluationStore): Co
         backfillNamedScoreWeights(existingPrompt.metrics);
       }
 
+      columns.push({ promptIdx: prompts.length, prompt });
       prompts.push({
         ...prompt,
         id: promptId,
         provider: providerKey,
         label: prompt.label,
-        metrics: existingPrompt?.metrics || createDefaultPromptMetrics(),
+        // `existingPromptsMap` is still keyed by identity, so duplicate providers resolve
+        // to the same stored prompt. Clone its metrics so the columns do not accumulate
+        // into one shared object. (Resume has deeper duplicate-provider problems; see
+        // `doEval`, which rebuilds `testSuite.prompts` from the previous run's columns.)
+        metrics: existingPrompt?.metrics
+          ? structuredClone(existingPrompt.metrics)
+          : createDefaultPromptMetrics(),
       });
     }
+
+    columnsByProvider.push({ provider, columns });
   }
 
-  return prompts;
-}
-
-function buildPromptIndexMap(prompts: CompletedPrompt[]) {
-  const promptIndexMap = new Map<string, number[]>();
-  for (let i = 0; i < prompts.length; i++) {
-    const key = `${prompts[i].provider}:${prompts[i].id}`;
-    const promptIndices = promptIndexMap.get(key) ?? [];
-    promptIndices.push(i);
-    promptIndexMap.set(key, promptIndices);
-  }
-  return promptIndexMap;
+  return { prompts, columnsByProvider };
 }
 
 function resolveAssertionProviderReferences(
@@ -2248,7 +2272,7 @@ async function buildRunEvalOptions({
   conversations,
   evalId,
   options,
-  promptIndexMap,
+  columnsByProvider,
   providerAbortSignal,
   rateLimitRegistry,
   registers,
@@ -2259,7 +2283,7 @@ async function buildRunEvalOptions({
   conversations: EvalConversations;
   evalId: string;
   options: InternalEvaluateOptions;
-  promptIndexMap: Map<string, number[]>;
+  columnsByProvider: ProviderColumns[];
   providerAbortSignal?: AbortSignal;
   rateLimitRegistry?: RateLimitRegistryRef;
   registers: EvalRegisters;
@@ -2267,11 +2291,7 @@ async function buildRunEvalOptions({
   tests: AtomicTestCase[];
 }): Promise<RunEvalOptions[]> {
   const runEvalOptions: RunEvalOptions[] = [];
-  const promptIdCache = new Map<Prompt, string>();
   const configuredProviderMap = buildConfiguredProviderMap(testSuite.providers);
-  for (const prompt of testSuite.prompts) {
-    promptIdCache.set(prompt, generateIdFromPrompt(prompt));
-  }
 
   let testIdx = 0;
   for (let index = 0; index < tests.length; index++) {
@@ -2284,8 +2304,7 @@ async function buildRunEvalOptions({
       evalId,
       nextTestIdx: testIdx,
       options,
-      promptIdCache,
-      promptIndexMap,
+      columnsByProvider,
       providerAbortSignal,
       rateLimitRegistry,
       registers,
@@ -2371,8 +2390,7 @@ function appendRunEvalOptionsForTestCase({
   evalId,
   nextTestIdx,
   options,
-  promptIdCache,
-  promptIndexMap,
+  columnsByProvider,
   providerAbortSignal,
   rateLimitRegistry,
   registers,
@@ -2385,8 +2403,7 @@ function appendRunEvalOptionsForTestCase({
   evalId: string;
   nextTestIdx: number;
   options: InternalEvaluateOptions;
-  promptIdCache: Map<Prompt, string>;
-  promptIndexMap: Map<string, number[]>;
+  columnsByProvider: ProviderColumns[];
   providerAbortSignal?: AbortSignal;
   rateLimitRegistry?: RateLimitRegistryRef;
   registers: EvalRegisters;
@@ -2414,8 +2431,7 @@ function appendRunEvalOptionsForTestCase({
         conversations,
         evalId,
         options: effectiveOptions,
-        promptIdCache,
-        promptIndexMap,
+        columnsByProvider,
         promptPrefix,
         promptSuffix,
         providerAbortSignal,
@@ -2440,8 +2456,7 @@ function appendRunEvalOptionsForVars({
   conversations,
   evalId,
   options,
-  promptIdCache,
-  promptIndexMap,
+  columnsByProvider,
   promptPrefix,
   promptSuffix,
   providerAbortSignal,
@@ -2458,8 +2473,7 @@ function appendRunEvalOptionsForVars({
   conversations: EvalConversations;
   evalId: string;
   options: InternalEvaluateOptions;
-  promptIdCache: Map<Prompt, string>;
-  promptIndexMap: Map<string, number[]>;
+  columnsByProvider: ProviderColumns[];
   promptPrefix: string;
   promptSuffix: string;
   providerAbortSignal?: AbortSignal;
@@ -2472,27 +2486,19 @@ function appendRunEvalOptionsForVars({
   testSuite: TestSuite;
   vars: Vars | undefined;
 }) {
-  const providerOccurrenceCounts = new Map<string, number>();
-  for (const provider of testSuite.providers) {
-    const providerKey = provider.label || provider.id();
-    const providerOccurrenceIndex = providerOccurrenceCounts.get(providerKey) ?? 0;
-    providerOccurrenceCounts.set(providerKey, providerOccurrenceIndex + 1);
-
+  for (const { provider, columns } of columnsByProvider) {
     if (!isProviderAllowed(provider, testCase.providers)) {
       continue;
     }
     appendRunEvalOptionsForProvider({
+      columns,
       concurrency,
       conversations,
       evalId,
       options,
-      promptIdCache,
-      promptIndexMap,
       promptPrefix,
       promptSuffix,
       provider,
-      providerKey,
-      providerOccurrenceIndex,
       providerAbortSignal,
       rateLimitRegistry,
       registers,
@@ -2507,17 +2513,14 @@ function appendRunEvalOptionsForVars({
 }
 
 function appendRunEvalOptionsForProvider({
+  columns,
   concurrency,
   conversations,
   evalId,
   options,
-  promptIdCache,
-  promptIndexMap,
   promptPrefix,
   promptSuffix,
   provider,
-  providerKey,
-  providerOccurrenceIndex,
   providerAbortSignal,
   rateLimitRegistry,
   registers,
@@ -2528,17 +2531,14 @@ function appendRunEvalOptionsForProvider({
   testSuite,
   vars,
 }: {
+  columns: ProviderColumns['columns'];
   concurrency: number;
   conversations: EvalConversations;
   evalId: string;
   options: InternalEvaluateOptions;
-  promptIdCache: Map<Prompt, string>;
-  promptIndexMap: Map<string, number[]>;
   promptPrefix: string;
   promptSuffix: string;
   provider: ApiProvider;
-  providerKey: string;
-  providerOccurrenceIndex: number;
   providerAbortSignal?: AbortSignal;
   rateLimitRegistry?: RateLimitRegistryRef;
   registers: EvalRegisters;
@@ -2549,17 +2549,8 @@ function appendRunEvalOptionsForProvider({
   testSuite: TestSuite;
   vars: Vars | undefined;
 }) {
-  for (const prompt of testSuite.prompts) {
-    if (!shouldRunPromptForTest(prompt, providerKey, testCase, testSuite)) {
-      continue;
-    }
-
-    const promptIndices = promptIndexMap.get(`${providerKey}:${promptIdCache.get(prompt)!}`);
-    const promptIdx = promptIndices?.[providerOccurrenceIndex];
-    if (promptIdx === undefined) {
-      logger.warn(
-        `Could not find prompt index for ${providerKey}:${promptIdCache.get(prompt)}, skipping`,
-      );
+  for (const { promptIdx, prompt } of columns) {
+    if (!isAllowedPrompt(prompt, testCase.prompts)) {
       continue;
     }
 
@@ -2585,18 +2576,6 @@ function appendRunEvalOptionsForProvider({
       }),
     );
   }
-}
-
-function shouldRunPromptForTest(
-  prompt: Prompt,
-  providerKey: string,
-  testCase: AtomicTestCase,
-  testSuite: TestSuite,
-) {
-  return (
-    isAllowedPrompt(prompt, testSuite.providerPromptMap?.[providerKey]) &&
-    isAllowedPrompt(prompt, testCase.prompts)
-  );
 }
 
 function createRunEvalOption({
@@ -4547,7 +4526,6 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
     // Add abort checks at key points
     checkAbort();
 
-    const prompts: CompletedPrompt[] = [];
     const assertionTypes = new Set<string>();
     const rowsWithSelectBestAssertion = new Set<number>();
     const rowsWithMaxScoreAssertion = new Set<number>();
@@ -4562,8 +4540,7 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
       return this.store.evaluation;
     }
 
-    prompts.push(...buildCompletedPrompts(testSuite, this.store));
-    const promptIndexMap = buildPromptIndexMap(prompts);
+    const { prompts, columnsByProvider } = buildCompletedPrompts(testSuite, this.store);
 
     await this.store.appendPrompts(prompts);
 
@@ -4583,7 +4560,7 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
       conversations: this.conversations,
       evalId: this.store.id,
       options,
-      promptIndexMap,
+      columnsByProvider,
       providerAbortSignal,
       rateLimitRegistry: this.rateLimitRegistry,
       registers: this.registers,

--- a/test/evaluator/routing.test.ts
+++ b/test/evaluator/routing.test.ts
@@ -181,6 +181,45 @@ describeEvaluator('evaluator prompt and provider routing', () => {
     expect(mockUnlabeledProvider.callApi).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps duplicate provider ids in separate prompt columns', async () => {
+    const firstProvider: ApiProvider = {
+      id: () => 'duplicate-provider',
+      callApi: vi.fn().mockResolvedValue({
+        output: 'First provider output',
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+    const secondProvider: ApiProvider = {
+      id: () => 'duplicate-provider',
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Second provider output',
+        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
+      }),
+    };
+
+    const testSuite: TestSuite = {
+      providers: [firstProvider, secondProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{ vars: { input: 'value' } }],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+
+    const table = await evalRecord.getTable();
+
+    expect(firstProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(secondProvider.callApi).toHaveBeenCalledTimes(1);
+    expect(table.head.prompts).toEqual([
+      expect.objectContaining({ provider: 'duplicate-provider' }),
+      expect.objectContaining({ provider: 'duplicate-provider' }),
+    ]);
+    expect(table.body[0].outputs).toMatchObject([
+      { text: 'First provider output', provider: 'duplicate-provider' },
+      { text: 'Second provider output', provider: 'duplicate-provider' },
+    ]);
+  });
+
   it('evaluate with test-level providers filter', async () => {
     const mockProvider1: ApiProvider = {
       id: () => 'provider-1',

--- a/test/evaluator/routing.test.ts
+++ b/test/evaluator/routing.test.ts
@@ -3,11 +3,23 @@ import './setup';
 import { randomUUID } from 'crypto';
 
 import { expect, it, vi } from 'vitest';
+import cliState from '../../src/cliState';
 import { evaluate } from '../../src/evaluator';
 import Eval from '../../src/models/eval';
-import { type ApiProvider, type TestSuite } from '../../src/types/index';
+import { generateIdFromPrompt } from '../../src/models/prompt';
+import { type ApiProvider, type Prompt, type TestSuite } from '../../src/types/index';
+import { createPromptMetrics } from '../factories/eval';
+import {
+  createMockProvider,
+  createProviderResponse,
+  createTokenUsage,
+} from '../factories/provider';
 import { mockApiProvider, toPrompt } from './helpers';
 import { describeEvaluator } from './lifecycle';
+
+function duplicateProvider(id: string, output: string, label?: string): ApiProvider {
+  return createMockProvider({ id, label, response: createProviderResponse({ output }) });
+}
 
 describeEvaluator('evaluator prompt and provider routing', () => {
   it('evaluate with providerPromptMap', async () => {
@@ -182,20 +194,8 @@ describeEvaluator('evaluator prompt and provider routing', () => {
   });
 
   it('keeps duplicate provider ids in separate prompt columns', async () => {
-    const firstProvider: ApiProvider = {
-      id: () => 'duplicate-provider',
-      callApi: vi.fn().mockResolvedValue({
-        output: 'First provider output',
-        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
-      }),
-    };
-    const secondProvider: ApiProvider = {
-      id: () => 'duplicate-provider',
-      callApi: vi.fn().mockResolvedValue({
-        output: 'Second provider output',
-        tokenUsage: { total: 10, prompt: 5, completion: 5, cached: 0, numRequests: 1 },
-      }),
-    };
+    const firstProvider = duplicateProvider('duplicate-provider', 'First provider output');
+    const secondProvider = duplicateProvider('duplicate-provider', 'Second provider output');
 
     const testSuite: TestSuite = {
       providers: [firstProvider, secondProvider],
@@ -217,6 +217,189 @@ describeEvaluator('evaluator prompt and provider routing', () => {
     expect(table.body[0].outputs).toMatchObject([
       { text: 'First provider output', provider: 'duplicate-provider' },
       { text: 'Second provider output', provider: 'duplicate-provider' },
+    ]);
+    // Each column accumulates only its own provider's metrics.
+    expect(table.head.prompts.map((prompt) => prompt.metrics?.tokenUsage?.numRequests)).toEqual([
+      1, 1,
+    ]);
+  });
+
+  it('keeps providers that share a label in separate prompt columns', async () => {
+    const firstProvider = duplicateProvider('provider-1', 'First provider output', 'shared-label');
+    const secondProvider = duplicateProvider(
+      'provider-2',
+      'Second provider output',
+      'shared-label',
+    );
+
+    const testSuite: TestSuite = {
+      providers: [firstProvider, secondProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{ vars: { input: 'value' } }],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+
+    const table = await evalRecord.getTable();
+
+    expect(table.body[0].outputs).toMatchObject([
+      { text: 'First provider output', provider: 'shared-label' },
+      { text: 'Second provider output', provider: 'shared-label' },
+    ]);
+  });
+
+  it('routes every prompt of every duplicate provider to its own column', async () => {
+    const firstProvider = duplicateProvider('duplicate-provider', 'First provider output');
+    const secondProvider = duplicateProvider('duplicate-provider', 'Second provider output');
+
+    const testSuite: TestSuite = {
+      providers: [firstProvider, secondProvider],
+      prompts: [toPrompt('Test prompt 1'), toPrompt('Test prompt 2')],
+      tests: [{ vars: { input: 'value' } }],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+
+    const table = await evalRecord.getTable();
+
+    expect(firstProvider.callApi).toHaveBeenCalledTimes(2);
+    expect(secondProvider.callApi).toHaveBeenCalledTimes(2);
+    expect(table.head.prompts.map((prompt) => prompt.label)).toEqual([
+      'Test prompt 1',
+      'Test prompt 2',
+      'Test prompt 1',
+      'Test prompt 2',
+    ]);
+    expect(table.body[0].outputs.map((output) => output.text)).toEqual([
+      'First provider output',
+      'First provider output',
+      'Second provider output',
+      'Second provider output',
+    ]);
+  });
+
+  it('routes prompts that share a prompt id to separate columns', async () => {
+    // Prompt ids are derived from the label, so distinct prompts can collide.
+    const firstPrompt: Prompt = { raw: 'First raw prompt', label: 'shared-prompt-label' };
+    const secondPrompt: Prompt = { raw: 'Second raw prompt', label: 'shared-prompt-label' };
+    const firstProvider = duplicateProvider('duplicate-provider', 'First provider output');
+    const secondProvider = duplicateProvider('duplicate-provider', 'Second provider output');
+
+    const testSuite: TestSuite = {
+      providers: [firstProvider, secondProvider],
+      prompts: [firstPrompt, secondPrompt],
+      tests: [{ vars: { input: 'value' } }],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+
+    const table = await evalRecord.getTable();
+
+    expect(table.head.prompts.map((prompt) => prompt.raw)).toEqual([
+      'First raw prompt',
+      'Second raw prompt',
+      'First raw prompt',
+      'Second raw prompt',
+    ]);
+    expect(table.body[0].outputs.map((output) => output.text)).toEqual([
+      'First provider output',
+      'First provider output',
+      'Second provider output',
+      'Second provider output',
+    ]);
+  });
+
+  it('keeps column alignment for duplicate providers when a test filters providers', async () => {
+    const firstProvider = duplicateProvider('provider-1', 'First provider output', 'shared-label');
+    const secondProvider = duplicateProvider(
+      'provider-2',
+      'Second provider output',
+      'shared-label',
+    );
+
+    const testSuite: TestSuite = {
+      providers: [firstProvider, secondProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{ vars: { input: 'value' }, providers: ['provider-2'] }],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+
+    const table = await evalRecord.getTable();
+
+    expect(firstProvider.callApi).not.toHaveBeenCalled();
+    expect(secondProvider.callApi).toHaveBeenCalledTimes(1);
+    // The filtered-out provider still owns column 0.
+    expect(table.body[0].outputs[0]).toBeUndefined();
+    expect(table.body[0].outputs[1]).toMatchObject({ text: 'Second provider output' });
+  });
+
+  it('keeps duplicate providers aligned when providerPromptMap filters prompts', async () => {
+    const firstProvider = duplicateProvider('duplicate-provider', 'First provider output');
+    const secondProvider = duplicateProvider('duplicate-provider', 'Second provider output');
+
+    const testSuite: TestSuite = {
+      providers: [firstProvider, secondProvider],
+      prompts: [toPrompt('Test prompt 1'), toPrompt('Test prompt 2')],
+      providerPromptMap: { 'duplicate-provider': ['Test prompt 2'] },
+      tests: [{ vars: { input: 'value' } }],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+
+    const table = await evalRecord.getTable();
+
+    expect(table.head.prompts.map((prompt) => prompt.label)).toEqual([
+      'Test prompt 2',
+      'Test prompt 2',
+    ]);
+    expect(table.body[0].outputs.map((output) => output.text)).toEqual([
+      'First provider output',
+      'Second provider output',
+    ]);
+  });
+
+  it('does not share resumed metrics between duplicate providers', async () => {
+    const firstProvider = duplicateProvider('duplicate-provider', 'First provider output');
+    const secondProvider = duplicateProvider('duplicate-provider', 'Second provider output');
+    const prompt = toPrompt('Test prompt');
+
+    const testSuite: TestSuite = {
+      providers: [firstProvider, secondProvider],
+      prompts: [prompt],
+      tests: [{ vars: { input: 'value' } }],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    // Both duplicate providers resolve to this single stored prompt on resume.
+    evalRecord.prompts = [
+      {
+        ...prompt,
+        id: generateIdFromPrompt(prompt),
+        provider: 'duplicate-provider',
+        metrics: createPromptMetrics({
+          testPassCount: 5,
+          tokenUsage: createTokenUsage({ numRequests: 3 }),
+        }),
+      },
+    ];
+    evalRecord.persisted = true;
+
+    cliState.resume = true;
+    await evaluate(testSuite, evalRecord, {});
+
+    const table = await evalRecord.getTable();
+
+    // Each column resumes from the stored totals and adds only its own result, rather
+    // than both accumulating into one shared metrics object.
+    expect(table.head.prompts.map((prompt) => prompt.metrics?.testPassCount)).toEqual([6, 6]);
+    expect(table.head.prompts.map((prompt) => prompt.metrics?.tokenUsage?.numRequests)).toEqual([
+      4, 4,
     ]);
   });
 


### PR DESCRIPTION
## Summary

Fix duplicate provider ids collapsing into a single results-table column.

The evaluator previously keyed `promptIndexMap` by `providerKey:promptId` and stored only one index. When multiple providers had the same resolved key (`label || id`), the later provider overwrote the earlier one. This caused outputs to be assigned to the last matching provider column.

The fix stores all prompt indices for a key and uses provider occurrence order to select the right column, without changing the provider display value.

## Repro Config

The issue can be reproduced with a config shaped like this:

```yaml
description: Repro for promptfoo view showing only the last provider when duplicate model ids have different configs

prompts:
  - |
    Answer in one short sentence.
    Topic: {{topic}}

providers:
  - id: openai:chat:gpt-5-mini
    config:
      temperature: 0
      max_tokens: 24

  - id: openai:chat:gpt-5-mini
    config:
      temperature: 1
      max_tokens: 96
      response_format:
        type: json_schema
        json_schema:
          name: custom_name
          strict: true
          schema:
            type: object
            additionalProperties: false
            required:
              - message
            properties:
              message:
                type: string
                description: message

tests:
  - vars:
      topic: why reproducible eval results matter
    assert:
      - type: contains-any
        value:
          - eval
          - reproducible
          - consistency

  - vars:
      topic: why model configuration should be visible in comparison views
    assert:
      - type: contains-any
        value:
          - configuration
          - comparison
          - visible
```

With duplicate provider ids and different provider configs, the results view should show separate output columns for each provider config.

## Screenshots

Before:

<img width="1405" height="612" alt="image" src="https://github.com/user-attachments/assets/ab136214-7b3d-4c9e-9d13-9f328d9d6f93" />

After:

<img width="1424" height="560" alt="image" src="https://github.com/user-attachments/assets/f6c1305f-4b9b-47ee-8718-c91550da98f9" />