### PR TITLE
docs: clarify API key persistence in getting started

### DIFF
--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -49,7 +49,7 @@ Most providers need authentication. For OpenAI:
 export OPENAI_API_KEY=sk-abc123
 ```
 
-This export only applies to the current terminal session. If you want the key to be available in future sessions on a local, trusted machine, you can add the same export line to your shell's startup file (for example, your shell profile or rc file). Avoid committing it to source control, and consider a secret manager or your operating system's keychain for longer-term secret storage.
+This command only applies to the current terminal session. If you want the key to be available in future sessions on a local, trusted machine, you can add the equivalent command for your shell (such as an `export` statement in your `.bashrc`/`.zshrc`, a `set` command in Fish, or setting a user environment variable on Windows) to your shell's startup or profile configuration.
 
 Then navigate to the example directory, run the eval, and view results:
 

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -49,7 +49,12 @@ Most providers need authentication. For OpenAI:
 export OPENAI_API_KEY=sk-abc123
 ```
 
-This command only applies to the current terminal session. If you want the key to be available in future sessions on a local, trusted machine, you can add the equivalent command for your shell (such as an `export` statement in your `.bashrc`/`.zshrc`, a `set` command in Fish, or setting a user environment variable on Windows) to your shell's startup or profile configuration.
+This command only applies to the current terminal session. If you want the key to be available in future sessions on a local, trusted machine, you can configure it permanently in your shell:
+- **Bash / Zsh:** Add `export OPENAI_API_KEY="your-key"` to your shell profile (e.g., `~/.bashrc` or `~/.zshrc`).
+- **Fish:** Add `set -gx OPENAI_API_KEY "your-key"` to your `~/.config/fish/config.fish` file.
+- **Windows (PowerShell):** Set a user environment variable through your system settings.
+
+**Security Best Practice:** Never commit API keys or hardcode secrets into source control. For long-term storage or production use, prefer utilizing a dedicated secret manager or your operating system's secure credential keychain.
 
 Then navigate to the example directory, run the eval, and view results:
 

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -18,25 +18,25 @@ After [installing](/docs/installation) promptfoo, you can set up your first conf
 
 Set up your first config file with a pre-built example by running this command with [npx](https://nodejs.org/en/download), [npm](https://nodejs.org/en/download), or [brew](https://brew.sh/):
 
-  <Tabs groupId="promptfoo-command">
-    <TabItem value="npx" label="npx" default>
-      ```bash
-      npx promptfoo@latest init --example getting-started
-      ```
-    </TabItem>
-    <TabItem value="npm" label="npm">
-      ```bash
-      npm install -g promptfoo
-      promptfoo init --example getting-started
-      ```
-    </TabItem>
-    <TabItem value="brew" label="brew">
-      ```bash
-      brew install promptfoo
-      promptfoo init --example getting-started
-      ```
-    </TabItem>
-  </Tabs>
+<Tabs groupId="promptfoo-command">
+  <TabItem value="npx" label="npx" default>
+    ```bash
+    npx promptfoo@latest init --example getting-started
+    ```
+  </TabItem>
+  <TabItem value="npm" label="npm">
+    ```bash
+    npm install -g promptfoo
+    promptfoo init --example getting-started
+    ```
+  </TabItem>
+  <TabItem value="brew" label="brew">
+    ```bash
+    brew install promptfoo
+    promptfoo init --example getting-started
+    ```
+  </TabItem>
+</Tabs>
 
 This will create a new directory with a [basic example](https://github.com/promptfoo/promptfoo/tree/main/examples/getting-started) that tests translation prompts across different models. The example includes:
 
@@ -50,6 +50,7 @@ export OPENAI_API_KEY=sk-abc123
 ```
 
 This command only applies to the current terminal session. If you want the key to be available in future sessions on a local, trusted machine, you can configure it permanently in your shell:
+
 - **Bash / Zsh (macOS / Linux):** Add `export OPENAI_API_KEY="your-key"` to your profile file (such as `~/.zshrc`, `~/.bash_profile`, or `~/.bashrc`).
 - **Fish:** Run `set -U -gx OPENAI_API_KEY "your-key"` to set a universal variable, or add it to your `~/.config/fish/config.fish` file.
 - **Windows (PowerShell):** Run `[Environment]::SetEnvironmentVariable("OPENAI_API_KEY", "your-key", "User")` to set a persistent user-level environment variable.
@@ -130,7 +131,7 @@ If you prefer a visual interface, run `promptfoo eval setup` to configure your f
 
 This opens a browser-based setup flow that walks you through creating prompts, choosing providers, and adding test cases.
 
-<div style={{ textAlign: 'center' }}>   
+<div style={{ textAlign: 'center' }}>
   <img src="/img/docs/eval-setup.png" alt="Promptfoo eval setup Web UI" style={{ width: '80%' }} />
 </div>
 
@@ -196,14 +197,14 @@ Now that you've created an initial configuration, you can update `promptfooconfi
        ```
      </TabItem>
      <TabItem value="npm" label="npm">
-      ```bash
-      promptfoo eval
-      ```
+       ```bash
+       promptfoo eval
+       ```
      </TabItem>
      <TabItem value="brew" label="brew">
-      ```bash
-      promptfoo eval
-      ```
+       ```bash
+       promptfoo eval
+       ```
      </TabItem>
    </Tabs>
 

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -49,6 +49,8 @@ Most providers need authentication. For OpenAI:
 export OPENAI_API_KEY=sk-abc123
 ```
 
+This export only applies to the current terminal session. If you want the key to be available in future sessions on a local, trusted machine, you can add the same export line to your shell's startup file (for example, your shell profile or rc file). Avoid committing it to source control, and consider a secret manager or your operating system's keychain for longer-term secret storage.
+
 Then navigate to the example directory, run the eval, and view results:
 
 <Tabs groupId="promptfoo-command">

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -50,11 +50,13 @@ export OPENAI_API_KEY=sk-abc123
 ```
 
 This command only applies to the current terminal session. If you want the key to be available in future sessions on a local, trusted machine, you can configure it permanently in your shell:
-- **Bash / Zsh:** Add `export OPENAI_API_KEY="your-key"` to your shell profile (e.g., `~/.bashrc` or `~/.zshrc`).
-- **Fish:** Add `set -gx OPENAI_API_KEY "your-key"` to your `~/.config/fish/config.fish` file.
-- **Windows (PowerShell):** Set a user environment variable through your system settings.
+- **Bash / Zsh (macOS / Linux):** Add `export OPENAI_API_KEY="your-key"` to your profile file (such as `~/.zshrc`, `~/.bash_profile`, or `~/.bashrc`).
+- **Fish:** Run `set -U -gx OPENAI_API_KEY "your-key"` to set a universal variable, or add it to your `~/.config/fish/config.fish` file.
+- **Windows (PowerShell):** Run `[Environment]::SetEnvironmentVariable("OPENAI_API_KEY", "your-key", "User")` to set a persistent user-level environment variable.
 
-**Security Best Practice:** Never commit API keys or hardcode secrets into source control. For long-term storage or production use, prefer utilizing a dedicated secret manager or your operating system's secure credential keychain.
+:::caution
+Never commit API keys or hardcode secrets into source control. For long-term storage or production use, prefer utilizing a dedicated secret manager or your operating system's secure credential keychain.
+:::
 
 Then navigate to the example directory, run the eval, and view results:
 

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -52,7 +52,7 @@ export OPENAI_API_KEY=sk-abc123
 This command only applies to the current terminal session. If you want the key to be available in future sessions on a local, trusted machine, you can configure it permanently in your shell:
 
 - **Bash / Zsh (macOS / Linux):** Add `export OPENAI_API_KEY="your-key"` to your profile file (such as `~/.zshrc`, `~/.bash_profile`, or `~/.bashrc`).
-- **Fish:** Run `set -U -gx OPENAI_API_KEY "your-key"` to set a universal variable, or add it to your `~/.config/fish/config.fish` file.
+- **Fish:** Run `set -Ux OPENAI_API_KEY "your-key"` to set a universal exported variable, or add `set -gx OPENAI_API_KEY "your-key"` to your `~/.config/fish/config.fish` file.
 - **Windows (PowerShell):** Run `[Environment]::SetEnvironmentVariable("OPENAI_API_KEY", "your-key", "User")` to set a persistent user-level environment variable.
 
 :::caution


### PR DESCRIPTION
Summary
This PR clarifies how OPENAI_API_KEY environment variable persistence works in the Getting Started guide.

What changed
Added guidance that export OPENAI_API_KEY=... only applies to the current terminal session.
Added instructions for making the variable available in future sessions on a local, trusted machine (shell startup file).
Added security guidance to avoid committing secrets and to prefer a secret manager or OS keychain for long-term storage.
Why
This reduces confusion for new users who expect environment variables to persist across terminal sessions, while reinforcing safe secret-handling practices.

Scope
Documentation-only change in:

[getting-started.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)