### PR TITLE
fix(deps): repair Biome and undici upgrade regressions

### DIFF
--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -1072,9 +1072,9 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
     }
 
     return {
-      guardrailIdentifier: String(this.config.guardrailIdentifier),
-      // biome-ignore lint/nursery/noUselessTypeConversion: YAML may deserialize versions as numbers.
-      guardrailVersion: String(this.config.guardrailVersion || 'DRAFT'),
+      // YAML can deserialize unquoted guardrail values as numbers despite their TypeScript types.
+      guardrailIdentifier: String(this.config.guardrailIdentifier as unknown),
+      guardrailVersion: String((this.config.guardrailVersion || 'DRAFT') as unknown),
       ...(this.config.trace ? { trace: this.config.trace as GuardrailTrace } : {}),
     };
   }

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -1072,8 +1072,9 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
     }
 
     return {
-      guardrailIdentifier: this.config.guardrailIdentifier,
-      guardrailVersion: this.config.guardrailVersion || 'DRAFT',
+      guardrailIdentifier: String(this.config.guardrailIdentifier),
+      // biome-ignore lint/nursery/noUselessTypeConversion: YAML may deserialize versions as numbers.
+      guardrailVersion: String(this.config.guardrailVersion || 'DRAFT'),
       ...(this.config.trace ? { trace: this.config.trace as GuardrailTrace } : {}),
     };
   }

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -520,6 +520,9 @@ describe('package manifests', () => {
       },
     ] as const;
 
+    const minimumVersions: string[] = [];
+    const directResolvedVersions: string[] = [];
+
     for (const { manifest, lockfile, field } of projects) {
       const packageJson =
         readPackageJson<Record<string, Record<string, string> | undefined>>(manifest);
@@ -527,22 +530,43 @@ describe('package manifests', () => {
 
       expect(pinnedRange, `${manifest} must pin undici under "${field}"`).toBeDefined();
       expect(validRange(pinnedRange as string)).not.toBeNull();
+
+      const minimum = minVersion(pinnedRange as string);
       expect(
-        minVersion(pinnedRange as string)?.compare(PATCHED_UNDICI),
+        minimum?.compare(PATCHED_UNDICI),
         `${manifest} must not allow undici below ${PATCHED_UNDICI}`,
       ).toBeGreaterThanOrEqual(0);
+      minimumVersions.push(minimum?.version ?? '');
 
       const packageLock = readPackageJson<{
         packages: Record<string, { version?: string }>;
       }>(lockfile);
-      const resolved = packageLock.packages['node_modules/undici']?.version;
+      const installations = Object.entries(packageLock.packages).filter(
+        ([packagePath]) =>
+          packagePath === 'node_modules/undici' || packagePath.endsWith('/node_modules/undici'),
+      );
 
-      expect(resolved, `${lockfile} must resolve undici`).toBeDefined();
-      expect(
-        minVersion(resolved as string)?.compare(PATCHED_UNDICI),
-        `${lockfile} resolves undici ${resolved}`,
-      ).toBeGreaterThanOrEqual(0);
+      expect(installations, `${lockfile} must resolve undici`).not.toHaveLength(0);
+      for (const [packagePath, installation] of installations) {
+        expect(
+          installation.version,
+          `${lockfile}:${packagePath} must have a version`,
+        ).toBeDefined();
+        expect(
+          minVersion(installation.version as string)?.compare(PATCHED_UNDICI),
+          `${lockfile}:${packagePath} resolves vulnerable undici ${installation.version}`,
+        ).toBeGreaterThanOrEqual(0);
+      }
+
+      const resolved = packageLock.packages['node_modules/undici']?.version;
+      expect(resolved, `${lockfile} must resolve a top-level undici installation`).toBeDefined();
+      directResolvedVersions.push(resolved as string);
     }
+
+    expect(new Set(minimumVersions).size, 'undici minimum versions must stay aligned').toBe(1);
+    expect(new Set(directResolvedVersions).size, 'resolved undici versions must stay aligned').toBe(
+      1,
+    );
   });
 
   it('does not import jsdom from root src/', () => {

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -2063,6 +2063,32 @@ Third line`;
       );
     });
 
+    it('should coerce numeric YAML guardrail identifiers and versions to strings', async () => {
+      const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
+        config: {
+          region: 'us-east-1',
+          guardrailIdentifier: 12345 as unknown as string,
+          guardrailVersion: 2 as unknown as string,
+        },
+      });
+
+      mockSend.mockResolvedValueOnce(createMockConverseResponse('Test'));
+
+      await provider.callApi('Test');
+
+      const { ConverseCommand } = (await import(
+        '@aws-sdk/client-bedrock-runtime'
+      )) as unknown as MockBedrockModule;
+      expect(ConverseCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          guardrailConfig: {
+            guardrailIdentifier: '12345',
+            guardrailVersion: '2',
+          },
+        }),
+      );
+    });
+
     it('should use DRAFT as default guardrail version', async () => {
       const provider = new AwsBedrockConverseProvider('anthropic.claude-3-5-sonnet-20241022-v2:0', {
         config: {


### PR DESCRIPTION
## Summary

Fix two regressions that survived recently merged dependency upgrades:

- Restore Bedrock Converse guardrail identifier/version string coercion removed by the Biome 2.5.5 autofix in #10221. Numeric YAML values must be sent to AWS as strings.
- Strengthen the undici security guard added in #10278 so every nested lockfile installation is checked and both projects must agree on their minimum and resolved versions.

## Verification

- 231 focused Bedrock, dependency-manifest, and XLSX tests pass.
- `npm run tsc -- --pretty false`, `npm run depcheck`, and full Biome CI pass.
- The new Bedrock test reproduces the actual AWS `ConverseCommand` payload regression before the fix.
- Mutation checks prove the old undici guard accepted a vulnerable nested 7.28.0 copy, mismatched manifest minimums, and mismatched resolved versions; the repaired guard rejects all three.
