### PR TITLE
fix(deps): patch undici in code-scan-action and guard both lockfiles

### DIFF
--- a/code-scan-action/package-lock.json
+++ b/code-scan-action/package-lock.json
@@ -1635,9 +1635,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/code-scan-action/package.json
+++ b/code-scan-action/package.json
@@ -30,6 +30,6 @@
     "typescript": "^7.0.0"
   },
   "overrides": {
-    "undici": "^7.28.0"
+    "undici": ">=7.29.0 <8"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "socket.io-client": "^4.8.3",
         "text-extensions": "^3.1.0",
         "tsx": "^4.21.0",
-        "undici": ">=7.28.0 <8",
+        "undici": ">=7.29.0 <8",
         "winston": "^3.19.0",
         "ws": "^8.21.1",
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -395,7 +395,7 @@
     "socket.io-client": "^4.8.3",
     "text-extensions": "^3.1.0",
     "tsx": "^4.21.0",
-    "undici": ">=7.28.0 <8",
+    "undici": ">=7.29.0 <8",
     "winston": "^3.19.0",
     "ws": "^8.21.1",
     "zod": "^4.3.6"

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -445,6 +445,48 @@ describe('package manifests', () => {
     expect(lockfile.packages?.['']?.dependencies?.ws).toBe(rootPackageJson.dependencies?.ws);
   });
 
+  it('keeps undici patched and aligned across the root and code-scan-action manifests', () => {
+    // GHSA-4cwx-7wf7-3272 and four sibling advisories were fixed in undici 7.29.0.
+    // The root fix landed in #10269 but code-scan-action/ carries its own lockfile,
+    // so it kept resolving 7.28.0 and stayed on five open Dependabot alerts. Both
+    // projects override undici; assert the floors and the resolved copies together.
+    const PATCHED_UNDICI = '7.29.0';
+    const projects = [
+      // The root declares undici directly; code-scan-action only pins it through an
+      // override, since it arrives transitively via @actions/github.
+      { manifest: 'package.json', lockfile: 'package-lock.json', field: 'dependencies' },
+      {
+        manifest: 'code-scan-action/package.json',
+        lockfile: 'code-scan-action/package-lock.json',
+        field: 'overrides',
+      },
+    ] as const;
+
+    for (const { manifest, lockfile, field } of projects) {
+      const packageJson =
+        readPackageJson<Record<string, Record<string, string> | undefined>>(manifest);
+      const pinnedRange = packageJson[field]?.undici;
+
+      expect(pinnedRange, `${manifest} must pin undici under "${field}"`).toBeDefined();
+      expect(validRange(pinnedRange as string)).not.toBeNull();
+      expect(
+        minVersion(pinnedRange as string)?.compare(PATCHED_UNDICI),
+        `${manifest} must not allow undici below ${PATCHED_UNDICI}`,
+      ).toBeGreaterThanOrEqual(0);
+
+      const packageLock = readPackageJson<{
+        packages: Record<string, { version?: string }>;
+      }>(lockfile);
+      const resolved = packageLock.packages['node_modules/undici']?.version;
+
+      expect(resolved, `${lockfile} must resolve undici`).toBeDefined();
+      expect(
+        minVersion(resolved as string)?.compare(PATCHED_UNDICI),
+        `${lockfile} resolves undici ${resolved}`,
+      ).toBeGreaterThanOrEqual(0);
+    }
+  });
+
   it('does not import jsdom from root src/', () => {
     // Guards against re-introducing jsdom into the CLI startup graph, which
     // previously broke `npx promptfoo` on Node 24 via ERR_REQUIRE_ASYNC_MODULE.


### PR DESCRIPTION
## Summary

`code-scan-action/` carries its own `package-lock.json`, so the root undici 7.29.0 bump in #10269 never reached it. It was still resolving 7.28.0 with **five open Dependabot alerts**:

| Severity | Advisory |
|---|---|
| High | [GHSA-4cwx-7wf7-3272](https://github.com/nodejs/undici/security/advisories/GHSA-4cwx-7wf7-3272) — cross-user disclosure via malformed qualified `private` Cache-Control |
| Medium | [GHSA-m8rv-5g2x-5cg5](https://github.com/nodejs/undici/security/advisories/GHSA-m8rv-5g2x-5cg5) — CRLF injection via duck-typed blob `type` |
| Medium | [GHSA-jr45-8vmc-qm54](https://github.com/nodejs/undici/security/advisories/GHSA-jr45-8vmc-qm54) — shared-cache bypass via whitespace around `=` |
| Medium | [GHSA-8xcm-r25x-g524](https://github.com/nodejs/undici/security/advisories/GHSA-8xcm-r25x-g524) — stale `Content-Length` after partial-response resume |
| Medium | [GHSA-v3r7-h72x-cjcm](https://github.com/nodejs/undici/security/advisories/GHSA-v3r7-h72x-cjcm) — cookie attribute injection via `setCookie()` |

undici reaches the action transitively through `@actions/github` → `@actions/http-client`, and `code-scan-action/package.json` pins it with an `overrides` entry.

**This is not cosmetic.** `publish-code-scan-action` in `.github/workflows/release-please.yml` runs `npm ci` in `code-scan-action/` and rebuilds `dist/index.js` with esbuild before mirroring to `promptfoo/code-scan-action`, so the lockfile is exactly what the published action bundles.

## Changes

- Raise the undici floor to `>=7.29.0 <8` in both the root `dependencies` and the `code-scan-action` `overrides`, and regenerate both lockfiles. Both now resolve 7.29.0.
- Add a `package-manifests` guard asserting the pin **and** the resolved copy for each project. `renovate.json` already has a "Keep undici in sync across root and code-scan-action" rule, but nothing failed the build when the two drifted apart — this closes that hole.

## Verification

`test/package-manifests.test.ts` — 20 passed. Confirmed the new guard fails on the pre-fix state rather than passing vacuously:

```
AssertionError: code-scan-action/package-lock.json resolves undici 7.28.0:
  expected -1 to be greater than or equal to 0
```