### PR TITLE
fix(deps): bundle the runtime cache dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "promptfoo",
       "version": "0.122.0",
+      "bundleDependencies": [
+        "cache-manager"
+      ],
       "license": "MIT",
       "workspaces": [
         "src/app",
@@ -4561,6 +4564,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
       "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "hashery": "^1.5.1",
@@ -11992,6 +11996,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/@kurkle/color": {
@@ -21862,6 +21867,7 @@
       "version": "7.2.9",
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.9.tgz",
       "integrity": "sha512-d4vceEyYe95gPxEyQchlEOH9vJlkNRW8G6gzFzzMTxJK9PahYMhC9chrEqgZN0HulROjgw3IzmWVNk7Q7ytiGw==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/utils": "^2.5.0",
@@ -27586,6 +27592,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
       "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "hookified": "^1.15.0"
@@ -27882,6 +27889,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
       "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/hpack.js": {
@@ -29606,6 +29614,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "promptfoo": "dist/src/entrypoint.js",
     "pf": "dist/src/entrypoint.js"
   },
+  "bundleDependencies": [
+    "cache-manager"
+  ],
   "scripts": {
     "audit:fix": "npm audit fix && npm audit fix --prefix src/app && npm audit fix --prefix site",
     "architecture:baseline": "tsx scripts/regenerateEdgeBaseline.ts",

--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -63,6 +63,8 @@ const requiredPackagedPaths = [
   'dist/src/tracing/proto/opentelemetry/proto/common/v1/common.proto',
   'dist/src/tracing/proto/opentelemetry/proto/resource/v1/resource.proto',
   'dist/src/tracing/proto/opentelemetry/proto/trace/v1/trace.proto',
+  'node_modules/@cacheable/utils/package.json',
+  'node_modules/cache-manager/package.json',
 ];
 
 function listFiles(rootDir: string): string[] {
@@ -185,8 +187,8 @@ function assertPackagedFiles(packResult: PackResult): void {
     `Missing packaged web app files: ${missingWebAppFiles.join(', ')}`,
   );
   assert(
-    packResult.files.every((file) => !file.path.endsWith('.map')),
-    'Source maps should be excluded from the package',
+    packResult.files.every((file) => !file.path.startsWith('dist/') || !file.path.endsWith('.map')),
+    'Application source maps should be excluded from the package',
   );
   assert(
     packResult.files.every((file) => !file.path.startsWith('dist/test/')),

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -113,6 +113,33 @@ describe('package manifests', () => {
     expect(packageJson.typesVersions?.['*']?.contracts).toEqual(['dist/src/contracts.d.ts']);
   });
 
+  it('bundles the resolved runtime cache dependency', () => {
+    const packageJson = readPackageJson<PackageManifest & { bundleDependencies?: string[] }>(
+      'package.json',
+    );
+    const packageLock = readPackageJson<{
+      packages: Record<
+        string,
+        {
+          bundleDependencies?: string[];
+          dependencies?: Record<string, string>;
+          inBundle?: boolean;
+          version?: string;
+        }
+      >;
+    }>('package-lock.json');
+
+    expect(packageJson.bundleDependencies).toEqual(['cache-manager']);
+    expect(packageLock.packages[''].bundleDependencies).toEqual(packageJson.bundleDependencies);
+
+    for (const dependencyName of ['cache-manager', '@cacheable/utils']) {
+      const dependency = packageLock.packages[`node_modules/${dependencyName}`];
+
+      expect(dependency?.version, `${dependencyName} must be resolved`).toBeDefined();
+      expect(dependency?.inBundle, `${dependencyName} must be bundled`).toBe(true);
+    }
+  });
+
   it('keeps the contracts subpath extension-safe for emitted ESM', () => {
     const contractsDir = path.join(process.cwd(), 'src', 'contracts');
     const files = [


### PR DESCRIPTION
## Summary

- Bundle the runtime cache dependency with its resolved dependency tree.
- Verify bundled cache files in manifest and package-artifact checks.
- Scope application source-map checks to application output.

## Validation

- `npx vitest run test/package-manifests.test.ts test/cache.test.ts` (98 tests)
- `npx @biomejs/biome check package.json scripts/testPackageArtifact.ts test/package-manifests.test.ts`
- `npm pack --ignore-scripts --dry-run --json`
- Verified bundled dependency resolution in a consuming application.
