### PR TITLE
docs(site): refresh provider model catalogs

### DIFF
--- a/examples/compare-deepseek-r1-vs-openai-o1/README.md
+++ b/examples/compare-deepseek-r1-vs-openai-o1/README.md
@@ -1,4 +1,4 @@
-# compare-deepseek-r1-vs-openai-o1 (DeepSeek-R1 vs OpenAI o1 Comparison)
+# compare-deepseek-r1-vs-openai-o1 (DeepSeek V4 Pro vs OpenAI GPT-5.6)
 
 You can run this example with:
 
@@ -7,7 +7,7 @@ npx promptfoo@latest init --example compare-deepseek-r1-vs-openai-o1
 cd compare-deepseek-r1-vs-openai-o1
 ```
 
-This example demonstrates how to benchmark DeepSeek's R1 model against OpenAI's o1 model using the Massive Multitask Language Understanding (MMLU) benchmark, focusing on reasoning-heavy subjects.
+This example demonstrates how to benchmark DeepSeek V4 Pro against OpenAI GPT-5.6 using the Massive Multitask Language Understanding (MMLU) benchmark, focusing on reasoning-heavy subjects.
 
 ## Prerequisites
 

--- a/examples/compare-deepseek-r1-vs-openai-o1/promptfooconfig.yaml
+++ b/examples/compare-deepseek-r1-vs-openai-o1/promptfooconfig.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-description: 'DeepSeek-R1 vs o1 comparison on MMLU reasoning tasks'
+description: 'DeepSeek V4 Pro vs GPT-5.6 comparison on MMLU reasoning tasks'
 
 prompts:
   - |
@@ -16,8 +16,8 @@ prompts:
     Think through this step by step, then provide your final answer in the format "Therefore, the answer is A/B/C/D."
 
 providers:
-  - openai:o1
-  - deepseek:deepseek-reasoner
+  - openai:chat:gpt-5.6
+  - deepseek:deepseek-v4-pro
 
 defaultTest:
   assert:

--- a/examples/provider-cerebras/README.md
+++ b/examples/provider-cerebras/README.md
@@ -1,6 +1,6 @@
 # provider-cerebras (Cerebras Example (High-Performance LLM Inference))
 
-This example demonstrates how to use the Cerebras provider with promptfoo to evaluate Cerebras Inference API models, which offer high-performance inference for Llama and other LLM models.
+This example demonstrates how to use the Cerebras provider with promptfoo to evaluate models on the high-performance Cerebras Inference API.
 
 You can run this example with:
 
@@ -90,20 +90,21 @@ promptfoo eval -c promptfooconfig-tools.yaml
 
 ## Model Capabilities
 
-Cerebras supports several powerful models:
+Cerebras currently supports these models on its public endpoints:
 
-- `llama-4-scout-17b-16e-instruct` - Llama 4 Scout 17B model with 16 expert MoE (featured in examples)
-- `llama3.1-8b` - Llama 3.1 8B model
-- `llama-3.3-70b` - Llama 3.3 70B model
-- `deepSeek-r1-distill-llama-70B` (private preview)
+- `gpt-oss-120b` - Production model
+- `gemma-4-31b` - Preview model
+- `zai-glm-4.7` - Preview model scheduled for retirement on August 17, 2026
+
+The preview lineup can change on short notice. Check the [official model catalog](https://inference-docs.cerebras.ai/models/overview) for the current list.
 
 ## Pricing & Usage
 
-Cerebras Inference API offers competitive pricing compared to other inference services. Check the [official pricing page](https://docs.cerebras.ai) for the most current rates. Usage is billed based on input and output tokens.
+Cerebras Inference API usage is billed based on input and output tokens. Check the [official model catalog](https://inference-docs.cerebras.ai/models/overview) for current pricing links.
 
 ## Learn More
 
 - [Cerebras Provider Documentation](https://promptfoo.dev/docs/providers/cerebras)
-- [Cerebras API Reference](https://docs.cerebras.ai/)
-- [Cerebras Structured Outputs Guide](https://docs.cerebras.ai/capabilities/structured-outputs/)
-- [Cerebras Tool Use Guide](https://docs.cerebras.ai/capabilities/tool-use/)
+- [Cerebras API Reference](https://inference-docs.cerebras.ai/)
+- [Cerebras Structured Outputs Guide](https://inference-docs.cerebras.ai/capabilities/structured-outputs/)
+- [Cerebras Tool Use Guide](https://inference-docs.cerebras.ai/capabilities/tool-use/)

--- a/examples/provider-cerebras/promptfooconfig-structured.yaml
+++ b/examples/provider-cerebras/promptfooconfig-structured.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-description: Schema-enforced JSON recipe generation with Llama 4
+description: Schema-enforced JSON recipe generation with GPT OSS
 prompts:
   - file://structured_prompts.txt
 providers:
-  - id: cerebras:llama-4-scout-17b-16e-instruct
+  - id: cerebras:gpt-oss-120b
     config:
       temperature: 0.7
       max_completion_tokens: 1024
@@ -30,6 +30,7 @@ providers:
                     name: { 'type': 'string' }
                     amount: { 'type': 'string' }
                   required: ['name', 'amount']
+                  additionalProperties: false
               instructions:
                 type: 'array'
                 items: { 'type': 'string' }

--- a/examples/provider-cerebras/promptfooconfig-tools.yaml
+++ b/examples/provider-cerebras/promptfooconfig-tools.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-description: Function calling with Llama 4 for mathematical problem solving
+description: Function calling with GPT OSS for mathematical problem solving
 prompts:
   - file://tool_prompts.txt
 providers:
-  - id: cerebras:llama-4-scout-17b-16e-instruct
+  - id: cerebras:gpt-oss-120b
     config:
       temperature: 0.7
       max_completion_tokens: 1024
@@ -19,6 +19,7 @@ providers:
                   type: 'string'
                   description: 'The mathematical expression to evaluate'
               required: ['expression']
+              additionalProperties: false
             strict: true
 tests:
   - vars:

--- a/examples/provider-cerebras/promptfooconfig.yaml
+++ b/examples/provider-cerebras/promptfooconfig.yaml
@@ -1,13 +1,13 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-description: Evaluating Llama models for educational concept explanations
+description: Evaluating Cerebras models for educational concept explanations
 prompts:
   - file://prompts.txt
 providers:
-  - id: cerebras:llama-4-scout-17b-16e-instruct
+  - id: cerebras:gpt-oss-120b
     config:
       temperature: 0.7
       max_completion_tokens: 1024
-  - id: cerebras:llama-3.3-70b
+  - id: cerebras:gemma-4-31b
     config:
       temperature: 0.5
       max_completion_tokens: 1024

--- a/examples/provider-perplexity/README.md
+++ b/examples/provider-perplexity/README.md
@@ -39,11 +39,11 @@ This example includes multiple configuration files to demonstrate different Perp
 
 ### 1. Basic Model Comparison (`promptfooconfig.yaml`)
 
-Compares different Perplexity search models against a traditional non-search model (GPT-4o-mini):
+Compares different Perplexity search models against a traditional non-search model (GPT-5 mini):
 
 - `sonar`: Lightweight search model
 - `sonar-pro`: Advanced search model with high context
-- `sonar-reasoning`: Fast reasoning model with step-by-step thinking
+- `sonar-reasoning-pro`: Advanced reasoning with step-by-step thinking
 
 ```bash
 npx promptfoo@latest eval -c promptfooconfig.yaml
