### PR TITLE
feat(providers): add templated request metadata for a2a provider

### DIFF
--- a/site/docs/providers/a2a.md
+++ b/site/docs/providers/a2a.md
@@ -84,6 +84,7 @@ context, similar to how the MCP provider uses discovered tools.
 | `polling.timeoutMs`  | number                       | `300000` | Maximum time to wait for task completion                                    |
 | `message`            | object                       | -        | Custom A2A message template                                                 |
 | `configuration`      | object                       | -        | A2A message configuration sent with each request                            |
+| `metadata`           | object                       | -        | A2A request metadata sent with each request                                 |
 | `transformResponse`  | string \| Function           | -        | JavaScript transform for reshaping the final provider response              |
 | `timeoutMs`          | number                       | -        | Per-request HTTP timeout. Defaults to promptfoo's provider request timeout. |
 
@@ -229,9 +230,11 @@ providers:
           - text: '{{prompt}}'
       configuration:
         returnImmediately: false
+      metadata:
+        metadata_field: '{{metadata_field_value}}'
 ```
 
-Promptfoo renders Nunjucks variables in `message`, `auth`, `headers`, `agentCardUrl`, `url`, and
+Promptfoo renders Nunjucks variables in `message`, `auth`, `headers`, `agentCardUrl`, `url`, `metadata` and
 `configuration`. It also adds a stable `messageId` and uses `sessionId` as the A2A `contextId` when
 available.
 

--- a/src/providers/a2a/index.ts
+++ b/src/providers/a2a/index.ts
@@ -685,6 +685,9 @@ export class A2AProvider implements ApiProvider {
         ...(this.config.configuration
           ? { configuration: renderTemplate(this.config.configuration, vars, context) }
           : {}),
+        ...(this.config.metadata
+          ? { metadata: renderTemplate(this.config.metadata, vars, context) }
+          : {}),
       };
 
       const final =

--- a/src/providers/a2a/types.ts
+++ b/src/providers/a2a/types.ts
@@ -105,6 +105,7 @@ export const A2AProviderConfigSchema = z
     agentCardUrl: z.string().optional(),
     auth: A2AAuthSchema.optional(),
     configuration: RecordSchema.optional(),
+    metadata: RecordSchema.optional(),
     headers: z.record(z.string(), z.string()).optional(),
     message: RecordSchema.optional(),
     mode: z.enum(['auto', 'send', 'stream']).prefault('auto'),

--- a/test/providers/a2a/provider.test.ts
+++ b/test/providers/a2a/provider.test.ts
@@ -128,6 +128,39 @@ describe('A2AProvider', () => {
     expect(requestBody.message.messageId).toMatch(/^promptfoo-/);
   });
 
+  it('sends a non-streaming message with templated request metadata', async () => {
+    vi.mocked(fetchWithTimeout).mockResolvedValueOnce(
+      jsonResponse({
+        message: {
+          role: 'ROLE_AGENT',
+          parts: [{ text: 'hello from a2a' }],
+        },
+      }),
+    );
+
+    const result = await provider({
+      message: { role: 'ROLE_USER', parts: [{ text: 'Question: {{prompt}}' }] },
+      metadata: { metadata_field: '{{metadata_field}}' },
+    }).callApi('hi', {
+      prompt: { raw: '{{prompt}}', label: 'prompt' },
+      vars: { metadata_field: 'value-1' },
+      testCaseId: 'case-1',
+    });
+
+    expect(result.output).toBe('hello from a2a');
+    expect(fetchWithTimeout).toHaveBeenCalledWith(
+      'https://agent.example.com/a2a/v1/message:send',
+      expect.objectContaining({
+        body: expect.stringContaining('Question: hi'),
+        method: 'POST',
+      }),
+      expect.any(Number),
+    );
+    const requestBody = JSON.parse(vi.mocked(fetchWithTimeout).mock.calls[0]?.[1]?.body as string);
+    expect(requestBody.message.messageId).toMatch(/^promptfoo-/);
+    expect(requestBody.metadata).toEqual({ metadata_field: 'value-1' });
+  });
+
   it('sends standards-compliant default A2A messages', async () => {
     vi.mocked(fetchWithTimeout).mockResolvedValueOnce(
       jsonResponse({


### PR DESCRIPTION
## What this PR Proposes

- add `metadata` to the A2A provider configuration, field is complaint with current `sendMessageRequest` parameters in [a2a specs](https://a2a-protocol.org/latest/specification/#321-sendmessagerequest)
- render metadata templates and send the result with each A2A request
- document the metadata option and add request-body test coverage