### PR TITLE
fix(assertions): return 0 for empty GLEU candidate instead of throwing

### DIFF
--- a/src/assertions/gleu.ts
+++ b/src/assertions/gleu.ts
@@ -31,7 +31,8 @@ import type { AssertionParams, GradingResult } from '../types/index';
  * @param minN - Minimum n-gram length to consider (default: 1)
  * @param maxN - Maximum n-gram length to consider (default: 4)
  * @returns GLEU score between 0 and 1, where higher scores indicate better matches
- * @throws When candidate or references are invalid
+ *   (0 for an empty or whitespace-only candidate)
+ * @throws When the candidate is null/undefined or references is empty
  */
 export function calculateGleuScore(
   candidate: string,
@@ -39,8 +40,13 @@ export function calculateGleuScore(
   minN: number = 1,
   maxN: number = 4,
 ): number {
-  if (!candidate || references.length === 0) {
+  if (candidate == null || references.length === 0) {
     throw new Error('Invalid inputs');
+  }
+  // An empty or whitespace-only candidate (a refusal/truncated generation) shares no
+  // n-grams with any reference; return 0 like bleu/rouge instead of throwing on ''.
+  if (candidate.trim() === '') {
+    return 0;
   }
 
   const candidateWords = candidate

--- a/test/assertions/gleu.test.ts
+++ b/test/assertions/gleu.test.ts
@@ -97,6 +97,22 @@ describe('GLEU score calculation', () => {
     }).toThrow('Invalid inputs');
   });
 
+  it('should return 0 for an empty candidate instead of throwing', () => {
+    expect(calculateGleuScore('', ['some reference'])).toBe(0);
+  });
+
+  it('should return 0 for a whitespace-only candidate', () => {
+    expect(calculateGleuScore('   ', ['some reference'])).toBe(0);
+    expect(calculateGleuScore('\n\t', ['some reference'])).toBe(0);
+  });
+
+  it('should still throw for a null or undefined candidate', () => {
+    expect(() => calculateGleuScore(null as never, ['some reference'])).toThrow('Invalid inputs');
+    expect(() => calculateGleuScore(undefined as never, ['some reference'])).toThrow(
+      'Invalid inputs',
+    );
+  });
+
   it('should handle multiple references with varying lengths', () => {
     const references = ['The small cat sat.', 'A cat was sitting.', 'The cat is on the mat.'];
     const candidate = 'The small cat sat.';
@@ -211,6 +227,42 @@ describe('GLEU score calculation', () => {
         reason: expect.stringMatching(/GLEU score \d+\.\d+ is less than threshold 0\.5/),
         assertion: expect.any(Object),
       });
+    });
+
+    it('should return pass:false score:0 for empty output instead of throwing', () => {
+      const params = {
+        assertion: { type: 'gleu', value: 'some reference' },
+        renderedValue: 'some reference',
+        outputString: '',
+        inverse: false,
+      } as AssertionParams;
+      const result = handleGleuScore(params);
+      expect(result.pass).toBe(false);
+      expect(result.score).toBe(0);
+    });
+
+    it('should treat whitespace-only output like empty output', () => {
+      const params = {
+        assertion: { type: 'gleu', value: 'some reference' },
+        renderedValue: 'some reference',
+        outputString: '   \n\t',
+        inverse: false,
+      } as AssertionParams;
+      const result = handleGleuScore(params);
+      expect(result.pass).toBe(false);
+      expect(result.score).toBe(0);
+    });
+
+    it('should pass an inverse assertion for empty output (score inverts to 1)', () => {
+      const params = {
+        assertion: { type: 'gleu', value: 'some reference' },
+        renderedValue: 'some reference',
+        outputString: '',
+        inverse: true,
+      } as AssertionParams;
+      const result = handleGleuScore(params);
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(1);
     });
   });
 });


### PR DESCRIPTION
A GLEU assertion crashes with `Invalid inputs` when the model output is an empty string — `calculateGleuScore` treats `!candidate` as invalid and throws. A whitespace-only output slips past that check but then tokenizes to a single empty token and scores a degenerate value.

Empty output is a normal thing to score (a refusal or a truncated generation), and the sibling `bleu` and `rouge` assertions already handle it by returning 0. GLEU is the odd one out — an empty completion errors the whole assertion instead of just failing the threshold, and a `not-gleu` inverse assertion that should pass on empty output errors too.

Made GLEU match: an empty or whitespace-only candidate returns 0, and the throw is now reserved for a genuinely null/undefined candidate or an empty references array. Added tests at both the score and handler level (including the inverse case), mirroring the existing bleu coverage.