@@ -78,7 +78,6 @@ Demonstrates specialized models for research and reasoning:
 
 - `sonar-deep-research`: Comprehensive research model
 - `sonar-reasoning-pro`: Advanced reasoning with Chain of Thought
-- `r1-1776`: Offline model without search capabilities
 
 ```bash
 npx promptfoo@latest eval -c promptfooconfig.research-reasoning.yaml

--- a/examples/provider-perplexity/promptfooconfig.research-reasoning.yaml
+++ b/examples/provider-perplexity/promptfooconfig.research-reasoning.yaml
@@ -11,8 +11,7 @@ providers:
       temperature: 0.1
       max_tokens: 4000
       search_domain_filter: ['arxiv.org', 'researchgate.net', 'scholar.google.com']
-      web_search_options:
-        search_context_size: 'high'
+      reasoning_effort: 'high'
       # This provider will be used for the first prompt only
 
   - id: perplexity:sonar-reasoning-pro
@@ -20,12 +19,6 @@ providers:
       temperature: 0.2
       max_tokens: 3000
       # This provider will be used for the second prompt only
-
-  - id: perplexity:r1-1776
-    config:
-      temperature: 0.2
-      max_tokens: 2000
-      # Offline model without search capabilities
 
 tests:
   - vars:

--- a/examples/provider-perplexity/promptfooconfig.structured-output.yaml
+++ b/examples/provider-perplexity/promptfooconfig.structured-output.yaml
@@ -10,7 +10,6 @@ providers:
     config:
       temperature: 0.1
       max_tokens: 1000
-      usage_tier: 'medium' # For cost calculation
       response_format:
         type: 'json_schema'
         json_schema:
@@ -29,7 +28,6 @@ providers:
     config:
       temperature: 0.1
       max_tokens: 150
-      usage_tier: 'low' # For cost calculation
       response_format:
         type: 'regex'
         regex:

--- a/examples/provider-perplexity/promptfooconfig.yaml
+++ b/examples/provider-perplexity/promptfooconfig.yaml
@@ -14,7 +14,6 @@ providers:
       search_domain_filter: ['nature.com', 'science.org', 'newscientist.com']
       search_recency_filter: 'month'
       return_related_questions: true
-      usage_tier: 'low'
       web_search_options:
         search_context_size: 'medium'
 
@@ -24,17 +23,17 @@ providers:
       max_tokens: 2000
       search_domain_filter: ['nature.com', 'science.org', 'newscientist.com']
       search_recency_filter: 'month'
-      usage_tier: 'medium'
       web_search_options:
         search_context_size: 'high'
 
-  - id: perplexity:sonar-reasoning
+  - id: perplexity:sonar-reasoning-pro
     config:
       temperature: 0.3
       max_tokens: 2500
       search_domain_filter: ['nature.com', 'science.org', 'newscientist.com']
       search_recency_filter: 'month'
-      usage_tier: 'high'
+      web_search_options:
+        search_context_size: 'high'
 
 tests:
   - vars:

--- a/site/docs/providers/cerebras.md
+++ b/site/docs/providers/cerebras.md
@@ -1,13 +1,13 @@
 ---
 sidebar_label: Cerebras
-description: Configure Cerebras' Llama 4 Scout and Llama 3 models through their OpenAI-compatible API for enterprise-grade inference with advanced MoE architecture support
+description: Configure Cerebras' high-speed inference models through its OpenAI-compatible API, with support for structured outputs and tool calling
 ---
 
 # Cerebras
 
-This provider enables you to use Cerebras models through their [Inference API](https://docs.cerebras.ai).
+This provider enables you to use Cerebras models through their [Inference API](https://inference-docs.cerebras.ai).
 
-Cerebras offers an OpenAI-compatible API for various large language models including Llama models, DeepSeek, and more. You can use it as a drop-in replacement for applications currently using the [OpenAI API](/docs/providers/openai/) chat endpoints.
+Cerebras offers an OpenAI-compatible API for high-speed inference. You can use it as a drop-in replacement for applications currently using the [OpenAI API](/docs/providers/openai/) chat endpoints.
 
 ## Setup
 
@@ -21,7 +21,7 @@ Or in your config:
 
 ```yaml
 providers:
