### PR TITLE
fix(assertions): ignore grader prose in context-relevance scoring

### DIFF
--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -225,6 +225,32 @@ export async function matchesContextRecall(
   };
 }
 
+// Leading enumeration/bullet markers a grader may add when listing the sentences
+// it selected ("1. ", "2) ", "- ", "* "). They are formatting, not content, so
+// they are stripped before matching a segment back to the context.
+const LEADING_LIST_MARKER = /^\s*(?:\d+[.)]|[-*•])\s+/;
+// Quotes a grader may wrap an echoed sentence in, and trailing punctuation it may
+// add or drop. Both sides of a match are normalized so `Paris is the capital of
+// France` still matches a context reading `Paris is the capital of France.`
+const SURROUNDING_QUOTES = /^["'`]+|["'`]+$/g;
+const TRAILING_PUNCTUATION = /[\s.,;:!?]+$/;
+
+/** Lowercase and collapse all whitespace (including newlines) so a quoted span that
+ * wraps across lines in the source context still matches. */
+function normalizeForContextMatch(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+/** Normalize one grader-emitted segment for comparison against the context. */
+function normalizeSegmentForContextMatch(segment: string): string {
+  return normalizeForContextMatch(
+    segment
+      .replace(LEADING_LIST_MARKER, '')
+      .replace(SURROUNDING_QUOTES, '')
+      .replace(TRAILING_PUNCTUATION, ''),
+  );
+}
+
 export async function matchesContextRelevance(
   question: string,
   context: string | string[],
@@ -284,9 +310,25 @@ export async function matchesContextRelevance(
   // would score 1/N instead of 1.0).
   const insufficientInformation = resp.output.includes(CONTEXT_RELEVANCE_BAD);
   const segmentRelevant = contextIsPreSegmented ? splitIntoSentences : splitTextIntoSentences;
+  // A relevant unit must actually come from the context. The grading prompt does
+  // not constrain the response format, and graders routinely prefix their answer
+  // with a header of their own ("candidate sentences:", "Relevant sentences:").
+  // That header is a segment like any other, so counting it inflated the
+  // numerator: a header plus one genuinely relevant sentence scored 2/4 instead
+  // of 1/4, which flips a threshold-0.5 assertion from fail to pass purely on
+  // incidental formatting of the grader's prose.
+  //
+  // Segments are matched against the whole whitespace-normalized context rather
+  // than against individual units, because a grader legitimately quotes text
+  // that spans a unit boundary — a wrapped line in a formatted document, or two
+  // sentences of one chunk. Matching per unit would undercount those.
+  const normalizedContext = normalizeForContextMatch(contextUnits.join(' '));
   const relevantSentences = insufficientInformation
     ? []
-    : [...new Set(segmentRelevant(resp.output))];
+    : [...new Set(segmentRelevant(resp.output))].filter((sentence) => {
+        const normalized = normalizeSegmentForContextMatch(sentence);
+        return normalized.length > 0 && normalizedContext.includes(normalized);
+      });
   // Cap at the total so the score never exceeds 1.
   const numerator = Math.min(relevantSentences.length, totalContextUnits);
 

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -438,4 +438,81 @@ This policy excludes all staff going on any outgoing structured programs, short 
       expect(result.metadata?.relevantSentenceCount).toBe(1);
     });
   });
