### PR TITLE
fix(eval): isolate conversation history by result column

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -671,11 +671,16 @@ function mergeProviderPromptConfig(
 function createRunEvalState({
   provider,
   prompt,
+  promptIndex,
   test,
-}: Pick<RunEvalOptions, 'provider' | 'prompt' | 'test'>): RunEvalState {
+}: Pick<RunEvalOptions, 'provider' | 'prompt' | 'test'> & {
+  promptIndex: number;
+}): RunEvalState {
   const vars = structuredClone(test.vars || {});
   const fileMetadata = collectFileMetadata(vars);
-  const conversationKey = `${provider.label || provider.id()}:${prompt.id}${test.metadata?.conversationId ? `:${test.metadata.conversationId}` : ''}`;
+  // Provider identifiers and prompt ids can both collide, but every result-table
+  // column has a unique index. Include it so separate columns never share history.
+  const conversationKey = `${provider.label || provider.id()}:${prompt.id}:${promptIndex}${test.metadata?.conversationId ? `:${test.metadata.conversationId}` : ''}`;
 
   const setup = createRunEvalSetup({
     provider,
@@ -1435,7 +1440,7 @@ async function runEvalInternal({
     `Provider delay should be set for ${provider.label}`,
   );
 
-  const state = createRunEvalState({ provider, prompt, test });
+  const state = createRunEvalState({ provider, prompt, promptIndex, test });
   attachConversationVar({
     conversations,
     conversationKey: state.conversationKey,

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -679,8 +679,14 @@ function createRunEvalState({
   const vars = structuredClone(test.vars || {});
   const fileMetadata = collectFileMetadata(vars);
   // Provider identifiers and prompt ids can both collide, but every result-table
-  // column has a unique index. Include it so separate columns never share history.
-  const conversationKey = `${provider.label || provider.id()}:${prompt.id}:${promptIndex}${test.metadata?.conversationId ? `:${test.metadata.conversationId}` : ''}`;
+  // column has a unique index. Encode the components as a tuple because identifiers
+  // can contain separators that would make concatenated keys ambiguous.
+  const conversationKey = JSON.stringify([
+    getProviderIdentifier(provider),
+    prompt.id,
+    promptIndex,
+    test.metadata?.conversationId,
+  ]);
 
   const setup = createRunEvalSetup({
     provider,

--- a/test/evaluator/routing.test.ts
+++ b/test/evaluator/routing.test.ts
@@ -249,6 +249,108 @@ describeEvaluator('evaluator prompt and provider routing', () => {
     ]);
   });
 
+  it.each([
+    {
+      description: 'duplicate provider ids',
+      firstId: 'duplicate-provider',
+      secondId: 'duplicate-provider',
+    },
+    {
+      description: 'shared provider labels',
+      firstId: 'provider-1',
+      secondId: 'provider-2',
+      label: 'shared-label',
+    },
+    {
+      description: 'duplicate provider ids with an explicit conversation id',
+      firstId: 'duplicate-provider',
+      secondId: 'duplicate-provider',
+      conversationId: 'shared-conversation',
+    },
+  ])('isolates conversation histories for $description', async ({
+    firstId,
+    secondId,
+    label,
+    conversationId,
+  }) => {
+    const firstProvider = duplicateProvider(firstId, 'First provider output', label);
+    const secondProvider = duplicateProvider(secondId, 'Second provider output', label);
+    const metadata = conversationId ? { conversationId } : undefined;
+
+    const testSuite: TestSuite = {
+      providers: [firstProvider, secondProvider],
+      prompts: [
+        toPrompt(
+          '{% if _conversation.length %}prior={{ _conversation[0].output }} {% endif %}now={{ input }}',
+        ),
+      ],
+      tests: [
+        { vars: { input: 'first' }, metadata },
+        { vars: { input: 'second' }, metadata },
+      ],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+
+    expect(firstProvider.callApi).toHaveBeenNthCalledWith(
+      1,
+      'now=first',
+      expect.anything(),
+      undefined,
+    );
+    expect(secondProvider.callApi).toHaveBeenNthCalledWith(
+      1,
+      'now=first',
+      expect.anything(),
+      undefined,
+    );
+    expect(firstProvider.callApi).toHaveBeenNthCalledWith(
+      2,
+      'prior=First provider output now=second',
+      expect.anything(),
+      undefined,
+    );
+    expect(secondProvider.callApi).toHaveBeenNthCalledWith(
+      2,
+      'prior=Second provider output now=second',
+      expect.anything(),
+      undefined,
+    );
+  });
+
+  it('isolates conversation histories for prompts that share a label', async () => {
+    const provider = createMockProvider({
+      id: 'test-provider',
+      callApi: async (prompt) => createProviderResponse({ output: prompt }),
+    });
+
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [
+        {
+          raw: 'first {% if _conversation.length %}prior={{ _conversation[0].output }} {% endif %}now={{ input }}',
+          label: 'shared-prompt-label',
+        },
+        {
+          raw: 'second {% if _conversation.length %}prior={{ _conversation[0].output }} {% endif %}now={{ input }}',
+          label: 'shared-prompt-label',
+        },
+      ],
+      tests: [{ vars: { input: 'one' } }, { vars: { input: 'two' } }],
+    };
+
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, {});
+
+    expect(provider.callApi.mock.calls.map(([prompt]) => prompt)).toEqual([
+      'first now=one',
+      'second now=one',
+      'first prior=first now=one now=two',
+      'second prior=second now=one now=two',
+    ]);
+  });
+
   it('routes every prompt of every duplicate provider to its own column', async () => {
     const firstProvider = duplicateProvider('duplicate-provider', 'First provider output');
     const secondProvider = duplicateProvider('duplicate-provider', 'Second provider output');

--- a/test/evaluator/runEval.test.ts
+++ b/test/evaluator/runEval.test.ts
@@ -320,9 +320,10 @@ describe('runEval', () => {
     });
     const result = results[0];
     expect(result.success).toBe(true);
-    expect(conversations).toHaveProperty('test-provider:undefined:0');
-    expect(conversations['test-provider:undefined:0']).toHaveLength(1);
-    expect(conversations['test-provider:undefined:0'][0]).toEqual({
+    const conversationKey = JSON.stringify(['test-provider', null, 0, null]);
+    expect(conversations).toHaveProperty([conversationKey]);
+    expect(conversations[conversationKey]).toHaveLength(1);
+    expect(conversations[conversationKey][0]).toEqual({
       prompt: 'Hello ',
       input: 'Hello ',
       output: 'Test output',
@@ -342,7 +343,42 @@ describe('runEval', () => {
     });
     const result = results[0];
     expect(result.success).toBe(true);
-    expect(conversations).toHaveProperty('test-provider:custom-id:0:conv1');
+    expect(conversations).toHaveProperty([
+      JSON.stringify(['test-provider', 'custom-id', 0, 'conv1']),
+    ]);
+  });
+
+  it('keeps colon-delimited prompt and conversation identifiers from colliding', async () => {
+    const conversations = {};
+    const promptTemplate =
+      '{% if _conversation.length %}prior={{ _conversation[0].output }} {% endif %}now={{ turn }}';
+
+    await runEval({
+      ...defaultOptions,
+      provider: mockProvider,
+      prompt: { raw: promptTemplate, label: 'first prompt', id: 'prompt:1' },
+      test: { metadata: { conversationId: 'shared' }, vars: { turn: 'first' } },
+      conversations,
+      registers: {},
+    });
+
+    await runEval({
+      ...defaultOptions,
+      promptIdx: 1,
+      provider: mockProvider,
+      prompt: { raw: promptTemplate, label: 'second prompt', id: 'prompt' },
+      test: { metadata: { conversationId: '0:shared' }, vars: { turn: 'second' } },
+      conversations,
+      registers: {},
+    });
+
+    expect(mockProvider.callApi).toHaveBeenNthCalledWith(
+      2,
+      'now=second',
+      expect.anything(),
+      undefined,
+    );
+    expect(Object.keys(conversations)).toHaveLength(2);
   });
 
   it('should include sessionId from response in result metadata', async () => {

--- a/test/evaluator/runEval.test.ts
+++ b/test/evaluator/runEval.test.ts
@@ -320,9 +320,9 @@ describe('runEval', () => {
     });
     const result = results[0];
     expect(result.success).toBe(true);
-    expect(conversations).toHaveProperty('test-provider:undefined');
-    expect(conversations['test-provider:undefined']).toHaveLength(1);
-    expect(conversations['test-provider:undefined'][0]).toEqual({
+    expect(conversations).toHaveProperty('test-provider:undefined:0');
+    expect(conversations['test-provider:undefined:0']).toHaveLength(1);
+    expect(conversations['test-provider:undefined:0'][0]).toEqual({
       prompt: 'Hello ',
       input: 'Hello ',
       output: 'Test output',
@@ -342,7 +342,7 @@ describe('runEval', () => {
     });
     const result = results[0];
     expect(result.success).toBe(true);
-    expect(conversations).toHaveProperty('test-provider:custom-id:conv1');
+    expect(conversations).toHaveProperty('test-provider:custom-id:0:conv1');
   });
 
   it('should include sessionId from response in result metadata', async () => {

--- a/test/evaluator/runEval.test.ts
+++ b/test/evaluator/runEval.test.ts
@@ -348,7 +348,21 @@ describe('runEval', () => {
     ]);
   });
 
-  it('keeps colon-delimited prompt and conversation identifiers from colliding', async () => {
+  it.each([
+    {
+      description: 'legacy provider, prompt, and conversation keys',
+      conversationId: '1:shared',
+      promptIdx: 0,
+    },
+    {
+      description: 'column-aware conversation keys',
+      conversationId: '0:shared',
+      promptIdx: 1,
+    },
+  ])('keeps colon-delimited identifiers from colliding for $description', async ({
+    conversationId,
+    promptIdx,
+  }) => {
     const conversations = {};
     const promptTemplate =
       '{% if _conversation.length %}prior={{ _conversation[0].output }} {% endif %}now={{ turn }}';
@@ -364,10 +378,10 @@ describe('runEval', () => {
 
     await runEval({
       ...defaultOptions,
-      promptIdx: 1,
+      promptIdx,
       provider: mockProvider,
       prompt: { raw: promptTemplate, label: 'second prompt', id: 'prompt' },
-      test: { metadata: { conversationId: '0:shared' }, vars: { turn: 'second' } },
+      test: { metadata: { conversationId }, vars: { turn: 'second' } },
       conversations,
       registers: {},
     });


### PR DESCRIPTION
## Summary

- isolate `_conversation` history by results-table column so duplicate provider IDs, shared provider labels, and colliding prompt labels cannot leak prior outputs across evaluation targets
- encode provider, prompt, column, and conversation identifiers as an unambiguous tuple, preventing delimiter-based collision bypasses
- preserve explicit `metadata.conversationId` scoping while keeping each provider/prompt column independent
- add six fail-first regression cases and update direct `runEval` conversation-key expectations

## Root cause

Recent duplicate-provider column routing fixes made result columns positional, but conversation history still used only `provider label/id + prompt id`. Both identifiers can collide, so one provider's first prompt received another provider's completed output; distinct prompts sharing a label leaked history for the same reason. Naively joining user-controlled identifiers with colons also creates ambiguous keys, so conversation state now uses a JSON-encoded identity tuple.

## Validation

- Confirmed all six regression cases fail before their respective fixes and pass afterward, including the original pre-PR delimiter collision
- `./node_modules/.bin/vitest run test/evaluator --configLoader runner --no-cache --maxWorkers 4` — 450 tests passed
- `./node_modules/.bin/vitest run test/test-hygiene.test.ts --configLoader runner --no-cache` — 88 tests passed
- `npm run tsc`
- `npm run architecture:check`
- `npm run knip -- --no-progress`
- `npm run l && npm run f`
- Real uncached CLI eval with two identically labeled `echo` providers using distinct configurations: four provider-turn results passed; zero failures or errors