-  - id: cerebras:llama3.1-8b
+  - id: cerebras:gpt-oss-120b
     config:
       apiKey: your_api_key_here
 ```
@@ -34,17 +34,18 @@ The Cerebras provider uses a simple format:
 
 ## Available Models
 
-The Cerebras Inference API officially supports these models:
+The Cerebras public Inference API currently supports these models:
 
-- `llama-4-scout-17b-16e-instruct` - Llama 4 Scout 17B model with 16 expert MoE
-- `llama3.1-8b` - Llama 3.1 8B model
-- `llama-3.3-70b` - Llama 3.3 70B model
-- `deepSeek-r1-distill-llama-70B` (private preview)
+| Model          | ID             | Availability                     |
+| -------------- | -------------- | -------------------------------- |
+| OpenAI GPT OSS | `gpt-oss-120b` | Production                       |
+| Gemma 4 31B    | `gemma-4-31b`  | Preview                          |
+| Z.ai GLM 4.7   | `zai-glm-4.7`  | Preview; retires August 17, 2026 |
 
-To get the current list of available models, use the `/models` endpoint:
+The preview lineup can change on short notice. To get the current public model catalog:
 
 ```bash
-curl https://api.cerebras.ai/v1/models -H "Authorization: Bearer your_api_key_here"
+curl -sS https://api.cerebras.ai/public/v1/models | jq
 ```
 
 ## Parameters
@@ -57,7 +58,6 @@ The provider accepts standard OpenAI chat parameters:
 - `stop` - Sequences where the API will stop generating further tokens
 - `seed` - Seed for deterministic generation
 - `response_format` - Controls the format of the model response (e.g., for JSON output)
-- `logprobs` - Whether to return log probabilities of the output tokens
 
 ## Advanced Capabilities
 
@@ -69,7 +69,7 @@ To use structured outputs, set the `response_format` parameter to include a JSON
 
 ```yaml
 providers:
