### PR TITLE
fix(providers): correct Nscale model identifiers

### DIFF
--- a/examples/provider-nscale/README.md
+++ b/examples/provider-nscale/README.md
@@ -60,27 +60,27 @@ Nscale supports many popular models with competitive pricing:
 
 - `openai/gpt-oss-120b` - OpenAI's 120B open-weight model
 - `openai/gpt-oss-20b` - OpenAI's 20B model
-- `qwen/qwen-3-235b-a22b-instruct` - Qwen 3 235B model
-- `qwen/qwen-3-235b-a22b-instruct-2507` - Qwen 3 235B Instruct 2507
-- `qwen/qwen-3-4b-thinking-2507` - Qwen 3 4B Thinking 2507
-- `qwen/qwen-3-8b` - Qwen 3 8B model
-- `qwen/qwen-3-14b` - Qwen 3 14B model
-- `qwen/qwen-3-32b` - Qwen 3 32B model
-- `qwen/qwen-2.5-coder-3b-instruct` - Qwen 2.5 Coder 3B Instruct
-- `qwen/qwen-2.5-coder-7b-instruct` - Qwen 2.5 Coder 7B Instruct
-- `qwen/qwen-2.5-coder-32b-instruct` - Qwen 2.5 Coder 32B Instruct
-- `qwen/qwq-32b` - Qwen QwQ 32B model
-- `meta/llama-3.3-70b-instruct` - Meta's Llama 3.3 70B model
-- `meta/llama-3.1-8b-instruct` - Meta's Llama 3.1 8B model
-- `meta/llama-4-scout-17b-16e-instruct` - Llama 4 Scout 17B model (Image-Text-to-Text)
-- `deepseek/deepseek-r1-distill-llama-70b` - DeepSeek R1 Distill Llama 70B
-- `deepseek/deepseek-r1-distill-llama-8b` - DeepSeek R1 Distill Llama 8B
-- `deepseek/deepseek-r1-distill-qwen-1.5b` - DeepSeek R1 Distill Qwen 1.5B
-- `deepseek/deepseek-r1-distill-qwen-7b` - DeepSeek R1 Distill Qwen 7B
-- `deepseek/deepseek-r1-distill-qwen-14b` - DeepSeek R1 Distill Qwen 14B
-- `deepseek/deepseek-r1-distill-qwen-32b` - DeepSeek R1 Distill Qwen 32B
-- `mistral/devstral-small-2505` - Mistral's Devstral Small model
-- `mistral/mixtral-8x22b-instruct-v0.1` - Mixtral 8x22B Instruct
+- `Qwen/Qwen3-235B-A22B` - Qwen 3 235B model
+- `Qwen/Qwen3-235B-A22B-Instruct-2507` - Qwen 3 235B Instruct 2507
+- `Qwen/Qwen3-4B-Thinking-2507` - Qwen 3 4B Thinking 2507
+- `Qwen/Qwen3-8B` - Qwen 3 8B model
+- `Qwen/Qwen3-14B` - Qwen 3 14B model
+- `Qwen/Qwen3-32B` - Qwen 3 32B model
+- `Qwen/Qwen2.5-Coder-3B-Instruct` - Qwen 2.5 Coder 3B Instruct
+- `Qwen/Qwen2.5-Coder-7B-Instruct` - Qwen 2.5 Coder 7B Instruct
+- `Qwen/Qwen2.5-Coder-32B-Instruct` - Qwen 2.5 Coder 32B Instruct
+- `Qwen/QwQ-32B` - Qwen QwQ 32B model
+- `meta-llama/Llama-3.3-70B-Instruct` - Meta's Llama 3.3 70B model
+- `meta-llama/Llama-3.1-8B-Instruct` - Meta's Llama 3.1 8B model
+- `meta-llama/Llama-4-Scout-17B-16E-Instruct` - Llama 4 Scout 17B model (Image-Text-to-Text)
+- `deepseek-ai/DeepSeek-R1-Distill-Llama-70B` - DeepSeek R1 Distill Llama 70B
+- `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` - DeepSeek R1 Distill Llama 8B
+- `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B` - DeepSeek R1 Distill Qwen 1.5B
+- `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B` - DeepSeek R1 Distill Qwen 7B
+- `deepseek-ai/DeepSeek-R1-Distill-Qwen-14B` - DeepSeek R1 Distill Qwen 14B
+- `deepseek-ai/DeepSeek-R1-Distill-Qwen-32B` - DeepSeek R1 Distill Qwen 32B
+- `mistralai/Devstral-Small-2505` - Mistral's Devstral Small model
+- `mistralai/Mixtral-8x22B-Instruct-v0.1` - Mixtral 8x22B Instruct
 
 **Embedding Models:**
 
