### PR TITLE
fix(util): ignore braces inside strings when extracting JSON objects

### DIFF
--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -221,13 +221,27 @@ export function extractJsonObjects(str: string): object[] {
       let openBraces = 1;
       let closeBraces = 0;
       let j = i + 1;
+      let inString = false;
+      let escaped = false;
 
       // Track braces as we go to detect potential JSON objects
       while (j < Math.min(i + maxJsonLength, str.length) && openBraces > closeBraces) {
-        if (str[j] === '{') {
+        const ch = str[j];
+        // Ignore braces inside string literals so a `}` in a value doesn't
+        // prematurely balance the object (e.g. `{"a": "}"}`).
+        if (inString) {
+          if (escaped) {
+            escaped = false;
+          } else if (ch === '\\') {
+            escaped = true;
+          } else if (ch === '"') {
+            inString = false;
+          }
+        } else if (ch === '"') {
+          inString = true;
+        } else if (ch === '{') {
           openBraces++;
-        }
-        if (str[j] === '}') {
+        } else if (ch === '}') {
           closeBraces++;
         }
         j++;

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -223,10 +223,11 @@ export function extractJsonObjects(str: string): object[] {
       let j = i + 1;
       let inString = false;
       let escaped = false;
-      // A `"` only opens a quoted scalar at a key/value boundary; a YAML plain
-      // scalar can contain a bare `"` mid-value (e.g. `mentions "admin`) that
-      // must not be mistaken for the start of a string, or the real closing
-      // `}` gets swallowed as string content and never counted.
+      // A `"` only opens a quoted scalar at a key/value boundary (also right
+      // after `[`, so a string that's the first array element is tracked); a
+      // YAML plain scalar can contain a bare `"` mid-value (e.g. `mentions
+      // "admin`) that must not be mistaken for the start of a string, or the
+      // real closing `}` gets swallowed as string content and never counted.
       let atValueStart = true;
 
       // Track braces as we go to detect potential JSON objects
@@ -245,11 +246,15 @@ export function extractJsonObjects(str: string): object[] {
           }
         } else if (ch === '"' && atValueStart) {
           inString = true;
-        } else if (ch === '{') {
-          openBraces++;
+        } else if (ch === '{' || ch === '[') {
+          if (ch === '{') {
+            openBraces++;
+          }
           atValueStart = true;
-        } else if (ch === '}') {
-          closeBraces++;
+        } else if (ch === '}' || ch === ']') {
+          if (ch === '}') {
+            closeBraces++;
+          }
           atValueStart = false;
         } else if (ch === ':' || ch === ',') {
           atValueStart = true;

--- a/src/util/json.ts
+++ b/src/util/json.ts
@@ -223,6 +223,11 @@ export function extractJsonObjects(str: string): object[] {
       let j = i + 1;
       let inString = false;
       let escaped = false;
+      // A `"` only opens a quoted scalar at a key/value boundary; a YAML plain
+      // scalar can contain a bare `"` mid-value (e.g. `mentions "admin`) that
+      // must not be mistaken for the start of a string, or the real closing
+      // `}` gets swallowed as string content and never counted.
+      let atValueStart = true;
 
       // Track braces as we go to detect potential JSON objects
       while (j < Math.min(i + maxJsonLength, str.length) && openBraces > closeBraces) {
@@ -236,13 +241,20 @@ export function extractJsonObjects(str: string): object[] {
             escaped = true;
           } else if (ch === '"') {
             inString = false;
+            atValueStart = false;
           }
-        } else if (ch === '"') {
+        } else if (ch === '"' && atValueStart) {
           inString = true;
         } else if (ch === '{') {
           openBraces++;
+          atValueStart = true;
         } else if (ch === '}') {
           closeBraces++;
+          atValueStart = false;
+        } else if (ch === ':' || ch === ',') {
+          atValueStart = true;
+        } else if (!/\s/.test(ch)) {
+          atValueStart = false;
         }
         j++;
 

--- a/test/util/json.test.ts
+++ b/test/util/json.test.ts
@@ -355,6 +355,13 @@ describe('json utilities', () => {
       expect(extractJsonObjects(input)).toEqual([{ reason: 'mentions "admin', score: 1 }]);
     });
 
+    it('should not treat braces inside a string that is the first array element as structural', () => {
+      expect(extractJsonObjects('{"messages":["}"]}')).toEqual([{ messages: ['}'] }]);
+      expect(extractJsonObjects('{"tags": ["{open", "close}"]}')).toEqual([
+        { tags: ['{open', 'close}'] },
+      ]);
+    });
+
     describe('convertSlashCommentsToHash', () => {
       it('should convert basic // comments to # comments', () => {
         const input = 'some text // this is a comment';

--- a/test/util/json.test.ts
+++ b/test/util/json.test.ts
@@ -350,6 +350,11 @@ describe('json utilities', () => {
       expect(extractJsonObjects(input)).toEqual([{ quote: 'say "}" now' }]);
     });
 
+    it('should not treat a bare quote inside a plain scalar as opening a string', () => {
+      const input = '{reason: mentions "admin, score: 1}';
+      expect(extractJsonObjects(input)).toEqual([{ reason: 'mentions "admin', score: 1 }]);
+    });
+
     describe('convertSlashCommentsToHash', () => {
       it('should convert basic // comments to # comments', () => {
         const input = 'some text // this is a comment';

--- a/test/util/json.test.ts
+++ b/test/util/json.test.ts
@@ -332,6 +332,24 @@ describe('json utilities', () => {
       expect(extractJsonObjects(input)).toEqual(expectedOutput);
     });
 
+    it('should not treat braces inside string values as structural', () => {
+      expect(extractJsonObjects('{"a": "}"}')).toEqual([{ a: '}' }]);
+      expect(extractJsonObjects('{"note": "closing brace } inside", "status": "ok"}')).toEqual([
+        { note: 'closing brace } inside', status: 'ok' },
+      ]);
+      expect(extractJsonObjects('{"open": "{ unbalanced"}')).toEqual([{ open: '{ unbalanced' }]);
+    });
+
+    it('should extract JSON with string braces from surrounding text', () => {
+      const input = 'The result is {"status": "ok", "note": "brace } here"} done';
+      expect(extractJsonObjects(input)).toEqual([{ status: 'ok', note: 'brace } here' }]);
+    });
+
+    it('should not be confused by an escaped quote before a string brace', () => {
+      const input = '{"quote": "say \\"}\\" now"}';
+      expect(extractJsonObjects(input)).toEqual([{ quote: 'say "}" now' }]);
+    });
+
     describe('convertSlashCommentsToHash', () => {
       it('should convert basic // comments to # comments', () => {
         const input = 'some text // this is a comment';


### PR DESCRIPTION
`extractJsonObjects` counts every `{` and `}` literally, including braces that appear inside string values. A `}` inside a string balances the brace counter early, so the slice it cuts is truncated invalid JSON — the object fails to parse and gets silently dropped. `extractJsonObjects('{"a": "}"}')` returns `[]` instead of `[{ a: '}' }]`, and a model output like `The result is {"status": "ok", "note": "brace } here"} done` yields nothing.

This hits `contains-json` and every `extractFirstJsonObject` consumer (rubric matcher, synthesis, redteam parsers) whenever a JSON value legitimately contains a brace.

Fixed by tracking string state (with escape handling) while scanning, so braces inside "..." no longer affect the open/close count. Only double-quoted JSON strings are tracked, matching the JSON case; single-quoted YAML braces stay out of scope as before. Added tests for a brace and an unbalanced brace inside a value, extraction from surrounding text, and an escaped quote preceding a string brace.