### PR TITLE
fix(assertions): do not skip JSON schema validation for falsy values

### DIFF
--- a/src/assertions/json.ts
+++ b/src/assertions/json.ts
@@ -21,7 +21,7 @@ export function handleIsJson({
     pass = inverse;
   }
 
-  if (parsedJson !== undefined && renderedValue) {
+  if (parsedJson !== undefined && renderedValue !== undefined) {
     let validate: ValidateFunction;
     if (typeof renderedValue === 'string') {
       if (renderedValue.startsWith('file://')) {
@@ -33,7 +33,7 @@ export function handleIsJson({
         const scheme = loadYaml(renderedValue) as object;
         validate = getAjv().compile(scheme);
       }
-    } else if (typeof renderedValue === 'object') {
+    } else if (renderedValue !== null && typeof renderedValue === 'object') {
       validate = getAjv().compile(renderedValue);
     } else {
       throw new Error('is-json assertion must have a string or object value');
@@ -73,7 +73,7 @@ export function handleContainsJson({
   const jsonObjects = extractJsonObjects(outputString);
   let pass = inverse ? jsonObjects.length === 0 : jsonObjects.length > 0;
   for (const jsonObject of jsonObjects) {
-    if (renderedValue) {
+    if (renderedValue !== undefined) {
       let validate: ValidateFunction;
       if (typeof renderedValue === 'string') {
         if (renderedValue.startsWith('file://')) {
@@ -85,7 +85,7 @@ export function handleContainsJson({
           const scheme = loadYaml(renderedValue) as object;
           validate = getAjv().compile(scheme);
         }
-      } else if (typeof renderedValue === 'object') {
+      } else if (renderedValue !== null && typeof renderedValue === 'object') {
         validate = getAjv().compile(renderedValue);
       } else {
         throw new Error('contains-json assertion must have a string or object value');

--- a/test/assertions/json.test.ts
+++ b/test/assertions/json.test.ts
@@ -109,6 +109,22 @@ describe('handleIsJson', () => {
       ),
     ).toThrow('is-json assertion must have a string or object value');
   });
+
+  it.each([
+    ['false', false],
+    ['0', 0],
+    ['null', null],
+  ])('rejects the unsupported schema value %s instead of skipping validation', (_label, value) => {
+    expect(() =>
+      handleIsJson(
+        makeParams({
+          assertion: { type: 'is-json' },
+          renderedValue: value as unknown as AssertionValue,
+          outputString: '{"a": 1}',
+        }),
+      ),
+    ).toThrow('is-json assertion must have a string or object value');
+  });
 });
 
 describe('handleContainsJson', () => {
@@ -179,6 +195,22 @@ describe('handleContainsJson', () => {
           assertion: { type: 'contains-json' },
           renderedValue: 42 as unknown as AssertionValue,
           outputString: '{"a": 1}',
+        }),
+      ),
+    ).toThrow('contains-json assertion must have a string or object value');
+  });
+
+  it.each([
+    ['false', false],
+    ['0', 0],
+    ['null', null],
+  ])('rejects the unsupported schema value %s instead of skipping validation', (_label, value) => {
+    expect(() =>
+      handleContainsJson(
+        makeParams({
+          assertion: { type: 'contains-json' },
+          renderedValue: value as unknown as AssertionValue,
+          outputString: 'result: {"a": 1}',
         }),
       ),
     ).toThrow('contains-json assertion must have a string or object value');


### PR DESCRIPTION
## Problem

`is-json` and `contains-json` gate schema validation on truthiness:

```ts
if (parsedJson !== undefined && renderedValue) {
```

`renderedValue` of `false`, `0`, or `null` is therefore indistinguishable from no
schema at all, so the handler skips validation entirely and the assertion passes
against any valid JSON. An assertion that can never fail is worse than one that
errors — the eval reports green and the misconfiguration stays invisible.

`false` is the case most likely to be hit in practice: it is a valid JSON Schema
meaning "reject every value", so the strictest possible schema currently produces
the most permissive outcome.

## Change

Four lines in `src/assertions/json.ts`:

- gate on `renderedValue !== undefined` rather than truthiness, so an omitted
  schema still skips validation while a supplied falsy one does not;
- exclude `null` from the `typeof === 'object'` branch, so it reaches the existing
  error instead of `ajv.compile(null)` — which throws
  `Cannot read properties of null (reading '$id')`.

Unsupported values now raise the handlers' existing
`must have a string or object value` error rather than silently passing.

## Scope

Deliberately narrow. This does **not** add JSON Schema boolean support — `true`
and `false` as schemas are rejected here rather than honored. That is a feature
with a contract question attached, and it belongs in its own PR; this one only
stops the silent skip. The `file://` path is untouched: it already errors on a
falsy exported schema via `invariant`.

Behavior change worth naming: an explicit empty YAML `value:` parses as `null`
and today behaves like an omitted value, so it now errors. Omitting the field
entirely is unaffected. Happy to let `null` stay schema-free if maintainers
prefer.

## Verification

Run on Node 26.4.0, biome + prettier + `tsc --noEmit` clean:

| Check | Result |
|---|---|
| `vitest run test/assertions/json.test.ts --sequence.shuffle=false` | 16 passed |
| Same suite, randomized order | 16 passed |
| **Same suite with the `json.ts` change reverted** | **6 failed, 10 passed** |
| `vitest run test/assertions/` | 60 files, 1330 passed |
| `tsc --noEmit` | clean |
| `biome check` on both changed files | clean |
| `git diff --check` | clean |

The six new cases fail without the fix and pass with it — the reverted-source run
above is the evidence, not just the green one.
