### PR TITLE
fix(output): separate duplicate JUnit columns

### DIFF
--- a/src/util/junit.ts
+++ b/src/util/junit.ts
@@ -81,7 +81,7 @@ function getSuiteKey(result: JunitProjectedResult): string {
   // Distinguish providers that share an id but differ by label (and vice versa)
   // so multi-target redteam runs do not collapse into a single suite.
   const providerKey = `${result.provider.id ?? ''}${SUITE_PROVIDER_SEPARATOR}${result.provider.label ?? ''}`;
-  const promptKey = result.promptId || `prompt-index:${result.promptIdx}`;
+  const promptKey = `prompt-index:${result.promptIdx}`;
   return `${providerKey}${SUITE_KEY_SEPARATOR}${promptKey}`;
 }
 
@@ -209,7 +209,7 @@ async function buildJunitSuites(evalRecord: Eval): Promise<JunitSuite[]> {
     let suite = suites.get(key);
     if (!suite) {
       const providerName = getProviderName(result);
-      const promptKey = result.promptId || `prompt-index:${result.promptIdx}`;
+      const promptKey = `prompt-index:${result.promptIdx}`;
       let promptOrdinals = promptOrdinalsByProvider.get(providerName);
       if (!promptOrdinals) {
         promptOrdinals = new Map();

--- a/src/util/junit.ts
+++ b/src/util/junit.ts
@@ -199,9 +199,8 @@ async function* iterateJunitProjectedResults(
 
 async function buildJunitSuites(evalRecord: Eval): Promise<JunitSuite[]> {
   const suites = new Map<string, JunitSuite>();
-  // Assign each unique provider+prompt combination a stable 1-based ordinal so
-  // the suite display name (and every contained testcase classname) match
-  // regardless of which result happened to insert the suite first.
+  // Assign each result column a 1-based ordinal within its provider display name so
+  // the suite display name and every contained testcase classname stay consistent.
   const promptOrdinalsByProvider = new Map<string, Map<string, number>>();
 
   for await (const result of iterateJunitProjectedResults(evalRecord)) {

--- a/src/util/junit.ts
+++ b/src/util/junit.ts
@@ -36,6 +36,8 @@ type JunitSuite = {
   displayName: string;
   errors: number;
   failures: number;
+  promptIdx: number;
+  providerName: string;
   skipped: number;
   testcases: { testIdx: number; testcase: Record<string, unknown> }[];
   tests: number;
@@ -199,30 +201,18 @@ async function* iterateJunitProjectedResults(
 
 async function buildJunitSuites(evalRecord: Eval): Promise<JunitSuite[]> {
   const suites = new Map<string, JunitSuite>();
-  // Assign each result column a 1-based ordinal within its provider display name so
-  // the suite display name and every contained testcase classname stay consistent.
-  const promptOrdinalsByProvider = new Map<string, Map<string, number>>();
 
   for await (const result of iterateJunitProjectedResults(evalRecord)) {
     const key = getSuiteKey(result);
     let suite = suites.get(key);
     if (!suite) {
       const providerName = getProviderName(result);
-      const promptKey = `prompt-index:${result.promptIdx}`;
-      let promptOrdinals = promptOrdinalsByProvider.get(providerName);
-      if (!promptOrdinals) {
-        promptOrdinals = new Map();
-        promptOrdinalsByProvider.set(providerName, promptOrdinals);
-      }
-      let ordinal = promptOrdinals.get(promptKey);
-      if (ordinal === undefined) {
-        ordinal = promptOrdinals.size + 1;
-        promptOrdinals.set(promptKey, ordinal);
-      }
       suite = {
-        displayName: `[${providerName}] prompt ${ordinal}`,
+        displayName: '',
         errors: 0,
         failures: 0,
+        promptIdx: result.promptIdx,
+        providerName,
         skipped: 0,
         testcases: [],
         tests: 0,
@@ -232,7 +222,7 @@ async function buildJunitSuites(evalRecord: Eval): Promise<JunitSuite[]> {
     }
 
     suite.testcases.push({
-      testcase: buildJunitTestCase(result, suite.displayName),
+      testcase: buildJunitTestCase(result),
       testIdx: result.testIdx,
     });
     suite.tests += 1;
@@ -246,12 +236,21 @@ async function buildJunitSuites(evalRecord: Eval): Promise<JunitSuite[]> {
     }
   }
 
-  return [...suites.values()];
+  // Results may arrive in completion or database order, so assign display names only
+  // after restoring the canonical result-column order.
+  const promptOrdinalsByProvider = new Map<string, number>();
+  return [...suites.values()]
+    .sort((a, b) => a.promptIdx - b.promptIdx)
+    .map((suite) => {
+      const ordinal = (promptOrdinalsByProvider.get(suite.providerName) ?? 0) + 1;
+      promptOrdinalsByProvider.set(suite.providerName, ordinal);
+      suite.displayName = `[${suite.providerName}] prompt ${ordinal}`;
+      return suite;
+    });
 }
 
-function buildJunitTestCase(result: JunitProjectedResult, classname: string) {
+function buildJunitTestCase(result: JunitProjectedResult) {
   const testcase: Record<string, unknown> = {
-    '@_classname': classname,
     '@_name': getTestCaseName(result),
     '@_time': formatDurationSeconds(result.latencyMs),
   };
@@ -312,7 +311,7 @@ export async function createJunitXml(evalRecord: Eval): Promise<string> {
         ...(timestamp ? { '@_timestamp': timestamp } : {}),
         testcase: suite.testcases
           .sort((a, b) => a.testIdx - b.testIdx)
-          .map(({ testcase }) => testcase),
+          .map(({ testcase }) => ({ '@_classname': suite.displayName, ...testcase })),
       })),
     },
   });

--- a/test/util/output.test.ts
+++ b/test/util/output.test.ts
@@ -959,30 +959,26 @@ describe('writeOutput', () => {
     ]);
   });
 
-  it('keeps JUnit testcase classnames consistent within a suite when promptIdx varies', async () => {
-    const baseResult = (promptIdx: number, testIdx: number, promptId: string): EvaluateResult => ({
-      success: true,
-      failureReason: ResultFailureReason.NONE,
-      score: 1,
+  it('separates JUnit suites when result columns share provider and prompt identity', async () => {
+    const baseResult = (promptIdx: number, success: boolean): EvaluateResult => ({
+      success,
+      failureReason: success ? ResultFailureReason.NONE : ResultFailureReason.ASSERT,
+      score: success ? 1 : 0,
       namedScores: {},
       latencyMs: 100,
-      provider: { id: 'echo' },
-      prompt: { raw: `prompt ${promptId}`, label: '' },
+      provider: { id: 'echo', label: 'target' },
+      prompt: { raw: 'shared prompt', label: 'Shared prompt' },
       response: { output: '' },
       vars: {},
       promptIdx,
-      testIdx,
+      testIdx: 0,
       testCase: {},
-      promptId,
+      promptId: 'shared',
     });
     const eval_ = {
       createdAt: '2026-05-03T15:00:00.000Z',
       fetchResultsBatched: vi.fn(),
-      // Same promptId across non-contiguous promptIdx values would previously
-      // produce mixed classnames inside a single suite.
-      getResults: vi
-        .fn()
-        .mockResolvedValue([baseResult(0, 0, 'shared'), baseResult(2, 1, 'shared')]),
+      getResults: vi.fn().mockResolvedValue([baseResult(0, true), baseResult(1, false)]),
       persisted: false,
       results: [],
       useOldResults: () => true,
@@ -991,13 +987,20 @@ describe('writeOutput', () => {
     const xml = await createJunitXml(eval_);
     const parsed = new XMLParser({ ignoreAttributes: false }).parse(xml);
 
-    expect(parsed.testsuites.testsuite).toMatchObject({
-      '@_name': '[echo] prompt 1',
-      '@_tests': '2',
-    });
-    for (const testcase of parsed.testsuites.testsuite.testcase) {
-      expect(testcase['@_classname']).toBe('[echo] prompt 1');
-    }
+    expect(parsed.testsuites.testsuite).toEqual([
+      expect.objectContaining({
+        '@_failures': '0',
+        '@_name': '[target] prompt 1',
+        '@_tests': '1',
+        testcase: expect.objectContaining({ '@_classname': '[target] prompt 1' }),
+      }),
+      expect.objectContaining({
+        '@_failures': '1',
+        '@_name': '[target] prompt 2',
+        '@_tests': '1',
+        testcase: expect.objectContaining({ '@_classname': '[target] prompt 2' }),
+      }),
+    ]);
   });
 
   it('omits raw JUnit error text when it matches the inline reason', async () => {

--- a/test/util/output.test.ts
+++ b/test/util/output.test.ts
@@ -959,7 +959,7 @@ describe('writeOutput', () => {
     ]);
   });
 
-  it('separates JUnit suites when result columns share provider and prompt identity', async () => {
+  it('separates JUnit suites in column order when result columns share identity', async () => {
     const baseResult = (promptIdx: number, success: boolean): EvaluateResult => ({
       success,
       failureReason: success ? ResultFailureReason.NONE : ResultFailureReason.ASSERT,
@@ -978,7 +978,7 @@ describe('writeOutput', () => {
     const eval_ = {
       createdAt: '2026-05-03T15:00:00.000Z',
       fetchResultsBatched: vi.fn(),
-      getResults: vi.fn().mockResolvedValue([baseResult(0, true), baseResult(1, false)]),
+      getResults: vi.fn().mockResolvedValue([baseResult(1, false), baseResult(0, true)]),
       persisted: false,
       results: [],
       useOldResults: () => true,


### PR DESCRIPTION
## Summary

- group JUnit suites by the canonical result-column index instead of prompt identity
- assign per-provider suite ordinals in canonical column order, independent of result arrival order
- keep duplicate provider/config columns separate even when their provider and prompt identities match
- update regression coverage for suite names, testcase classnames, and per-suite failure counts

## Why

Duplicate provider entries with different configs are a supported comparison workflow. Those columns can share the same provider ID, label, and prompt ID while still representing distinct result columns.

JUnit output previously keyed suites by provider and prompt identity, so it collapsed those columns into one suite. The evaluator now assigns a stable `promptIdx` to each result column, so the JUnit exporter can use that existing positional identity directly. Because concurrent or persisted results may be read out of order, the exporter assigns display ordinals only after restoring canonical column order.

Follow-up to #10208.

## Result

A deterministic eval with two `echo` provider configs and one prompt produces two JUnit suites:

- `[target] prompt 1` with one testcase
- `[target] prompt 2` with one testcase

The regression test fails on `main`, where both columns are emitted as one two-test suite.

## Testing

- `npx vitest run test/util/output.test.ts` — 62 passed
- `npm run tsc`
- `npm run l`
- `npm run f`
- `npm test` — 811 test files passed; 22,323 tests passed; 10 skipped
- `npm run build`
- built CLI eval with two differently configured `echo` providers, `--no-cache`, and JUnit output; inspected the generated XML for two one-test suites
- `git diff --check`