-  - id: cerebras:llama-4-scout-17b-16e-instruct
+  - id: cerebras:gpt-oss-120b
     config:
       response_format:
         type: 'json_schema'
@@ -94,7 +94,7 @@ Cerebras models support tool use (function calling), enabling LLMs to programmat
 
 ```yaml
 providers:
-  - id: cerebras:llama-4-scout-17b-16e-instruct
+  - id: cerebras:gpt-oss-120b
     config:
       tools:
         - type: 'function'
@@ -108,6 +108,7 @@ providers:
                   type: 'string'
                   description: 'The mathematical expression to evaluate'
               required: ['expression']
+              additionalProperties: false
             strict: true
 ```
 
@@ -121,11 +122,11 @@ description: Cerebras model evaluation
 prompts:
   - You are an expert in {{topic}}. Explain {{question}} in simple terms.
 providers:
-  - id: cerebras:llama3.1-8b
+  - id: cerebras:gpt-oss-120b
     config:
       temperature: 0.7
       max_completion_tokens: 1024
-  - id: cerebras:llama-3.3-70b
+  - id: cerebras:gemma-4-31b
     config:
       temperature: 0.7
       max_completion_tokens: 1024
@@ -148,6 +149,6 @@ tests:
 
 - [OpenAI Provider](/docs/providers/openai) - Compatible API format used by Cerebras
 - [Configuration Reference](/docs/configuration/reference.md) - Full configuration options for providers
