### PR TITLE
fix(deps): pin socket.io-parser above the packet-decoder DoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40395,9 +40395,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
       ".": "2.5.8",
       "ws": "$ws"
     },
+    "socket.io-parser": ">=4.2.7 <5",
     "qs": ">=6.15.2 <7.0.0",
     "@isaacs/brace-expansion": ">=5.0.1",
     "brace-expansion@5": "^5.0.6",


### PR DESCRIPTION
## Summary

`socket.io-parser@4.2.6` is vulnerable to [GHSA-2m8v-j782-fhvr](https://github.com/socketio/socket.io-parser/security/advisories/GHSA-2m8v-j782-fhvr) — **high, CVSS 7.5** (`AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`). A packet that declares binary attachments which never arrive leaves the decoder's reconstructor alive, so an unauthenticated client can exhaust server memory.

**This one is reachable, not theoretical.** `startServer()` in `src/server/server.ts` calls `httpServer.listen(port, ...)` with no host argument, so it binds `0.0.0.0`, and `io.on('connection', ...)` decodes packets straight from the network. Every `promptfoo view`, `redteam report`, `redteam setup`, and `eval setup` session starts that server.

It arrives transitively through two parents that both declare `~4.2.4`:

```
promptfoo -> socket.io@4.8.3        -> socket.io-parser ~4.2.4
promptfoo -> socket.io-client@4.8.3 -> socket.io-parser ~4.2.4
```

Neither parent has cut a release that raises the floor (`socket.io@latest` is still 4.8.3 declaring `~4.2.4`), so there is no upstream bump to wait for.

## Changes

Pin the floor with an override, alongside the `engine.io` / `engine.io-client` / `socket.io-adapter` pins already in the same block:

```json
"socket.io-parser": ">=4.2.7 <5",
```

4.2.7 satisfies both parents' `~4.2.4`, so nothing else in the tree moves — the lockfile diff is three lines.

## Verification

- `npm audit`: high findings 11 → 8; `socket.io-parser` no longer appears.
- Lockfile is idempotent under a second `npm install --package-lock-only`.
- `npx vitest run test/server` with 4.2.7 actually installed — **28 files, 527 tests passed**.

## Notes

Found while auditing the remaining Dependabot alerts. Most of the rest are docs-site or optional-dependency noise; this was the only high-severity advisory reachable from the shipped runtime. The related `code-scan-action` undici gap is #10278.