### PR TITLE
fix(webui): stop rendering long test descriptions as base64 images

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -1005,6 +1005,42 @@ describe('ResultsTable Metrics Display', () => {
         providerImagePrompt,
       );
     });
+
+    it('renders a long hyphen/underscore test description as plain text, not an image', () => {
+      const longDescription = 'golden-047-brushless-dc-motor-assemblies-for-applia-a45abef4';
+      vi.mocked(useTableStore).mockImplementation(() => ({
+        config: {},
+        evalId: '123',
+        setTable: vi.fn(),
+        table: {
+          body: [
+            {
+              outputs: [{ pass: true, score: 1, text: 'test output' }],
+              test: { description: longDescription },
+              vars: [],
+            },
+          ],
+          head: {
+            prompts: [{}],
+            vars: [],
+          },
+        },
+        version: 4,
+        fetchEvalData: vi.fn(),
+        filters: {
+          values: {},
+          appliedCount: 0,
+          options: {
+            metric: [],
+          },
+        },
+      }));
+
+      renderWithProviders(<ResultsTable {...defaultProps} />);
+
+      expect(screen.getByText(longDescription)).toBeInTheDocument();
+      expect(screen.queryByRole('img', { name: 'Base64 encoded image' })).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -1271,7 +1271,11 @@ function getImageSourceForCell({
   headVars: string[];
   injectVarName: string;
 }): string | undefined {
-  if (typeof value !== 'string' || hasFileMetadataForColumn({ columnId, row, headVars })) {
+  if (
+    columnId === 'description' ||
+    typeof value !== 'string' ||
+    hasFileMetadataForColumn({ columnId, row, headVars })
+  ) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Fixes #10284.

The eval results webui's per-test **Description** column renders as a broken image (alt `"Base64 encoded image"`) instead of plain text whenever `test.description` is a plain-text id/slug that's at least 60 characters long and made up only of letters, digits, hyphens, and/or underscores — e.g. `golden-047-brushless-dc-motor-assemblies-for-applia-a45abef4` (60 chars).

`resolveImageSource`'s base64-ish heuristic in `src/app/src/utils/media.ts` has no positive signal that a string is actually image data (no decode/magic-byte check), so it false-positives on ordinary ids/slugs/hashes once they cross the length threshold — a common shape for auto-generated per-test descriptions. `getImageSourceForCell` in `ResultsTable.tsx` reaches this heuristic for the `description` column even though `TestCase.description` is typed `z.string().optional()` with no image semantics anywhere in the schema or docs, so there's no legitimate case where this column should be interpreted as image data.

Rather than tightening the regex further (which just moves the false-positive boundary), this excludes the `description` column from image resolution outright.

## Test plan

- [x] Added a regression test that reproduces the exact failure (a 60-char hyphen/underscore description) and confirms it renders as plain text with no image role in the DOM.
- [x] Verified the new test fails on `main` (reverted the fix locally, test failed as expected) and passes with the fix.
- [x] `npx vitest run src/pages/eval/components/ResultsTable.test.tsx` — 90/90 pass
- [x] `npx tsc -b` (src/app) — clean
- [x] `npx @biomejs/biome check` on both changed files — clean, pre-commit lint hook passed