@@ -88,10 +88,9 @@ Nscale supports many popular models with competitive pricing:
 
 **Text-to-Image Models:**
 
-- `BlackForestLabs/FLUX.1-schnell` - Flux.1 Schnell image generation model
+- `black-forest-labs/FLUX.1-schnell` - Flux.1 Schnell image generation model
 - `stabilityai/stable-diffusion-xl-base-1.0` - Stable Diffusion XL 1.0
-- `ByteDance/SDXL-Lightning-4step` - SDXL Lightning 4-step
-- `ByteDance/SDXL-Lightning-8step` - SDXL Lightning 8-step
+- `ByteDance/SDXL-Lightning` - SDXL Lightning
 
 ## Pricing & Usage
 

--- a/examples/provider-nscale/image-promptfooconfig.yaml
+++ b/examples/provider-nscale/image-promptfooconfig.yaml
@@ -1,11 +1,11 @@
 description: 'Nscale Image Generation Example - comparing different image models'
 
 providers:
-  - id: nscale:image:BlackForestLabs/FLUX.1-schnell
+  - id: nscale:image:black-forest-labs/FLUX.1-schnell
     config:
       size: '1024x1024'
       n: 1
-  - id: nscale:image:ByteDance/SDXL-Lightning-4step
+  - id: nscale:image:ByteDance/SDXL-Lightning
     config:
       size: '1024x1024'
       n: 1

--- a/examples/provider-nscale/promptfooconfig.yaml
+++ b/examples/provider-nscale/promptfooconfig.yaml
@@ -7,7 +7,7 @@ providers:
     config:
       temperature: 0.7
       max_tokens: 1024
-  - id: nscale:meta/llama-3.3-70b-instruct
+  - id: nscale:meta-llama/Llama-3.3-70B-Instruct
     config:
       temperature: 0.5
       max_tokens: 1024

--- a/site/docs/providers/nscale.md
+++ b/site/docs/providers/nscale.md
@@ -35,9 +35,11 @@ To use Nscale models in your promptfoo configuration, use the `nscale:` prefix f
 ```yaml
 providers:
   - nscale:openai/gpt-oss-120b
-  - nscale:meta/llama-3.3-70b-instruct
-  - nscale:qwen/qwen-3-235b-a22b-instruct
+  - nscale:meta-llama/Llama-3.3-70B-Instruct
+  - nscale:Qwen/Qwen3-235B-A22B-Instruct-2507
 ```
+
+Model IDs are the upstream Hugging Face repository IDs and are case-sensitive.
 
 ## Model Types
 
@@ -68,41 +70,61 @@ For embedding models:
 
 ```yaml
 providers:
-  - nscale:embedding:qwen/qwen3-embedding-8b
-  - nscale:embeddings:qwen/qwen3-embedding-8b # Alternative format
+  - nscale:embedding:Qwen/Qwen3-Embedding-8B
+  - nscale:embeddings:Qwen/Qwen3-Embedding-8B # Alternative format
+```
+
+### Text-to-Image Models
+
+For image generation models:
+
+```yaml
+providers:
+  - nscale:image:black-forest-labs/FLUX.1-schnell
 ```
 
 ## Popular Models
 
