### PR TITLE
fix(redteam): preserve cached provider selection across requests

### DIFF
--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -50,14 +50,15 @@ export type RedteamProviderSelectionSource = 'explicit' | 'cache' | 'fallback' |
 /**
  * A provider chosen for one red-team generation request.
  *
- * localProviderSpec is intentionally runtime-only: provider option objects can
- * contain resolved credentials, but are still needed to build local JSON-only
- * variants of an explicitly configured provider. Only persistableId may cross
- * a serialization boundary.
+ * cachedJsonOnlyProvider and localProviderSpec are intentionally runtime-only:
+ * the cached provider must remain request-scoped, and provider option objects
+ * can contain resolved credentials. Only persistableId may cross a serialization
+ * boundary.
  */
 export interface RedteamProviderSelection {
   provider: ApiProvider;
   source: RedteamProviderSelectionSource;
+  cachedJsonOnlyProvider?: ApiProvider;
   localProviderSpec?: RedteamFileConfig['provider'];
   persistableId?: string;
 }
@@ -315,6 +316,9 @@ class RedteamProviderManager {
     return {
       provider: await this.loadProviderCandidate(candidate, { jsonOnly, preferSmallModel }),
       source: candidate.source,
+      ...(candidate.source === 'cache' && candidate.cachedJsonOnlyProvider
+        ? { cachedJsonOnlyProvider: this.wrapProvider(candidate.cachedJsonOnlyProvider) }
+        : {}),
       localProviderSpec: candidate.spec,
       persistableId: typeof candidate.spec === 'string' ? candidate.spec : undefined,
     };

--- a/src/redteam/strategies/types.ts
+++ b/src/redteam/strategies/types.ts
@@ -52,6 +52,10 @@ export async function getStrategyGenerationProvider({
       }
     }
 
+    if (selection?.source === 'cache' && jsonOnly && selection.cachedJsonOnlyProvider) {
+      return wrap(selection.cachedJsonOnlyProvider);
+    }
+
     const provider =
       selection?.source === 'default'
         ? await redteamProviderManager.getDefaultProvider({ jsonOnly, preferSmallModel })

--- a/test/redteam/strategies/types.test.ts
+++ b/test/redteam/strategies/types.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { redteamProviderManager } from '../../../src/redteam/providers/shared';
+import {
+  redteamProviderManager,
+  setRedteamProviderLoader,
+} from '../../../src/redteam/providers/shared';
 import {
   getStrategyGenerationProvider,
   withPersistableGenerationProvider,
@@ -30,6 +33,38 @@ describe('getStrategyGenerationProvider', () => {
 
     expect(result).toBe(cachedJsonProvider);
     expect(getProvider).toHaveBeenCalledWith({ jsonOnly: true, preferSmallModel: true });
+  });
+
+  it('keeps the selected cached JSON provider when another request replaces the cache', async () => {
+    const firstProvider = { id: () => 'first-provider', callApi: vi.fn() } as any;
+    const firstJsonProvider = { id: () => 'first-json-provider', callApi: vi.fn() } as any;
+    const secondProvider = { id: () => 'second-provider', callApi: vi.fn() } as any;
+    const secondJsonProvider = { id: () => 'second-json-provider', callApi: vi.fn() } as any;
+    const loader = vi
+      .fn()
+      .mockResolvedValueOnce([firstProvider])
+      .mockResolvedValueOnce([firstJsonProvider])
+      .mockResolvedValueOnce([secondProvider])
+      .mockResolvedValueOnce([secondJsonProvider]);
+    const restoreLoader = setRedteamProviderLoader(loader);
+
+    try {
+      await redteamProviderManager.setProvider('first-provider');
+      const selection = await redteamProviderManager.getProviderSelection();
+      await redteamProviderManager.setProvider('second-provider');
+
+      const result = await getStrategyGenerationProvider({
+        runtimeContext: { generationProviderSelection: selection },
+        jsonOnly: true,
+        preferSmallModel: true,
+      });
+
+      expect(result.id()).toBe('first-json-provider');
+      expect(result).toBe(firstJsonProvider);
+    } finally {
+      redteamProviderManager.clearProvider();
+      restoreLoader();
+    }
   });
 
   it('prefers the dedicated multilingual cache for cached selections', async () => {


### PR DESCRIPTION
## Summary

- snapshot the JSON-only variant when a red-team generation request selects a cached provider
- reuse that request-scoped variant during local strategy generation even if another request replaces the shared provider cache
- add a failing-first regression that switches the cache between selection and strategy execution

## Why

The recent provider-selection refactor preserved the regular provider chosen for a request, but local JSON-producing strategies looked up the JSON variant from the mutable global cache later. If another request changed that cache in the meantime, the original request silently generated attacks with a different backend. This can cross provider, credential, or organizational boundaries.

## Verification

- Confirmed the new regression fails on the unmodified branch and passes after the fix.
- `node node_modules/vitest/vitest.mjs run test/redteam/strategies/types.test.ts test/redteam/providers/shared.test.ts test/redteam/strategies/mathPrompt.test.ts test/redteam/strategies/multilingual.test.ts test/redteam/index.test.ts test/server/routes/redteam.test.ts --configLoader runner --no-cache` — 278 tests passed.
- Ran the real source-module provider-switch scenario: request A retained `request-a-json` while the current global cache returned `request-b-json`.
- `PROMPTFOO_DISABLE_TELEMETRY=1 PROMPTFOO_DISABLE_UPDATE=true PROMPTFOO_CONFIG_DIR=/tmp/promptfoo-provider-snapshot-20260729 npm run local -- eval -c test/smoke/fixtures/configs/basic.yaml --no-cache -o /tmp/promptfoo-provider-snapshot-20260729-results.json` — 1 passed, 0 failed, 0 errors.
- `npm run l && npm run f` and `git diff --check`.
- Full `npm run tsc` could not be completed locally because the available dependency tree predates current `main`; an isolated `npm ci` was blocked by the organization package firewall with HTTP 403 for `postcss@8.5.23`.
