### PR TITLE
feat(redteam): add Turkish letter coverage to homoglyph map

### DIFF
--- a/site/docs/red-team/strategies/homoglyph.md
+++ b/site/docs/red-team/strategies/homoglyph.md
@@ -48,14 +48,14 @@ The homoglyph strategy works by:
 
 ## Example Scenarios
 
-| Original Character | Homoglyph Replacement | Unicode Name                      |
-| ------------------ | --------------------- | --------------------------------- |
-| a                  | а                     | Cyrillic Small Letter A (U+0430)  |
-| e                  | е                     | Cyrillic Small Letter Ie (U+0435) |
-| o                  | о                     | Cyrillic Small Letter O (U+043E)  |
-| p                  | р                     | Cyrillic Small Letter Er (U+0440) |
-| x                  | х                     | Cyrillic Small Letter Ha (U+0445) |
-| ş                  | ș                     | Latin Small Letter S With Comma Below (U+0219) |
+| Original Character | Homoglyph Replacement | Unicode Name                                    |
+| ------------------ | --------------------- | ----------------------------------------------- |
+| a                  | а                     | Cyrillic Small Letter A (U+0430)                |
+| e                  | е                     | Cyrillic Small Letter Ie (U+0435)               |
+| o                  | о                     | Cyrillic Small Letter O (U+043E)                |
+| p                  | р                     | Cyrillic Small Letter Er (U+0440)               |
+| x                  | х                     | Cyrillic Small Letter Ha (U+0445)               |
+| ş                  | ș                     | Latin Small Letter S With Comma Below (U+0219)  |
 | ö                  | ӧ                     | Cyrillic Small Letter O With Diaeresis (U+04E7) |
 
 The map also covers the Turkish letters `ç Ç ş Ş ğ Ğ ö Ö ı`. Without them, a Turkish-language prompt keeps its language-specific letters unchanged while the surrounding ASCII is substituted, leaving an obvious untouched signal. Each maps to a precomposed cross-script confusable with a different code point. The Turkish dotless `ı` (U+0131) has no close single-code-point twin; the mathematical italic dotless i is used as the nearest match, though it renders in a math style, so the visual similarity is weaker than the other entries. The letters `ü`, `Ü`, and `İ` are intentionally not mapped: their only visually identical alternatives are canonical (NFD) decompositions that recompose to the original character under NFC normalization, so they would have no effect.

--- a/site/docs/red-team/strategies/homoglyph.md
+++ b/site/docs/red-team/strategies/homoglyph.md
@@ -55,6 +55,10 @@ The homoglyph strategy works by:
 | o                  | о                     | Cyrillic Small Letter O (U+043E)  |
 | p                  | р                     | Cyrillic Small Letter Er (U+0440) |
 | x                  | х                     | Cyrillic Small Letter Ha (U+0445) |
+| ş                  | ș                     | Latin Small Letter S With Comma Below (U+0219) |
+| ö                  | ӧ                     | Cyrillic Small Letter O With Diaeresis (U+04E7) |
+
+The map also covers the Turkish letters `ç Ç ş Ş ğ Ğ ö Ö ı`. Without them, a Turkish-language prompt keeps its language-specific letters unchanged while the surrounding ASCII is substituted, leaving an obvious untouched signal. Each maps to a precomposed cross-script confusable with a different code point. The Turkish dotless `ı` (U+0131) has no close single-code-point twin; the mathematical italic dotless i is used as the nearest match, though it renders in a math style, so the visual similarity is weaker than the other entries. The letters `ü`, `Ü`, and `İ` are intentionally not mapped: their only visually identical alternatives are canonical (NFD) decompositions that recompose to the original character under NFC normalization, so they would have no effect.
 
 **Examples:**
 

