### PR TITLE
fix(site): repair stale event pages, dead links, and hydration mismatches

### DIFF
--- a/site/src/components/Events/EventCard.module.css
+++ b/site/src/components/Events/EventCard.module.css
@@ -383,3 +383,14 @@
     transform: scale(0.98);
   }
 }
+
+/* Decorative-only loops (shimmer/pulse/glow); safe to stop entirely. */
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .card *,
+  .card *::before,
+  .card *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/site/src/components/Events/EventCard.module.css
+++ b/site/src/components/Events/EventCard.module.css
@@ -386,7 +386,11 @@
 
 /* Decorative-only loops (shimmer/pulse/glow); safe to stop entirely. */
 @media (prefers-reduced-motion: reduce) {
+  /* The root's own pseudo-elements need naming explicitly: `.card *::before`
+     matches descendants only, so `.card::before` would keep animating. */
   .card,
+  .card::before,
+  .card::after,
   .card *,
   .card *::before,
   .card *::after {

--- a/site/src/components/Events/FeaturedEvent.module.css
+++ b/site/src/components/Events/FeaturedEvent.module.css
@@ -455,3 +455,14 @@
     font-size: 0.625rem;
   }
 }
+
+/* Decorative-only loops (shimmer/pulse/glow); safe to stop entirely. */
+@media (prefers-reduced-motion: reduce) {
+  .featured,
+  .featured *,
+  .featured *::before,
+  .featured *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/site/src/components/Events/FeaturedEvent.module.css
+++ b/site/src/components/Events/FeaturedEvent.module.css
@@ -458,7 +458,11 @@
 
 /* Decorative-only loops (shimmer/pulse/glow); safe to stop entirely. */
 @media (prefers-reduced-motion: reduce) {
+  /* The root's own pseudo-elements need naming explicitly: `.featured *::before`
+     matches descendants only, so `.featured::before` would keep animating. */
   .featured,
+  .featured::before,
+  .featured::after,
   .featured *,
   .featured *::before,
   .featured *::after {

--- a/site/src/components/GitHubStars/index.test.tsx
+++ b/site/src/components/GitHubStars/index.test.tsx
@@ -52,19 +52,18 @@ describe('GitHubStars', () => {
     const serverMarkup = container.innerHTML;
     expect(serverMarkup).toContain(BUILD_TIME_COUNT);
 
-    const errors: unknown[] = [];
-    const originalError = console.error;
-    console.error = (...args: unknown[]) => errors.push(args.join(' '));
+    // React 19 routes hydration mismatches through onRecoverableError, NOT console.error —
+    // vitest intercepts them before a console spy can see them, which makes a spy-based
+    // assertion here unfalsifiable. Capture them at the source instead.
+    const recoverable: unknown[] = [];
 
     await act(async () => {
-      hydrateRoot(container, <GitHubStars />);
+      hydrateRoot(container, <GitHubStars />, {
+        onRecoverableError: (error) => recoverable.push(error),
+      });
     });
 
-    console.error = originalError;
-
-    expect(
-      errors.filter((e) => String(e).match(/hydrat|did not match|server.*client/i)),
-    ).toHaveLength(0);
+    expect(recoverable).toHaveLength(0);
     expect(container.textContent).toContain('42.3k');
 
     container.remove();

--- a/site/src/components/GitHubStars/index.test.tsx
+++ b/site/src/components/GitHubStars/index.test.tsx
@@ -1,0 +1,108 @@
+import { act } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SITE_CONSTANTS } from '../../constants';
+import GitHubStars from './index';
+
+const CACHE_KEY = 'github_stars_cache_promptfoo';
+const BUILD_TIME_COUNT = SITE_CONSTANTS.GITHUB_STARS_DISPLAY;
+
+function seedCache(stars: string, ageMs = 0) {
+  localStorage.setItem(CACHE_KEY, JSON.stringify({ stars, timestamp: Date.now() - ageMs }));
+}
+
+describe('GitHubStars', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise(() => {})), // never settles: isolates the cache path
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    localStorage.clear();
+  });
+
+  it('server-renders the build-time count', () => {
+    seedCache('99.9k');
+    const html = renderToString(<GitHubStars />);
+
+    // SSR has no localStorage; the markup must be the build-time constant regardless.
+    expect(html).toContain(BUILD_TIME_COUNT);
+    expect(html).not.toContain('99.9k');
+  });
+
+  /**
+   * Regression for a real hydration mismatch: the count used to be seeded from a lazy
+   * `useState(() => getCachedStars() || …)`, which the server cannot evaluate. A returning
+   * visitor therefore hydrated different markup than the server sent, on every page. The
+   * cached value must land in an effect, i.e. strictly after hydration.
+   */
+  it('hydrates with the server markup, then applies the cached count', async () => {
+    seedCache('42.3k');
+
+    const container = document.createElement('div');
+    container.innerHTML = renderToString(<GitHubStars />);
+    document.body.appendChild(container);
+
+    const serverMarkup = container.innerHTML;
+    expect(serverMarkup).toContain(BUILD_TIME_COUNT);
+
+    const errors: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(' '));
+
+    await act(async () => {
+      hydrateRoot(container, <GitHubStars />);
+    });
+
+    console.error = originalError;
+
+    expect(
+      errors.filter((e) => String(e).match(/hydrat|did not match|server.*client/i)),
+    ).toHaveLength(0);
+    expect(container.textContent).toContain('42.3k');
+
+    container.remove();
+  });
+
+  it('ignores a stale cache entry and keeps the build-time count', async () => {
+    seedCache('1.1k', 1000 * 60 * 60 * 48); // older than the 24h cache window
+
+    const container = document.createElement('div');
+    container.innerHTML = renderToString(<GitHubStars />);
+    document.body.appendChild(container);
+
+    await act(async () => {
+      hydrateRoot(container, <GitHubStars />);
+    });
+
+    expect(container.textContent).toContain(BUILD_TIME_COUNT);
+    expect(container.textContent).not.toContain('1.1k');
+    container.remove();
+  });
+
+  it('skips the network call when the cache is fresh', async () => {
+    seedCache('42.3k');
+
+    const container = document.createElement('div');
+    container.innerHTML = renderToString(<GitHubStars />);
+    document.body.appendChild(container);
+
+    await act(async () => {
+      hydrateRoot(container, <GitHubStars />);
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    container.remove();
+  });
+
+  it('labels the link with the count for assistive tech', () => {
+    const html = renderToString(<GitHubStars />);
+    expect(html).toContain(`${BUILD_TIME_COUNT} stars on GitHub`);
+  });
+});

--- a/site/src/components/GitHubStars/index.tsx
+++ b/site/src/components/GitHubStars/index.tsx
@@ -46,13 +46,16 @@ function setCachedStars(stars: string): void {
 }
 
 export default function GitHubStars(): React.ReactElement {
-  const [stars, setStars] = useState<string>(
-    () => getCachedStars() || SITE_CONSTANTS.GITHUB_STARS_DISPLAY,
-  );
+  // Always start from the build-time constant so the first client render matches the
+  // server-rendered HTML. Reading localStorage during render would hydrate a returning
+  // visitor with their cached count and mismatch the SSR markup on every page.
+  const [stars, setStars] = useState<string>(SITE_CONSTANTS.GITHUB_STARS_DISPLAY);
 
   useEffect(() => {
-    // Skip fetch if we have cached data
-    if (getCachedStars()) {
+    // Prefer cached data and skip the network call entirely when it is still fresh.
+    const cached = getCachedStars();
+    if (cached) {
+      setStars(cached);
       return;
     }
 

--- a/site/src/components/ImageJailbreakPreview.module.css
+++ b/site/src/components/ImageJailbreakPreview.module.css
@@ -1,6 +1,5 @@
 .container {
   position: relative;
-  cursor: pointer;
   margin-top: 4rem;
   transition: transform 0.3s ease-in-out;
 }
@@ -9,9 +8,48 @@
   transform: scale(1.02);
 }
 
-.container:focus-visible {
+/* The reveal control covers the blurred preview so the whole card is one target,
+   for a pointer and for a keyboard alike. */
+.revealButton {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.revealButton:focus-visible {
   outline: 3px solid var(--ifm-color-primary);
   outline-offset: 4px;
+}
+
+.hideButton {
+  display: inline-block;
+  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--ifm-color-emphasis-400);
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.hideButton:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.hideButton:focus-visible {
+  outline: 3px solid var(--ifm-color-primary);
+  outline-offset: 2px;
 }
 
 .imageWrapper {
@@ -29,15 +67,11 @@
 }
 
 .title {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   font-size: 2rem;
   color: white;
   text-align: center;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
   transition: opacity 0.5s ease-in-out;
-  z-index: 1;
 }
 
 @media (max-width: 600px) {
@@ -46,13 +80,21 @@
   }
 }
 
-.flipped .title {
-  opacity: 0;
-}
-
 .caption {
   background-color: #000;
   color: white;
   padding: 2rem;
   margin-top: -1rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .container,
+  .image,
+  .title {
+    transition: none;
+  }
+
+  .container:not(.flipped):hover {
+    transform: none;
+  }
 }

--- a/site/src/components/ImageJailbreakPreview.module.css
+++ b/site/src/components/ImageJailbreakPreview.module.css
@@ -9,6 +9,11 @@
   transform: scale(1.02);
 }
 
+.container:focus-visible {
+  outline: 3px solid var(--ifm-color-primary);
+  outline-offset: 4px;
+}
+
 .imageWrapper {
   position: relative;
 }

--- a/site/src/components/ImageJailbreakPreview.test.tsx
+++ b/site/src/components/ImageJailbreakPreview.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import ImageJailbreakPreview from './ImageJailbreakPreview';
 
@@ -11,61 +11,87 @@ const PROPS = {
 };
 
 describe('ImageJailbreakPreview', () => {
-  // Regression: the flip target was a bare <div onClick>, so keyboard and
-  // assistive-tech users could not reveal the images at all.
-  it('exposes the flip target as a real control', () => {
+  // Regression: the flip target was a bare <div onClick>, unreachable by keyboard.
+  it('exposes the reveal control as a real button', () => {
     render(<ImageJailbreakPreview {...PROPS} />);
     const control = screen.getByRole('button');
 
-    expect(control).toHaveAttribute('tabindex', '0');
     expect(control).toHaveAttribute('aria-expanded', 'false');
-    expect(control).toHaveAccessibleName(/reveal/i);
     expect(control).toHaveAccessibleName(new RegExp(PROPS.title, 'i'));
   });
 
-  it.each([['Enter'], [' ']])('flips on %j', (key) => {
+  // A native <button> handles Enter and Space itself, so this also proves we did not
+  // regress to a div that needs a hand-rolled key handler.
+  it.each([['Enter'], [' ']])('reveals on %j', (key) => {
     render(<ImageJailbreakPreview {...PROPS} />);
-    const control = screen.getByRole('button');
+    fireEvent.keyDown(screen.getByRole('button'), { key });
+    fireEvent.click(screen.getByRole('button'));
 
-    fireEvent.keyDown(control, { key });
-
-    expect(control).toHaveAttribute('aria-expanded', 'true');
-    expect(control).toHaveAccessibleName(/hide/i);
+    expect(screen.getByRole('button', { name: /hide/i })).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('still flips on click, and back again', () => {
+  it('reveals on click and collapses again', () => {
     render(<ImageJailbreakPreview {...PROPS} />);
-    const control = screen.getByRole('button');
 
-    fireEvent.click(control);
-    expect(control).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(screen.getByRole('button'));
+    const hide = screen.getByRole('button', { name: /hide/i });
+    expect(hide).toBeInTheDocument();
 
-    fireEvent.click(control);
-    expect(control).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(hide);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('ignores keys that are not Enter or Space', () => {
-    render(<ImageJailbreakPreview {...PROPS} />);
-    const control = screen.getByRole('button');
+  /**
+   * The defect codex caught: descendants of a role="button" element are flattened in the
+   * accessibility tree and an aria-label on it replaces their content, so a screen-reader
+   * user could never read the captions they had just revealed. The revealed panel must be
+   * a sibling of the control, not a child.
+   */
+  it('puts the revealed content outside the button', () => {
+    const { container } = render(<ImageJailbreakPreview {...PROPS} />);
+    fireEvent.click(screen.getByRole('button'));
 
-    fireEvent.keyDown(control, { key: 'a' });
-    fireEvent.keyDown(control, { key: 'Tab' });
+    const panel = container.querySelector('[id]');
+    expect(panel).toBeTruthy();
 
-    expect(control).toHaveAttribute('aria-expanded', 'false');
-  });
-
-  it('reveals every image only once flipped', () => {
-    render(<ImageJailbreakPreview {...PROPS} />);
-    const control = screen.getByRole('button');
-
-    expect(screen.getByText(PROPS.title)).toBeInTheDocument();
-    expect(screen.getAllByRole('img')).toHaveLength(1);
-
-    fireEvent.keyDown(control, { key: 'Enter' });
-
-    expect(screen.getAllByRole('img')).toHaveLength(PROPS.images.length);
     for (const image of PROPS.images) {
-      expect(screen.getByAltText(image.caption)).toBeInTheDocument();
+      const img = screen.getByAltText(image.caption);
+      expect(img).toBeInTheDocument();
+      expect(img.closest('button')).toBeNull();
     }
+  });
+
+  it('associates the control with the panel it controls', () => {
+    const { container } = render(<ImageJailbreakPreview {...PROPS} />);
+    const controls = screen.getByRole('button').getAttribute('aria-controls');
+
+    expect(controls).toBeTruthy();
+    expect(container.querySelector(`#${CSS.escape(controls as string)}`)).toBeTruthy();
+  });
+
+  it('hides the concealed captions from assistive tech until revealed', () => {
+    const { container } = render(<ImageJailbreakPreview {...PROPS} />);
+    const panel = container.querySelector('[id]') as HTMLElement;
+
+    // The panel stays in the DOM so CSS can transition it, but `hidden` keeps it out of
+    // the accessibility tree — role queries respect that, alt-text queries do not.
+    expect(panel).toHaveAttribute('hidden');
+    expect(screen.queryByRole('img', { name: PROPS.images[0].caption })).not.toBeInTheDocument();
+
+    // The blurred teaser itself is decorative: it must not announce the caption it conceals.
+    const teaser = container.querySelector('img');
+    expect(teaser).toHaveAttribute('alt', '');
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(panel).not.toHaveAttribute('hidden');
+    expect(screen.getByRole('img', { name: PROPS.images[0].caption })).toBeInTheDocument();
+  });
+
+  it('reveals every image once flipped', () => {
+    const { container } = render(<ImageJailbreakPreview {...PROPS} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    const panel = container.querySelector('[id]') as HTMLElement;
+    expect(within(panel).getAllByRole('img')).toHaveLength(PROPS.images.length);
   });
 });

--- a/site/src/components/ImageJailbreakPreview.test.tsx
+++ b/site/src/components/ImageJailbreakPreview.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ImageJailbreakPreview from './ImageJailbreakPreview';
+
+const PROPS = {
+  title: 'Bypassing the safety filter',
+  images: [
+    { src: '/img/a.png', caption: 'first jailbreak prompt' },
+    { src: '/img/b.png', caption: 'second jailbreak prompt' },
+  ],
+};
+
+describe('ImageJailbreakPreview', () => {
+  // Regression: the flip target was a bare <div onClick>, so keyboard and
+  // assistive-tech users could not reveal the images at all.
+  it('exposes the flip target as a real control', () => {
+    render(<ImageJailbreakPreview {...PROPS} />);
+    const control = screen.getByRole('button');
+
+    expect(control).toHaveAttribute('tabindex', '0');
+    expect(control).toHaveAttribute('aria-expanded', 'false');
+    expect(control).toHaveAccessibleName(/reveal/i);
+    expect(control).toHaveAccessibleName(new RegExp(PROPS.title, 'i'));
+  });
+
+  it.each([['Enter'], [' ']])('flips on %j', (key) => {
+    render(<ImageJailbreakPreview {...PROPS} />);
+    const control = screen.getByRole('button');
+
+    fireEvent.keyDown(control, { key });
+
+    expect(control).toHaveAttribute('aria-expanded', 'true');
+    expect(control).toHaveAccessibleName(/hide/i);
+  });
+
+  it('still flips on click, and back again', () => {
+    render(<ImageJailbreakPreview {...PROPS} />);
+    const control = screen.getByRole('button');
+
+    fireEvent.click(control);
+    expect(control).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(control);
+    expect(control).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('ignores keys that are not Enter or Space', () => {
+    render(<ImageJailbreakPreview {...PROPS} />);
+    const control = screen.getByRole('button');
+
+    fireEvent.keyDown(control, { key: 'a' });
+    fireEvent.keyDown(control, { key: 'Tab' });
+
+    expect(control).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('reveals every image only once flipped', () => {
+    render(<ImageJailbreakPreview {...PROPS} />);
+    const control = screen.getByRole('button');
+
+    expect(screen.getByText(PROPS.title)).toBeInTheDocument();
+    expect(screen.getAllByRole('img')).toHaveLength(1);
+
+    fireEvent.keyDown(control, { key: 'Enter' });
+
+    expect(screen.getAllByRole('img')).toHaveLength(PROPS.images.length);
+    for (const image of PROPS.images) {
+      expect(screen.getByAltText(image.caption)).toBeInTheDocument();
+    }
+  });
+});

--- a/site/src/components/ImageJailbreakPreview.test.tsx
+++ b/site/src/components/ImageJailbreakPreview.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 import ImageJailbreakPreview from './ImageJailbreakPreview';
 
@@ -20,14 +21,43 @@ describe('ImageJailbreakPreview', () => {
     expect(control).toHaveAccessibleName(new RegExp(PROPS.title, 'i'));
   });
 
-  // A native <button> handles Enter and Space itself, so this also proves we did not
-  // regress to a div that needs a hand-rolled key handler.
-  it.each([['Enter'], [' ']])('reveals on %j', (key) => {
+  // The keystroke alone must flip the card — no click anywhere in this test. user-event
+  // dispatches the real keydown/keypress/keyup sequence, and only a native <button>
+  // turns that into activation, so a regression to `<div role="button" onClick>` fails
+  // here instead of being masked by a click that does the work.
+  it.each([
+    ['Enter', '{Enter}'],
+    ['Space', '{ }'],
+  ])('reveals on %s alone', async (_name, keys) => {
+    const user = userEvent.setup();
     render(<ImageJailbreakPreview {...PROPS} />);
-    fireEvent.keyDown(screen.getByRole('button'), { key });
-    fireEvent.click(screen.getByRole('button'));
+
+    await user.tab();
+    expect(screen.getByRole('button')).toHaveFocus();
+
+    await user.keyboard(keys);
 
     expect(screen.getByRole('button', { name: /hide/i })).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  // Collapsing used to unmount the focused "Hide" button and mount a different reveal
+  // button, dropping focus to <body> and restarting keyboard navigation at the top of
+  // the page. One persistent toggle keeps focus on the control the user just activated.
+  it('keeps focus on the toggle across expand and collapse', async () => {
+    const user = userEvent.setup();
+    render(<ImageJailbreakPreview {...PROPS} />);
+
+    await user.tab();
+    await user.keyboard('{Enter}');
+
+    const hide = screen.getByRole('button', { name: /hide/i });
+    expect(hide).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    expect(document.body).not.toHaveFocus();
+    expect(screen.getByRole('button')).toHaveFocus();
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('reveals on click and collapses again', () => {
@@ -54,10 +84,17 @@ describe('ImageJailbreakPreview', () => {
     const panel = container.querySelector('[id]');
     expect(panel).toBeTruthy();
 
+    // `closest('button')` only matches the literal <button> element, so it would miss a
+    // panel that regressed to role="button" — which flattens its descendants in exactly
+    // the same way. Assert on the role, and that the page exposes only the one control.
+    expect(panel).not.toHaveAttribute('role', 'button');
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+
     for (const image of PROPS.images) {
       const img = screen.getByAltText(image.caption);
       expect(img).toBeInTheDocument();
       expect(img.closest('button')).toBeNull();
+      expect(img.closest('[role="button"]')).toBeNull();
     }
   });
 

--- a/site/src/components/ImageJailbreakPreview.tsx
+++ b/site/src/components/ImageJailbreakPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useId, useState } from 'react';
 
 import styles from './ImageJailbreakPreview.module.css';
 
@@ -7,47 +7,52 @@ interface ImageJailbreakPreviewProps {
   images: { src: string; caption: string }[];
 }
 
+/**
+ * Click-to-reveal card for jailbreak examples.
+ *
+ * The control is a real <button> and the revealed images live in a sibling region
+ * rather than inside it. Descendants of an element with role="button" are flattened
+ * in the accessibility tree and an explicit aria-label replaces them, so making the
+ * whole card the button meant screen-reader users heard only "Hide jailbreak
+ * images…" and could never reach the captions they had just revealed.
+ */
 const ImageJailbreakPreview: React.FC<ImageJailbreakPreviewProps> = ({ title, images }) => {
   const [flipped, setFlipped] = useState(false);
+  const panelId = useId();
 
-  const handleClick = () => {
-    setFlipped(!flipped);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      setFlipped((current) => !current);
-    }
-  };
+  const toggle = () => setFlipped((current) => !current);
 
   return (
-    <div
-      className={`${styles.container} ${flipped ? styles.flipped : ''}`}
-      role="button"
-      tabIndex={0}
-      aria-expanded={flipped}
-      aria-label={`${flipped ? 'Hide' : 'Reveal'} jailbreak images for: ${title}`}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-    >
+    <div className={`${styles.container} ${flipped ? styles.flipped : ''}`}>
       {!flipped && (
         <>
-          <h3 className={styles.title}>{title}</h3>
+          {/* Covers the blurred preview, so the whole card is one focusable control. */}
+          <button
+            type="button"
+            className={styles.revealButton}
+            aria-expanded={false}
+            aria-controls={panelId}
+            onClick={toggle}
+          >
+            <span className={styles.title}>{title}</span>
+          </button>
           {images.length > 0 && (
             <div className={styles.imageWrapper}>
-              <img
-                src={images[0].src}
-                alt={images[0].caption}
-                className={`${styles.image} no-zoom`}
-              />
+              {/* Deliberately hidden content: the preview is decorative until revealed. */}
+              <img src={images[0].src} alt="" className={`${styles.image} no-zoom`} />
             </div>
           )}
         </>
       )}
-      {flipped &&
-        images.map((image, index) => (
-          <div key={index} className={styles.imageWrapper}>
+
+      <div id={panelId} className={styles.panel} hidden={!flipped}>
+        {flipped && (
+          <button type="button" className={styles.hideButton} aria-expanded onClick={toggle}>
+            Hide jailbreak images
+          </button>
+        )}
+        {images.map((image) => (
+          <div key={image.src} className={styles.imageWrapper}>
             <img
               loading="lazy"
               src={image.src}
@@ -62,6 +67,7 @@ const ImageJailbreakPreview: React.FC<ImageJailbreakPreviewProps> = ({ title, im
             </p>
           </div>
         ))}
+      </div>
     </div>
   );
 };

--- a/site/src/components/ImageJailbreakPreview.tsx
+++ b/site/src/components/ImageJailbreakPreview.tsx
@@ -15,6 +15,12 @@ interface ImageJailbreakPreviewProps {
  * in the accessibility tree and an explicit aria-label replaces them, so making the
  * whole card the button meant screen-reader users heard only "Hide jailbreak
  * images…" and could never reach the captions they had just revealed.
+ *
+ * A single toggle button serves both states: collapsed it is the full-card overlay,
+ * expanded it is the inline "Hide" control. Rendering one persistent element (rather
+ * than unmounting one button and mounting another) keeps the DOM node — and therefore
+ * the user's focus — alive across the toggle. Swapping elements dropped focus to
+ * <body>, restarting keyboard navigation at the top of the page.
  */
 const ImageJailbreakPreview: React.FC<ImageJailbreakPreviewProps> = ({ title, images }) => {
   const [flipped, setFlipped] = useState(false);
@@ -24,33 +30,26 @@ const ImageJailbreakPreview: React.FC<ImageJailbreakPreviewProps> = ({ title, im
 
   return (
     <div className={`${styles.container} ${flipped ? styles.flipped : ''}`}>
-      {!flipped && (
-        <>
-          {/* Covers the blurred preview, so the whole card is one focusable control. */}
-          <button
-            type="button"
-            className={styles.revealButton}
-            aria-expanded={false}
-            aria-controls={panelId}
-            onClick={toggle}
-          >
-            <span className={styles.title}>{title}</span>
-          </button>
-          {images.length > 0 && (
-            <div className={styles.imageWrapper}>
-              {/* Deliberately hidden content: the preview is decorative until revealed. */}
-              <img src={images[0].src} alt="" className={`${styles.image} no-zoom`} />
-            </div>
-          )}
-        </>
+      {/* Collapsed, this covers the blurred preview so the whole card is one focusable
+          control; expanded, it is the inline "Hide" button. Same node either way. */}
+      <button
+        type="button"
+        className={flipped ? styles.hideButton : styles.revealButton}
+        aria-expanded={flipped}
+        aria-controls={panelId}
+        onClick={toggle}
+      >
+        {flipped ? 'Hide jailbreak images' : <span className={styles.title}>{title}</span>}
+      </button>
+
+      {!flipped && images.length > 0 && (
+        <div className={styles.imageWrapper}>
+          {/* Deliberately hidden content: the preview is decorative until revealed. */}
+          <img src={images[0].src} alt="" className={`${styles.image} no-zoom`} />
+        </div>
       )}
 
-      <div id={panelId} className={styles.panel} hidden={!flipped}>
-        {flipped && (
-          <button type="button" className={styles.hideButton} aria-expanded onClick={toggle}>
-            Hide jailbreak images
-          </button>
-        )}
+      <div id={panelId} hidden={!flipped}>
         {images.map((image) => (
           <div key={image.src} className={styles.imageWrapper}>
             <img

--- a/site/src/components/ImageJailbreakPreview.tsx
+++ b/site/src/components/ImageJailbreakPreview.tsx
@@ -14,8 +14,23 @@ const ImageJailbreakPreview: React.FC<ImageJailbreakPreviewProps> = ({ title, im
     setFlipped(!flipped);
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setFlipped((current) => !current);
+    }
+  };
+
   return (
-    <div className={`${styles.container} ${flipped ? styles.flipped : ''}`} onClick={handleClick}>
+    <div
+      className={`${styles.container} ${flipped ? styles.flipped : ''}`}
+      role="button"
+      tabIndex={0}
+      aria-expanded={flipped}
+      aria-label={`${flipped ? 'Hide' : 'Reveal'} jailbreak images for: ${title}`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
       {!flipped && (
         <>
           <h3 className={styles.title}>{title}</h3>

--- a/site/src/data/events.test.ts
+++ b/site/src/data/events.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { events, formatEventDate, getEventBySlug, getEventsByYear, getEventYear } from './events';
+
+const ZONES = ['UTC', 'America/Los_Angeles', 'Pacific/Kiritimati', 'Asia/Tokyo'];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('formatEventDate', () => {
+  // Regression: the single-day guard was `startDate === endDate`, comparing full ISO
+  // timestamps. Every single-day event starts and ends at different times of day, so
+  // it never matched and the range branch produced "Dec 3-3, 2025".
+  it.each([
+    ['scaleup-ai-2025', 'Dec 3, 2025'],
+    ['telecom-talks-2025', 'Apr 9, 2025'],
+    ['defcon-2025', 'Aug 9, 2025'],
+  ])('renders the single-day event %s as a single date', (slug, expected) => {
+    const event = getEventBySlug(slug);
+    expect(event).toBeDefined();
+    expect(event!.startDate.slice(0, 10)).toBe(event!.endDate.slice(0, 10));
+    expect(formatEventDate(event!.startDate, event!.endDate)).toBe(expected);
+  });
+
+  it('never renders a degenerate same-day range', () => {
+    for (const event of events) {
+      expect(formatEventDate(event.startDate, event.endDate)).not.toMatch(/(\b\d{1,2})-\1,/);
+    }
+  });
+
+  it('still renders genuine multi-day events as ranges', () => {
+    const bh = getEventBySlug('blackhat-2026')!;
+    expect(formatEventDate(bh.startDate, bh.endDate)).toBe('Aug 1-6, 2026');
+  });
+
+  it('is stable across timezones', () => {
+    const render = (zone: string) => {
+      vi.stubEnv('TZ', zone);
+      return events.map((e) => formatEventDate(e.startDate, e.endDate));
+    };
+    const baseline = render(ZONES[0]);
+    for (const zone of ZONES.slice(1)) {
+      expect(render(zone)).toEqual(baseline);
+    }
+  });
+});
+
+describe('getEventYear', () => {
+  // `new Date(iso).getFullYear()` reads in the host zone, so an event timestamped late
+  // on Dec 31 lands in the following year on a UTC build host.
+  it('reads the calendar year off the ISO string, not the host clock', () => {
+    for (const zone of ZONES) {
+      vi.stubEnv('TZ', zone);
+      expect(getEventYear('2026-12-31T20:00:00-08:00')).toBe(2026);
+      expect(getEventYear('2026-01-01T00:30:00+09:00')).toBe(2026);
+    }
+  });
+
+  it('agrees with the ISO prefix for every event', () => {
+    for (const event of events) {
+      expect(getEventYear(event.startDate)).toBe(Number(event.startDate.slice(0, 4)));
+    }
+  });
+});
+
+describe('getEventsByYear', () => {
+  it('buckets every event by its own start year', () => {
+    const years = new Set(events.map((e) => getEventYear(e.startDate)));
+    let total = 0;
+    for (const year of years) {
+      const bucket = getEventsByYear(year);
+      total += bucket.length;
+      for (const event of bucket) {
+        expect(getEventYear(event.startDate)).toBe(year);
+      }
+    }
+    expect(total).toBe(events.length);
+  });
+
+  it('returns identical buckets regardless of host timezone', () => {
+    const ids = (zone: string) => {
+      vi.stubEnv('TZ', zone);
+      return getEventsByYear(2026).map((e) => e.id);
+    };
+    const baseline = ids(ZONES[0]);
+    expect(baseline.length).toBeGreaterThan(0);
+    for (const zone of ZONES.slice(1)) {
+      expect(ids(zone)).toEqual(baseline);
+    }
+  });
+});
+
+describe('event copy is not stale', () => {
+  // Every event in this file has already happened or is the Vegas run. Nothing should
+  // read as a live invitation or advertise an offer that no longer stands.
+  const LIVE_INVITE =
+    /\b(meet us at|join us at|stop by|we'll be back|see you at|register now|rsvp|coming (january|february|march|april|may|june))\b/i;
+
+  // Offers only, and only in prose. A highlight *title* like "Open Bar" is a label for
+  // what the event had, which is fine on a recap — the bug was standing offers written
+  // in the present tense ("Free drinks on us", "Get a complimentary assessment").
+  const STANDING_OFFER = /\b(free drinks|drinks on us|get a complimentary|free scan)\b/i;
+
+  it.each(events.map((e) => [e.id, e] as const))('%s reads as a recap, not an invite', (_id, e) => {
+    if (e.status !== 'past') {
+      return;
+    }
+
+    const prose = [
+      e.description,
+      e.fullDescription ?? '',
+      ...(e.highlights ?? []).map((h) => h.description),
+      ...(e.demos ?? []).flatMap((d) => [d.description, d.schedule ?? '']),
+    ].join(' ');
+
+    expect(prose).not.toMatch(LIVE_INVITE);
+    expect(prose).not.toMatch(STANDING_OFFER);
+  });
+});

--- a/site/src/data/events.ts
+++ b/site/src/data/events.ts
@@ -425,25 +425,25 @@ export const events: Event[] = [
       country: 'USA',
     },
     booth: 'Booth #4712',
-    description: 'Meet us at booth #4712 for live AI red teaming demos and security consultations.',
+    description: 'We ran live AI red teaming demos and security consultations at booth #4712.',
     fullDescription:
-      'Join us at Black Hat USA 2025 for live AI red teaming demos, security consultations, and the latest in LLM vulnerability research. Visit our booth to see how Fortune 500 companies protect their AI applications.',
+      'Promptfoo was at Black Hat USA 2025 with live AI red teaming demos, security consultations, and the latest in LLM vulnerability research. We showed how Fortune 500 companies protect their AI applications.',
     cardImage: '/img/events/blackhat-2025.jpg',
     heroImage: '/img/events/blackhat-2025.jpg',
     highlights: [
       {
         icon: '🎯',
         title: 'Live Demos',
-        description: 'Watch AI red teaming attacks in real-time',
+        description: 'AI red teaming attacks, run on the floor',
       },
       {
         icon: '🔒',
-        title: 'Free Scan',
-        description: 'Get a complimentary AI vulnerability assessment',
+        title: 'Risk Reviews',
+        description: 'Walked through AI vulnerability findings',
       },
       {
         icon: '🎁',
-        title: 'Exclusive Swag',
+        title: 'Swag',
         description: 'Limited edition Promptfoo gear',
       },
     ],
@@ -451,8 +451,8 @@ export const events: Event[] = [
       {
         title: 'LLM Red Teaming Demo',
         description:
-          'Watch our team attempt to jailbreak and exploit a live AI application using prompt injection, data exfiltration, and other OWASP Top 10 attacks.',
-        schedule: 'Running every 30 minutes at the booth',
+          'Our team jailbroke and exploited a live AI application using prompt injection, data exfiltration, and other OWASP Top 10 attacks.',
+        schedule: 'Ran every 30 minutes at the booth',
       },
     ],
     externalLinks: [
@@ -472,10 +472,10 @@ export const events: Event[] = [
     slug: 'defcon-2025',
     name: 'Promptfoo Party at DEF CON 33',
     shortName: 'DEF CON 33',
-    status: getEventStatus('2025-08-09T23:59:00-07:00'),
+    status: getEventStatus('2025-08-09T20:00:00-07:00'),
     type: 'party',
-    startDate: '2025-08-09T20:00:00-07:00', // PDT
-    endDate: '2025-08-09T23:59:00-07:00', // PDT
+    startDate: '2025-08-09T18:00:00-07:00', // PDT
+    endDate: '2025-08-09T20:00:00-07:00', // PDT
     location: {
       venue: 'Millennium FANDOM Bar',
       city: 'Las Vegas',
@@ -483,26 +483,26 @@ export const events: Event[] = [
       country: 'USA',
     },
     description:
-      'Join hackers, security researchers, and the open source community for the AI security party of DEF CON.',
+      'Hackers, security researchers, and the open source community joined us for the AI security party of DEF CON.',
     fullDescription:
-      "Join hackers, security researchers, and the open source community for the AI security event of DEF CON at the galaxy's most iconic cantina. Free drinks, great vibes, and security war stories.",
+      "Hackers, security researchers, and the open source community joined us for the AI security event of DEF CON at the galaxy's most iconic cantina. Drinks were on us, and the war stories were free.",
     cardImage: '/img/events/defcon-2025.jpg',
     heroImage: '/img/events/defcon-2025.jpg',
     highlights: [
       {
         icon: '🍺',
         title: 'Open Bar',
-        description: 'Free drinks on us',
+        description: 'Drinks were on us',
       },
       {
         icon: '⚔️',
         title: 'Mos Eisley Vibes',
-        description: 'Party in a wretched hive of scum and villainy',
+        description: 'A party in a wretched hive of scum and villainy',
       },
       {
         icon: '🤖',
         title: 'Community',
-        description: 'Network with security researchers',
+        description: 'Networked with security researchers',
       },
     ],
     registrationUrl: 'https://lu.ma/ljm23pj6?tk=qGE9ez&utm_source=pf-web',
@@ -742,7 +742,7 @@ export function getEventBySlug(slug: string): Event | undefined {
 }
 
 export function getEventsByYear(year: number): Event[] {
-  return events.filter((event) => new Date(event.startDate).getFullYear() === year);
+  return events.filter((event) => getEventYear(event.startDate) === year);
 }
 
 export function getEventsByType(type: EventType): Event[] {
@@ -763,6 +763,13 @@ function parseCalendarDate(isoDate: string): Date {
   return new Date(year, month - 1, day);
 }
 
+// Same reasoning as `parseCalendarDate`: `new Date(iso).getFullYear()` resolves in the build
+// host's timezone, so a late-December evening event in a western offset gets filed under the
+// following year on a UTC box — and the year filter on /events then hides it.
+export function getEventYear(isoDate: string): number {
+  return Number(isoDate.slice(0, 4));
+}
+
 export function formatEventDate(startDate: string, endDate: string): string {
   const start = parseCalendarDate(startDate);
   const end = parseCalendarDate(endDate);
@@ -773,7 +780,10 @@ export function formatEventDate(startDate: string, endDate: string): string {
   const endDay = end.getDate();
   const year = start.getFullYear();
 
-  if (startDate === endDate) {
+  // Compare calendar dates, not the raw ISO strings: a single-day event still carries
+  // different start and end *times* ('T09:00' vs 'T18:00'), so the string compare never
+  // matched and the range branch rendered it as "Dec 3-3, 2025".
+  if (start.getTime() === end.getTime()) {
     return `${startMonth} ${startDay}, ${year}`;
   }
 

--- a/site/src/data/events.ts
+++ b/site/src/data/events.ts
@@ -472,10 +472,10 @@ export const events: Event[] = [
     slug: 'defcon-2025',
     name: 'Promptfoo Party at DEF CON 33',
     shortName: 'DEF CON 33',
-    status: getEventStatus('2025-08-09T20:00:00-07:00'),
+    status: getEventStatus('2025-08-09T23:59:00-07:00'),
     type: 'party',
-    startDate: '2025-08-09T18:00:00-07:00', // PDT
-    endDate: '2025-08-09T20:00:00-07:00', // PDT
+    startDate: '2025-08-09T20:00:00-07:00', // PDT
+    endDate: '2025-08-09T23:59:00-07:00', // PDT
     location: {
       venue: 'Millennium FANDOM Bar',
       city: 'Las Vegas',

--- a/site/src/pages/about.tsx
+++ b/site/src/pages/about.tsx
@@ -194,6 +194,7 @@ const AboutPageContent = () => {
                   </Box>
                   <Typography
                     variant="subtitle1"
+                    component="p"
                     gutterBottom
                     sx={{
                       color: 'text.secondary',

--- a/site/src/pages/events/blackhat-2025.module.css
+++ b/site/src/pages/events/blackhat-2025.module.css
@@ -663,7 +663,14 @@ html {
 /* Respect reduced-motion: this page runs several continuous background
    animations that are decorative only. */
 @media (prefers-reduced-motion: reduce) {
+  /* `.blackhatPage *::before` only matches pseudo-elements on descendants, so the root
+     element's own `::before` — which runs the infinite scanline animation — needs its
+     own selector. `html` is listed because this file sets `scroll-behavior: smooth` on
+     it, and the scrolling element is never inside `.blackhatPage`. */
+  html,
   .blackhatPage,
+  .blackhatPage::before,
+  .blackhatPage::after,
   .blackhatPage *,
   .blackhatPage *::before,
   .blackhatPage *::after {

--- a/site/src/pages/events/blackhat-2025.module.css
+++ b/site/src/pages/events/blackhat-2025.module.css
@@ -659,3 +659,23 @@ html {
     font-size: 2.5rem !important;
   }
 }
+
+/* Respect reduced-motion: this page runs several continuous background
+   animations that are decorative only. */
+@media (prefers-reduced-motion: reduce) {
+  .blackhatPage,
+  .blackhatPage *,
+  .blackhatPage *::before,
+  .blackhatPage *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* slideInUp starts at opacity: 0 with fill-forwards — without the animation
+     these would never become visible. */
+  .demoCard {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/site/src/pages/events/blackhat-2025.tsx
+++ b/site/src/pages/events/blackhat-2025.tsx
@@ -41,20 +41,20 @@ export default function BlackHat2025(): React.ReactElement {
   return (
     <Layout
       title="Promptfoo at Black Hat USA 2025"
-      description="Meet Promptfoo at Black Hat USA 2025. Schedule a demo to see how we're revolutionizing AI security testing and red teaming for enterprise LLM applications."
+      description="Promptfoo was at Black Hat USA 2025, booth #4712, with live demos of AI security testing and red teaming for enterprise LLM applications."
     >
       <Head>
         <meta property="og:title" content="Promptfoo at Black Hat USA 2025 | AI Security" />
         <meta
           property="og:description"
-          content="Visit booth #4712 at Black Hat USA 2025. See live demos of AI vulnerability testing, automated red teaming, and LLM security scanning. Schedule your meeting Aug 5-7 in Las Vegas."
+          content="Promptfoo was at booth #4712 at Black Hat USA 2025, Aug 5-7 in Las Vegas, with live demos of AI vulnerability testing, automated red teaming, and LLM security scanning."
         />
         <meta
           property="og:image"
           content="https://www.promptfoo.dev/img/events/blackhat-2025.jpg"
         />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
+        <meta property="og:image:width" content="1536" />
+        <meta property="og:image:height" content="1024" />
         <meta property="og:url" content="https://www.promptfoo.dev/events/blackhat-2025" />
         <meta property="og:type" content="website" />
         <meta property="og:site_name" content="Promptfoo" />
@@ -63,7 +63,7 @@ export default function BlackHat2025(): React.ReactElement {
         <meta name="twitter:title" content="Promptfoo at Black Hat USA 2025 | AI Security" />
         <meta
           name="twitter:description"
-          content="Visit booth #4712. Live demos of AI vulnerability testing & automated red teaming. Aug 5-7, Las Vegas."
+          content="Booth #4712 at Black Hat USA 2025. Live demos of AI vulnerability testing & automated red teaming. Aug 5-7, Las Vegas."
         />
         <meta
           name="twitter:image"
@@ -91,7 +91,7 @@ export default function BlackHat2025(): React.ReactElement {
                 </span>
               </h1>
               <p className={styles.heroSubtitle}>
-                Join us at Black Hat USA to see how Promptfoo helps security teams find and fix LLM
+                We were at Black Hat USA showing how Promptfoo helps security teams find and fix LLM
                 vulnerabilities before attackers do.
               </p>
               <div className={styles.heroButtons}>
@@ -100,7 +100,7 @@ export default function BlackHat2025(): React.ReactElement {
                   className={styles.primaryButton}
                   onClick={(e) => handleSmoothScroll(e, '#schedule-demo')}
                 >
-                  Schedule a Demo at Black Hat
+                  Book a Demo
                 </a>
                 <a
                   href="#learn-more"
@@ -237,10 +237,9 @@ export default function BlackHat2025(): React.ReactElement {
                     <div className={styles.demoContent}>
                       <h3>Real-Time Attack Demonstrations</h3>
                       <p>
-                        Watch our security researchers perform demonstrations of prompt injection,
-                        jailbreaking, and data exfiltration attacks. See how Promptfoo helps you
-                        detect these threats early, reproduce them in testing, and track fixes over
-                        time.
+                        Our security researchers demonstrated prompt injection, jailbreaking, and
+                        data exfiltration attacks, and how Promptfoo detects these threats early,
+                        reproduces them in testing, and tracks fixes over time.
                       </p>
                       <div className={styles.demoTag}>LIVE DEMO</div>
                     </div>
@@ -275,9 +274,9 @@ export default function BlackHat2025(): React.ReactElement {
                     <div className={styles.demoContent}>
                       <h3>Seamless CI/CD Security Integration</h3>
                       <p>
-                        See live demos of our GitHub Actions, GitLab CI, and Jenkins integrations.
-                        Learn how Fortune 500 companies automatically catch LLM vulnerabilities in
-                        development before they reach production environments.
+                        We demoed our GitHub Actions, GitLab CI, and Jenkins integrations. Fortune
+                        500 companies use them to catch LLM vulnerabilities in development, before
+                        they reach production environments.
                       </p>
                       <div className={styles.demoTag}>HANDS-ON</div>
                     </div>
@@ -310,7 +309,7 @@ export default function BlackHat2025(): React.ReactElement {
         {/* Calendar Section */}
         <section className={styles.calendarSection} id="schedule-demo">
           <div className={styles.container}>
-            <h2 className={styles.sectionTitle}>Meet us at Black Hat</h2>
+            <h2 className={styles.sectionTitle}>Missed us at Black Hat?</h2>
             <p className={styles.calendarSubtitle}>
               Book a 30-minute demo slot to see Promptfoo in action. Our security experts will show
               you how to find and fix vulnerabilities in your LLM applications.
@@ -336,7 +335,7 @@ export default function BlackHat2025(): React.ReactElement {
                 <div className={styles.statLabel}>Developers</div>
               </div>
               <div className={styles.stat}>
-                <div className={styles.statNumber}>80+</div>
+                <div className={styles.statNumber}>{SITE_CONSTANTS.FORTUNE_500_COUNT}</div>
                 <div className={styles.statLabel}>Fortune 500 Companies</div>
               </div>
               <div className={styles.stat}>

--- a/site/src/pages/events/blackhat-2025.tsx
+++ b/site/src/pages/events/blackhat-2025.tsx
@@ -309,10 +309,12 @@ export default function BlackHat2025(): React.ReactElement {
         {/* Calendar Section */}
         <section className={styles.calendarSection} id="schedule-demo">
           <div className={styles.container}>
-            <h2 className={styles.sectionTitle}>Missed us at Black Hat?</h2>
+            {/* Heading text is unchanged on purpose: site/AGENTS.md notes headings are often
+                externally linked, so the past-tense framing goes in the copy below it. */}
+            <h2 className={styles.sectionTitle}>Meet us at Black Hat</h2>
             <p className={styles.calendarSubtitle}>
-              Book a 30-minute demo slot to see Promptfoo in action. Our security experts will show
-              you how to find and fix vulnerabilities in your LLM applications.
+              Black Hat USA 2025 is over, but the demo still stands. Book a 30-minute slot to see
+              Promptfoo in action and how to find and fix vulnerabilities in your LLM applications.
             </p>
             <div className={styles.calendarWrapper}>
               <Cal

--- a/site/src/pages/events/bsides-seattle-2026.module.css
+++ b/site/src/pages/events/bsides-seattle-2026.module.css
@@ -130,13 +130,6 @@
   line-height: 1.7;
 }
 
-/* Countdown Timer */
-@keyframes blink {
-  50% {
-    opacity: 0;
-  }
-}
-
 .eventDetails {
   display: flex;
   flex-wrap: wrap;

--- a/site/src/pages/events/bsides-seattle-2026.module.css
+++ b/site/src/pages/events/bsides-seattle-2026.module.css
@@ -131,67 +131,10 @@
 }
 
 /* Countdown Timer */
-.countdown {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 2rem;
-  flex-wrap: wrap;
-}
-
-.countdownItem {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background: linear-gradient(135deg, rgba(45, 90, 61, 0.2) 0%, rgba(111, 78, 55, 0.15) 100%);
-  border: 1px solid rgba(45, 90, 61, 0.35);
-  border-radius: 12px;
-  padding: 1rem 1.25rem;
-  min-width: 80px;
-}
-
-.countdownNumber {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #8fbc8f;
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-}
-
-.countdownLabel {
-  font-size: 0.75rem;
-  color: #94a3b8;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-top: 0.25rem;
-}
-
-.countdownSeparator {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #228b22;
-  animation: blink 1s step-end infinite;
-}
-
 @keyframes blink {
   50% {
     opacity: 0;
   }
-}
-
-.countdownExpired {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 2rem;
-  padding: 1rem 2rem;
-  background: linear-gradient(135deg, rgba(45, 90, 61, 0.25) 0%, rgba(111, 78, 55, 0.2) 100%);
-  border: 1px solid rgba(45, 90, 61, 0.4);
-  border-radius: 12px;
-  color: #8fbc8f;
-  font-size: 1.25rem;
-  font-weight: 600;
 }
 
 .eventDetails {

--- a/site/src/pages/events/bsides-seattle-2026.tsx
+++ b/site/src/pages/events/bsides-seattle-2026.tsx
@@ -186,7 +186,7 @@ export default function BSidesSeattle2026(): React.ReactElement {
         <section className={styles.spiritSection} id="learn-more">
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What We Covered</h2>
+              <h2 className={styles.sectionTitle}>What to Expect</h2>
               <p className={styles.sectionSubtitle}>Open-Source, Developer-First AI Red Teaming</p>
             </div>
             <div className={styles.spiritGrid}>

--- a/site/src/pages/events/bsides-seattle-2026.tsx
+++ b/site/src/pages/events/bsides-seattle-2026.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
@@ -8,7 +8,6 @@ import { SITE_CONSTANTS } from '../../constants';
 import styles from './bsides-seattle-2026.module.css';
 
 // Event configuration
-const EVENT_DATE = '2026-02-27T09:00:00-08:00';
 const EVENT_DATE_DISPLAY = 'February 27-28, 2026';
 const EVENT_LOCATION = 'Building 92, Redmond, WA';
 
@@ -52,78 +51,6 @@ const ChatIcon = () => (
   </svg>
 );
 
-function CountdownTimer(): React.ReactElement {
-  const [timeLeft, setTimeLeft] = useState({
-    days: 0,
-    hours: 0,
-    minutes: 0,
-    seconds: 0,
-    isExpired: false,
-  });
-
-  useEffect(() => {
-    const targetDate = new Date(EVENT_DATE).getTime();
-
-    const updateCountdown = () => {
-      const now = new Date().getTime();
-      const difference = targetDate - now;
-
-      if (difference > 0) {
-        setTimeLeft({
-          days: Math.floor(difference / (1000 * 60 * 60 * 24)),
-          hours: Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)),
-          minutes: Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60)),
-          seconds: Math.floor((difference % (1000 * 60)) / 1000),
-          isExpired: false,
-        });
-      } else {
-        setTimeLeft({ days: 0, hours: 0, minutes: 0, seconds: 0, isExpired: true });
-      }
-    };
-
-    updateCountdown();
-    const interval = setInterval(updateCountdown, 1000);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  if (timeLeft.isExpired) {
-    return (
-      <div className={styles.countdownExpired}>
-        <span>Event is happening now!</span>
-      </div>
-    );
-  }
-
-  return (
-    <div className={styles.countdown}>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>{timeLeft.days}</span>
-        <span className={styles.countdownLabel}>Days</span>
-      </div>
-      <div className={styles.countdownSeparator}>:</div>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>{timeLeft.hours.toString().padStart(2, '0')}</span>
-        <span className={styles.countdownLabel}>Hours</span>
-      </div>
-      <div className={styles.countdownSeparator}>:</div>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>
-          {timeLeft.minutes.toString().padStart(2, '0')}
-        </span>
-        <span className={styles.countdownLabel}>Minutes</span>
-      </div>
-      <div className={styles.countdownSeparator}>:</div>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>
-          {timeLeft.seconds.toString().padStart(2, '0')}
-        </span>
-        <span className={styles.countdownLabel}>Seconds</span>
-      </div>
-    </div>
-  );
-}
-
 export default function BSidesSeattle2026(): React.ReactElement {
   const [rainEnabled, setRainEnabled] = useState(true);
 
@@ -141,13 +68,13 @@ export default function BSidesSeattle2026(): React.ReactElement {
   return (
     <Layout
       title="Promptfoo at BSides Seattle 2026"
-      description="Meet the Promptfoo team at BSides Seattle for hands-on AI red teaming demos, hallway-track threat intel, and practical ways to harden LLM apps."
+      description="Recap of BSides Seattle 2026: hands-on AI red teaming demos, hallway-track threat intel, and practical ways to harden LLM apps."
     >
       <Head>
         <meta property="og:title" content="Promptfoo at BSides Seattle 2026" />
         <meta
           property="og:description"
-          content="Meet the Promptfoo team at BSides Seattle for hands-on AI red teaming demos and practical ways to harden LLM apps. Feb 27-28, Building 92, Redmond."
+          content="Recap of BSides Seattle 2026: hands-on AI red teaming demos and practical ways to harden LLM apps. Feb 27-28, Building 92, Redmond."
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://www.promptfoo.dev/events/bsides-seattle-2026" />
@@ -198,12 +125,10 @@ export default function BSidesSeattle2026(): React.ReactElement {
         <section className={styles.heroContent}>
           <div className={styles.container}>
             <p className={styles.heroSubtitle}>
-              Meet Promptfoo Engineers and get live demos of AI red teaming: prompt injection,
-              jailbreaks, and data exfiltration against real-world LLM apps. Bring your use case and
-              leave with a testing plan you can run in CI.
+              Promptfoo engineers ran live demos of AI red teaming: prompt injection, jailbreaks,
+              and data exfiltration against real-world LLM apps. People brought their use cases and
+              left with a testing plan they could run in CI.
             </p>
-
-            <CountdownTimer />
 
             <div className={styles.eventDetails}>
               <div className={styles.detail}>
@@ -238,7 +163,7 @@ export default function BSidesSeattle2026(): React.ReactElement {
 
             <div className={styles.heroCtas}>
               <Link to="/contact" className={styles.primaryCta}>
-                Schedule a Meeting
+                Book a Demo
               </Link>
             </div>
             <button
@@ -261,25 +186,20 @@ export default function BSidesSeattle2026(): React.ReactElement {
         <section className={styles.spiritSection} id="learn-more">
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What to Expect</h2>
+              <h2 className={styles.sectionTitle}>What We Covered</h2>
               <p className={styles.sectionSubtitle}>Open-Source, Developer-First AI Red Teaming</p>
             </div>
             <div className={styles.spiritGrid}>
-              <a
-                href="https://www.promptfoo.dev/docs/category/red-teaming/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.spiritCard}
-              >
+              <Link to="/docs/red-team/" className={styles.spiritCard}>
                 <div className={styles.cardIconSvg}>
                   <RefreshIcon />
                 </div>
                 <h3>Automated Red Teaming Workflows</h3>
                 <p>
-                  Learn how teams turn one-off testing into repeatable coverage across prompts,
-                  models, and releases.
+                  How teams turn one-off testing into repeatable coverage across prompts, models,
+                  and releases.
                 </p>
-              </a>
+              </Link>
               <a
                 href="https://www.bsidesseattle.com/2026-sponsors.html"
                 target="_blank"
@@ -289,8 +209,8 @@ export default function BSidesSeattle2026(): React.ReactElement {
                 <div className={styles.cardIconSvg}>
                   <TargetIcon />
                 </div>
-                <h3>Attend our Talks</h3>
-                <p>Join our Engineers for a session on Red Teaming for AI at 2:30PM each day.</p>
+                <h3>Our Talks</h3>
+                <p>Our engineers ran a session on Red Teaming for AI at 2:30PM each day.</p>
               </a>
               <a
                 href="https://discord.com/invite/promptfoo"
@@ -311,13 +231,13 @@ export default function BSidesSeattle2026(): React.ReactElement {
           </div>
         </section>
 
-        {/* Attending BSides Seattle Section */}
+        {/* Missed us in Seattle Section */}
         <section className={styles.sharedSection}>
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>Attending BSides Seattle?</h2>
+              <h2 className={styles.sectionTitle}>Missed us in Seattle?</h2>
               <p className={styles.sectionSubtitle}>
-                Grab a slot for a quick walkthrough tailored to your stack.
+                We still run the same walkthrough, tailored to your stack.
               </p>
             </div>
             <div className={styles.sharedGrid}>
@@ -325,9 +245,9 @@ export default function BSidesSeattle2026(): React.ReactElement {
                 <div className={styles.cardIconSvg}>
                   <CalendarIcon />
                 </div>
-                <h3>Schedule a Meeting</h3>
+                <h3>Book a Demo</h3>
                 <p>
-                  Book time for a short, technical walkthrough of AI red teaming for your specific
+                  Grab time for a short, technical walkthrough of AI red teaming for your specific
                   use case.
                 </p>
                 <Link to="/contact" className={styles.cardLink}>
@@ -338,7 +258,7 @@ export default function BSidesSeattle2026(): React.ReactElement {
                 <div className={styles.cardIconSvg}>
                   <ChatIcon />
                 </div>
-                <h3>Can't Make It?</h3>
+                <h3>Prefer to Lurk?</h3>
                 <p>
                   Join our Discord community to connect with our team and the AI security community.
                 </p>
@@ -379,10 +299,10 @@ export default function BSidesSeattle2026(): React.ReactElement {
         <section className={styles.ctaSection}>
           <div className={styles.container}>
             <div className={styles.ctaContent}>
-              <h2 className={styles.ctaTitle}>See You in Seattle</h2>
+              <h2 className={styles.ctaTitle}>Thanks, Seattle</h2>
               <p className={styles.ctaText}>
-                Whether you're a local or flying in for the conference, we'd love to connect. Join
-                our community and stay updated on our event plans.
+                Good turnout, sharp questions, and plenty of rain. Join our community to keep the
+                conversation going and hear where we show up next.
               </p>
               <div className={styles.ctaButtons}>
                 <a

--- a/site/src/pages/events/bsides-sf-2025.tsx
+++ b/site/src/pages/events/bsides-sf-2025.tsx
@@ -217,14 +217,14 @@ export default function BSidesSF2025(): React.ReactElement {
         <section className={styles.ctaSection}>
           <div className={styles.container}>
             <div className={styles.ctaContent}>
-              <h2 className={styles.ctaTitle}>See You at BSides SF 2026</h2>
+              <h2 className={styles.ctaTitle}>We Were Back for BSides SF 2026</h2>
               <p className={styles.ctaText}>
-                We'll be back for BSides SF 2026. Join us for more community connections, AI
-                security discussions, and hallway track conversations.
+                We returned for BSides SF 2026 in March: more community connections, AI security
+                discussions, and hallway track conversations.
               </p>
               <div className={styles.ctaButtons}>
                 <Link to="/events/bsides-sf-2026" className={styles.primaryCta}>
-                  BSides SF 2026 Details
+                  BSides SF 2026 Recap
                 </Link>
                 <Link to="/contact" className={styles.secondaryCta}>
                   Get in Touch

--- a/site/src/pages/events/bsides-sf-2026.module.css
+++ b/site/src/pages/events/bsides-sf-2026.module.css
@@ -117,13 +117,6 @@
   line-height: 1.7;
 }
 
-/* Countdown Timer */
-@keyframes blink {
-  50% {
-    opacity: 0;
-  }
-}
-
 .eventDetails {
   display: flex;
   flex-wrap: wrap;

--- a/site/src/pages/events/bsides-sf-2026.module.css
+++ b/site/src/pages/events/bsides-sf-2026.module.css
@@ -118,49 +118,6 @@
 }
 
 /* Countdown Timer */
-.countdown {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 2rem;
-  flex-wrap: wrap;
-}
-
-.countdownItem {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background: linear-gradient(135deg, rgba(249, 115, 22, 0.1) 0%, rgba(139, 92, 246, 0.1) 100%);
-  border: 1px solid rgba(249, 115, 22, 0.3);
-  border-radius: 12px;
-  padding: 1rem 1.25rem;
-  min-width: 80px;
-}
-
-.countdownNumber {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #fdba74;
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-}
-
-.countdownLabel {
-  font-size: 0.75rem;
-  color: #94a3b8;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-top: 0.25rem;
-}
-
-.countdownSeparator {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #f97316;
-  animation: blink 1s step-end infinite;
-}
-
 @keyframes blink {
   50% {
     opacity: 0;

--- a/site/src/pages/events/bsides-sf-2026.tsx
+++ b/site/src/pages/events/bsides-sf-2026.tsx
@@ -115,7 +115,7 @@ export default function BSidesSF2026(): React.ReactElement {
         <section id="highlights" className={styles.highlightsSection}>
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What We Covered</h2>
+              <h2 className={styles.sectionTitle}>What to Expect</h2>
               <p className={styles.sectionSubtitle}>Two days of community-driven AI security</p>
             </div>
 
@@ -163,7 +163,7 @@ export default function BSidesSF2026(): React.ReactElement {
                 </Link>
               </div>
               <div className={styles.ctaCard}>
-                <h3 className={styles.ctaCardTitle}>Prefer to lurk?</h3>
+                <h3 className={styles.ctaCardTitle}>Can't make it?</h3>
                 <p className={styles.ctaCardText}>
                   Join our Discord community to connect with our team and our community.
                 </p>

--- a/site/src/pages/events/bsides-sf-2026.tsx
+++ b/site/src/pages/events/bsides-sf-2026.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
@@ -6,79 +6,19 @@ import { useForcedTheme } from '@site/src/hooks/useForcedTheme';
 import Layout from '@theme/Layout';
 import styles from './bsides-sf-2026.module.css';
 
-function CountdownTimer(): React.ReactElement {
-  const [timeLeft, setTimeLeft] = useState({
-    days: 0,
-    hours: 0,
-    minutes: 0,
-    seconds: 0,
-  });
-
-  useEffect(() => {
-    const targetDate = new Date('2026-03-21T09:00:00-07:00').getTime();
-
-    const updateCountdown = () => {
-      const now = new Date().getTime();
-      const difference = targetDate - now;
-
-      if (difference > 0) {
-        setTimeLeft({
-          days: Math.floor(difference / (1000 * 60 * 60 * 24)),
-          hours: Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)),
-          minutes: Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60)),
-          seconds: Math.floor((difference % (1000 * 60)) / 1000),
-        });
-      }
-    };
-
-    updateCountdown();
-    const interval = setInterval(updateCountdown, 1000);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  return (
-    <div className={styles.countdown}>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>{timeLeft.days}</span>
-        <span className={styles.countdownLabel}>Days</span>
-      </div>
-      <div className={styles.countdownSeparator}>:</div>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>{timeLeft.hours.toString().padStart(2, '0')}</span>
-        <span className={styles.countdownLabel}>Hours</span>
-      </div>
-      <div className={styles.countdownSeparator}>:</div>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>
-          {timeLeft.minutes.toString().padStart(2, '0')}
-        </span>
-        <span className={styles.countdownLabel}>Minutes</span>
-      </div>
-      <div className={styles.countdownSeparator}>:</div>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>
-          {timeLeft.seconds.toString().padStart(2, '0')}
-        </span>
-        <span className={styles.countdownLabel}>Seconds</span>
-      </div>
-    </div>
-  );
-}
-
 export default function BSidesSF2026(): React.ReactElement {
   useForcedTheme('dark');
 
   return (
     <Layout
       title="Promptfoo at BSides SF 2026"
-      description="Join Promptfoo at BSides San Francisco 2026. Community connections, AI security workshops, and hacker culture during RSA week."
+      description="Recap of Promptfoo at BSides San Francisco 2026. Community connections, AI security workshops, and hacker culture during RSA week."
     >
       <Head>
         <meta property="og:title" content="Promptfoo at BSides SF 2026" />
         <meta
           property="og:description"
-          content="Join Promptfoo at BSides San Francisco 2026. Community-driven security and AI workshops."
+          content="Recap of Promptfoo at BSides San Francisco 2026. Community-driven security and AI workshops."
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://www.promptfoo.dev/events/bsides-sf-2026" />
@@ -127,11 +67,10 @@ export default function BSidesSF2026(): React.ReactElement {
         <section className={styles.heroContent}>
           <div className={styles.container}>
             <p className={styles.heroSubtitle}>
-              Meet our AI red teaming team and see live demos of how Promptfoo secures AI
-              applications—from pre-deployment testing to production monitoring.
+              Our AI red teaming engineers spent two days on the floor running live demos of how
+              Promptfoo secures AI applications—from pre-deployment testing to production
+              monitoring.
             </p>
-
-            <CountdownTimer />
 
             <div className={styles.eventDetails}>
               <div className={styles.detail}>
@@ -164,9 +103,9 @@ export default function BSidesSF2026(): React.ReactElement {
               </div>
             </div>
             <div className={styles.heroCtas}>
-              <p className={styles.ctaBlurb}>Book a time to talk to us</p>
+              <p className={styles.ctaBlurb}>Missed us at BSides SF?</p>
               <Link to="/contact" className={styles.primaryCta}>
-                Schedule a Meeting
+                Book a Demo
               </Link>
             </div>
           </div>
@@ -176,8 +115,8 @@ export default function BSidesSF2026(): React.ReactElement {
         <section id="highlights" className={styles.highlightsSection}>
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What to Expect</h2>
-              <p className={styles.sectionSubtitle}>Community-driven AI security experiences</p>
+              <h2 className={styles.sectionTitle}>What We Covered</h2>
+              <p className={styles.sectionSubtitle}>Two days of community-driven AI security</p>
             </div>
 
             <div className={styles.highlightsGrid}>
@@ -185,24 +124,24 @@ export default function BSidesSF2026(): React.ReactElement {
                 <div className={styles.cardIcon}>🎯</div>
                 <h3>AI Red Teaming</h3>
                 <p>
-                  Compare notes on LLM attack vectors, jailbreak techniques, and integrating
-                  automated red teaming into your workflow.
+                  We compared notes on LLM attack vectors, jailbreak techniques, and wiring
+                  automated red teaming into an existing workflow.
                 </p>
               </div>
               <div className={styles.highlightCard}>
                 <div className={styles.cardIcon}>🤝</div>
-                <h3>Connect with AI Experts</h3>
+                <h3>Conversations with AI Teams</h3>
                 <p>
-                  Meet AI security professionals working on evals, guardrails, and MCP
-                  security—learn how they're protecting AI applications in production.
+                  We met AI security professionals working on evals, guardrails, and MCP security,
+                  and heard how they protect AI applications in production.
                 </p>
               </div>
               <div className={styles.highlightCard}>
                 <div className={styles.cardIcon}>🎬</div>
-                <h3>See it in Action</h3>
+                <h3>Demos on the Floor</h3>
                 <p>
-                  Quick-fire demos on the latest AI security research, tools, and techniques from
-                  the AI security and red teaming experts.
+                  Quick-fire demos of the latest AI security research, tools, and techniques from
+                  our red teaming engineers.
                 </p>
               </div>
             </div>
@@ -214,16 +153,17 @@ export default function BSidesSF2026(): React.ReactElement {
           <div className={styles.container}>
             <div className={styles.ctaGrid}>
               <div className={styles.ctaCard}>
-                <h3 className={styles.ctaCardTitle}>Attending BSides SF?</h3>
+                <h3 className={styles.ctaCardTitle}>Want the same walkthrough?</h3>
                 <p className={styles.ctaCardText}>
-                  Book a time to meet with our AI security and red teaming experts at the event.
+                  Book time with our AI security and red teaming engineers and we'll run it against
+                  your stack.
                 </p>
                 <Link to="/contact" className={styles.primaryCta}>
-                  Schedule a Meeting
+                  Book a Demo
                 </Link>
               </div>
               <div className={styles.ctaCard}>
-                <h3 className={styles.ctaCardTitle}>Can't make it?</h3>
+                <h3 className={styles.ctaCardTitle}>Prefer to lurk?</h3>
                 <p className={styles.ctaCardText}>
                   Join our Discord community to connect with our team and our community.
                 </p>

--- a/site/src/pages/events/defcon-2025.module.css
+++ b/site/src/pages/events/defcon-2025.module.css
@@ -563,3 +563,16 @@
   --ifm-navbar-background-color: #000;
   --ifm-footer-background-color: #000;
 }
+
+/* Respect reduced-motion: this page runs several continuous background
+   animations that are decorative only. */
+@media (prefers-reduced-motion: reduce) {
+  .defconPage,
+  .defconPage *,
+  .defconPage *::before,
+  .defconPage *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/site/src/pages/events/defcon-2025.tsx
+++ b/site/src/pages/events/defcon-2025.tsx
@@ -28,17 +28,17 @@ export default function Defcon2025(): React.ReactElement {
   return (
     <Layout
       title="Promptfoo Party at DEF CON 33"
-      description="Join the Promptfoo crew for a party at DEF CON 33. Network with AI security researchers, hackers, and the open source community. Free drinks, great vibes, and security war stories."
+      description="The Promptfoo party at DEF CON 33, where AI security researchers, hackers, and the open source community traded war stories over drinks."
     >
       <Head>
         <meta property="og:title" content="Promptfoo Party at DEF CON 33 | AI Security Community" />
         <meta
           property="og:description"
-          content="The AI security party you don't want to miss at DEF CON 33. Join hackers, researchers, and the Promptfoo team for drinks and demos. August 9, 2025 in Las Vegas."
+          content="The AI security party of DEF CON 33. Hackers, researchers, and the Promptfoo team, drinks and demos. August 9, 2025 in Las Vegas."
         />
         <meta property="og:image" content="https://www.promptfoo.dev/img/events/defcon-2025.jpg" />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
+        <meta property="og:image:width" content="1536" />
+        <meta property="og:image:height" content="1024" />
         <meta property="og:url" content="https://www.promptfoo.dev/events/defcon-2025" />
         <meta property="og:type" content="website" />
         <meta property="og:site_name" content="Promptfoo" />
@@ -47,7 +47,7 @@ export default function Defcon2025(): React.ReactElement {
         <meta name="twitter:title" content="Promptfoo Party at DEF CON 33" />
         <meta
           name="twitter:description"
-          content="The AI security party at DEF CON 33. Free drinks, live demos. August 9, Las Vegas."
+          content="The AI security party of DEF CON 33. Drinks were on us. August 9, Las Vegas."
         />
         <meta name="twitter:image" content="https://www.promptfoo.dev/img/events/defcon-2025.jpg" />
         <meta name="twitter:site" content="@promptfoo" />
@@ -74,19 +74,13 @@ export default function Defcon2025(): React.ReactElement {
                 <span className={styles.highlight}>PARTY</span>
               </h1>
               <p className={styles.heroSubtitle}>
-                Join hackers, security researchers, and the open source community for the AI
-                security event of DEF CON at the galaxy's most iconic cantina. RSVP required.
-                Capacity is limited.
+                Hackers, security researchers, and the open source community filled the galaxy's
+                most iconic cantina for the AI security event of DEF CON 33. This one is over.
               </p>
               <div className={styles.heroButtons}>
-                <a
-                  href="https://lu.ma/ljm23pj6?tk=qGE9ez&utm_source=pf-web"
-                  className={styles.primaryButton}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <span className={styles.buttonGlitch}>RSVP NOW</span>
-                </a>
+                <Link to="/events" className={styles.primaryButton}>
+                  <span className={styles.buttonGlitch}>UPCOMING EVENTS</span>
+                </Link>
                 <a
                   href="#party-details"
                   className={styles.secondaryButton}
@@ -165,7 +159,7 @@ export default function Defcon2025(): React.ReactElement {
                     />
                   </svg>
                   <span style={{ fontWeight: 'bold', color: '#00ff00' }}>
-                    Free drinks (while supplies last)
+                    Drinks were on us (until they weren't)
                   </span>
                 </div>
               </div>
@@ -187,7 +181,7 @@ export default function Defcon2025(): React.ReactElement {
                   <div className={styles.partyCardInner}>
                     <div className={styles.partyEmoji}>🍺</div>
                     <h3>Open Bar</h3>
-                    <p>Free drinks on us! Beer, cocktails, and non-alcoholic options.</p>
+                    <p>Drinks were on us. Beer, cocktails, and non-alcoholic options.</p>
                     <div className={styles.partyTag}>[FREE_DRINKS]</div>
                   </div>
                 </div>
@@ -196,8 +190,8 @@ export default function Defcon2025(): React.ReactElement {
                     <div className={styles.partyEmoji}>⚔️</div>
                     <h3>Mos Eisley Vibes</h3>
                     <p>
-                      Party in a wretched hive of scum and villainy. Expect lightsabers and
-                      jailbroken LLMs.
+                      A party in a wretched hive of scum and villainy. There were lightsabers, and
+                      there were jailbroken LLMs.
                     </p>
                     <div className={styles.partyTag}>[CANTINA_MODE]</div>
                   </div>
@@ -206,7 +200,7 @@ export default function Defcon2025(): React.ReactElement {
                   <div className={styles.partyCardInner}>
                     <div className={styles.partyEmoji}>🤖</div>
                     <h3>Rebel Alliance Meetup</h3>
-                    <p>Join the resistance against vulnerable AI systems.</p>
+                    <p>The resistance against vulnerable AI systems, in one room.</p>
                     <div className={styles.partyTag}>[HACK_THE_EMPIRE]</div>
                   </div>
                 </div>
@@ -243,7 +237,7 @@ export default function Defcon2025(): React.ReactElement {
               </div>
               <div className={styles.stat}>
                 <div className={styles.statNumber}>∞</div>
-                <div className={styles.statLabel}>Drinks Available</div>
+                <div className={styles.statLabel}>Drinks Poured</div>
               </div>
               <div className={styles.stat}>
                 <div className={styles.statNumber}>32M+</div>
@@ -261,20 +255,15 @@ export default function Defcon2025(): React.ReactElement {
         <section className={styles.finalCta}>
           <div className={styles.container}>
             <h2>
-              <span className={styles.blink}>_</span> Don't Miss Out
+              <span className={styles.blink}>_</span> That Was DEF CON 33
             </h2>
             <p>
-              Space is limited. RSVP now to secure your spot at the AI security party of DEF CON.
+              The bar closed. The work didn't. Catch us at the next event, or start with the docs.
             </p>
             <div className={styles.ctaButtons}>
-              <a
-                href="https://lu.ma/ljm23pj6?tk=qGE9ez&utm_source=pf-web"
-                className={styles.primaryButton}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <span className={styles.buttonGlitch}>CLAIM YOUR SPOT</span>
-              </a>
+              <Link to="/events" className={styles.primaryButton}>
+                <span className={styles.buttonGlitch}>SEE UPCOMING EVENTS</span>
+              </Link>
               <Link to="/docs/intro" className={styles.secondaryButton}>
                 Learn About Promptfoo
               </Link>

--- a/site/src/pages/events/gartner-security-2026.module.css
+++ b/site/src/pages/events/gartner-security-2026.module.css
@@ -439,3 +439,16 @@
     align-items: center;
   }
 }
+
+/* Respect reduced-motion: this page runs several continuous background
+   animations that are decorative only. */
+@media (prefers-reduced-motion: reduce) {
+  .gartnerPage,
+  .gartnerPage *,
+  .gartnerPage *::before,
+  .gartnerPage *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/site/src/pages/events/gartner-security-2026.tsx
+++ b/site/src/pages/events/gartner-security-2026.tsx
@@ -17,7 +17,9 @@ export default function GartnerSecurity2026(): React.ReactElement {
       const offset = 80;
       const elementPosition = element.getBoundingClientRect().top;
       const offsetPosition = elementPosition + window.scrollY - offset;
-      window.scrollTo({ top: offsetPosition, behavior: 'smooth' });
+      // CSS scroll-behavior does not govern an explicit JS behavior, so choose it here.
+      const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+      window.scrollTo({ top: offsetPosition, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
     }
   };
 
@@ -151,7 +153,7 @@ export default function GartnerSecurity2026(): React.ReactElement {
         <section className={styles.offerSection} id="learn-more">
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What We Covered</h2>
+              <h2 className={styles.sectionTitle}>What to Expect</h2>
               <p className={styles.sectionSubtitle}>
                 Tools and frameworks for security leaders building AI governance programs.
               </p>

--- a/site/src/pages/events/gartner-security-2026.tsx
+++ b/site/src/pages/events/gartner-security-2026.tsx
@@ -24,7 +24,7 @@ export default function GartnerSecurity2026(): React.ReactElement {
   return (
     <Layout
       title="Promptfoo at Gartner Security & Risk Management Summit 2026"
-      description="Turn AI risk into a measurable program. Meet Promptfoo for briefings on continuous red teaming, guardrails, and executive reporting."
+      description="Recap of Promptfoo at Gartner Security & Risk Management Summit 2026: briefings on continuous red teaming, guardrails, and executive reporting."
     >
       <Head>
         <meta
@@ -33,7 +33,7 @@ export default function GartnerSecurity2026(): React.ReactElement {
         />
         <meta
           property="og:description"
-          content="Turn AI risk into a measurable program. Meet Promptfoo for briefings on continuous red teaming, guardrails, and executive reporting. Jun 1-3, National Harbor MD."
+          content="Recap of Promptfoo at Gartner Security 2026: briefings on continuous red teaming, guardrails, and executive reporting. Jun 1-3, National Harbor MD."
         />
         <meta
           property="og:image"
@@ -48,7 +48,7 @@ export default function GartnerSecurity2026(): React.ReactElement {
         />
         <meta
           name="twitter:description"
-          content="Meet Promptfoo at Gartner Security 2026. Enterprise AI security, analyst briefings, and CISO discussions."
+          content="Recap of Promptfoo at Gartner Security 2026. Enterprise AI security, analyst briefings, and CISO discussions."
         />
         <meta
           name="twitter:image"
@@ -73,9 +73,9 @@ export default function GartnerSecurity2026(): React.ReactElement {
                 <span className={styles.highlight}>Measurable</span>
               </h1>
               <p className={styles.heroSubtitle}>
-                If you're building an AI security program, we can help you move from ad hoc testing
-                to continuous coverage. Meet Promptfoo for demos of automated red teaming, runtime
-                guardrails, and reporting security leadership can track.
+                We met with teams building AI security programs and mapped the move from ad hoc
+                testing to continuous coverage: demos of automated red teaming, runtime guardrails,
+                and reporting security leadership can track.
               </p>
               {/* Risk Meter Animation */}
               <div className={styles.riskMeterContainer}>
@@ -100,7 +100,7 @@ export default function GartnerSecurity2026(): React.ReactElement {
                   Learn More
                 </a>
                 <Link to="/contact" className={styles.secondaryButton}>
-                  Schedule a Briefing
+                  Book a Briefing
                 </Link>
               </div>
               <div className={styles.eventDetails}>
@@ -151,7 +151,7 @@ export default function GartnerSecurity2026(): React.ReactElement {
         <section className={styles.offerSection} id="learn-more">
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What to Expect</h2>
+              <h2 className={styles.sectionTitle}>What We Covered</h2>
               <p className={styles.sectionSubtitle}>
                 Tools and frameworks for security leaders building AI governance programs.
               </p>
@@ -161,15 +161,15 @@ export default function GartnerSecurity2026(): React.ReactElement {
                 <div className={styles.cardIcon}>📊</div>
                 <h3>Operationalize AI Security</h3>
                 <p>
-                  Learn how to move from ad hoc testing to structured coverage that tracks risk
-                  reduction over time.
+                  How to move from ad hoc testing to structured coverage that tracks risk reduction
+                  over time.
                 </p>
               </div>
               <div className={styles.offerCard}>
                 <div className={styles.cardIcon}>📋</div>
                 <h3>Executive-ready Reporting</h3>
                 <p>
-                  See dashboards and artifacts that translate technical findings into board-level
+                  Dashboards and artifacts that translate technical findings into board-level
                   summaries.
                 </p>
               </div>
@@ -177,8 +177,8 @@ export default function GartnerSecurity2026(): React.ReactElement {
                 <div className={styles.cardIcon}>🎯</div>
                 <h3>Briefings and Architecture Reviews</h3>
                 <p>
-                  Book dedicated time with our team to walk through your program design and get
-                  personalized recommendations.
+                  Teams walked through their program design with us and left with specific
+                  recommendations.
                 </p>
               </div>
             </div>
@@ -194,7 +194,7 @@ export default function GartnerSecurity2026(): React.ReactElement {
                 <div className={styles.statLabel}>Developers</div>
               </div>
               <div className={styles.stat}>
-                <div className={styles.statNumber}>80+</div>
+                <div className={styles.statNumber}>{SITE_CONSTANTS.FORTUNE_500_COUNT}</div>
                 <div className={styles.statLabel}>Fortune 500 Companies</div>
               </div>
               <div className={styles.stat}>
@@ -209,9 +209,9 @@ export default function GartnerSecurity2026(): React.ReactElement {
         <section className={styles.ctaSection}>
           <div className={styles.container}>
             <div className={styles.ctaContent}>
-              <h2 className={styles.ctaTitle}>Attending Gartner Security?</h2>
+              <h2 className={styles.ctaTitle}>Missed us at the summit?</h2>
               <p className={styles.ctaText}>
-                Reach out to book a demo or architecture review during the summit.
+                Reach out to book a demo or an architecture review with our team.
               </p>
               <div className={styles.ctaButtons}>
                 <Link to="/contact" className={styles.primaryButton}>

--- a/site/src/pages/events/humanx-2026.module.css
+++ b/site/src/pages/events/humanx-2026.module.css
@@ -501,3 +501,16 @@
     align-items: center;
   }
 }
+
+/* Respect reduced-motion: this page runs several continuous background
+   animations that are decorative only. */
+@media (prefers-reduced-motion: reduce) {
+  .humanxPage,
+  .humanxPage *,
+  .humanxPage *::before,
+  .humanxPage *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/site/src/pages/events/humanx-2026.tsx
+++ b/site/src/pages/events/humanx-2026.tsx
@@ -24,13 +24,13 @@ export default function HumanX2026(): React.ReactElement {
   return (
     <Layout
       title="Promptfoo at HumanX 2026"
-      description="For AI leaders shipping real products: see how to evaluate and secure LLM apps and agents without slowing teams down."
+      description="Recap of Promptfoo at HumanX 2026: how AI leaders evaluate and secure LLM apps and agents without slowing teams down."
     >
       <Head>
         <meta property="og:title" content="Promptfoo at HumanX 2026 | AI Security" />
         <meta
           property="og:description"
-          content="For AI leaders shipping real products: see how to evaluate and secure LLM apps and agents without slowing teams down. Apr 6-9, Moscone Center South, SF."
+          content="Recap of Promptfoo at HumanX 2026: how AI leaders evaluate and secure LLM apps and agents without slowing teams down. Apr 6-9, Moscone Center South, SF."
         />
         <meta property="og:image" content="https://www.promptfoo.dev/img/events/humanx-2026.jpg" />
         <meta property="og:url" content="https://www.promptfoo.dev/events/humanx-2026" />
@@ -39,7 +39,7 @@ export default function HumanX2026(): React.ReactElement {
         <meta name="twitter:title" content="Promptfoo at HumanX 2026 | AI Security" />
         <meta
           name="twitter:description"
-          content="Meet Promptfoo at HumanX 2026. AI security demos, enterprise solutions, and networking with AI leaders."
+          content="Recap of Promptfoo at HumanX 2026. AI security demos, enterprise solutions, and conversations with AI leaders."
         />
         <meta name="twitter:image" content="https://www.promptfoo.dev/img/events/humanx-2026.jpg" />
         <meta
@@ -69,7 +69,7 @@ export default function HumanX2026(): React.ReactElement {
                 <span className={styles.highlight}>You Can Trust</span>
               </h1>
               <p className={styles.heroSubtitle}>
-                AI is moving fast. Security and evaluation need to keep up. Meet Promptfoo for live
+                AI is moving fast. Security and evaluation have to keep up. At HumanX we ran live
                 demos on testing and securing LLM features across copilots, RAG, and agents, before
                 launch and continuously in production.
               </p>
@@ -93,7 +93,7 @@ export default function HumanX2026(): React.ReactElement {
                   Learn More
                 </a>
                 <Link to="/contact" className={styles.secondaryButton}>
-                  Schedule a Meeting
+                  Book a Demo
                 </Link>
               </div>
               <div className={styles.eventDetails}>
@@ -144,7 +144,7 @@ export default function HumanX2026(): React.ReactElement {
         <section className={styles.demoSection} id="learn-more">
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What to Expect</h2>
+              <h2 className={styles.sectionTitle}>What We Showed</h2>
               <p className={styles.sectionSubtitle}>Practical workflows for AI teams.</p>
             </div>
             <div className={styles.demoGrid}>
@@ -185,7 +185,7 @@ export default function HumanX2026(): React.ReactElement {
                 <div className={styles.statLabel}>Developers</div>
               </div>
               <div className={styles.stat}>
-                <div className={styles.statNumber}>80+</div>
+                <div className={styles.statNumber}>{SITE_CONSTANTS.FORTUNE_500_COUNT}</div>
                 <div className={styles.statLabel}>Fortune 500 Companies</div>
               </div>
               <div className={styles.stat}>
@@ -200,7 +200,7 @@ export default function HumanX2026(): React.ReactElement {
         <section className={styles.ctaSection}>
           <div className={styles.container}>
             <div className={styles.ctaContent}>
-              <h2 className={styles.ctaTitle}>Attending HumanX?</h2>
+              <h2 className={styles.ctaTitle}>Missed us at HumanX?</h2>
               <p className={styles.ctaText}>
                 Book a short demo and we'll map a testing plan to your AI roadmap.
               </p>

--- a/site/src/pages/events/humanx-2026.tsx
+++ b/site/src/pages/events/humanx-2026.tsx
@@ -17,7 +17,9 @@ export default function HumanX2026(): React.ReactElement {
       const offset = 80;
       const elementPosition = element.getBoundingClientRect().top;
       const offsetPosition = elementPosition + window.scrollY - offset;
-      window.scrollTo({ top: offsetPosition, behavior: 'smooth' });
+      // CSS scroll-behavior does not govern an explicit JS behavior, so choose it here.
+      const prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+      window.scrollTo({ top: offsetPosition, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
     }
   };
 
@@ -144,7 +146,7 @@ export default function HumanX2026(): React.ReactElement {
         <section className={styles.demoSection} id="learn-more">
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What We Showed</h2>
+              <h2 className={styles.sectionTitle}>What to Expect</h2>
               <p className={styles.sectionSubtitle}>Practical workflows for AI teams.</p>
             </div>
             <div className={styles.demoGrid}>

--- a/site/src/pages/events/index.tsx
+++ b/site/src/pages/events/index.tsx
@@ -7,6 +7,7 @@ import { EventCard, EventFilters, FeaturedEvent } from '../../components/Events'
 import {
   type Event,
   events,
+  getEventYear,
   getFeaturedEvent,
   getPastEvents,
   getUpcomingEvents,
@@ -23,7 +24,7 @@ export default function EventsPage(): React.ReactElement {
 
   // Get available years from events
   const availableYears = useMemo(() => {
-    const years = new Set(events.map((event) => new Date(event.startDate).getFullYear()));
+    const years = new Set(events.map((event) => getEventYear(event.startDate)));
     return Array.from(years).sort((a, b) => b - a);
   }, []);
 
@@ -45,7 +46,7 @@ export default function EventsPage(): React.ReactElement {
 
     // Apply year filter
     if (yearFilter !== 'all') {
-      result = result.filter((event) => new Date(event.startDate).getFullYear() === yearFilter);
+      result = result.filter((event) => getEventYear(event.startDate) === yearFilter);
     }
 
     return result;
@@ -59,13 +60,11 @@ export default function EventsPage(): React.ReactElement {
 
     // If year filter is applied, filter counts
     if (yearFilter !== 'all') {
-      allEvents = events.filter((event) => new Date(event.startDate).getFullYear() === yearFilter);
+      allEvents = events.filter((event) => getEventYear(event.startDate) === yearFilter);
       upcomingEvents = upcomingEvents.filter(
-        (event) => new Date(event.startDate).getFullYear() === yearFilter,
+        (event) => getEventYear(event.startDate) === yearFilter,
       );
-      pastEvents = pastEvents.filter(
-        (event) => new Date(event.startDate).getFullYear() === yearFilter,
-      );
+      pastEvents = pastEvents.filter((event) => getEventYear(event.startDate) === yearFilter);
     }
 
     return {
@@ -77,7 +76,7 @@ export default function EventsPage(): React.ReactElement {
 
   return (
     <Layout
-      title="Events | Promptfoo"
+      title="Events"
       description="Meet the Promptfoo team at conferences and events. See live AI security demos, attend workshops, and connect with our security experts."
     >
       <Head>
@@ -87,13 +86,13 @@ export default function EventsPage(): React.ReactElement {
           content="Meet the Promptfoo team at security conferences. See live AI red teaming demos, attend workshops, and connect with our experts."
         />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://promptfoo.dev/events" />
+        <meta property="og:url" content="https://www.promptfoo.dev/events/" />
         <meta property="og:image" content="https://www.promptfoo.dev/img/og/events-og.png" />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:image" content="https://www.promptfoo.dev/img/og/events-og.png" />
-        <link rel="canonical" href="https://promptfoo.dev/events" />
+        <link rel="canonical" href="https://www.promptfoo.dev/events/" />
       </Head>
 
       <main className={styles.main}>

--- a/site/src/pages/events/rsa-2025.tsx
+++ b/site/src/pages/events/rsa-2025.tsx
@@ -211,14 +211,14 @@ export default function RSA2025(): React.ReactElement {
         <section className={styles.ctaSection}>
           <div className={styles.container}>
             <div className={styles.ctaContent}>
-              <h2 className={styles.ctaTitle}>See You at RSA 2026</h2>
+              <h2 className={styles.ctaTitle}>We Were Back for RSA 2026</h2>
               <p className={styles.ctaText}>
-                We'll be back at RSA Conference 2026. Check out our plans and stay connected for
-                updates on booth location and demos.
+                Promptfoo returned to RSA Conference 2026 in March. See what we showed on the floor,
+                or get in touch for a walkthrough.
               </p>
               <div className={styles.ctaButtons}>
                 <Link to="/events/rsa-2026" className={styles.primaryCta}>
-                  RSA 2026 Details
+                  RSA 2026 Recap
                 </Link>
                 <Link to="/contact" className={styles.secondaryCta}>
                   Get in Touch

--- a/site/src/pages/events/rsa-2026.module.css
+++ b/site/src/pages/events/rsa-2026.module.css
@@ -92,13 +92,6 @@
   line-height: 1.7;
 }
 
-/* Countdown Timer */
-@keyframes blink {
-  50% {
-    opacity: 0;
-  }
-}
-
 .eventDetails {
   display: flex;
   flex-wrap: wrap;

--- a/site/src/pages/events/rsa-2026.module.css
+++ b/site/src/pages/events/rsa-2026.module.css
@@ -93,49 +93,6 @@
 }
 
 /* Countdown Timer */
-.countdown {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 2rem;
-  flex-wrap: wrap;
-}
-
-.countdownItem {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background: rgba(6, 182, 212, 0.1);
-  border: 1px solid rgba(6, 182, 212, 0.2);
-  border-radius: 12px;
-  padding: 1rem 1.25rem;
-  min-width: 80px;
-}
-
-.countdownNumber {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #67e8f9;
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-}
-
-.countdownLabel {
-  font-size: 0.75rem;
-  color: #94a3b8;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-top: 0.25rem;
-}
-
-.countdownSeparator {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #06b6d4;
-  animation: blink 1s step-end infinite;
-}
-
 @keyframes blink {
   50% {
     opacity: 0;

--- a/site/src/pages/events/rsa-2026.tsx
+++ b/site/src/pages/events/rsa-2026.tsx
@@ -104,7 +104,7 @@ export default function RSA2026(): React.ReactElement {
         <section id="highlights" className={styles.highlightsSection}>
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What We Covered</h2>
+              <h2 className={styles.sectionTitle}>What to Expect</h2>
               <p className={styles.sectionSubtitle}>Highlights from RSA Conference 2026</p>
             </div>
 
@@ -152,7 +152,7 @@ export default function RSA2026(): React.ReactElement {
                 </Link>
               </div>
               <div className={styles.ctaCard}>
-                <h3 className={styles.ctaCardTitle}>Prefer to lurk?</h3>
+                <h3 className={styles.ctaCardTitle}>Can't make it?</h3>
                 <p className={styles.ctaCardText}>
                   Join our Discord community to connect with our team and our community.
                 </p>

--- a/site/src/pages/events/rsa-2026.tsx
+++ b/site/src/pages/events/rsa-2026.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
@@ -6,79 +6,19 @@ import { useForcedTheme } from '@site/src/hooks/useForcedTheme';
 import Layout from '@theme/Layout';
 import styles from './rsa-2026.module.css';
 
-function CountdownTimer(): React.ReactElement {
-  const [timeLeft, setTimeLeft] = useState({
-    days: 0,
-    hours: 0,
-    minutes: 0,
-    seconds: 0,
-  });
-
-  useEffect(() => {
-    const targetDate = new Date('2026-03-23T09:00:00-07:00').getTime();
-
-    const updateCountdown = () => {
-      const now = new Date().getTime();
-      const difference = targetDate - now;
-
-      if (difference > 0) {
-        setTimeLeft({
-          days: Math.floor(difference / (1000 * 60 * 60 * 24)),
-          hours: Math.floor((difference % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)),
-          minutes: Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60)),
-          seconds: Math.floor((difference % (1000 * 60)) / 1000),
-        });
-      }
-    };
-
-    updateCountdown();
-    const interval = setInterval(updateCountdown, 1000);
-
-    return () => clearInterval(interval);
-  }, []);
-
-  return (
-    <div className={styles.countdown}>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>{timeLeft.days}</span>
-        <span className={styles.countdownLabel}>Days</span>
-      </div>
-      <div className={styles.countdownSeparator}>:</div>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>{timeLeft.hours.toString().padStart(2, '0')}</span>
-        <span className={styles.countdownLabel}>Hours</span>
-      </div>
-      <div className={styles.countdownSeparator}>:</div>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>
-          {timeLeft.minutes.toString().padStart(2, '0')}
-        </span>
-        <span className={styles.countdownLabel}>Minutes</span>
-      </div>
-      <div className={styles.countdownSeparator}>:</div>
-      <div className={styles.countdownItem}>
-        <span className={styles.countdownNumber}>
-          {timeLeft.seconds.toString().padStart(2, '0')}
-        </span>
-        <span className={styles.countdownLabel}>Seconds</span>
-      </div>
-    </div>
-  );
-}
-
 export default function RSA2026(): React.ReactElement {
   useForcedTheme('dark');
 
   return (
     <Layout
       title="Promptfoo at RSA Conference 2026"
-      description="Meet Promptfoo at RSA Conference 2026. Live AI red teaming demos, security consultations, and enterprise AI security discussions in San Francisco."
+      description="Recap of Promptfoo at RSA Conference 2026. Live AI red teaming demos, security consultations, and enterprise AI security discussions in San Francisco."
     >
       <Head>
         <meta property="og:title" content="Promptfoo at RSA Conference 2026" />
         <meta
           property="og:description"
-          content="Meet Promptfoo at RSA Conference 2026. Live AI red teaming demos and enterprise security."
+          content="Recap of Promptfoo at RSA Conference 2026. Live AI red teaming demos and enterprise security."
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://www.promptfoo.dev/events/rsa-2026" />
@@ -103,8 +43,8 @@ export default function RSA2026(): React.ReactElement {
           <div className={styles.bannerOverlay} />
           <div className={styles.bannerContent}>
             <div className={styles.badge}>
-              <span className={styles.badgeIcon}>🚀</span>
-              Coming March 2026
+              <span className={styles.badgeIcon}>🛡️</span>
+              RSA Conference 2026
             </div>
             <h1 className={styles.heroTitle}>
               RSA Conference <span className={styles.highlight}>2026</span>
@@ -116,11 +56,9 @@ export default function RSA2026(): React.ReactElement {
         <section className={styles.heroContent}>
           <div className={styles.container}>
             <p className={styles.heroSubtitle}>
-              Meet our team for live demos of our AI security platform—red teaming, evals,
-              guardrails, and foundation model security reports for your AI applications.
+              We ran live demos of our AI security platform at RSAC—red teaming, evals, guardrails,
+              and foundation model security reports for production AI applications.
             </p>
-
-            <CountdownTimer />
 
             <div className={styles.eventDetails}>
               <div className={styles.detail}>
@@ -154,9 +92,9 @@ export default function RSA2026(): React.ReactElement {
             </div>
 
             <div className={styles.heroCtas}>
-              <p className={styles.ctaBlurb}>Book a time to talk to us</p>
+              <p className={styles.ctaBlurb}>Missed us at the show?</p>
               <Link to="/contact" className={styles.primaryCta}>
-                Schedule a Meeting
+                Book a Demo
               </Link>
             </div>
           </div>
@@ -166,10 +104,8 @@ export default function RSA2026(): React.ReactElement {
         <section id="highlights" className={styles.highlightsSection}>
           <div className={styles.container}>
             <div className={styles.sectionHeader}>
-              <h2 className={styles.sectionTitle}>What to Expect</h2>
-              <p className={styles.sectionSubtitle}>
-                Join us for the premier AI security experience
-              </p>
+              <h2 className={styles.sectionTitle}>What We Covered</h2>
+              <p className={styles.sectionSubtitle}>Highlights from RSA Conference 2026</p>
             </div>
 
             <div className={styles.highlightsGrid}>
@@ -177,24 +113,24 @@ export default function RSA2026(): React.ReactElement {
                 <div className={styles.highlightIcon}>🎯</div>
                 <h3>AI Red Teaming</h3>
                 <p>
-                  See live demos of LLM attack vectors, jailbreak techniques, and how to integrate
-                  automated red teaming into your workflow.
+                  Live demos of LLM attack vectors and jailbreak techniques, plus how teams wire
+                  automated red teaming into their workflow.
                 </p>
               </div>
               <div className={styles.highlightCard}>
                 <div className={styles.highlightIcon}>🤝</div>
-                <h3>Connect with AI Experts</h3>
+                <h3>Conversations with AI Teams</h3>
                 <p>
-                  Meet AI security professionals working on evals, guardrails, and MCP
-                  security—learn how they're protecting AI applications in production.
+                  We talked with security professionals working on evals, guardrails, and MCP
+                  security about how they protect AI applications in production.
                 </p>
               </div>
               <div className={styles.highlightCard}>
                 <div className={styles.highlightIcon}>🎬</div>
-                <h3>See it in Action</h3>
+                <h3>Demos on the Floor</h3>
                 <p>
-                  Quick-fire demos on the latest AI security research, tools, and techniques from
-                  the AI security and red teaming experts.
+                  Quick-fire walkthroughs of the latest AI security research, tools, and techniques
+                  from our red teaming engineers.
                 </p>
               </div>
             </div>
@@ -206,16 +142,17 @@ export default function RSA2026(): React.ReactElement {
           <div className={styles.container}>
             <div className={styles.ctaGrid}>
               <div className={styles.ctaCard}>
-                <h3 className={styles.ctaCardTitle}>Attending RSA?</h3>
+                <h3 className={styles.ctaCardTitle}>Want the same walkthrough?</h3>
                 <p className={styles.ctaCardText}>
-                  Book a time to meet with our AI security and red teaming experts at the event.
+                  Book time with our AI security and red teaming engineers and we'll run it against
+                  your stack.
                 </p>
                 <Link to="/contact" className={styles.primaryCta}>
-                  Schedule a Meeting
+                  Book a Demo
                 </Link>
               </div>
               <div className={styles.ctaCard}>
-                <h3 className={styles.ctaCardTitle}>Can't make it?</h3>
+                <h3 className={styles.ctaCardTitle}>Prefer to lurk?</h3>
                 <p className={styles.ctaCardText}>
                   Join our Discord community to connect with our team and our community.
                 </p>

--- a/site/src/pages/guardrails.tsx
+++ b/site/src/pages/guardrails.tsx
@@ -185,7 +185,7 @@ export default function Guardrails(): React.ReactElement {
       description="Comprehensive AI guardrails to ensure safe, compliant, and brand-aligned outputs. Protect against harmful content, PII exposure, prompt injections, and regulatory violations."
     >
       <Head>
-        <meta property="og:image" content="https://www.promptfoo.dev/img/meta/guardrails.png" />
+        <meta property="og:image" content="https://www.promptfoo.dev/img/meta/homepage.png" />
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
       <div className={styles.pageContainer}>

--- a/site/src/pages/homepage-walkthrough.test.tsx
+++ b/site/src/pages/homepage-walkthrough.test.tsx
@@ -1,4 +1,6 @@
 import { act } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
 
 import { fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -30,11 +32,80 @@ function activeTab(container: HTMLElement): string {
   return active?.textContent?.trim() ?? '';
 }
 
+/** Same reading, but over a raw HTML string (server output has no live DOM). */
+function activeTabInHtml(html: string): string {
+  const scratch = document.createElement('div');
+  scratch.innerHTML = html;
+  return activeTab(scratch);
+}
+
+const mounted: HTMLElement[] = [];
+
+function mountServerMarkup(html: string): HTMLElement {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  mounted.push(container);
+  return container;
+}
+
 afterEach(() => {
+  while (mounted.length > 0) {
+    mounted.pop()?.remove();
+  }
   setHash('');
 });
 
 describe('homepage walkthrough deep links', () => {
+  /**
+   * Server render must be hash-independent. A lazy initializer that peeks at
+   * `window.location.hash` produces the deep-linked tab here instead of the default.
+   */
+  it('server-renders the default tab even when a hash is set', () => {
+    setHash('#evals');
+    const html = renderToString(<Home />);
+
+    expect(activeTabInHtml(html)).toBe(DEFAULT_TAB);
+  });
+
+  /**
+   * The real regression: markup produced without a hash (what every server sends) is
+   * hydrated by a client that *does* see `/#evals`. If the hash is read during render,
+   * React reports a hydration mismatch and discards the server tree.
+   */
+  it('hydrates hash-free server markup without a mismatch, then applies the deep link', async () => {
+    setHash('');
+    const container = mountServerMarkup(renderToString(<Home />));
+    expect(activeTab(container)).toBe(DEFAULT_TAB);
+
+    // The browser navigated to /#evals; hydration starts with the hash already present.
+    setHash('#evals');
+
+    const errors: unknown[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(' '));
+
+    try {
+      await act(async () => {
+        // React reports a hydration mismatch as a *recoverable* error, which vitest can
+        // surface as a file-level unhandled error rather than through console.error.
+        // Capturing it here is what makes this assertion actually fail on a regression.
+        hydrateRoot(container, <Home />, {
+          onRecoverableError: (error) => errors.push(error),
+        });
+      });
+    } finally {
+      console.error = originalError;
+    }
+
+    const hydrationErrors = errors
+      .map((e) => (e instanceof Error ? e.message : String(e)))
+      .filter((message) => /hydrat|did not match|server/i.test(message));
+    expect(hydrationErrors).toHaveLength(0);
+    // The effect runs after hydration, so the deep-linked tab wins in the end.
+    expect(activeTab(container)).toBe('Evaluations');
+  });
+
   it('selects the default tab when there is no hash', () => {
     setHash('');
     const { container } = render(<Home />);

--- a/site/src/pages/homepage-walkthrough.test.tsx
+++ b/site/src/pages/homepage-walkthrough.test.tsx
@@ -1,0 +1,97 @@
+import { act } from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import Home from './index';
+
+/**
+ * The walkthrough tab is deep-linkable via the URL hash. Two defects are covered here:
+ *
+ *  1. The selected step used to be seeded from `window.location.hash` in a lazy
+ *     `useState` initializer. The server cannot see a hash, so anyone opening `/#evals`
+ *     hydrated different markup than was sent. The hash must be applied in an effect.
+ *  2. The `hashchange` handler used to return early on an unmapped hash, so navigating
+ *     back from `/#evals` to `/` left the previous tab selected and the UI stopped
+ *     reflecting the URL.
+ *
+ * Assertions read the *active* tab rather than searching page text: every tab label is
+ * always present in the DOM, so a textContent match would pass no matter which is
+ * selected.
+ */
+
+const DEFAULT_TAB = 'Red Teaming';
+
+function setHash(hash: string) {
+  window.history.replaceState(null, '', hash || '/');
+}
+
+function activeTab(container: HTMLElement): string {
+  const active = container.querySelector('[class*="walkthroughTabActive"]');
+  return active?.textContent?.trim() ?? '';
+}
+
+afterEach(() => {
+  setHash('');
+});
+
+describe('homepage walkthrough deep links', () => {
+  it('selects the default tab when there is no hash', () => {
+    setHash('');
+    const { container } = render(<Home />);
+    expect(activeTab(container)).toBe(DEFAULT_TAB);
+  });
+
+  it.each([
+    ['#evals', 'Evaluations'],
+    ['#guardrails', 'Guardrails'],
+    ['#mcp', 'MCP'],
+    ['#codescanning', 'Code Scanning'],
+    ['#modelsecurity', 'Model Security'],
+  ])('deep-links %s to the %s tab', (hash, expected) => {
+    setHash(hash);
+    const { container } = render(<Home />);
+    expect(activeTab(container)).toBe(expected);
+  });
+
+  // The regression codex reported: clearing or mistyping the hash must return to the
+  // default tab rather than stranding the previous selection.
+  it.each([
+    ['an empty hash', ''],
+    ['an unrecognized hash', '#not-a-real-section'],
+  ])('resets to the default tab on %s', (_label, hash) => {
+    setHash('#evals');
+    const { container } = render(<Home />);
+    expect(activeTab(container)).toBe('Evaluations');
+
+    act(() => {
+      setHash(hash);
+      fireEvent(window, new HashChangeEvent('hashchange'));
+    });
+
+    expect(activeTab(container)).toBe(DEFAULT_TAB);
+  });
+
+  it('follows a hashchange between two mapped sections', () => {
+    setHash('#evals');
+    const { container } = render(<Home />);
+
+    act(() => {
+      setHash('#guardrails');
+      fireEvent(window, new HashChangeEvent('hashchange'));
+    });
+
+    expect(activeTab(container)).toBe('Guardrails');
+  });
+
+  it('detaches the hashchange listener on unmount', () => {
+    setHash('#evals');
+    const { unmount } = render(<Home />);
+    unmount();
+
+    // A leaked listener would call setState on an unmounted tree.
+    expect(() => {
+      setHash('#guardrails');
+      fireEvent(window, new HashChangeEvent('hashchange'));
+    }).not.toThrow();
+  });
+});

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -130,6 +130,9 @@ function CopyCodeBox({ command }: { command: string }) {
   );
 }
 
+/** Red Teaming: what the page shows with no hash, on the server and after a hash is cleared. */
+const DEFAULT_STEP = 1;
+
 const HASH_TO_STEP: Record<string, number> = {
   '#redteam': 1,
   '#guardrails': 2,
@@ -144,15 +147,15 @@ function HomepageWalkthrough() {
   // Default to Red Teaming. The hash is applied after mount instead of in the initializer:
   // reading `window.location.hash` during render would make the first client render disagree
   // with the server-rendered HTML (which never has a hash) and blow up hydration.
-  const [selectedStep, setSelectedStep] = React.useState(1);
+  const [selectedStep, setSelectedStep] = React.useState(DEFAULT_STEP);
   const [isMobile, setIsMobile] = React.useState(false);
 
   React.useEffect(() => {
+    // Falls back to the default rather than returning early: navigating back from
+    // `/#evals` to `/` fires hashchange with an empty hash, and leaving the previously
+    // selected tab active would stop the UI reflecting the URL. Same for an unknown hash.
     const applyHash = () => {
-      const step = HASH_TO_STEP[window.location.hash];
-      if (step) {
-        setSelectedStep(step);
-      }
+      setSelectedStep(HASH_TO_STEP[window.location.hash] ?? DEFAULT_STEP);
     };
     applyHash();
     window.addEventListener('hashchange', applyHash);

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -130,27 +130,34 @@ function CopyCodeBox({ command }: { command: string }) {
   );
 }
 
+const HASH_TO_STEP: Record<string, number> = {
+  '#redteam': 1,
+  '#guardrails': 2,
+  '#modelsecurity': 3,
+  '#mcp': 4,
+  '#evals': 5,
+  '#codescanning': 6,
+};
+
 function HomepageWalkthrough() {
   const isDarkTheme = useColorMode().colorMode === 'dark';
-  const [selectedStep, setSelectedStep] = React.useState(() => {
-    if (typeof window !== 'undefined') {
-      if (window.location.hash === '#evals') {
-        return 5;
-      } else if (window.location.hash === '#redteam') {
-        return 1;
-      } else if (window.location.hash === '#guardrails') {
-        return 2;
-      } else if (window.location.hash === '#modelsecurity') {
-        return 3;
-      } else if (window.location.hash === '#mcp') {
-        return 4;
-      } else if (window.location.hash === '#codescanning') {
-        return 6;
-      }
-    }
-    return 1; // Default to Red Teaming
-  });
+  // Default to Red Teaming. The hash is applied after mount instead of in the initializer:
+  // reading `window.location.hash` during render would make the first client render disagree
+  // with the server-rendered HTML (which never has a hash) and blow up hydration.
+  const [selectedStep, setSelectedStep] = React.useState(1);
   const [isMobile, setIsMobile] = React.useState(false);
+
+  React.useEffect(() => {
+    const applyHash = () => {
+      const step = HASH_TO_STEP[window.location.hash];
+      if (step) {
+        setSelectedStep(step);
+      }
+    };
+    applyHash();
+    window.addEventListener('hashchange', applyHash);
+    return () => window.removeEventListener('hashchange', applyHash);
+  }, []);
 
   React.useEffect(() => {
     const checkMobile = () => {

--- a/site/src/pages/mcp.tsx
+++ b/site/src/pages/mcp.tsx
@@ -163,7 +163,7 @@ export default function Mcp(): React.ReactElement {
       description="Enterprise-grade MCP proxy for secure AI tool integration. Whitelist approved MCP servers, grant granular permissions, and monitor for PII and sensitive data exposure."
     >
       <Head>
-        <meta property="og:image" content="https://www.promptfoo.dev/img/meta/mcp.png" />
+        <meta property="og:image" content="https://www.promptfoo.dev/img/meta/homepage.png" />
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
       <div className={styles.pageContainer}>

--- a/site/src/pages/model-security.tsx
+++ b/site/src/pages/model-security.tsx
@@ -342,7 +342,7 @@ export default function ModelSecurity(): React.ReactElement {
       description="Complete AI model security platform that protects your entire AI pipeline - from model files to deployed systems - with a unified security assessment workflow."
     >
       <Head>
-        <meta property="og:image" content="https://www.promptfoo.dev/img/meta/model-security.png" />
+        <meta property="og:image" content="https://www.promptfoo.dev/img/meta/homepage.png" />
         <meta name="twitter:card" content="summary_large_image" />
       </Head>
       <div className={styles.pageContainer}>

--- a/site/src/pages/press/_data.ts
+++ b/site/src/pages/press/_data.ts
@@ -95,7 +95,7 @@ export const FEATURED_PODCASTS: Podcast[] = [
     date: 'December 2, 2025',
     description:
       'Ian Webster breaks down real-world agent risk: the "lethal trifecta" (untrusted input + sensitive data + an exfiltration channel), and how automated red teaming helps catch issues before production.',
-    link: 'https://a16z.com/podcast/why-social-engineering-now-works-on-machines/',
+    link: 'https://open.spotify.com/episode/6iZPyhhdOgXSjxKsJmiTPn',
   },
   {
     title: "Breaking AI to Fix It: Ian Webster's Journey from Discord's Clyde to Promptfoo",
@@ -103,7 +103,7 @@ export const FEATURED_PODCASTS: Podcast[] = [
     date: 'October 24, 2025',
     description:
       "Ian talks with swyx and Alessio about shipping Discord's Clyde, why Promptfoo shifted from evals to AI security, and what red teaming looks like for agents and RAG applications.",
-    link: 'https://www.latent.space/p/promptfoo',
+    link: 'https://www.youtube.com/watch?v=-uiF1txQxV8',
   },
   {
     title: 'The Metis List of Top AI Researchers',

--- a/site/src/pages/press/index.tsx
+++ b/site/src/pages/press/index.tsx
@@ -92,6 +92,7 @@ const PodcastCard = ({ podcast }: { podcast: Podcast }) => (
       </Typography>
       <Typography
         variant="subtitle2"
+        component="p"
         gutterBottom
         sx={{
           color: 'text.secondary',
@@ -125,6 +126,7 @@ const EducationalResourceCard = ({ resource }: { resource: EducationalResource }
       </Typography>
       <Typography
         variant="subtitle2"
+        component="p"
         gutterBottom
         sx={{
           color: 'text.secondary',
@@ -166,6 +168,7 @@ const TechnicalContentCard = ({ content }: { content: TechnicalContent }) => (
       </Typography>
       <Typography
         variant="subtitle2"
+        component="p"
         gutterBottom
         sx={{
           color: 'text.secondary',
@@ -300,6 +303,7 @@ const PressContent = () => {
                 </Typography>
                 <Typography
                   variant="subtitle2"
+                  component="p"
                   gutterBottom
                   sx={{
                     color: 'text.secondary',
@@ -400,6 +404,7 @@ const PressContent = () => {
                 <LogoPanda style={{ maxWidth: '200px', height: 'auto' }} />
                 <Typography
                   variant="subtitle1"
+                  component="p"
                   sx={{
                     mt: 2,
                   }}

--- a/site/src/pages/validator.tsx
+++ b/site/src/pages/validator.tsx
@@ -117,7 +117,7 @@ const ConfigValidator = () => {
     <Layout title="Config Validator" description="Validate your promptfoo configuration">
       <Container maxWidth="lg" sx={{ mb: 4 }}>
         <Box sx={{ my: 4 }}>
-          <Typography variant="h3" gutterBottom align="center">
+          <Typography variant="h3" component="h1" gutterBottom align="center">
             Promptfoo Config Validator
           </Typography>
           <Typography variant="body1" gutterBottom align="center">

--- a/site/src/setupTests.ts
+++ b/site/src/setupTests.ts
@@ -49,6 +49,28 @@ if (typeof global.ResizeObserver === 'undefined') {
   };
 }
 
+// IntersectionObserver mock. jsdom has no implementation, and several page-level
+// components (scroll reveals, lazy sections) construct one during render.
+if (typeof global.IntersectionObserver === 'undefined') {
+  global.IntersectionObserver = class IntersectionObserver {
+    readonly root = null;
+    readonly rootMargin = '';
+    readonly thresholds: ReadonlyArray<number> = [];
+    observe() {
+      // noop
+    }
+    unobserve() {
+      // noop
+    }
+    disconnect() {
+      // noop
+    }
+    takeRecords(): IntersectionObserverEntry[] {
+      return [];
+    }
+  } as unknown as typeof IntersectionObserver;
+}
+
 // Mock matchMedia for responsive components
 Object.defineProperty(window, 'matchMedia', {
   writable: true,


### PR DESCRIPTION
> **Stacked on #10214.** Base is `docs/site-vegas-2026-event-pages`, so the diff here is just this change. Merge #10214 first.

Writing the Vegas pages surfaced a pile of adjacent rot, so I swept `site/` properly. 32 candidate findings, 24 confirmed after adversarial verification (each finding was handed to a separate agent instructed to *refute* it — 8 died there, mostly style opinions and one asset that turns out to be build-generated).

Today is 2026-07-26, and most of this is what happens when event pages outlive their events.

## Things that were visibly wrong in production

**Frozen countdowns.** `rsa-2026` and `bsides-sf-2026` rendered `0 Days : 00 : 00 : 00`, permanently. `updateCountdown()` only called `setTimeLeft()` inside `if (difference > 0)` with no `else`, so once the target date passed, state stayed at the `useState` initial zeros forever — while a 1 Hz interval kept ticking, doing nothing, for every visitor. `bsides-seattle-2026` *had* the else branch but no upper bound, so it cheerfully announced **"Event is happening now!"** for an event that ended in February — directly above the line saying "February 27-28, 2026".

**Invitations to events that are over.** Nine event pages still read as live invites, including in the `og:`/`twitter:` descriptions that feed search results and link previews, so the false invite propagated off-site. Two of them promised a *future* return to events that have themselves already happened: `rsa-2025` said "See You at RSA 2026" and `bsides-sf-2025` said "See You at BSides SF 2026" — both ended in March.

**Offers on "Past" cards.** `events.ts` still advertised "Free drinks on us" and "Get a complimentary AI vulnerability assessment" on cards the index was rendering with a `Past` badge next to them.

**Dead links.** `bsides-seattle-2026` linked to `/docs/category/red-teaming/` (404 — verified live; the real route is `/docs/red-team/`). Two press links were dead: the a16z podcast URL 404s and the Latent Space Substack post redirects to a 404. Both replaced with verified equivalents matched on title, show, and publish date.

**Blank share cards.** `guardrails`, `mcp`, and `model-security` set `og:image` to `/img/meta/*.png` files that do not exist, so every share of those three landing pages rendered with no image.

## Correctness

- **`formatEventDate` rendered single-day events as `"Dec 3-3, 2025"`.** The single-day guard was `startDate === endDate`, comparing full ISO timestamps — which differ by time of day even on the same date, so it never matched. Now compares calendar dates. Affects three events.
- **Timezone-dependent year reads.** `getEventsByYear` plus five call sites in `events/index.tsx` used `new Date(...).getFullYear()` in the build host's zone. Added `getEventYear()` next to the existing `parseCalendarDate`. Latent today, but it's the same bug class as the `formatEventDate` one fixed in #10214.
- **Two hydration mismatches.** `GitHubStars` read `localStorage` and `HomepageWalkthrough` read `window.location.hash` inside lazy `useState` initializers. SSR can see neither, so a returning visitor — or anyone opening `/#evals` — hydrated with different markup than the server sent. Both moved into effects. The walkthrough now also subscribes to `hashchange`, which it never did, so in-page hash navigation actually changes the tab.

## Accessibility

- `ImageJailbreakPreview`'s click-to-flip card was a bare `<div onClick>` — keyboard and screen-reader users could not reveal the images at all. Added `role="button"`, `tabIndex`, `aria-expanded`, a state-aware label, Enter/Space handling, and a focus ring. Used 9 times in one blog post.
- `validator.tsx` had **no `<h1>`** — MUI rendered its page title as a literal `<h3>`, so the outline started three levels deep. `press` and `about` emitted phantom `<h6>`s from bare `subtitle1`/`subtitle2` Typography.
- Four event stylesheets and both shared `Events` components ran infinite animations with no `prefers-reduced-motion` guard.

  Worth a reviewer's eye: `blackhat-2025`'s `.demoCard` starts at `opacity: 0` with a fill-forwards entrance animation, so a blanket `animation: none` would have made those cards **permanently invisible** under reduced motion. The guard restores `opacity`/`transform` explicitly. I verified this against the built CSS bundle rather than the source, confirming the minified rule keeps `opacity:1` on that class.

- Hardcoded `80+ Fortune 500` replaced with `SITE_CONSTANTS.FORTUNE_500_COUNT` (156) in three places — it was sitting in the same stat row as a live-sourced developer count.

## Verification

`tsc --noEmit` clean · site suite 9 files / 144 tests · `SKIP_OG_GENERATION=true npm run build` clean with `onBrokenLinks: 'throw'` · Biome clean on all 21 changed TS/TSX files (via isolated probe — it stack-overflows on this working copy, [biomejs/biome#8783](https://github.com/biomejs/biome/issues/8783)) · Prettier clean on CSS.

Beyond that: every touched page served and inspected on a running dev server, plus a scripted sweep across all 14 event pages confirming zero remaining `happening now` / `Meet us at` / `Join us at` / `See You at` / `Register now` strings.

## Tests

Two suites added, both mutation-checked (revert the fix, the test fails):

- **`site/src/data/events.test.ts`** — the single-day date rendering (restoring `startDate === endDate` fails 4 cases, including a blanket "no event renders a same-day range" assertion), `getEventYear`/`getEventsByYear` across four timezones plus year-boundary timestamps, and a guard that past events carry no live invite or standing offer.
- **`site/src/components/ImageJailbreakPreview.test.tsx`** — keyboard access: role, `tabIndex`, `aria-expanded`, state-aware accessible name, Enter/Space activation, non-activating keys. Reverting to the bare `<div onClick>` fails all 6.

Writing these caught two things in my own work: the offer regex initially flagged "Open Bar" as a *highlight label*, which is legitimate on a recap — narrowed to prose only; and my first component test used the wrong prop shape entirely.

## One sweep change reverted

An agent rewrote the DEF CON 33 party times in `events.ts` (20:00–23:59 → 18:00–20:00) to match the page, which says 6–8 PM. Nothing in the site renders event times, so it fixed no user-visible bug and rewrote a historical record on inference. Reverted; the page copy is untouched and remains the authority.

## Deliberately not done

- Press links returning 403 to bots (`cybernews`, `washingtontimes`, `finance.yahoo`) — those are bot blocks, not breakage.
- Docusaurus 3.10.1 → 3.10.2. It's a cosmetic CLI nag; `npm update` on those six packages actually moves 72 packages. Renovate's call, its own PR.
