### PR TITLE
fix(cli): correct URL query-parameter credential redaction

### DIFF
--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -13,8 +13,37 @@ export const REDACTED = '[REDACTED]';
 
 // Query-parameter names that imply a credential value. Shared by sanitizeUrl's
 // per-param redaction and the fail-closed decision for unparseable URLs.
+//
+// Each alternative must sit on a word boundary — the start/end of the name or a
+// non-alphanumeric separator. Matching these as bare substrings redacted any
+// name that merely CONTAINS one: `design`, `signal`, `designer` and
+// `significance` all contain `sig`; `tokenizer` and `tokens_used` contain
+// `token`; `secretary` contains `secret`; `passwordless_flow` contains
+// `password`. Those are ordinary parameters, and destroying them corrupts
+// persisted eval results and debug logs for no security benefit.
 const SENSITIVE_URL_PARAM_NAMES =
-  /(api[_-]?key|token|password|secret|signature|sig|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|authorization)/i;
+  /(?:^|[^a-z0-9])(?:api[_-]?key|apikey|access[_-]?token|refresh[_-]?token|id[_-]?token|client[_-]?secret|authorization|signature|private[_-]?key|signing[_-]?key|credential|password|passwd|bearer|secret|token|auth|pwd|sig)(?:$|[^a-z0-9])/i;
+
+/**
+ * Whether a query-parameter or form-field name implies a credential value.
+ *
+ * Unifies the two matchers that had drifted apart: `sanitizeUrl` checked only
+ * the name regex above, while `sanitizeUrlEncodedString` checked only
+ * {@link isSecretField} (exact names from `SECRET_FIELD_NAMES`). Each caught
+ * credentials the other missed — `auth=` leaked from the plain-URL path, while
+ * `my_api_key_param=` and `session_token=` leaked from the templated path.
+ */
+function isSensitiveParamName(name: string): boolean {
+  if (SENSITIVE_URL_PARAM_NAMES.test(name)) {
+    return true;
+  }
+  // Split nested-key syntax (`user[password]`, `a.b.password`) so the leaf name
+  // can be matched against the shared secret-field list.
+  return name
+    .split(/[.\[\]]+/)
+    .filter(Boolean)
+    .some(isSecretField);
+}
 const OPAQUE_CREDENTIAL_PATH_SEGMENT =
   /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9a-f]{32,}|(?:token|key|secret|credential|auth)[-_][a-z0-9._-]{8,}|eyJ[a-zA-Z0-9_-]*\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+)$/i;
 