+
+  describe('Grader prose is not a context unit', () => {
+    // Regression (#10245): the grading prompt does not constrain the response
+    // format, so graders routinely prefix their answer with a header of their
+    // own. Every segment of the response used to count toward the numerator, so
+    // that header counted as an extracted relevant sentence and inflated the
+    // score — flipping a test from fail to pass purely on incidental formatting.
+    const PYTHON_CONTEXT =
+      'Python is a high-level, general-purpose programming language known for readability. It has a large standard library. It was created by Guido van Rossum and released in 1991. Python is widely used in data science, web development, and automation.';
+
+    it('does not count the grader response header as a relevant sentence', async () => {
+      const mockCallApi = vi.fn().mockResolvedValue({
+        output: 'candidate sentences:\nIt was created by Guido van Rossum and released in 1991.',
+        tokenUsage: { total: 10, prompt: 5, completion: 5 },
+      });
+      vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+      const result = await matchesContextRelevance('Who created Python?', PYTHON_CONTEXT, 0.5);
+
+      // Exactly one of the four context sentences answers the question, so the
+      // score is 1/4. Counting the "candidate sentences:" header doubled the
+      // numerator to 2/4 = 0.5, which passed the 0.5 threshold.
+      expect(result.score).toBeCloseTo(0.25, 2);
+      expect(result.pass).toBe(false);
+      expect(result.metadata?.totalContextUnits).toBe(4);
+      expect(result.metadata?.relevantSentenceCount).toBe(1);
+      expect(result.metadata?.extractedSentences).toEqual([
+        'It was created by Guido van Rossum and released in 1991.',
+      ]);
+    });
+
+    it('drops grader commentary that does not appear in the context', async () => {
+      const mockCallApi = vi.fn().mockResolvedValue({
+        output:
+          'Here are the relevant sentences:\nIt was created by Guido van Rossum and released in 1991.\nThat sentence directly answers the question.',
+        tokenUsage: { total: 10, prompt: 5, completion: 5 },
+      });
+      vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+      const result = await matchesContextRelevance('Who created Python?', PYTHON_CONTEXT, 0.5);
+
+      // Both the preamble and the trailing justification are the grader's own
+      // prose, not context units.
+      expect(result.metadata?.relevantSentenceCount).toBe(1);
+      expect(result.score).toBeCloseTo(0.25, 2);
+    });
+
+    it('still counts a sentence the grader echoes without its trailing period', async () => {
+      const mockCallApi = vi.fn().mockResolvedValue({
+        output: 'It was created by Guido van Rossum and released in 1991',
+        tokenUsage: { total: 10, prompt: 5, completion: 5 },
+      });
+      vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+      const result = await matchesContextRelevance('Who created Python?', PYTHON_CONTEXT, 0.2);
+
+      // Matching must tolerate punctuation drift, otherwise filtering out grader
+      // prose would silently undercount genuinely relevant sentences.
+      expect(result.metadata?.relevantSentenceCount).toBe(1);
+      expect(result.pass).toBe(true);
+    });
+
+    it('still counts sentences the grader returns as a quoted numbered list', async () => {
+      const mockCallApi = vi.fn().mockResolvedValue({
+        output:
+          'Relevant sentences:\n1. "It has a large standard library."\n2. "It was created by Guido van Rossum and released in 1991."',
+        tokenUsage: { total: 10, prompt: 5, completion: 5 },
+      });
+      vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+      const result = await matchesContextRelevance('Tell me about Python', PYTHON_CONTEXT, 0.5);
+
+      // List markers and surrounding quotes are formatting, not content.
+      expect(result.metadata?.relevantSentenceCount).toBe(2);
+      expect(result.score).toBeCloseTo(0.5, 2);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #10245

## Summary

`context-relevance` counts the grader's own response header as an extracted relevant sentence, inflating the score.

The grading prompt does not constrain the response format, so graders routinely prefix their answer with a header of their own — `candidate sentences:`, `Relevant sentences:`. Every segment of the grader response counted toward the numerator, and that header is a segment like any other.

## Reproduction

Four-sentence context, exactly one sentence answers the question:

```yaml
tests:
  - vars:
      query: 'Who created Python?'
      context: 'Python is a high-level, general-purpose programming language known for readability. It has a large standard library. It was created by Guido van Rossum and released in 1991. Python is widely used in data science, web development, and automation.'
    assert:
      - type: context-relevance
        threshold: 0.5
```

Grader replies:

```
candidate sentences:
It was created by Guido van Rossum and released in 1991.
```

| | before | after |
| --- | --- | --- |
| `extractedSentences` | `["candidate sentences:", "It was created by…"]` | `["It was created by…"]` |
| `relevantSentenceCount` | 2 | 1 |
| `score` | 0.5 | 0.25 |
| `threshold: 0.5` | **pass** | **fail** |

The assertion passed only because of incidental formatting in the grader's prose, not because of the content of the context.

## Fix

A relevant unit must actually come from the context, so segments that do not appear in it are dropped.

Segments are matched against the **whole whitespace-normalized context** rather than against individual context units. This matters: a grader legitimately quotes a span that crosses a unit boundary — a wrapped line in a formatted document, or two sentences of a single chunk. Per-unit matching would undercount those and trade one scoring bug for another. The existing `Formatted Document Test` covers exactly that case, where the grader quotes `The scope of this policy covers entitlement and guidelines for all categories of leaves in the office` — text that spans a line wrap in the source.

Leading list markers (`1.`, `-`, `*`), surrounding quotes, and trailing punctuation are normalized away, so filtering grader prose does not discard genuinely relevant sentences the grader reformatted.

## Test plan

Four regression cases added. Verified they are genuine guards by reverting `src/matchers/rag.ts` and re-running:

```
without fix -> 3 failed  (expected 0.5 to be close to 0.25; expected 3 to be 1; expected 3 to be 2)
with fix    -> 20 passed
```

The fourth case (grader echoes a sentence without its trailing period) passes both ways by design — it guards against over-correcting into an undercount.

- All 16 pre-existing `context-relevance` cases pass unchanged
- `npx vitest run test/matchers/ test/assertions/` — 60 files, 1324 passed
- `npm run tsc` — clean
- Biome clean on both changed files