### PR TITLE
fix(matchers): ignore grader chatter in context-relevance numerator

### DIFF
--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -282,11 +282,37 @@ export async function matchesContextRelevance(
   // text with no newlines, so counting by line alone would treat a multi-sentence
   // answer as one unit and undercount relevance (e.g. echoing the whole context
   // would score 1/N instead of 1.0).
+  //
+  // Only units that actually occur in the context count. The rubric requires verbatim
+  // extraction ("you're not allowed to make any changes to sentences from given
+  // context"), so anything absent from the context is the grader talking rather than
+  // extracting. Most often that is the rubric's own trailing `candidate sentences:`
+  // cue echoed back by chat models, which segmented into a unit and inflated the
+  // numerator — the denominator is derived from the context, so counting free text on
+  // the other side of the ratio made the score model-dependent.
+  //
+  // Matching is on normalised containment, not equality: graders routinely echo a
+  // sentence without its terminal punctuation or with altered whitespace, and a
+  // pre-segmented context may hold several sentences per unit.
   const insufficientInformation = resp.output.includes(CONTEXT_RELEVANCE_BAD);
   const segmentRelevant = contextIsPreSegmented ? splitIntoSentences : splitTextIntoSentences;
+  // A leading list marker is the grader's formatting, not part of the extracted
+  // sentence, so it is dropped before matching — `1. Paris is…` must still match
+  // `Paris is…` in the context. The marker must be followed by whitespace, so a
+  // sentence that genuinely opens with a number ("1991 saw…") is left alone.
+  const normalizeForMatch = (text: string) =>
+    text
+      .replace(/^\s*(?:[-*•]|\d+[.)])\s+/, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim();
+  const normalizedContext = normalizeForMatch(contextString);
   const relevantSentences = insufficientInformation
     ? []
-    : [...new Set(segmentRelevant(resp.output))];
+    : [...new Set(segmentRelevant(resp.output))].filter((sentence) => {
+        const normalized = normalizeForMatch(sentence);
+        return normalized.length > 0 && normalizedContext.includes(normalized);
+      });
   // Cap at the total so the score never exceeds 1.
   const numerator = Math.min(relevantSentences.length, totalContextUnits);
 

--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -323,10 +323,28 @@ export async function matchesContextRelevance(
   const insufficientInformation = resp.output.includes(CONTEXT_RELEVANCE_BAD);
   const segmentRelevant = contextIsPreSegmented ? splitIntoSentences : splitTextIntoSentences;
   const normalizedContext = normalizeForMatch(contextString);
-  const isFromContext = (text: string) => {
+  const matchesContext = (text: string) => {
     const normalized = normalizeForMatch(text);
     return normalized.length > 0 && normalizedContext.includes(normalized);
   };
+
+  // A grader may put its cue on the same line as the first extraction
+  // ("candidate sentences: Alpha is first."). The label is only dropped when doing so
+  // turns a non-matching segment into a verbatim context sentence, so a context
+  // sentence that legitimately contains a colon is left alone.
+  const withoutInlineLabel = (text: string) => {
+    const stripped = text.replace(/^[^:\n]{0,80}:\s+/, '');
+    return stripped !== text && matchesContext(stripped) ? stripped : text;
+  };
+
+  // A segment that is nothing but a list marker carries no content. Sentence-mode
+  // splitting leaves `A.` standing alone, and it normalises to `a` — a substring of
+  // very nearly any context — so without this it would be counted as a relevant
+  // sentence and inflate the numerator, which is the failure this filter exists to
+  // prevent. `splitTextIntoSentences` already drops the numeric form.
+  const isMarkerOnly = (text: string) => /^\s*\(?[\p{N}A-Za-z][.)]\s*$/u.test(text);
+
+  const isFromContext = (text: string) => !isMarkerOnly(text) && matchesContext(text);
 
   // Chatter is dropped BEFORE segmentation rather than after. `splitTextIntoSentences`
   // picks line mode as soon as the completion spans two or more non-empty lines, so an
@@ -336,12 +354,16 @@ export async function matchesContextRelevance(
   // would have had without it.
   const graderOutput = resp.output
     .split('\n')
-    .filter((line) => line.trim() === '' || splitTextIntoSentences(line).some(isFromContext))
+    .filter(
+      (line) =>
+        line.trim() === '' ||
+        splitTextIntoSentences(line).map(withoutInlineLabel).some(isFromContext),
+    )
     .join('\n');
 
   const relevantSentences = insufficientInformation
     ? []
-    : [...new Set(segmentRelevant(graderOutput))].filter(isFromContext);
+    : [...new Set(segmentRelevant(graderOutput).map(withoutInlineLabel))].filter(isFromContext);
   // Cap at the total so the score never exceeds 1.
   const numerator = Math.min(relevantSentences.length, totalContextUnits);
 

--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -225,6 +225,31 @@ export async function matchesContextRecall(
   };
 }
 
+/**
+ * A leading list marker is the grader's formatting, not part of the extracted sentence,
+ * so `1. Paris is…`, `(2) Paris is…` and `a) Paris is…` all still match `Paris is…` in
+ * the context. The marker must be followed by whitespace, so a sentence that genuinely
+ * opens with a number ("1991 saw…") is left alone. Only ASCII letters are treated as
+ * markers — a CJK sentence can begin with a single character that is a word, not a label.
+ */
+const LIST_MARKER_PREFIX = /^\s*(?:[-*\u2022\u2013\u2014]|\(?\d+[.)]|\(?[a-zA-Z][.)])\s+/;
+
+/**
+ * Normalises text for context membership checks: strips a leading list marker, lowercases,
+ * and collapses everything that is not a letter or number into single spaces.
+ *
+ * Uses the Unicode letter/number properties rather than `[a-z0-9]`. An ASCII-only class
+ * erases CJK, Arabic, Cyrillic and similar scripts entirely, which would drop every
+ * extraction in a non-Latin RAG eval and score it 0.
+ */
+function normalizeForMatch(text: string): string {
+  return text
+    .replace(LIST_MARKER_PREFIX, '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim();
+}
+
 export async function matchesContextRelevance(
   question: string,
   context: string | string[],
@@ -293,26 +318,30 @@ export async function matchesContextRelevance(
   //
   // Matching is on normalised containment, not equality: graders routinely echo a
   // sentence without its terminal punctuation or with altered whitespace, and a
-  // pre-segmented context may hold several sentences per unit.
+  // pre-segmented context may hold several sentences per unit. See
+  // {@link normalizeForMatch}.
   const insufficientInformation = resp.output.includes(CONTEXT_RELEVANCE_BAD);
   const segmentRelevant = contextIsPreSegmented ? splitIntoSentences : splitTextIntoSentences;
-  // A leading list marker is the grader's formatting, not part of the extracted
-  // sentence, so it is dropped before matching — `1. Paris is…` must still match
-  // `Paris is…` in the context. The marker must be followed by whitespace, so a
-  // sentence that genuinely opens with a number ("1991 saw…") is left alone.
-  const normalizeForMatch = (text: string) =>
-    text
-      .replace(/^\s*(?:[-*•]|\d+[.)])\s+/, '')
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, ' ')
-      .trim();
   const normalizedContext = normalizeForMatch(contextString);
+  const isFromContext = (text: string) => {
+    const normalized = normalizeForMatch(text);
+    return normalized.length > 0 && normalizedContext.includes(normalized);
+  };
+
+  // Chatter is dropped BEFORE segmentation rather than after. `splitTextIntoSentences`
+  // picks line mode as soon as the completion spans two or more non-empty lines, so an
+  // echoed cue on its own line switches the rest of the response to line mode too — a
+  // line carrying two context sentences would then count as one unit, turning a 2/3
+  // score into 1/3. Removing the chatter first restores the segmentation the response
+  // would have had without it.
+  const graderOutput = resp.output
+    .split('\n')
+    .filter((line) => line.trim() === '' || splitTextIntoSentences(line).some(isFromContext))
+    .join('\n');
+
   const relevantSentences = insufficientInformation
     ? []
-    : [...new Set(segmentRelevant(resp.output))].filter((sentence) => {
-        const normalized = normalizeForMatch(sentence);
-        return normalized.length > 0 && normalizedContext.includes(normalized);
-      });
+    : [...new Set(segmentRelevant(graderOutput))].filter(isFromContext);
   // Cap at the total so the score never exceeds 1.
   const numerator = Math.min(relevantSentences.length, totalContextUnits);
 

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -521,4 +521,40 @@ This policy excludes all staff going on any outgoing structured programs, short 
     expect(result.metadata?.relevantSentenceCount).toBe(1);
     expect(result.score).toBeCloseTo(0.33, 2);
   });
+
+  it('should count both sentences when the cue shares a line with the first', async () => {
+    // Segmenting leaves the cue attached to the first sentence, so the membership
+    // check rejected an otherwise verbatim extraction and 2/3 became 1/3.
+    const input = 'What comes first and second?';
+    const context = 'Alpha is first. Beta is second. Gamma is third.';
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: 'candidate sentences: Alpha is first. Beta is second.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, 0.2);
+
+    expect(result.metadata?.relevantSentenceCount).toBe(2);
+    expect(result.score).toBeCloseTo(0.67, 2);
+  });
+
+  it('should not count a bare list marker left standing by sentence splitting', async () => {
+    // `A.` splits into its own segment and normalizes to `a`, which is a substring of
+    // nearly any context — counting it inflates the numerator, the very failure this
+    // filter exists to prevent.
+    const input = 'What is the capital of France?';
+    const context = 'Paris is the capital of France. Berlin is the capital of Germany.';
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: 'A. Paris is the capital of France.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, 0.2);
+
+    expect(result.metadata?.extractedSentences).toEqual(['Paris is the capital of France.']);
+    expect(result.metadata?.relevantSentenceCount).toBe(1);
+    expect(result.score).toBeCloseTo(0.5, 2);
+  });
 });

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -438,4 +438,32 @@ This policy excludes all staff going on any outgoing structured programs, short 
       expect(result.metadata?.relevantSentenceCount).toBe(1);
     });
   });