-Nscale offers a wide range of popular AI models:
+Model IDs are the upstream Hugging Face repository IDs and are case-sensitive
+(`meta-llama/Llama-3.3-70B-Instruct`, not `meta/llama-3.3-70b-instruct`). The
+authoritative list for your account is `GET https://inference.api.nscale.com/v1/models`,
+which also returns pricing and context length:
+
+```bash
+curl https://inference.api.nscale.com/v1/models \
+  -H "Authorization: Bearer $NSCALE_SERVICE_TOKEN"
+```
 
 ### Text Generation Models
 
-| Model                         | Provider Format                                 | Use Case                            |
-| ----------------------------- | ----------------------------------------------- | ----------------------------------- |
-| GPT OSS 120B                  | `nscale:openai/gpt-oss-120b`                    | General-purpose reasoning and tasks |
-| GPT OSS 20B                   | `nscale:openai/gpt-oss-20b`                     | Lightweight general-purpose model   |
-| Qwen 3 235B Instruct          | `nscale:qwen/qwen-3-235b-a22b-instruct`         | Large-scale language understanding  |
-| Qwen 3 235B Instruct 2507     | `nscale:qwen/qwen-3-235b-a22b-instruct-2507`    | Latest Qwen 3 235B variant          |
-| Qwen 3 4B Thinking 2507       | `nscale:qwen/qwen-3-4b-thinking-2507`           | Reasoning and thinking tasks        |
-| Qwen 3 8B                     | `nscale:qwen/qwen-3-8b`                         | Mid-size general-purpose model      |
-| Qwen 3 14B                    | `nscale:qwen/qwen-3-14b`                        | Enhanced reasoning capabilities     |
-| Qwen 3 32B                    | `nscale:qwen/qwen-3-32b`                        | Large-scale reasoning and analysis  |
-| Qwen 2.5 Coder 3B Instruct    | `nscale:qwen/qwen-2.5-coder-3b-instruct`        | Lightweight code generation         |
-| Qwen 2.5 Coder 7B Instruct    | `nscale:qwen/qwen-2.5-coder-7b-instruct`        | Code generation and programming     |
-| Qwen 2.5 Coder 32B Instruct   | `nscale:qwen/qwen-2.5-coder-32b-instruct`       | Advanced code generation            |
-| Qwen QwQ 32B                  | `nscale:qwen/qwq-32b`                           | Specialized reasoning model         |
-| Llama 3.3 70B Instruct        | `nscale:meta/llama-3.3-70b-instruct`            | High-quality instruction following  |
-| Llama 3.1 8B Instruct         | `nscale:meta/llama-3.1-8b-instruct`             | Efficient instruction following     |
-| Llama 4 Scout 17B             | `nscale:meta/llama-4-scout-17b-16e-instruct`    | Image-Text-to-Text capabilities     |
-| DeepSeek R1 Distill Llama 70B | `nscale:deepseek/deepseek-r1-distill-llama-70b` | Efficient reasoning model           |
-| DeepSeek R1 Distill Llama 8B  | `nscale:deepseek/deepseek-r1-distill-llama-8b`  | Lightweight reasoning model         |
-| DeepSeek R1 Distill Qwen 1.5B | `nscale:deepseek/deepseek-r1-distill-qwen-1.5b` | Ultra-lightweight reasoning         |
-| DeepSeek R1 Distill Qwen 7B   | `nscale:deepseek/deepseek-r1-distill-qwen-7b`   | Compact reasoning model             |
-| DeepSeek R1 Distill Qwen 14B  | `nscale:deepseek/deepseek-r1-distill-qwen-14b`  | Mid-size reasoning model            |
-| DeepSeek R1 Distill Qwen 32B  | `nscale:deepseek/deepseek-r1-distill-qwen-32b`  | Large reasoning model               |
-| Devstral Small 2505           | `nscale:mistral/devstral-small-2505`            | Code generation and development     |
-| Mixtral 8x22B Instruct        | `nscale:mistral/mixtral-8x22b-instruct-v0.1`    | Large mixture-of-experts model      |
+| Model                          | Provider Format                                    | Use Case                            |
+| ------------------------------ | -------------------------------------------------- | ----------------------------------- |
+| GPT OSS 120B                   | `nscale:openai/gpt-oss-120b`                       | General-purpose reasoning and tasks |
+| GPT OSS 20B                    | `nscale:openai/gpt-oss-20b`                        | Lightweight general-purpose model   |
+| Kimi K2.5                      | `nscale:moonshotai/Kimi-K2.5`                      | Large-scale agentic reasoning       |
+| Qwen 3 235B A22B               | `nscale:Qwen/Qwen3-235B-A22B`                      | Large-scale language understanding  |
+| Qwen 3 235B A22B Instruct 2507 | `nscale:Qwen/Qwen3-235B-A22B-Instruct-2507`        | Latest Qwen 3 235B variant          |
+| Qwen 3 4B Instruct 2507        | `nscale:Qwen/Qwen3-4B-Instruct-2507`               | Lightweight instruction following   |
+| Qwen 3 4B Thinking 2507        | `nscale:Qwen/Qwen3-4B-Thinking-2507`               | Reasoning and thinking tasks        |
+| Qwen 3 8B                      | `nscale:Qwen/Qwen3-8B`                             | Mid-size general-purpose model      |
+| Qwen 3 14B                     | `nscale:Qwen/Qwen3-14B`                            | Enhanced reasoning capabilities     |
+| Qwen 3 32B                     | `nscale:Qwen/Qwen3-32B`                            | Large-scale reasoning and analysis  |
+| Qwen 2.5 Coder 3B Instruct     | `nscale:Qwen/Qwen2.5-Coder-3B-Instruct`            | Lightweight code generation         |
+| Qwen 2.5 Coder 7B Instruct     | `nscale:Qwen/Qwen2.5-Coder-7B-Instruct`            | Code generation and programming     |
+| Qwen 2.5 Coder 32B Instruct    | `nscale:Qwen/Qwen2.5-Coder-32B-Instruct`           | Advanced code generation            |
+| Qwen QwQ 32B                   | `nscale:Qwen/QwQ-32B`                              | Specialized reasoning model         |
+| Llama 3.3 70B Instruct         | `nscale:meta-llama/Llama-3.3-70B-Instruct`         | High-quality instruction following  |
+| Llama 3.1 8B Instruct          | `nscale:meta-llama/Llama-3.1-8B-Instruct`          | Efficient instruction following     |
+| Llama 3.2 11B Vision Instruct  | `nscale:meta-llama/Llama-3.2-11B-Vision-Instruct`  | Vision-language tasks               |
+| Llama 4 Scout 17B              | `nscale:meta-llama/Llama-4-Scout-17B-16E-Instruct` | Image-Text-to-Text capabilities     |
+| DeepSeek R1 Distill Llama 70B  | `nscale:deepseek-ai/DeepSeek-R1-Distill-Llama-70B` | Efficient reasoning model           |
+| DeepSeek R1 Distill Llama 8B   | `nscale:deepseek-ai/DeepSeek-R1-Distill-Llama-8B`  | Lightweight reasoning model         |
+| DeepSeek R1 Distill Qwen 1.5B  | `nscale:deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B` | Ultra-lightweight reasoning         |
+| DeepSeek R1 Distill Qwen 7B    | `nscale:deepseek-ai/DeepSeek-R1-Distill-Qwen-7B`   | Compact reasoning model             |
+| DeepSeek R1 Distill Qwen 14B   | `nscale:deepseek-ai/DeepSeek-R1-Distill-Qwen-14B`  | Mid-size reasoning model            |
+| DeepSeek R1 Distill Qwen 32B   | `nscale:deepseek-ai/DeepSeek-R1-Distill-Qwen-32B`  | Large reasoning model               |
+| Devstral Small 2505            | `nscale:mistralai/Devstral-Small-2505`             | Code generation and development     |
+| Mixtral 8x22B Instruct         | `nscale:mistralai/Mixtral-8x22B-Instruct-v0.1`     | Large mixture-of-experts model      |
 
 ### Embedding Models
 
