### PR TITLE
docs(site): document Modelsell OpenAI-compatible config

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -70,6 +70,21 @@ providers:
 
 > **Note:** OpenAI models can also be accessed through [Azure OpenAI](/docs/providers/azure/), which offers additional enterprise features, compliance options, and regional availability.
 
+## OpenAI-compatible endpoints
+
+For OpenAI-compatible services, keep the `openai:chat` provider and set `apiBaseUrl` and `apiKeyEnvar`. For example, [Modelsell](https://modelsell.com/) can be configured without a dedicated provider:
+
+```yaml title="promptfooconfig.yaml"
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+providers:
+  - id: 'openai:chat:{{env.MODELSELL_MODEL}}'
+    config:
+      apiBaseUrl: https://modelsell.com/v1
+      apiKeyEnvar: MODELSELL_API_KEY
+```
+
+Create a [Modelsell API key](https://modelsell.com/console/token), then set `MODELSELL_MODEL` to an exact model ID returned by the authenticated [`GET /v1/models`](https://modelsell.com/docs/api-reference) endpoint. The available catalog can vary by account, so avoid hard-coding a model ID in shared configs.
+
 Requests sent by built-in OpenAI providers to the OpenAI API include the
 `X-OpenAI-Originator: promptfoo` header for source attribution. To route requests with a
 different originator value, override this header through the `headers` configuration option.
@@ -162,7 +177,10 @@ interface OpenAiConfig {
   function_call?: 'none' | 'auto' | { name: string };
   tools?: OpenAiTool[];
   tool_choice?: 'none' | 'auto' | 'required' | { type: 'function'; function?: { name: string } };
-  response_format?: { type: 'json_object' | 'json_schema'; json_schema?: object };
+  response_format?: {
+    type: 'json_object' | 'json_schema';
+    json_schema?: object;
+  };
   stop?: string[];
   seed?: number;
   user?: string;

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -77,13 +77,13 @@ For OpenAI-compatible services, keep the `openai:chat` provider and set `apiBase
 ```yaml
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 providers:
-  - id: 'openai:chat:{{env.MODELSELL_MODEL}}'
+  - id: "openai:chat:{{ env.MODELSELL_MODEL | default('missing-modelsell-model', true) }}"
     config:
       apiBaseUrl: https://modelsell.com/v1
       apiKey: "{{ env.MODELSELL_API_KEY | default('missing-modelsell-api-key', true) }}"
 ```
 
-The fallback value ensures a missing or blank Modelsell key fails authentication instead of causing the generic provider to reuse `OPENAI_API_KEY`. Create a [Modelsell API key](https://modelsell.com/console/token), then set `MODELSELL_MODEL` to an exact model ID returned by the authenticated [`GET /v1/models`](https://modelsell.com/docs/api-reference/%E8%B4%A6%E6%88%B7%E7%AE%A1%E7%90%86/listModels) endpoint. The available catalog can vary by account, so avoid hard-coding a model ID in shared configs.
+The fallback values make missing or blank Modelsell settings fail predictably instead of selecting Promptfoo's default OpenAI model or causing the generic provider to reuse `OPENAI_API_KEY`. Create a [Modelsell API key](https://modelsell.com/console/token), then set `MODELSELL_MODEL` to an exact model ID returned by the authenticated [`GET /v1/models`](https://modelsell.com/docs/api-reference/%E8%B4%A6%E6%88%B7%E7%AE%A1%E7%90%86/listModels) endpoint. The available catalog can vary by account, so avoid hard-coding a model ID in shared configs.
 
 :::warning
 

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -72,18 +72,24 @@ providers:
 
 ## OpenAI-compatible endpoints
 
-For OpenAI-compatible services, keep the `openai:chat` provider and set `apiBaseUrl` and `apiKeyEnvar`. For example, [Modelsell](https://modelsell.com/) can be configured without a dedicated provider:
+For OpenAI-compatible services, keep the `openai:chat` provider and set `apiBaseUrl` and an explicit `apiKey`. For example, [Modelsell](https://modelsell.com/) can be configured without a dedicated provider:
 
-```yaml title="promptfooconfig.yaml"
+```yaml
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 providers:
   - id: 'openai:chat:{{env.MODELSELL_MODEL}}'
     config:
       apiBaseUrl: https://modelsell.com/v1
-      apiKeyEnvar: MODELSELL_API_KEY
+      apiKey: '{{ env.MODELSELL_API_KEY }}'
 ```
 
 Create a [Modelsell API key](https://modelsell.com/console/token), then set `MODELSELL_MODEL` to an exact model ID returned by the authenticated [`GET /v1/models`](https://modelsell.com/docs/api-reference) endpoint. The available catalog can vary by account, so avoid hard-coding a model ID in shared configs.
+
+:::warning
+
+Run Modelsell evals with `OPENAI_ORGANIZATION` unset. The generic OpenAI provider forwards this variable to custom endpoints, where it can disclose your OpenAI organization identifier.
+
+:::
 
 Requests sent by built-in OpenAI providers to the OpenAI API include the
 `X-OpenAI-Originator: promptfoo` header for source attribution. To route requests with a

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -80,10 +80,10 @@ providers:
   - id: 'openai:chat:{{env.MODELSELL_MODEL}}'
     config:
       apiBaseUrl: https://modelsell.com/v1
-      apiKey: '{{ env.MODELSELL_API_KEY }}'
+      apiKey: "{{ env.MODELSELL_API_KEY | default('missing-modelsell-api-key', true) }}"
 ```
 
-Create a [Modelsell API key](https://modelsell.com/console/token), then set `MODELSELL_MODEL` to an exact model ID returned by the authenticated [`GET /v1/models`](https://modelsell.com/docs/api-reference) endpoint. The available catalog can vary by account, so avoid hard-coding a model ID in shared configs.
+The fallback value ensures a missing or blank Modelsell key fails authentication instead of causing the generic provider to reuse `OPENAI_API_KEY`. Create a [Modelsell API key](https://modelsell.com/console/token), then set `MODELSELL_MODEL` to an exact model ID returned by the authenticated [`GET /v1/models`](https://modelsell.com/docs/api-reference/%E8%B4%A6%E6%88%B7%E7%AE%A1%E7%90%86/listModels) endpoint. The available catalog can vary by account, so avoid hard-coding a model ID in shared configs.
 
 :::warning
 


### PR DESCRIPTION
## Summary

- document Modelsell through Promptfoo's generic OpenAI-compatible provider path
- configure the Modelsell base URL and API key environment variable without adding a dedicated provider prefix or registry entry
- resolve the model ID from `MODELSELL_MODEL`, with the account-specific catalog discovered through authenticated `GET /v1/models`

This follows the contribution guidance for services that only require a custom OpenAI-compatible URL and API key.

Disclosure: I represent Modelsell.

No live authenticated Modelsell API call was performed.

## Validation

- `npx --yes prettier@3.8.1 --check site/docs/providers/openai.md`
- parsed the documented YAML with Ruby `Psych` and verified the provider ID, base URL, and key environment variable
- `git diff --check`
- verified the Modelsell homepage, token console, and API reference return HTTP 200