+  it('should not count the grader echoing the prompt cue as a relevant sentence', async () => {
+    // The rubric ends with a `candidate sentences:` cue; chat models frequently echo it
+    // back before answering. Segmenting the raw completion turned that echo into an
+    // extracted sentence, so the numerator counted it and the score came out double.
+    const input = 'Who created Python?';
+    const context =
+      'Python is a high-level, general-purpose programming language known for readability. ' +
+      'It has a large standard library. ' +
+      'It was created by Guido van Rossum and released in 1991. ' +
+      'Python is widely used in data science, web development, and automation.';
+    const threshold = 0.2;
+
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: 'candidate sentences:\nIt was created by Guido van Rossum and released in 1991.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, threshold);
+
+    // one of four context sentences is relevant
+    expect(result.metadata?.totalContextUnits).toBe(4);
+    expect(result.metadata?.extractedSentences).toEqual([
+      'It was created by Guido van Rossum and released in 1991.',
+    ]);
+    expect(result.metadata?.relevantSentenceCount).toBe(1);
+    expect(result.score).toBeCloseTo(0.25, 2);
+  });
 });

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -466,4 +466,59 @@ This policy excludes all staff going on any outgoing structured programs, short 
     expect(result.metadata?.relevantSentenceCount).toBe(1);
     expect(result.score).toBeCloseTo(0.25, 2);
   });