@@ -112,12 +134,11 @@ Nscale offers a wide range of popular AI models:
 
 ### Text-to-Image Models
 
-| Model                 | Provider Format                                         | Use Case                      |
-| --------------------- | ------------------------------------------------------- | ----------------------------- |
-| Flux.1 Schnell        | `nscale:image:BlackForestLabs/FLUX.1-schnell`           | Fast image generation         |
-| Stable Diffusion XL   | `nscale:image:stabilityai/stable-diffusion-xl-base-1.0` | High-quality image generation |
-| SDXL Lightning 4-step | `nscale:image:ByteDance/SDXL-Lightning-4step`           | Ultra-fast image generation   |
-| SDXL Lightning 8-step | `nscale:image:ByteDance/SDXL-Lightning-8step`           | Balanced speed and quality    |
+| Model               | Provider Format                                         | Use Case                      |
+| ------------------- | ------------------------------------------------------- | ----------------------------- |
+| Flux.1 Schnell      | `nscale:image:black-forest-labs/FLUX.1-schnell`         | Fast image generation         |
+| Stable Diffusion XL | `nscale:image:stabilityai/stable-diffusion-xl-base-1.0` | High-quality image generation |
+| SDXL Lightning      | `nscale:image:ByteDance/SDXL-Lightning`                 | Ultra-fast image generation   |
 
 ## Configuration Options
 
