### PR TITLE
fix(providers): guard empty image data in openai formatOutput

### DIFF
--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -578,15 +578,17 @@ export function formatOutput(
   responseFormat?: string,
   outputFormat?: string,
 ): string | { error: string } {
+  const image = Array.isArray(data.data) ? data.data[0] : undefined;
+
   if (responseFormat === 'b64_json') {
-    const b64Json = data.data[0].b64_json;
+    const b64Json = image?.b64_json;
     if (!b64Json) {
       return { error: `No base64 image data found in response: ${JSON.stringify(data)}` };
     }
 
     return `data:${getMimeTypeForOutputFormat(outputFormat)};base64,${b64Json}`;
   } else {
-    const url = data.data[0].url;
+    const url = image?.url;
     if (!url) {
       return { error: `No image URL found in response: ${JSON.stringify(data)}` };
     }
@@ -796,6 +798,7 @@ export async function processApiResponse(
   try {
     const formattedOutput = formatOutput(data, prompt, responseFormat, outputFormat);
     if (typeof formattedOutput === 'object') {
+      await data?.deleteFromCache?.();
       return formattedOutput;
     }
 

--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -606,15 +606,17 @@ export function formatOutput(
   responseFormat?: string,
   outputFormat?: string,
 ): string | { error: string } {
+  const image = Array.isArray(data.data) ? data.data[0] : undefined;
+
   if (responseFormat === 'b64_json') {
-    const b64Json = data.data[0].b64_json;
+    const b64Json = image?.b64_json;
     if (!b64Json) {
       return { error: `No base64 image data found in response: ${JSON.stringify(data)}` };
     }
 
     return `data:${getMimeTypeForOutputFormat(outputFormat)};base64,${b64Json}`;
   } else {
-    const url = data.data[0].url;
+    const url = image?.url;
     if (!url) {
       return { error: `No image URL found in response: ${JSON.stringify(data)}` };
     }
@@ -828,6 +830,7 @@ export async function processApiResponse(
   try {
     const formattedOutput = formatOutput(data, prompt, responseFormat, outputFormat);
     if (typeof formattedOutput === 'object') {
+      await data?.deleteFromCache?.();
       return formattedOutput;
     }
 

--- a/test/providers/openai/image.functions.test.ts
+++ b/test/providers/openai/image.functions.test.ts
@@ -588,8 +588,8 @@ describe('OpenAI Image Provider Functions', () => {
       );
 
       expect(result).toHaveProperty('error');
-      expect(result.error).toContain('API error: TypeError');
-      expect(result.error).toContain('Cannot read properties of undefined');
+      expect(result.error).toContain('No image URL found in response');
+      expect(result.error).not.toContain('TypeError');
       expect(mockDeleteFromCache).toHaveBeenCalledWith();
     });
 
@@ -611,7 +611,8 @@ describe('OpenAI Image Provider Functions', () => {
       );
 
       expect(result).toHaveProperty('error');
-      expect(result.error).toContain('API error:');
+      expect(result.error).toContain('No image URL found in response');
+      expect(result.error).not.toContain('TypeError');
       expect(mockDeleteFromCache).toHaveBeenCalledWith();
     });
   });

--- a/test/providers/openai/image.test.ts
+++ b/test/providers/openai/image.test.ts
@@ -333,6 +333,60 @@ describe('OpenAiImageProvider', () => {
       expect(result.error).toContain('No image URL found in response');
     });
 
+    it('should handle an empty data array without throwing', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { data: [] },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toContain('No image URL found in response');
+      expect(result.error).not.toContain('TypeError');
+    });
+
+    it('should handle a response with no data field without throwing', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { created: 123 },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toContain('No image URL found in response');
+      expect(result.error).not.toContain('TypeError');
+    });
+
+    it('should handle an empty data array for b64_json format without throwing', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key', response_format: 'b64_json' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { data: [] },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toContain('No base64 image data found in response');
+      expect(result.error).not.toContain('TypeError');
+    });
+
     it('should handle error with minimal details', async () => {
       const provider = new OpenAiImageProvider('dall-e-3', {
         config: { apiKey: 'test-key' },

--- a/test/providers/openai/image.test.ts
+++ b/test/providers/openai/image.test.ts
@@ -330,6 +330,60 @@ describe('OpenAiImageProvider', () => {
       expect(result.error).toContain('No image URL found in response');
     });
 
+    it('should handle an empty data array without throwing', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { data: [] },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toContain('No image URL found in response');
+      expect(result.error).not.toContain('TypeError');
+    });
+
+    it('should handle a response with no data field without throwing', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { created: 123 },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toContain('No image URL found in response');
+      expect(result.error).not.toContain('TypeError');
+    });
+
+    it('should handle an empty data array for b64_json format without throwing', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key', response_format: 'b64_json' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { data: [] },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.error).toContain('No base64 image data found in response');
+      expect(result.error).not.toContain('TypeError');
+    });
+
     it('should handle error with minimal details', async () => {
       const provider = new OpenAiImageProvider('dall-e-3', {
         config: { apiKey: 'test-key' },


### PR DESCRIPTION
Fixes #10262

## What broke

`formatOutput` in `src/providers/openai/image.ts` read `data.data[0]` before checking that `data.data` was a non-empty array. A 200 response with an empty `data: []` array, or no `data` field, made `data.data[0]` undefined, so reading `.url` or `.b64_json` threw. `processApiResponse` caught the throw and turned it into an opaque error.

Observed on `main` at `26b725bd`, from the new tests running against the unpatched code:

```
{ "data": [] }      (url)       -> API error: TypeError: Cannot read properties of undefined (reading 'url'): {"data":[]}
{ "created": 123 }  (url)       -> API error: TypeError: Cannot read properties of undefined (reading '0'): {"created":123}
{ "data": [] }      (b64_json)  -> API error: TypeError: Cannot read properties of undefined (reading 'b64_json'): {"data":[]}
```

The function already has clean errors for a present-but-empty entry (`data: [{}]`). The empty or missing array just threw before reaching them. `buildStructuredImageOutputs`, a few lines up, already guards the array with `!Array.isArray(data.data) || data.data.length === 0`.

## The fix

- Guard the array once (`const image = Array.isArray(data.data) ? data.data[0] : undefined`) and read fields with `image?.`.
- Route empty, missing, and non-array `data` to the existing `No image URL found` / `No base64 image data found` errors instead of throwing.
- Evict the cache on the error-object path in `processApiResponse`, matching the `data.error` and catch branches, so a malformed response is not served again from cache.

Same shape as the Azure fixes (#10124 completion, #9867 chat), where `choices[0]` was left unguarded next to an optional-chained sibling. The nscale, xai, and cometapi image providers reuse this code and get the fix for free.

## Out of scope

The cache eviction on the error path is a no-op in production today, and that predates this change. `deleteFromCache` is a sibling of `data` in `FetchWithCacheResult`, but `callOpenAiImageApi` drops it and `callApi` never threads it through, so `data.deleteFromCache` is always undefined. The two existing eviction calls have the same gap. I kept the new call consistent with them rather than rewire the cache plumbing here. Worth a separate PR.

## Test plan

- [x] `npx vitest run test/providers/openai/image.test.ts` passes (83).
- [x] The three new cases fail on the parent commit with a `TypeError` and pass here.
- [x] `should handle deleteFromCache when response parsing fails` still passes.
- [x] xai, nscale, and cometapi image suites still pass.
- [x] `npx tsc --noEmit` is clean.
- [x] `npx biome check src/providers/openai/image.ts test/providers/openai/image.test.ts` is clean.

Results on my machine (node 24.18.1):

- `test/providers/openai/image.test.ts`: 83 passed. The three new tests fail on parent `26b725bd`, pass here.
- openai image + xai image + nscale + cometapi together: 156 passed.
- `tsc --noEmit`: 0 errors.
- `biome check` on both files: no fixes, clean.
