### PR TITLE
fix(deps): pin PostCSS to approved release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34437,9 +34437,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -45608,7 +45608,7 @@
         "js-yaml": "5.2.2",
         "jsdom": "^29.0.0",
         "lucide-react": "^1.0.0",
-        "postcss": "^8.5.18",
+        "postcss": "8.5.22",
         "posthog-js": "1.379.1",
         "prismjs": "^1.30.0",
         "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "chokidar": "5.0.0",
     "whatwg-url": "16.0.1",
     "esbuild": "0.28.1",
+    "postcss": "8.5.22",
     "jsdom": {
       "@asamuzakjp/css-color": "5.1.11"
     },

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -55,7 +55,7 @@
     "js-yaml": "5.2.2",
     "jsdom": "^29.0.0",
     "lucide-react": "^1.0.0",
-    "postcss": "^8.5.18",
+    "postcss": "8.5.22",
     "posthog-js": "1.379.1",
     "prismjs": "^1.30.0",
     "react": "^19.2.4",


### PR DESCRIPTION
## Summary
- Pin PostCSS to the policy-approved 8.5.22 release in the root override, app manifest, and lockfile.
- Preserve security-patched js-yaml 5.2.2; that package still needs a Socket policy exception.

## Validation
- npm run tsc
- npx vitest run test/package-manifests.test.ts test/util/yamlLoad.test.ts (22 tests passing)
- npx @biomejs/biome check package.json src/app/package.json
- Confirmed postcss@8.5.22 downloads through the configured Socket registry.