### PR TITLE
chore(deps): stop Renovate bumping the parser-pinned Chevrotain packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -224,6 +224,16 @@
       "groupName": "jsdom"
     },
     {
+      "description": "Chevrotain's sub-packages are pinned to the parser version, not to whatever is newest. chevrotain@11.2.0 declares each of @chevrotain/gast, @chevrotain/types, @chevrotain/regexp-to-ast and @chevrotain/utils at exactly 11.2.0, and test/package-manifests.test.ts asserts the overrides keep them equal to the pinned parser so a single shared instance is used. Renovate bumping them individually yields an incoherent tree (see the closed #10293 and #10294). Only @chevrotain/cst-dts-gen floats ahead, so it is deliberately not listed here. Re-enable if the pinned chevrotain parser itself moves.",
+      "matchPackageNames": [
+        "@chevrotain/gast",
+        "@chevrotain/types",
+        "@chevrotain/regexp-to-ast",
+        "@chevrotain/utils"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Keep undici in sync across root and code-scan-action",
       "matchPackageNames": ["undici"],
       "groupName": "undici"


### PR DESCRIPTION
## Problem

Renovate opened #10293 (`@chevrotain/gast` → 13.0.0) and #10294 (`@chevrotain/regexp-to-ast` → 13.0.0) within minutes of each other. Both are incoherent, and more will follow for `@chevrotain/types` and `@chevrotain/utils`.

`chevrotain@11.2.0` — the version this repo pins — declares each of those sub-packages at **exactly 11.2.0**:

```
$ npm view chevrotain@11.2.0 dependencies
{ "@chevrotain/gast": "11.2.0", "@chevrotain/types": "11.2.0",
  "@chevrotain/regexp-to-ast": "11.2.0", "@chevrotain/utils": "11.2.0", ... }
```

The overrides hold them there deliberately so the parser and the CST generator share a single instance instead of a duplicated nested copy. #10291 established that invariant, and #10292 encodes it as a guard. Applying #10293's `package.json` against that guard fails exactly as expected:

```
AssertionError: @chevrotain/cst-dts-gen must share the parser's @chevrotain/gast version:
  expected '13.0.0' to be '11.2.0'
```

Renovate has no way to know the pin is intentional, so it will keep proposing these.

## Change

Disable updates for the four parser-pinned packages, following the existing precedent of the disabled code-scan Node pin (a rule whose `description` explains why it exists).

`@chevrotain/cst-dts-gen` is **deliberately left enabled** — #10291 established that it is the one family member allowed to float ahead of the parser, and it currently sits at 13.0.0.

## Verification

- `renovate.json` parses; 48 package rules, new rule present with `enabled: false`
- `biome check` clean
- `test/package-manifests.test.ts` — 24 passed

## Follow-up

#10293 and #10294 are closed with this reasoning recorded. If the pinned `chevrotain` parser itself ever moves off 11.2.0, this rule should be revisited rather than deleted.