@@ -133,19 +154,27 @@ providers:
       frequency_penalty: 0.1
       presence_penalty: 0.2
       stop: ['END', 'STOP']
-      stream: true
+      seed: 42
 ```
 
 ### Supported Parameters
 
-- `temperature`: Controls randomness (0.0 to 2.0)
-- `max_tokens`: Maximum number of tokens to generate
+- `temperature`: Controls randomness (0.0 to 2.0). Defaults to `0` unless set.
+- `max_tokens`: Maximum number of tokens to generate. Defaults to `1024` unless set.
 - `top_p`: Nucleus sampling parameter
 - `frequency_penalty`: Reduces repetition based on frequency
 - `presence_penalty`: Reduces repetition based on presence
 - `stop`: Stop sequences to halt generation
-- `stream`: Enable streaming responses
 - `seed`: Deterministic sampling seed
+
+Any other parameter is forwarded to the Nscale API unchanged.
+
+:::note
+
+Streaming is not supported. Promptfoo reads each response as a single JSON body, so
+setting `stream: true` produces a response it cannot parse.
+
+:::
 
 ## Example Configuration
 
@@ -153,11 +182,11 @@ Here's a complete example configuration:
 
 ```yaml
 providers:
-  - id: nscale-gpt-oss
+  - id: nscale:openai/gpt-oss-120b
     config:
       temperature: 0.7
       max_tokens: 512
-  - id: nscale-llama
+  - id: nscale:meta-llama/Llama-3.3-70B-Instruct
     config:
       temperature: 0.5
       max_tokens: 1024

