### PR TITLE
fix(providers): stop leaking Nscale provider settings into the request body

### DIFF
--- a/src/providers/nscale.ts
+++ b/src/providers/nscale.ts
@@ -15,6 +15,33 @@ import type { ApiProvider, ProviderOptions } from '../types/index';
  *
  * Documentation: https://docs.nscale.com/
  */
+/**
+ * Config keys promptfoo consumes itself rather than forwarding to the model.
+ *
+ * `passthrough` is serialized verbatim into the request body, so anything spread
+ * into it is sent to Nscale as a model parameter. Spreading the whole user config
+ * put `apiKey` — the raw service token — into the JSON body, and diverted
+ * `headers` there too so custom headers never became HTTP headers.
+ *
+ * Mirrors `OpenAiSharedOptions` in `./openai/types`.
+ */
+const NSCALE_PROVIDER_LEVEL_OPTIONS = new Set([
+  'apiKey',
+  'apiKeyEnvar',
+  'apiKeyRequired',
+  'apiHost',
+  'apiBaseUrl',
+  'organization',
+  'headers',
+  'maxRetries',
+  'cost',
+  'inputCost',
+  'outputCost',
+  'audioCost',
+  'audioInputCost',
+  'audioOutputCost',
+]);
+
 export function createNscaleProvider(
   providerPath: string,
   options: {
@@ -26,6 +53,20 @@ export function createNscaleProvider(
   const splits = providerPath.split(':');
 
   const config = options.config?.config || {};
+
+  // Split the user's config into settings promptfoo handles (auth, routing,
+  // headers, cost overrides) and genuine model parameters, so only the latter
+  // reach the request body.
+  const { passthrough: explicitPassthrough, ...configOptions } = config;
+  const providerLevelOptions: Record<string, any> = {};
+  const modelParameters: Record<string, any> = {};
+  for (const [key, value] of Object.entries(configOptions)) {
+    if (NSCALE_PROVIDER_LEVEL_OPTIONS.has(key)) {
+      providerLevelOptions[key] = value;
+    } else {
+      modelParameters[key] = value;
+    }
+  }
 
   // Prefer service tokens over API keys (API keys deprecated Oct 30, 2025)
   const getApiKey = () => {
@@ -41,10 +82,14 @@ export function createNscaleProvider(
   const nscaleConfig = {
     ...options,
     config: {
-      apiBaseUrl: 'https://inference.api.nscale.com/v1',
+      ...providerLevelOptions,
+      // Honor an explicit apiBaseUrl (private/regional Nscale endpoints) instead
+      // of silently ignoring it while still shipping it in the request body.
+      apiBaseUrl: providerLevelOptions.apiBaseUrl || 'https://inference.api.nscale.com/v1',
       apiKey: getApiKey(),
       passthrough: {
-        ...config,
+        ...modelParameters,
+        ...explicitPassthrough,
       },
     },
   };

--- a/test/providers/nscaleRequest.test.ts
+++ b/test/providers/nscaleRequest.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `nscale.test.ts` mocks `src/providers/openai` wholesale, so it can only assert
+// the shape of the config object handed to the OpenAI provider — never what is
+// actually put on the wire. These tests mock only the transport, exercising the
+// real OpenAI provider, because the defects they guard against were invisible at
+// the config layer: the config looked correct while the request body carried the
+// service token and the user's headers.
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  fetchWithCache: vi.fn(),
+}));
+
+import { fetchWithCache } from '../../src/cache';
+import { createNscaleProvider } from '../../src/providers/nscale';
+
+function mockResponse() {
+  vi.mocked(fetchWithCache).mockResolvedValue({
+    data: {
+      choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    },
+    cached: false,
+    status: 200,
+    statusText: 'OK',
+  } as any);
+}
+
+async function callWithConfig(config: Record<string, unknown>) {
+  mockResponse();
+  const provider = createNscaleProvider('nscale:openai/gpt-oss-120b', {
+    config: { config } as any,
+  });
+  await provider.callApi('hello');
+  const [url, request] = vi.mocked(fetchWithCache).mock.calls[0] as any;
+  return { url, headers: request.headers, body: JSON.parse(request.body) };
+}
+
+describe('Nscale request construction', () => {
+  beforeEach(() => {
+    vi.mocked(fetchWithCache).mockReset();
+  });
+
+  it('does not send the service token in the request body', async () => {
+    // Regression: `passthrough: { ...config }` spread the whole user config into
+    // the body, so a configured `apiKey` was transmitted as a model parameter and
+    // persisted in the request payload alongside the Authorization header.
+    const { body, headers } = await callWithConfig({ apiKey: 'SERVICE-TOKEN-SECRET' });
+
+    expect(body).not.toHaveProperty('apiKey');
+    expect(JSON.stringify(body)).not.toContain('SERVICE-TOKEN-SECRET');
+    expect(headers.Authorization).toBe('Bearer SERVICE-TOKEN-SECRET');
+  });
+
+  it('applies configured headers as HTTP headers rather than body fields', async () => {
+    // Regression: `headers` landed in `passthrough`, so custom headers were
+    // serialized into the JSON body and silently never sent as headers.
+    const { body, headers } = await callWithConfig({
+      apiKey: 'tok',
+      headers: { 'X-Tenant': 'acme' },
+    });
+
+    expect(headers).toHaveProperty('X-Tenant', 'acme');
+    expect(body).not.toHaveProperty('headers');
+  });
+
+  it('honors a configured apiBaseUrl instead of shipping it in the body', async () => {
+    // Regression: apiBaseUrl was ignored for routing (the endpoint was hardcoded)
+    // yet still sent as a model parameter.
+    const { url, body } = await callWithConfig({
+      apiKey: 'tok',
+      apiBaseUrl: 'https://private.nscale.example/v1',
+    });
+
+    expect(url).toBe('https://private.nscale.example/v1/chat/completions');
+    expect(body).not.toHaveProperty('apiBaseUrl');
+  });
+
+  it('defaults to the public Nscale endpoint', async () => {
+    const { url } = await callWithConfig({ apiKey: 'tok' });
+
+    expect(url).toBe('https://inference.api.nscale.com/v1/chat/completions');
+  });
+
+  it('keeps forwarding genuine model parameters', async () => {
+    const { body } = await callWithConfig({
+      apiKey: 'tok',
+      temperature: 0.7,
+      top_p: 0.9,
+      frequency_penalty: 0.1,
+      seed: 42,
+      custom_param: 'value',
+    });
+
+    expect(body).toMatchObject({
+      model: 'openai/gpt-oss-120b',
+      temperature: 0.7,
+      top_p: 0.9,
+      frequency_penalty: 0.1,
+      seed: 42,
+      custom_param: 'value',
+    });
+  });
+
+  it('does not leak any promptfoo-level provider option into the body', async () => {
+    const { body } = await callWithConfig({
+      apiKey: 'tok',
+      apiKeyEnvar: 'NSCALE_SERVICE_TOKEN',
+      apiKeyRequired: true,
+      apiHost: 'inference.api.nscale.com',
+      organization: 'org-123',
+      maxRetries: 2,
+      cost: 0.000001,
+      inputCost: 0.0000005,
+      outputCost: 0.0000015,
+    });
+
+    for (const key of [
+      'apiKey',
+      'apiKeyEnvar',
+      'apiKeyRequired',
+      'apiHost',
+      'apiBaseUrl',
+      'organization',
+      'maxRetries',
+      'cost',
+      'inputCost',
+      'outputCost',
+    ]) {
+      expect(body).not.toHaveProperty(key);
+    }
+  });
+
+  it('merges an explicit passthrough block without nesting it', async () => {
+    const { body } = await callWithConfig({
+      apiKey: 'tok',
+      passthrough: { chat_template_kwargs: { thinking: true } },
+    });
+
+    expect(body).not.toHaveProperty('passthrough');
+    expect(body.chat_template_kwargs).toEqual({ thinking: true });
+  });
+});


### PR DESCRIPTION
## Summary

`createNscaleProvider` spreads the **entire** user config into `passthrough`, which the OpenAI-compatible provider serializes verbatim into the request body. So promptfoo-level provider settings get sent to Nscale as model parameters — and the settings that should have been consumed locally never take effect.

Given a config of `{ apiKey, headers, apiBaseUrl, organization, temperature }`, the body actually put on the wire is:

```
model, messages, max_tokens, temperature, apiKey, apiKeyEnvar, apiBaseUrl, organization, headers
```

## Consequences

| Setting | Expected | Actual |
| --- | --- | --- |
| `headers` | sent as HTTP headers | serialized into the JSON body; request went out with only `Content-Type` and `Authorization` |
| `apiBaseUrl` | routes the request | **ignored** (endpoint hardcoded), but still sent as a model parameter |
| `apiKey` | Authorization header only | also transmitted as a model parameter |

`headers` and `apiBaseUrl` are the user-visible breakages: a user pointing at a private/regional Nscale endpoint, or adding a tenant/routing header, gets silence rather than an error.

On `apiKey` — promptfoo's cache (`getStringForFetchCacheKey` → `fingerprintFetchCacheSecret`) and sanitizer layers do fingerprint/redact fields named `apiKey`, so this is **not** a plaintext-at-rest leak. But the credential has no business in the body, and strict OpenAI-compatible servers reject unknown body parameters.

## Change

Split the user config into settings promptfoo owns — auth, routing, headers, retries, cost overrides, mirroring `OpenAiSharedOptions` — and genuine model parameters, forwarding only the latter into `passthrough`. Additionally:

- an explicit `apiBaseUrl` is now honored instead of silently ignored;
- an explicit `passthrough` block merges rather than nesting under itself (previously `passthrough: {x}` became `passthrough: { passthrough: {x} }`).

Model parameters (`temperature`, `top_p`, `seed`, `custom_param`, …) are forwarded exactly as before.

## Why the existing tests missed it

`test/providers/nscale.test.ts` calls `vi.mock('../../src/providers/openai')`, so it can only assert the shape of the config object handed to the OpenAI provider. The config looked correct at that layer while the request body carried the token and the user's headers.

`test/providers/nscaleRequest.test.ts` mocks only the transport (`fetchWithCache`), exercising the real OpenAI provider and asserting what actually goes on the wire.

## Test plan

```
without fix -> 5 failed | 2 passed
  × does not send the service token in the request body
  × applies configured headers as HTTP headers rather than body fields
  × honors a configured apiBaseUrl instead of shipping it in the body
  × does not leak any promptfoo-level provider option into the body
  × merges an explicit passthrough block without nesting it
with fix    -> 7 passed
```

- `npx vitest run test/providers/nscale.test.ts test/providers/nscaleRequest.test.ts test/providers/registry.test.ts test/providers/togetherai.test.ts test/providers/cerebras.test.ts` — 143 passed
- `npm run tsc` clean; Biome clean

## Note for follow-up

`togetherai.ts` uses the same `passthrough: { ...config }` pattern and looks susceptible; `cerebras.ts` partially guards it (strips only `basePath`). Not touched here to keep this reviewable.