### PR TITLE
docs(site): retire announcement bars after long timer delays

### DIFF
--- a/site/src/theme/AnnouncementBar/index.test.tsx
+++ b/site/src/theme/AnnouncementBar/index.test.tsx
@@ -33,6 +33,7 @@ vi.mock('@theme-original/AnnouncementBar', () => ({
 }));
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
 describe('AnnouncementBar expiry wrapper', () => {
   beforeEach(() => {
@@ -125,6 +126,25 @@ describe('AnnouncementBar expiry wrapper', () => {
 
     act(() => {
       vi.advanceTimersByTime(5000);
+    });
+
+    expect(screen.queryByTestId(ORIGINAL_BAR_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('retires the bar after an expiry beyond the maximum timeout delay', () => {
+    const remainingAfterFirstTimeout = 5000;
+    vi.setSystemTime(VEGAS_BANNER_EXPIRY - MAX_TIMEOUT_MS - remainingAfterFirstTimeout);
+
+    render(<AnnouncementBar />);
+    expect(screen.getByTestId(ORIGINAL_BAR_TEST_ID)).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(MAX_TIMEOUT_MS);
+    });
+    expect(screen.getByTestId(ORIGINAL_BAR_TEST_ID)).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(remainingAfterFirstTimeout);
     });
 
     expect(screen.queryByTestId(ORIGINAL_BAR_TEST_ID)).not.toBeInTheDocument();

--- a/site/src/theme/AnnouncementBar/index.tsx
+++ b/site/src/theme/AnnouncementBar/index.tsx
@@ -10,8 +10,7 @@ import OriginalAnnouncementBar from '@theme-original/AnnouncementBar';
 
 /**
  * `setTimeout` stores its delay in a signed 32-bit int; anything larger overflows and the
- * callback fires immediately. A visitor arriving more than ~24 days before the expiry does
- * not need an in-place retirement — the next page load re-runs this effect.
+ * callback fires immediately. Longer waits must be split across multiple timers.
  */
 const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
@@ -54,12 +53,22 @@ export default function AnnouncementBar(): ReactNode {
     }
 
     // A tab left open across the expiry instant retires the bar where it stands.
-    const msUntilExpiry = VEGAS_BANNER_EXPIRY - now;
-    if (msUntilExpiry > MAX_TIMEOUT_MS) {
-      return;
-    }
+    let timer: ReturnType<typeof setTimeout>;
+    const scheduleExpiry = (msUntilExpiry: number) => {
+      timer = setTimeout(
+        () => {
+          const remainingMs = VEGAS_BANNER_EXPIRY - Date.now();
+          if (remainingMs > 0) {
+            scheduleExpiry(remainingMs);
+          } else {
+            setIsExpired(true);
+          }
+        },
+        Math.min(msUntilExpiry, MAX_TIMEOUT_MS),
+      );
+    };
 
-    const timer = setTimeout(() => setIsExpired(true), msUntilExpiry);
+    scheduleExpiry(VEGAS_BANNER_EXPIRY - now);
     return () => clearTimeout(timer);
   }, [isTimeLimitedBar]);
 


### PR DESCRIPTION
## Summary
- Keep the time-limited Vegas announcement bar scheduled when its expiry is farther away than JavaScript's maximum `setTimeout` delay.
- Chain bounded timers until the actual expiry and clear the active timer when the component unmounts.
- Add a fake-timer regression that reproduces the open GitHub AI finding by advancing through both the maximum-delay interval and the remaining time.

## Validation
- `npm run test -- --run src/theme/AnnouncementBar/index.test.tsx` in `site` (6 tests)
- `npm run test -- --run` in `site` (237 tests across 15 files)
- `npm run typecheck` in `site`
- `npm run tsc`
- `npm run l` and `npm run f`
- `SKIP_OG_GENERATION=true npm run build` in `site`
- Confirmed the new regression fails before the component fix and passes afterward.