--- a/src/providers/nscale/image.ts
+++ b/src/providers/nscale/image.ts
@@ -43,7 +43,7 @@ export class NscaleImageProvider extends OpenAiImageProvider {
   /**
    * Create a new Nscale image provider instance.
    *
-   * @param modelName - The Nscale image model name (e.g., 'ByteDance/SDXL-Lightning-4step')
+   * @param modelName - The Nscale image model name (e.g., 'black-forest-labs/FLUX.1-schnell')
    * @param options - Provider configuration options
    */
   constructor(
@@ -130,11 +130,14 @@ export class NscaleImageProvider extends OpenAiImageProvider {
    */
   private calculateImageCost(modelName: string, n: number = 1): number {
     // Nscale pricing varies by model - these are approximate based on their pricing page
+    // Keyed by the Hugging Face repository ID Nscale uses as its model ID. These
+    // were previously keyed on identifiers that do not exist upstream
+    // (`BlackForestLabs/...`, `ByteDance/SDXL-Lightning-4step`), so every lookup
+    // missed and silently fell through to the default rate below.
     const costPerImage: Record<string, number> = {
-      'BlackForestLabs/FLUX.1-schnell': 0.0013, // $0.0013 per 1M pixels for 1024x1024
+      'black-forest-labs/FLUX.1-schnell': 0.0013, // $0.0013 per 1M pixels for 1024x1024
       'stabilityai/stable-diffusion-xl-base-1.0': 0.003, // $0.003 per 1M pixels
-      'ByteDance/SDXL-Lightning-4step': 0.0008, // $0.0008 per 1M pixels
-      'ByteDance/SDXL-Lightning-8step': 0.0016, // $0.0016 per 1M pixels
+      'ByteDance/SDXL-Lightning': 0.0008, // $0.0008 per 1M pixels
     };
 
     const baseCost = costPerImage[modelName] || 0.002; // Default cost


### PR DESCRIPTION
## Summary

Nscale model IDs are the upstream Hugging Face repository IDs, but most of the ones we document use an invented `vendor/lowercase-name` scheme. Those IDs don't exist, so following our docs produces a failed lookup rather than a completed eval.

## Evidence

Nscale's own API example uses `"model": "moonshotai/Kimi-K2.5"`, and [LiteLLM's Nscale registry](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) uses the same convention. Checking each identifier against `huggingface.co/api/models` confirms our org prefixes aren't real orgs:

```
401  meta/llama-3.3-70b-instruct          200  meta-llama/Llama-3.3-70B-Instruct
401  deepseek/deepseek-r1-distill-...     200  deepseek-ai/DeepSeek-R1-Distill-...
401  BlackForestLabs/FLUX.1-schnell       200  black-forest-labs/FLUX.1-schnell
401  ByteDance/SDXL-Lightning-4step       200  ByteDance/SDXL-Lightning
401  Qwen/Qwen3-235B-A22B-Instruct        200  Qwen/Qwen3-235B-A22B
```

The two IDs that were already canonical — `openai/gpt-oss-120b` and `stabilityai/stable-diffusion-xl-base-1.0` — are presumably why this went unnoticed.

**Every model ID published in this PR is HTTP-verified against the Hugging Face API.**

## Also fixed in the same area

- **Image cost silently wrong.** `calculateImageCost` keyed on `BlackForestLabs/FLUX.1-schnell` and `ByteDance/SDXL-Lightning-4step`, so every lookup missed and fell through to the `0.002` default rate.
- **Both example configs** referenced `nscale:meta/llama-3.3-70b-instruct` and the non-existent SDXL Lightning step variants.
- **The docs' only complete example** used `- id: nscale-gpt-oss`. It has no `nscale:` prefix, so it throws `Could not identify provider: nscale-gpt-oss` — verified by resolving it through `loadApiProvider`.
- **The embedding ID was written two ways on the same page**: `qwen/qwen3-embedding-8b` in Model Types vs `Qwen/Qwen3-Embedding-8B` in the table.
- **`nscale:image:` was missing** from the Model Types section despite being supported.
- **`stream: true` was documented as supported.** There is no streaming path for chat providers, so it is forwarded to the API as a body parameter and the SSE response cannot be parsed. Replaced with a note; the `temperature: 0` / `max_tokens: 1024` defaults are now documented too, since both differ from the usual API defaults.

Adds Kimi K2.5, Qwen 3 4B Instruct 2507, Qwen 3 235B A22B, and Llama 3.2 11B Vision Instruct, and points readers at `GET /v1/models` as the authoritative per-account catalog.

## Scope note

I could not reach `GET /v1/models` — it requires a service token and there was none available, so I could not confirm which of these models Nscale currently serves for a given account. This PR corrects the **identifier format**, which is independently verifiable, and deliberately keeps the existing model set rather than removing entries I cannot confirm are retired. A follow-up with a real token should reconcile the list and add per-model pricing (text models currently report `cost: undefined` — `billing.ts` bails before the rate lookup for non-OpenAI model names).

## Test plan

- `npx vitest run test/providers/nscale.test.ts` — 17 passed
- `npm run tsc` clean; Biome clean; Prettier clean
- Every published ID checked against `huggingface.co/api/models` (all 200)