--- a/src/redteam/strategies/homoglyph.ts
+++ b/src/redteam/strategies/homoglyph.ts
@@ -64,6 +64,25 @@ export const homoglyphMap: { [key: string]: string } = {
   '7': '𝟽', // Mathematical monospace 7
   '8': '𝟾', // Mathematical monospace 8
   '9': '𝟿', // Mathematical monospace 9
+  // Turkish letters. Without these, Turkish-language prompts keep their
+  // language-specific letters as-is while the ASCII characters around them are
+  // substituted, leaving an obvious untouched signal. Each maps to a precomposed
+  // cross-script confusable with a different code point. (ü, Ü and İ
+  // are omitted: the only visually-identical alternatives are their NFD
+  // decompositions, which recompose to the original character under NFC and so
+  // have no effect.)
+  ç: 'ҫ', // Cyrillic small es with descender (U+04AB)
+  Ç: 'Ҫ', // Cyrillic capital es with descender (U+04AA)
+  ş: 'ș', // Latin small s with comma below (U+0219)
+  Ş: 'Ș', // Latin capital s with comma below (U+0218)
+  ğ: 'ǧ', // Latin small g with caron (U+01E7)
+  Ğ: 'Ǧ', // Latin capital g with caron (U+01E6)
+  ö: 'ӧ', // Cyrillic small o with diaeresis (U+04E7)
+  Ö: 'Ӧ', // Cyrillic capital o with diaeresis (U+04E6)
+  // Turkish dotless i (U+0131) has no close single-code-point cross-script twin;
+  // the mathematical italic dotless i is the nearest match, but it renders in a
+  // math style, so the visual similarity is weaker than the other entries.
+  ı: '𝚤', // Mathematical italic small dotless i (U+1D6A4)
 };
 
 /**

--- a/test/redteam/strategies/homoglyph.test.ts
+++ b/test/redteam/strategies/homoglyph.test.ts
@@ -88,6 +88,37 @@ describe('homoglyph strategy', () => {
     });
   });
 
+  describe('Turkish letter coverage', () => {
+    const turkishLetters = ['ç', 'Ç', 'ş', 'Ş', 'ğ', 'Ğ', 'ö', 'Ö', 'ı'];
+
+    it('maps each Turkish-specific letter to a distinct homoglyph', () => {
+      for (const char of turkishLetters) {
+        const mapped = homoglyphMap[char];
+        expect(mapped, `missing homoglyph for '${char}'`).toBeDefined();
+        expect(mapped, `'${char}' maps to itself`).not.toBe(char);
+        expect(toHomoglyphs(char), `'${char}' left unchanged`).not.toBe(char);
+      }
+    });
+
+    it('transforms a Turkish prompt that previously passed through unchanged', () => {
+      const input = 'Şifreyi çöz ve ışığı aç';
+      const output = toHomoglyphs(input);
+      expect(output).not.toBe(input);
+      // None of the mapped Turkish letters should survive in the output.
+      for (const char of turkishLetters) {
+        expect(output, `'${char}' still present in output`).not.toContain(char);
+      }
+    });
+
+    it('leaves other non-ASCII letters outside the map untouched', () => {
+      // German ß, Spanish ñ, Greek letters, and the Turkish letters that have no
+      // usable homoglyph (ü, Ü, İ) are not in the map and must pass through
+      // unchanged, so behaviour is byte-identical for inputs without mapped letters.
+      const untouched = 'ßñαβγüÜİ';
+      expect(toHomoglyphs(untouched)).toBe(untouched);
+    });
+  });
+
   describe('addHomoglyphs', () => {
     it('should convert text to homoglyphs', () => {
       const injectVar = 'prompt';


### PR DESCRIPTION
## What

Extends `homoglyphMap` in `src/redteam/strategies/homoglyph.ts` to cover the Turkish letters `ç Ç ş Ş ğ Ğ ö Ö ı`.

## Why

`homoglyphMap` currently only contains ASCII `a–z`, `A–Z`, and `0–9`. `toHomoglyphs()` passes every other character through unchanged, so a Turkish-language prompt has its ASCII characters substituted while its language-specific letters (`ç`, `ş`, `ğ`, `ö`, `ı`) are left untouched. That leaves an obvious, unsubstituted signal in the payload and reduces the strategy's coverage for Turkish inputs.

## How

Each added letter maps to a visually similar character with a different code point, matching the existing entries in the map — e.g. `ş` → `ș` (Latin small s with comma below, U+0219), `ö` → `ӧ` (Cyrillic small o with diaeresis, U+04E7), `ç` → `ҫ` (Cyrillic small es with descender, U+04AB).

The Turkish dotless `ı` (U+0131) has no close single-code-point cross-script twin. The mathematical italic dotless i (U+1D6A4) is used as the nearest match; it renders in a math style, so its visual similarity is weaker than the other entries. This tradeoff is called out in the code and docs.

The letters `ü`, `Ü`, and `İ` are deliberately left out. Their only visually identical alternatives are the NFD (base letter + combining mark) decompositions, which recompose to the original precomposed character under NFC normalization and therefore produce no homoglyph effect. Adding a no-op entry would be misleading, so they are omitted until a genuine cross-script confusable is identified.

## Blast radius

Every added key is a non-ASCII character, so the output for any input that does not contain these specific letters is byte-identical to before. Behaviour for existing ASCII `a–z`/`A–Z`/`0–9` inputs is unchanged. A regression test asserts that other non-ASCII letters outside the map (`ß`, `ñ`, Greek, and the unmapped `ü`/`Ü`/`İ`) still pass through untouched.

## Not a duplicate of the Unicode normalization work

This is orthogonal to the open Unicode-normalization strategy PR (#10056). That PR *normalizes* input as a defense; this change *generates* homoglyph payloads (the attack side of the same coin). It touches only the existing `homoglyph` strategy's lookup table and adds no new strategy, file, or config surface.

## Tests

Added focused cases in `test/redteam/strategies/homoglyph.test.ts`:

- Every added Turkish letter is mapped to a distinct, non-identical homoglyph.
- A Turkish prompt that previously passed through unchanged is now transformed, and none of the mapped Turkish letters survive in the output.
- Non-ASCII letters outside the map — including the intentionally unmapped `ü`/`Ü`/`İ` — are left untouched.

## Docs

Updated `site/docs/red-team/strategies/homoglyph.md` with two example rows and a short paragraph describing the Turkish letter coverage, including the `ı` tradeoff and why `ü`/`Ü`/`İ` are not mapped.