@@ -608,6 +637,13 @@ export function sanitizeUrlEncodedString(value: string): string {
     const decodedKey = decodeFormComponent(rawKey);
     // Split nested-key syntax (`user[password]`, `a.b.password`) into parts so we
     // can match the leaf name against SECRET_FIELD_NAMES.
+    //
+    // Deliberately does NOT use the broader isSensitiveParamName() matcher that
+    // sanitizeUrl uses. This function also scrubs request/response BODIES, where
+    // over-redaction is harmful rather than merely noisy: coding-agent redteam
+    // plugins plant canaries such as `PROMPTFOO_SYNTHETIC_SECRET=<value>` and
+    // grade on whether the agent echoed them back. Redacting a planted canary
+    // would turn a detected credential leak into a silent pass.
     const keyParts = decodedKey === undefined ? [] : decodedKey.split(/[.\[\]]+/).filter(Boolean);
     const keyIsSecret = keyParts.some(isSecretField);
 
@@ -805,6 +841,36 @@ function getSecretLookingRawQueryKeys(search: string): Set<string> {
   return secretKeys;
 }
 
+/**
+ * Redact `key=value` pairs in a URL query/fragment whose KEY names a credential,
+ * using the same matcher as the non-templated branch of {@link sanitizeUrl}.
+ *
+ * Pure Nunjucks placeholders are preserved: `password={{ user_password }}` is an
+ * unresolved config template, not a rendered secret.
+ */
+function redactSensitiveNamedPairs(queryString: string): string {
+  if (!queryString.includes('=')) {
+    return queryString;
+  }
+
+  return queryString
+    .split('&')
+    .map((pair) => {
+      const separatorIndex = pair.indexOf('=');
+      if (separatorIndex === -1) {
+        return pair;
+      }
+      const rawKey = pair.slice(0, separatorIndex);
+      const rawValue = pair.slice(separatorIndex + 1);
+      if (rawValue.length === 0 || isPureTemplateValue(rawValue)) {
+        return pair;
+      }
+      const decodedKey = decodeFormComponent(rawKey) ?? rawKey;
+      return isSensitiveParamName(decodedKey) ? `${rawKey}=${encodeURIComponent(REDACTED)}` : pair;
+    })
+    .join('&');
+}
+
 function sanitizeTemplatedUrl(url: string): string {
   // A template may coexist with an already-rendered env credential. Avoid URL
   // parsing here because it encodes the remaining Nunjucks syntax, but still
@@ -820,8 +886,14 @@ function sanitizeTemplatedUrl(url: string): string {
   const queryIndex = beforeHash.indexOf('?');
   const beforeQuery = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
   const query = queryIndex === -1 ? '' : beforeHash.slice(queryIndex + 1);
-  const sanitizedQuery = query ? sanitizeUrlEncodedString(query) : query;
-  const sanitizedHash = hash ? sanitizeUrlEncodedString(hash) : hash;
+  // sanitizeUrlEncodedString only matches exact SECRET_FIELD_NAMES on the key,
+  // because it also scrubs bodies where over-redaction destroys redteam canaries.
+  // A URL query is not a body, so apply the same param-name matcher the
+  // non-templated branch of sanitizeUrl uses; otherwise a credential leaks into
+  // persisted results purely because its URL also carried a Nunjucks template.
+  const scrubQuery = (value: string) => redactSensitiveNamedPairs(sanitizeUrlEncodedString(value));
+  const sanitizedQuery = query ? scrubQuery(query) : query;
+  const sanitizedHash = hash ? scrubQuery(hash) : hash;
 
   return `${beforeQuery}${queryIndex === -1 ? '' : `?${sanitizedQuery}`}${hashIndex === -1 ? '' : `#${sanitizedHash}`}`;
 }
@@ -859,7 +931,7 @@ export function sanitizeUrl(url: string): string {
     try {
       for (const [key, value] of Array.from(sanitizedUrl.searchParams.entries())) {
         if (
-          SENSITIVE_URL_PARAM_NAMES.test(key) ||
+          isSensitiveParamName(key) ||
           rawSecretParamKeys.has(key) ||
           looksLikeSecret(value) ||
           // URLSearchParams only splits on `&`, so a `;`-delimited credential

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -1878,12 +1878,58 @@ describe('sanitizeUrl', () => {
       );
     });
 
-    it('should sanitize parameters containing sensitive words', () => {
+    it('should sanitize parameters whose name segments are sensitive words', () => {
       const url = 'https://example.com/api?tokens_available=100&secret_santa=john';
       const result = sanitizeUrl(url);
-      // The regex in sanitizeUrl is broad and matches substrings, so these will be redacted
-      expect(result).toContain('tokens_available=%5BREDACTED%5D');
+      // `secret_santa` carries `secret` as its own `_`-delimited segment, so it is
+      // treated as a credential name. `tokens_available` does not — `tokens` is not
+      // `token` — and it is a plain count, so redacting it would destroy ordinary
+      // data in persisted eval results for no security benefit.
+      expect(result).toContain('tokens_available=100');
       expect(result).toContain('secret_santa=%5BREDACTED%5D');
+    });
+
+    it('should not redact ordinary parameters that merely contain a sensitive word', () => {
+      // Regression: the name matcher used unanchored substrings, so `design`,
+      // `signal` and `significance` matched `sig`, `tokenizer` matched `token`,
+      // `secretary` matched `secret`, and `passwordless_flow` matched `password`.
+      const url =
+        'https://example.com/api?design=modern&signal=on&tokenizer=bpe&secretary=jane&significance=0.05&passwordless_flow=true';
+      const result = sanitizeUrl(url);
+
+      expect(result).not.toContain('REDACTED');
+      expect(result).toContain('design=modern');
+      expect(result).toContain('signal=on');
+      expect(result).toContain('tokenizer=bpe');
+      expect(result).toContain('secretary=jane');
+      expect(result).toContain('significance=0.05');
+      expect(result).toContain('passwordless_flow=true');
+    });
+
+    it('should redact compound credential names in both the plain and templated paths', () => {
+      // Regression: the two paths used different matchers. sanitizeUrl matched only
+      // the name regex (so bare `auth` leaked), while the templated path matched
+      // only exact SECRET_FIELD_NAMES (so `my_api_key_param` and `session_token`
+      // leaked). Both now share one matcher.
+      for (const key of ['my_api_key_param', 'session_token', 'auth', 'x-api-key']) {
+        expect(sanitizeUrl(`https://example.com/api?${key}=supersecretvalue123`)).toContain(
+          `${key}=%5BREDACTED%5D`,
+        );
+        expect(sanitizeUrl(`https://example.com/{{ path }}?${key}=supersecretvalue123`)).toContain(
+          `${key}=%5BREDACTED%5D`,
+        );
+      }
+    });
+
+    it('should keep the broader URL param matcher out of body sanitization', () => {
+      // The URL param-name matcher must NOT be applied by sanitizeUrlEncodedString,
+      // which also scrubs request/response bodies. Coding-agent redteam plugins
+      // plant canaries like PROMPTFOO_SYNTHETIC_SECRET and grade on whether the
+      // agent echoed them back; redacting a planted canary would turn a detected
+      // credential leak into a silent pass.
+      expect(sanitizeUrlEncodedString('PROMPTFOO_SYNTHETIC_SECRET=synthetic-value')).toBe(
+        'PROMPTFOO_SYNTHETIC_SECRET=synthetic-value',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

The matcher deciding whether a URL query parameter names a credential is wrong in **both** directions, and the two paths that need it had drifted apart.

### Over-redaction — ordinary parameters destroyed

`SENSITIVE_URL_PARAM_NAMES` matched its alternatives as bare substrings, so any parameter whose name merely *contains* one was redacted:

| parameter | matched | because it contains |
| --- | --- | --- |
| `design`, `signal`, `designer`, `redesign`, `significance` | ❌ redacted | `sig` |
| `tokenizer`, `tokens_used` | ❌ redacted | `token` |
| `secretary` | ❌ redacted | `secret` |
| `passwordless_flow` | ❌ redacted | `password` |

`?design=modern` is persisted as `?design=%5BREDACTED%5D`. This runs on any field named `url` via `sanitizeObject`, so it corrupts eval results and debug logs for no security benefit. The pre-existing test even documented it — *"The regex in sanitizeUrl is broad and matches substrings, so these will be redacted"*.

### Under-redaction — real credentials leaked

`sanitizeUrl` checked only that regex; the templated-URL path checked only `isSecretField` (exact `SECRET_FIELD_NAMES`). Each missed what the other caught:

```
my_api_key_param   plain=REDACTED  templated=LEAKED
session_token      plain=REDACTED  templated=LEAKED
auth               plain=LEAKED    templated=REDACTED
```

## Change

- Anchor each alternative on a word boundary (start/end of name, or a non-alphanumeric separator).
- Add the credential names the substring behavior had covered only incidentally: `auth`, `credential`, `bearer`, `private_key`, `signing_key`, `passwd`, `pwd`.
- Route both URL paths through a single `isSensitiveParamName` helper, so plain and templated URLs redact identically.

## What is deliberately *not* changed

`sanitizeUrlEncodedString` keeps its narrower exact-name matching, because it also scrubs request/response **bodies**.

I initially applied the unified matcher there too, and it broke `test/providers/openai-codex-app-server.test.ts`. Coding-agent redteam plugins plant canaries like `PROMPTFOO_SYNTHETIC_SECRET=<value>` and grade on whether the agent echoed them back — the broader matcher redacted the planted canary, which would turn a **detected credential leak into a silent pass**. That boundary now has its own regression test so the mistake cannot be repeated.

## Test plan

- `test/util/sanitizer.test.ts` — 225 passed, including 4 new cases (benign names survive; compound credential names redact in both paths; body canary preserved). One pre-existing test that asserted the over-broad behavior was updated, with a comment explaining why `secret_santa` still redacts but `tokens_available` no longer does.
- `test/providers/openai-codex-app-server.test.ts` — 74 passed.
- Full backend suite: no new failures. The remaining reds (`test/node/retry.test.ts`, `test/providers/google/interactions.test.ts`, `test/providers/moonshot.test.ts`, `test/examples/readme.test.ts`) reproduce identically on clean `main` — they are local-environment artifacts, not related to this change.
- `npm run tsc` clean; Biome clean.