+
+  it('should keep verbatim extractions written in non-Latin scripts', async () => {
+    // The membership check must use Unicode letter/number properties. An ASCII-only
+    // class erases CJK, Arabic and Cyrillic entirely, so every extraction normalizes
+    // to the empty string and a correct grader scores 0.
+    const input = '法国的首都是哪里？';
+    const context = '巴黎是法国的首都。法国位于欧洲大陆。今天天气很好。';
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: '巴黎是法国的首都。',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, 0.2);
+
+    expect(result.metadata?.relevantSentenceCount).toBe(1);
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  it('should still segment by sentence when the grader echoes the cue on its own line', async () => {
+    // The echoed cue adds a second line, which flips splitTextIntoSentences into line
+    // mode for the whole response. Dropping chatter before segmentation keeps the two
+    // relevant sentences on the remaining line counted separately.
+    const input = 'What comes first and second?';
+    const context = 'Alpha is first. Beta is second. Gamma is third.';
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: 'candidate sentences:\nAlpha is first. Beta is second.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, 0.2);
+
+    expect(result.metadata?.totalContextUnits).toBe(3);
+    expect(result.metadata?.relevantSentenceCount).toBe(2);
+    expect(result.score).toBeCloseTo(0.67, 2);
+  });
+
+  it('should accept list markers beyond "1." when matching extractions', async () => {
+    // Graders vary their list formatting; a marker the stripper does not recognise
+    // leaves the candidate unmatchable and silently drops a real extraction.
+    const input = 'Who created Python?';
+    const context =
+      'Python is known for readability. It was created by Guido van Rossum. It is widely used.';
+    const mockCallApi = vi.fn().mockResolvedValue({
+      output: '(1) It was created by Guido van Rossum.',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+    const result = await matchesContextRelevance(input, context, 0.2);
+
+    expect(result.metadata?.relevantSentenceCount).toBe(1);
+    expect(result.score).toBeCloseTo(0.33, 2);
+  });
 });


### PR DESCRIPTION
Fixes #10245.

## Problem

The numerator is segmented from the grader's *entire* raw completion:

```ts
const relevantSentences = insufficientInformation
  ? []
  : [...new Set(segmentRelevant(resp.output))];
const numerator = Math.min(relevantSentences.length, totalContextUnits);
```

so anything the grader emits counts toward relevance. The rubric ends with a `candidate sentences:` cue and chat models routinely echo it back before answering, which segments into a unit of its own.

For the reported case that produces `extractedSentences: ["candidate sentences:", "It was created by Guido van Rossum and released in 1991."]` and a score of `2/4 = 0.5`, where only one of the four context sentences is relevant and `1/4 = 0.25` is correct.

The denominator is derived from the context while the numerator was derived from free text, so the two sides of the ratio weren't drawn from the same population — and the score varied with how chatty the grading model happened to be, since no part of the rubric pins down the header wording.

## Fix

Only units that actually occur in the context count. The rubric already requires verbatim extraction — *"you're not allowed to make any changes to sentences from given context"* — so anything absent from the context is the grader talking rather than extracting. That drops preambles and commentary without hard-coding particular header strings, which would only work for models that phrase them the same way.

Matching is **normalised containment**, not equality, because graders in practice:

- echo a sentence without its terminal punctuation — the existing `line-based sentence splitting` test mocks exactly this
- prefix it with a list marker (`1.`, `-`) — covered by the existing numbered-list test
- alter whitespace, or echo several sentences from one pre-segmented unit

A leading list marker is stripped before matching, and only when followed by whitespace, so a sentence genuinely opening with a number (`1991 saw…`) is untouched.

## Tests

Added a regression test using the reported scenario: a grader output carrying the `candidate sentences:` header over the four-sentence Python context, asserting `extractedSentences` holds only the real extraction and the score is `0.25`.

Verified it fails without the source change:

```
× should not count the grader echoing the prompt cue as a relevant sentence
  AssertionError: expected [ 'candidate sentences:', …(1) ] to deeply equal [ Array(1) ]
```

Worth noting the first iteration of this fix used exact matching and **broke the existing numbered-list test** — that's what surfaced the need to strip list markers and match on containment.

## Verification

- `341` tests pass across `test/matchers/` and `test/assertions/contextRelevance.test.ts` (22 files)
- `npm run l` and `npm run f` clean
- `npm run tsc` reports 7 pre-existing errors (`lru-cache`, `node-sql-parser` declarations) — identical set on a clean tree with this patch stashed, and none in the touched files