### PR TITLE
chore(deps): drop the node10 consumer typecheck from the artifact test

### DIFF
--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -380,19 +380,6 @@ function writeConsumerScripts(consumerDir: string): void {
     }),
   );
   fs.writeFileSync(
-    path.join(consumerDir, 'tsconfig.legacy.json'),
-    JSON.stringify({
-      compilerOptions: {
-        ignoreDeprecations: '6.0',
-        module: 'CommonJS',
-        moduleResolution: 'node',
-        noEmit: true,
-        strict: true,
-      },
-      include: ['import-contracts.ts'],
-    }),
-  );
-  fs.writeFileSync(
     path.join(consumerDir, 'require-contracts.cts'),
     [
       "import contracts = require('promptfoo/contracts');",
@@ -632,10 +619,13 @@ async function main(): Promise<void> {
     writeConsumerScripts(consumerDir);
     run(process.execPath, ['import-package.mjs'], consumerDir);
     run(process.execPath, ['require-package.cjs'], consumerDir);
-    const tsc6Path = path.join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc6');
-    const tsc7Path = path.join(ROOT, 'node_modules', '@typescript', 'native', 'bin', 'tsc');
-    for (const tsconfig of ['tsconfig.json', 'tsconfig.legacy.json', 'tsconfig.node16-cjs.json']) {
-      const tscPath = tsconfig === 'tsconfig.legacy.json' ? tsc6Path : tsc7Path;
+    // `typescript` is aliased to @typescript/typescript6 for its JS compiler API,
+    // which the TypeScript 7 native port no longer exposes; the compiler binary we
+    // typecheck consumers with is the 7.x one under @typescript/native. Both configs
+    // here must stay resolvable by that binary — TypeScript 7 removed
+    // `moduleResolution: node10`, so do not add a config that needs the 6.x `tsc6`.
+    const tscPath = path.join(ROOT, 'node_modules', '@typescript', 'native', 'bin', 'tsc');
+    for (const tsconfig of ['tsconfig.json', 'tsconfig.node16-cjs.json']) {
       run(process.execPath, [tscPath, '--project', tsconfig], consumerDir);
     }
     assertInstalledWebApp(installedPackageDir);


### PR DESCRIPTION
## Summary

Follow-up to #10140 (TypeScript 7).

`scripts/testPackageArtifact.ts` typechecks the packed package from a synthetic consumer under three tsconfigs. One of them, `tsconfig.legacy.json`, uses `moduleResolution: node10` — which TypeScript 7 **removed**:

```
tsconfig.legacy.json(1,87): error TS5108: Option 'moduleResolution=node10' has been removed.
                            Please remove it from your configuration.
```

So #10140 routed that single config to the 6.x `tsc6` binary, leaving the artifact test running two different compilers with a per-config ternary.

With `engines.node` at `>=22.22.0` there is no supported consumer left on the pre-Node-12 resolution algorithm, and TypeScript has removed the mode outright. Dropping the config lets the whole matrix run on one compiler.

```diff
-    const tsc6Path = path.join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc6');
-    const tsc7Path = path.join(ROOT, 'node_modules', '@typescript', 'native', 'bin', 'tsc');
-    for (const tsconfig of ['tsconfig.json', 'tsconfig.legacy.json', 'tsconfig.node16-cjs.json']) {
-      const tscPath = tsconfig === 'tsconfig.legacy.json' ? tsc6Path : tsc7Path;
+    const tscPath = path.join(ROOT, 'node_modules', '@typescript', 'native', 'bin', 'tsc');
+    for (const tsconfig of ['tsconfig.json', 'tsconfig.node16-cjs.json']) {
       run(process.execPath, [tscPath, '--project', tsconfig], consumerDir);
     }
```

plus the ~11-line fixture writer for that config, and a comment so nobody re-adds a config the 7.x binary can't parse.

## What this does *not* do

It does **not** remove the second compiler, which was the tempting-but-wrong version of this cleanup. `typescript` stays aliased to `@typescript/typescript6`, because the TypeScript 7 package is the native port and its `exports` map is only:

```json
{ ".": "./lib/version.cjs", "./unstable/sync": "...", "./unstable/ast": "..." }
```

There is no `lib/typescript.js`, so every tool that does `require('typescript')` for the JS compiler API — tsdown, knip, vitest, docusaurus, madge, depcheck — still needs 6.x. Only the *binary* invocation of `tsc6` goes away; the package stays.

## Coverage note

This does give up one axis: node10 ignores `exports` maps, so that check was what exercised the `main`/`types` fallback. The remaining two configs still cover both consumer shapes — `NodeNext` for `import ... from 'promptfoo/contracts'` and `Node16` for `import contracts = require('promptfoo/contracts')` — and `assertExportsResolve()` independently walks the published `exports` map.

## Verification

`tsc --noEmit` clean; `biome check` clean. Ran `npm run build && npm run test:package-artifact` locally against the real packed tarball: `Verified installed package artifact: promptfoo-0.121.20.tgz` (exit 0). Both remaining consumer configs typecheck on the 7.x binary.
