### PR TITLE
test(cli): add debug logger mock to export test

### DIFF
--- a/test/commands/export.test.ts
+++ b/test/commands/export.test.ts
@@ -43,6 +43,7 @@ vi.mock('../../src/logger', () => ({
   default: {
     info: vi.fn(),
     error: vi.fn(),
+    debug: vi.fn(),
   },
 }));
 


### PR DESCRIPTION
## What broke

`test/commands/export.test.ts` mocks `../../src/logger` with only `info` and `error`:

```ts
vi.mock('../../src/logger', () => ({
  default: {
    info: vi.fn(),
    error: vi.fn(),
  },
}));
```

That mock is incomplete. Some provider initialization paths call `logger.debug`.

In CI, this caused the export command test suite to fail before any tests ran:

```text
FAIL test/commands/export.test.ts

TypeError: default.debug is not a function

❯ new OpenAiChatCompletionProvider src/providers/openai/chat.ts:108:14
❯ src/providers/github/defaults.ts:10:45
❯ src/providers/defaults.ts:7:1
```

So the problem was not export command behavior itself. The test-level logger mock did not match the logger surface used by transitive imports.

## The fix

Add `debug: vi.fn()` to the mocked logger in `test/commands/export.test.ts`.

This keeps the test isolated while allowing transitive imports that call `logger.debug` during module initialization to load successfully.

## Tests fixed

This fixes the CI failure in:

```text
test/commands/export.test.ts
```

Specifically, the suite previously failed at import time with:

```text
TypeError: default.debug is not a function
```

After this change, the suite runs normally.

## Test plan

```bash
npx vitest run test/commands/export.test.ts
npx @biomejs/biome check --write test/commands/export.test.ts
```

Results on my machine, Node 24.18.0:

- `test/commands/export.test.ts`: 11 passed
- Biome check on `test/commands/export.test.ts`: clean
- pre-commit hook: passed