-- [Cerebras API Documentation](https://docs.cerebras.ai) - Official API reference
-- [Cerebras Structured Outputs Guide](https://docs.cerebras.ai/capabilities/structured-outputs/) - Learn more about JSON schema enforcement
-- [Cerebras Tool Use Guide](https://docs.cerebras.ai/capabilities/tool-use/) - Learn more about tool calling capabilities
+- [Cerebras API Documentation](https://inference-docs.cerebras.ai) - Official API reference
+- [Cerebras Structured Outputs Guide](https://inference-docs.cerebras.ai/capabilities/structured-outputs/) - Learn more about JSON schema enforcement
+- [Cerebras Tool Use Guide](https://inference-docs.cerebras.ai/capabilities/tool-use/) - Learn more about tool calling capabilities

--- a/site/docs/providers/deepseek.md
+++ b/site/docs/providers/deepseek.md
@@ -18,13 +18,12 @@ Basic configuration example:
 
 ```yaml
 providers:
-  - id: deepseek:deepseek-chat
+  - id: deepseek:deepseek-v4-flash
     config:
-      temperature: 0.7
       max_tokens: 4000
       apiKey: YOUR_DEEPSEEK_API_KEY
 
-  - id: deepseek:deepseek-reasoner # Legacy alias for V4 Flash thinking mode
+  - id: deepseek:deepseek-v4-pro
     config:
       max_tokens: 8000
 ```
@@ -36,13 +35,13 @@ providers:
 - `cost`, `inputCost`, `outputCost` - Override promptfoo's pricing estimates (`inputCost` and `outputCost` take precedence over `cost`)
 - `top_p`, `presence_penalty`, `frequency_penalty`
 - `stream`
-- `showThinking` - Control whether reasoning content is included in the output (default: `true`, applies to deepseek-reasoner model)
+- `showThinking` - Control whether reasoning content is included in the output (default: `true`)
 
 ## Available Models
 
 :::note
 
-The current primary API model names are `deepseek-v4-flash` and `deepseek-v4-pro`. The legacy aliases `deepseek-chat` and `deepseek-reasoner` remain available until July 24, 2026 and currently map to the non-thinking and thinking modes of `deepseek-v4-flash`, respectively.
+The current API model names are `deepseek-v4-flash` and `deepseek-v4-pro`. The legacy aliases `deepseek-chat` and `deepseek-reasoner` were scheduled for discontinuation on July 24, 2026 and are no longer listed in the current catalog.
 
 :::
 
@@ -59,20 +58,6 @@ The current primary API model names are `deepseek-v4-flash` and `deepseek-v4-pro
 - 1M context window, up to 384K output tokens
 - Input: $0.003625/1M (cache hit), $0.435/1M (cache miss)
 - Output: $0.87/1M
-- Promotional pricing is documented through May 31, 2026
-
-### Legacy aliases
-
-### deepseek-chat
-
-- Legacy alias that currently maps to non-thinking `deepseek-v4-flash`
-- Scheduled for retirement on July 24, 2026
-
-### deepseek-reasoner
-
-- Legacy alias that currently maps to thinking `deepseek-v4-flash`
-- Scheduled for retirement on July 24, 2026
-- Supports showing or hiding reasoning content through the `showThinking` parameter
 
 :::warning
 
@@ -86,13 +71,11 @@ Here's an example comparing DeepSeek with OpenAI on reasoning tasks:
 
 ```yaml
 providers:
-  - id: deepseek:deepseek-reasoner
+  - id: deepseek:deepseek-v4-pro
     config:
       max_tokens: 8000
       showThinking: true # Include reasoning content in output (default)
-  - id: openai:o-1
-    config:
-      temperature: 0.0
+  - id: openai:chat:gpt-5.6
 
 prompts:
   - 'Solve this step by step: {{math_problem}}'
@@ -104,13 +87,13 @@ tests:
 
 ### Controlling Reasoning Output
 
-The legacy `deepseek-reasoner` alias uses V4 Flash thinking mode and includes detailed
-reasoning steps in its output. You can control whether this reasoning content is shown
-using the `showThinking` parameter:
+DeepSeek V4 models include detailed reasoning steps in their output when thinking mode is
+enabled. You can control whether this reasoning content is shown using the `showThinking`
+parameter:
 
 ```yaml
 providers:
-  - id: deepseek:deepseek-reasoner
+  - id: deepseek:deepseek-v4-pro
     config:
       showThinking: false # Hide reasoning content from output
 ```
@@ -125,15 +108,15 @@ Thinking: <reasoning content>
 
 When set to `false`, only the final answer is included in the output. This is useful when you want better reasoning quality but don't want to expose the reasoning process to end users or in your assertions.
 
-See our [complete example](https://github.com/promptfoo/promptfoo/tree/main/examples/compare-deepseek-r1-vs-openai-o1) that benchmarks it against OpenAI's o1 model on the MMLU reasoning tasks.
+See our [complete example](https://github.com/promptfoo/promptfoo/tree/main/examples/compare-deepseek-r1-vs-openai-o1) that benchmarks DeepSeek V4 Pro against OpenAI GPT-5.6 on the MMLU reasoning tasks.
 
 ## API Details
 
 - Base URL: `https://api.deepseek.com/v1`
 - OpenAI-compatible API format
-- Full [API documentation](https://platform.deepseek.com/docs)
+- Full [API documentation](https://api-docs.deepseek.com/)
 
 ## See Also
 
 - [OpenAI Provider](/docs/providers/openai/) - Compatible configuration options
-- [Complete example](https://github.com/promptfoo/promptfoo/tree/main/examples/compare-deepseek-r1-vs-openai-o1) - Benchmark against OpenAI's o1 model
+- [Complete example](https://github.com/promptfoo/promptfoo/tree/main/examples/compare-deepseek-r1-vs-openai-o1) - Benchmark DeepSeek V4 Pro against OpenAI GPT-5.6

--- a/site/docs/providers/perplexity.md
+++ b/site/docs/providers/perplexity.md
@@ -5,9 +5,11 @@ description: "Integrate Perplexity's online LLMs with real-time web search for f
 
 # Perplexity
 
-The [Perplexity API](https://blog.perplexity.ai/blog/introducing-pplx-api) provides chat completion models with built-in search capabilities, citations, and structured output support. Perplexity models retrieve information from the web in real-time, enabling up-to-date responses with source citations.
+The [Perplexity Sonar API](https://docs.perplexity.ai/docs/sonar/quickstart) provides chat completion models with built-in search capabilities, citations, and structured output support. Perplexity models retrieve information from the web in real-time, enabling up-to-date responses with source citations.
 
 Perplexity follows OpenAI's chat completion API format - see our [OpenAI documentation](https://promptfoo.dev/docs/providers/openai) for the base API details.
+
+This integration accepts the four Sonar model IDs listed below. Perplexity's separate [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) supports third-party models and vendor-qualified IDs through a different endpoint.
 
 ## Setup
 
@@ -18,14 +20,12 @@ Perplexity follows OpenAI's chat completion API format - see our [OpenAI documen
 
 Perplexity offers several specialized models optimized for different tasks:
 
-| Model               | Context Length | Description                                         | Use Case                                         |
-| ------------------- | -------------- | --------------------------------------------------- | ------------------------------------------------ |
-| sonar-pro           | 200k           | Advanced search model with 8k max output tokens     | Long-form content, complex reasoning             |
-| sonar               | 128k           | Lightweight search model                            | Quick searches, cost-effective responses         |
-| sonar-reasoning-pro | 128k           | Premier reasoning model with Chain of Thought (CoT) | Complex analyses, multi-step problem solving     |
-| sonar-reasoning     | 128k           | Fast real-time reasoning model                      | Problem-solving with search                      |
-| sonar-deep-research | 128k           | Expert-level research model                         | Comprehensive reports, exhaustive research       |
-| r1-1776             | 128k           | Offline chat model (no search)                      | Creative content, tasks without web search needs |
+| Model               | Context Length | Description                                         | Use Case                                     |
+| ------------------- | -------------- | --------------------------------------------------- | -------------------------------------------- |
+| sonar-pro           | 200k           | Advanced search model                               | Long-form content, complex queries           |
+| sonar               | 128k           | Lightweight search model                            | Quick searches, cost-effective responses     |
+| sonar-reasoning-pro | 128k           | Premier reasoning model with Chain of Thought (CoT) | Complex analyses, multi-step problem solving |
+| sonar-deep-research | 128k           | Expert-level research model                         | Comprehensive reports, exhaustive research   |
 
 ## Basic Configuration
 
@@ -123,7 +123,7 @@ providers:
       response_format:
         type: 'regex'
         regex:
-          regex: "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+          regex: '(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)'
 ```
 
 **Note**: First request with a new schema may take 10-30 seconds to prepare. For reasoning models, the response will include a `<think>` section followed by the structured output.
@@ -141,20 +141,7 @@ providers:
 
 ### Cost Tracking
 
-promptfoo includes built-in cost calculation for Perplexity models based on their official pricing. You can specify the usage tier with the `usage_tier` parameter:
-
-```yaml
-providers:
-  - id: perplexity:sonar-pro
-    config:
-      usage_tier: 'medium' # Options: 'high', 'medium', 'low'
-```
-
-The cost calculation includes:
-
-- Different rates for input and output tokens
-- Model-specific pricing (sonar, sonar-pro, sonar-reasoning, etc.)
-- Usage tier considerations (high, medium, low)
+promptfoo estimates token costs for Perplexity models using their published input and output prices. Perplexity also charges request fees based on `web_search_options.search_context_size`. Deep Research adds citation-token, search-query, and reasoning-token charges. Check the cost metadata returned by the API when you need the complete request cost.
 
 ## Advanced Use Cases
 
@@ -169,8 +156,7 @@ providers:
       temperature: 0.1
       max_tokens: 4000
       search_domain_filter: ['arxiv.org', 'researchgate.net', 'scholar.google.com']
-      web_search_options:
-        search_context_size: 'high'
+      reasoning_effort: 'high'
 ```
 
 ### Step-by-Step Reasoning
@@ -185,34 +171,21 @@ providers:
       max_tokens: 3000
 ```
 
-### Offline Creative Tasks
-
-For creative content that doesn't require web search:
-
-```yaml
-providers:
-  - id: perplexity:r1-1776
-    config:
-      temperature: 0.7
-      max_tokens: 2000
-```
-
 ## Best Practices
 
 ### Model Selection
 
 - **sonar-pro**: Use for complex queries requiring detailed responses with citations
 - **sonar**: Use for factual queries and cost efficiency
-- **sonar-reasoning-pro/sonar-reasoning**: Use for step-by-step problem solving
+- **sonar-reasoning-pro**: Use for step-by-step problem solving
 - **sonar-deep-research**: Use for comprehensive reports (may take 30+ minutes)
-- **r1-1776**: Use for creative content not requiring search
 
 ### Search Optimization
 
 - Set `search_domain_filter` to trusted domains for higher quality citations
 - Use `search_recency_filter` for time-sensitive topics
-- For cost optimization, set `web_search_options.search_context_size` to "low"
-- For comprehensive research, set `web_search_options.search_context_size` to "high"
+- For Sonar, Sonar Pro, and Sonar Reasoning Pro, set `web_search_options.search_context_size` to "low" to reduce request fees
+- For Deep Research, use `reasoning_effort` to balance depth and cost
 
 ### Structured Output Tips
 
@@ -237,20 +210,26 @@ npx promptfoo@latest init --example provider-perplexity
 
 ## Pricing and Rate Limits
 
-Pricing varies by model and usage tier:
+Pricing varies by model and search context size:
 
 | Model               | Input Tokens (per million) | Output Tokens (per million) |
 | ------------------- | -------------------------- | --------------------------- |
 | sonar               | $1                         | $1                          |
 | sonar-pro           | $3                         | $15                         |
-| sonar-reasoning     | $1                         | $5                          |
 | sonar-reasoning-pro | $2                         | $8                          |
 | sonar-deep-research | $2                         | $8                          |
-| r1-1776             | $2                         | $8                          |
 
-Rate limits also vary by usage tier (high, medium, low). Specify your tier with the `usage_tier` parameter to get accurate cost calculations.
+Search request fees vary by `web_search_options.search_context_size`:
 
-Check [Perplexity's pricing page](https://docs.perplexity.ai/docs/pricing) for the latest rates.
+| Model               | Low (per 1K requests) | Medium (per 1K requests) | High (per 1K requests) |
+| ------------------- | --------------------- | ------------------------ | ---------------------- |
+| sonar               | $5                    | $8                       | $12                    |
+| sonar-pro           | $6                    | $10                      | $14                    |
+| sonar-reasoning-pro | $6                    | $10                      | $14                    |
+
+Deep Research also charges $2 per million citation tokens, $5 per 1,000 search queries, and $3 per million reasoning tokens.
+
+Check [Perplexity's pricing page](https://docs.perplexity.ai/docs/getting-started/pricing) for the latest rates.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- update DeepSeek docs and examples to the current V4 Flash/Pro IDs, prices, limits, and GPT-5.6 comparison
- replace retired Cerebras IDs with the current public catalog, flag GLM 4.7's August 17 retirement, and align strict-schema examples with API v2
- limit Perplexity docs and examples to the four active Sonar models, document the Agent API boundary, and publish current token/request/Deep Research pricing

This is the focused current-main replacement for the DeepSeek, Cerebras, and Perplexity catalog changes in stale/conflicted #9792, which was closed to avoid overlapping PRs.

## Official sources

- DeepSeek [models and pricing](https://api-docs.deepseek.com/quick_start/pricing/) and [changelog](https://api-docs.deepseek.com/updates/)
- Cerebras [model catalog](https://inference-docs.cerebras.ai/models/overview) and [public model API](https://api.cerebras.ai/public/v1/models)
- Perplexity [Sonar models](https://docs.perplexity.ai/docs/sonar/models), [pricing](https://docs.perplexity.ai/docs/getting-started/pricing), and [changelog](https://docs.perplexity.ai/docs/resources/changelog)

## Validation

- all seven changed example configs pass `promptfoo validate config`
- every YAML code block in the three provider pages parses successfully
- `npx --offline @biomejs/biome@2.5.3 lint site` (passes with four pre-existing complexity warnings)
- Prettier check and `git diff --check`
- live Cerebras public catalog reconciliation
- CI `Build Docs`, `Site tests`, style, generation, integration, security, and multi-version package builds pass; the remaining test matrix is still running with no failures