### PR TITLE
fix(redteam): harden risk reports and WebSocket timeout tests

### DIFF
--- a/src/app/src/pages/redteam/report/components/RiskCategories.test.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCategories.test.tsx
@@ -220,13 +220,37 @@ describe('RiskCategories', () => {
       },
     });
 
-    renderWithProviders(<RiskCategories {...mockProps} />);
+    const { container } = renderWithProviders(<RiskCategories {...mockProps} />);
 
     // SQL Injection should be visible (expanded by default)
     expect(screen.getByText('SQL Injection')).toBeInTheDocument();
 
     // RBAC should not be visible (no tests)
     expect(screen.queryByText('RBAC')).not.toBeInTheDocument();
+    expect(container.innerHTML).not.toContain('NaN');
+  });
+
+  it('renders category rows when a category description is missing', () => {
+    const categoryName = 'Security & Access Control';
+    const originalDescription = categoryDescriptions[categoryName];
+    Object.defineProperty(categoryDescriptions, categoryName, { value: undefined });
+
+    try {
+      const mockProps = createMockProps({
+        categoryStats: {
+          'sql-injection': { pass: 8, total: 10 },
+        },
+      });
+
+      renderWithProviders(<RiskCategories {...mockProps} />);
+
+      const categoryButton = screen.getByRole('button', {
+        name: 'Collapse Security & Access Control category, 8 of 10 passed, failing',
+      });
+      expect(categoryButton).not.toHaveAccessibleDescription();
+    } finally {
+      Object.defineProperty(categoryDescriptions, categoryName, { value: originalDescription });
+    }
   });
 
   it('should pass correct data to drawer when plugin is clicked', async () => {
@@ -312,12 +336,25 @@ describe('RiskCategories', () => {
       categoryDescriptions['Security & Access Control'],
     );
 
+    const pluginButton = screen.getByRole('button', {
+      name: 'View SQL Injection details, 8 of 10 passed, failing',
+    });
+    const collapsibleContent = pluginButton.closest('[data-state]');
+    expect(collapsibleContent).toHaveAttribute('data-state', 'open');
+    expect(collapseButton).toHaveAttribute('aria-controls', collapsibleContent?.id);
+
     await user.click(collapseButton);
 
     const expandButton = screen.getByRole('button', {
       name: 'Expand Security & Access Control category, 8 of 10 passed, failing',
     });
     expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+    expect(collapsibleContent).toHaveAttribute('data-state', 'closed');
+
+    await user.click(expandButton);
+
+    expect(collapseButton).toHaveAttribute('aria-expanded', 'true');
+    expect(collapsibleContent).toHaveAttribute('data-state', 'open');
   });
 
   it('keeps category disclosure and plugin details as independent native actions', async () => {

--- a/src/app/src/pages/redteam/report/components/RiskCategories.tsx
+++ b/src/app/src/pages/redteam/report/components/RiskCategories.tsx
@@ -60,7 +60,7 @@ interface PluginRowProps {
 }
 
 const PluginRow = ({ test, pluginPassRateThreshold, onPluginClick }: PluginRowProps) => {
-  const passRate = test.numPassed / test.total;
+  const passRate = test.total > 0 ? test.numPassed / test.total : 0;
   const isPassing = passRate >= pluginPassRateThreshold;
 
   const displayName =
@@ -293,7 +293,7 @@ const RiskCategories = ({
 
       return {
         name: category,
-        description: categoryDescriptions[categoryName as keyof typeof categoryDescriptions],
+        description: categoryDescriptions[categoryName as keyof typeof categoryDescriptions] ?? '',
         totalPasses,
         totalTests,
         testTypes,

--- a/test/providers/websocket.test.ts
+++ b/test/providers/websocket.test.ts
@@ -869,17 +869,28 @@ describe('WebSocketProvider', () => {
 
   describe('timeouts', () => {
     it('should timeout with streamResponse', async () => {
-      provider = new WebSocketProvider('ws://test.com', {
-        config: {
-          messageTemplate: '{{ prompt }}',
-          timeoutMs: 100,
-          // never signal completion; ensures timeout path is exercised
-          streamResponse: (acc: any, _data: any) => [acc, ''],
-        },
-      });
+      vi.useFakeTimers();
+      try {
+        provider = new WebSocketProvider('ws://test.com', {
+          config: {
+            messageTemplate: '{{ prompt }}',
+            timeoutMs: 100,
+            // never signal completion; ensures timeout path is exercised
+            streamResponse: (acc: any, _data: any) => [acc, ''],
+          },
+        });
 
-      await expect(provider.callApi('timeout test')).rejects.toThrow('WebSocket request timed out');
-      expect(mockWs.close).toHaveBeenCalled();
+        const timeoutPromise = expect(provider.callApi('timeout test')).rejects.toThrow(
+          'WebSocket request timed out',
+        );
+
+        await vi.runAllTimersAsync();
+        await timeoutPromise;
+
+        expect(mockWs.close).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Guard red-team plugin pass rates against empty test totals and provide a safe fallback when a risk category has no configured description.
- Verify accessible disclosure state stays synchronized with the actual expanded and collapsed risk-category content, including missing-description and empty-plugin coverage.
- Make the streaming WebSocket timeout regression test deterministic with fake timers and guaranteed timer cleanup.

## Validation

- `npm run test:app -- src/pages/redteam/report/components --run --configLoader runner --no-cache` (15 files, 204 tests)
- `npx vitest run test/providers/websocket.test.ts --configLoader runner --no-cache` (59 tests)
- `npm run tsc`
- `npm --prefix src/app run tsc -- --noEmit`
- `npm run f`
- `npm run l`
- `git diff --check`
