### PR TITLE
feat(eval): show Wilson 95% CI on the pass-rate summary line

### DIFF
--- a/src/util/eval/passRateStats.ts
+++ b/src/util/eval/passRateStats.ts
@@ -1,0 +1,36 @@
+/**
+ * Statistics for pass rates.
+ *
+ * An observed pass rate is a point estimate: 17/20 passing says something very
+ * different from 850/1000 passing, even though both round to 85%. The Wilson
+ * score interval quantifies that difference without assuming large samples,
+ * and behaves sensibly at 0% and 100% (where the naive normal interval
+ * collapses to zero width).
+ */
+
+/**
+ * Wilson score confidence interval for a binomial proportion.
+ *
+ * @param passes - Number of successes (0 <= passes <= total)
+ * @param total - Number of trials
+ * @param z - Standard-normal quantile for the confidence level (default 1.959964 ≈ 95%)
+ * @returns Lower and upper bounds of the interval, as proportions in [0, 1]
+ */
+export function wilsonInterval(
+  passes: number,
+  total: number,
+  z: number = 1.9599639845400545,
+): { low: number; high: number } {
+  if (total <= 0 || passes < 0 || passes > total) {
+    return { low: 0, high: 1 };
+  }
+  const p = passes / total;
+  const z2 = z * z;
+  const denominator = 1 + z2 / total;
+  const center = (p + z2 / (2 * total)) / denominator;
+  const half = (z * Math.sqrt((p * (1 - p)) / total + z2 / (4 * total * total))) / denominator;
+  return {
+    low: Math.max(0, center - half),
+    high: Math.min(1, center + half),
+  };
+}

--- a/src/util/eval/summary.ts
+++ b/src/util/eval/summary.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { formatDuration } from '../../util/formatDuration';
+import { wilsonInterval } from './passRateStats';
 
 import type { TokenUsage } from '../../types/index';
 import type { TokenUsageTracker } from '../../util/tokenUsage';
@@ -278,6 +279,11 @@ function formatResultLine(
   )} ${chalk.gray(`(${formatResultPercentage(count, totalTests)})`)}`;
 }
 
+function formatPassRateInterval(successes: number, totalTests: number): string {
+  const { low, high } = wilsonInterval(successes, totalTests);
+  return `95% CI ${(low * 100).toFixed(1)}–${(high * 100).toFixed(1)}%`;
+}
+
 function getResultsLines({
   successes,
   failures,
@@ -288,10 +294,22 @@ function getResultsLines({
   const totalTests = successes + failures + errors;
   const errorLabel = errors === 1 ? 'error' : 'errors';
 
+  const passedLine =
+    totalTests > 0
+      ? `  ${successes > 0 ? `${chalk.green('✓')} ` : ''}${chalk.white.bold(
+          successes.toLocaleString(),
+        )} ${chalk.white('passed')} ${chalk.gray(
+          `(${formatResultPercentage(successes, totalTests)}; ${formatPassRateInterval(
+            successes,
+            totalTests,
+          )})`,
+        )}`
+      : formatResultLine(successes, 'passed', undefined, chalk.green, totalTests);
+
   return [
     '',
     chalk.bold('Results:'),
-    formatResultLine(successes, 'passed', successes > 0 ? '✓' : undefined, chalk.green, totalTests),
+    passedLine,
     formatResultLine(failures, 'failed', failures > 0 ? '✗' : undefined, chalk.red, totalTests),
     formatResultLine(errors, errorLabel, errors > 0 ? '✗' : undefined, chalk.red, totalTests),
     chalk.gray(`Duration: ${formatDuration(duration)} (concurrency: ${maxConcurrency})`),

--- a/test/util/eval/passRateStats.test.ts
+++ b/test/util/eval/passRateStats.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { wilsonInterval } from '../../../src/util/eval/passRateStats';
+
+// Reference values computed with statsmodels' proportion_confint(method="wilson")
+// at alpha=0.05.
+describe('wilsonInterval', () => {
+  it('matches the reference implementation', () => {
+    const cases: Array<[number, number, number, number]> = [
+      [85, 100, 0.7671644040916763, 0.9069401471634337],
+      [1, 3, 0.06149194472039626, 0.7923403991979523],
+      [17, 20, 0.639581135259243, 0.9476312541037833],
+    ];
+    for (const [passes, total, low, high] of cases) {
+      const interval = wilsonInterval(passes, total);
+      expect(interval.low).toBeCloseTo(low, 9);
+      expect(interval.high).toBeCloseTo(high, 9);
+    }
+  });
+
+  it('behaves sensibly at the boundaries where the naive interval collapses', () => {
+    const allFail = wilsonInterval(0, 10);
+    expect(allFail.low).toBe(0);
+    expect(allFail.high).toBeCloseTo(0.27753279986288926, 9);
+
+    const allPass = wilsonInterval(10, 10);
+    expect(allPass.low).toBeCloseTo(0.7224672001371106, 9);
+    expect(allPass.high).toBe(1);
+  });
+
+  it('narrows as the sample grows at the same pass rate', () => {
+    const small = wilsonInterval(17, 20);
+    const large = wilsonInterval(850, 1000);
+    expect(large.high - large.low).toBeLessThan(small.high - small.low);
+  });
+
+  it('returns the uninformative interval for invalid inputs', () => {
+    expect(wilsonInterval(0, 0)).toEqual({ low: 0, high: 1 });
+    expect(wilsonInterval(-1, 10)).toEqual({ low: 0, high: 1 });
+    expect(wilsonInterval(11, 10)).toEqual({ low: 0, high: 1 });
+  });
+});

--- a/test/util/eval/summary.test.ts
+++ b/test/util/eval/summary.test.ts
@@ -476,7 +476,7 @@ describe('generateEvalSummary', () => {
       const plainOutput = stripAnsi(lines.join('\n'));
 
       expect(plainOutput).toContain('Results:');
-      expect(plainOutput).toContain('10 passed (100%)');
+      expect(plainOutput).toContain('10 passed (100%; 95% CI 72.2–100.0%)');
       expect(plainOutput).toContain('0 failed (0%)');
       expect(plainOutput).toContain('0 errors (0%)');
     });
@@ -503,7 +503,7 @@ describe('generateEvalSummary', () => {
       const plainOutput = stripAnsi(lines.join('\n'));
 
       expect(plainOutput).toContain('Results:');
-      expect(plainOutput).toContain('17 passed (85.00%)');
+      expect(plainOutput).toContain('17 passed (85.00%; 95% CI 64.0–94.8%)');
       expect(plainOutput).toContain('3 failed (15.00%)');
       expect(plainOutput).toContain('0 errors (0%)');
     });
@@ -530,7 +530,7 @@ describe('generateEvalSummary', () => {
       const plainOutput = stripAnsi(lines.join('\n'));
 
       expect(plainOutput).toContain('Results:');
-      expect(plainOutput).toContain('5 passed (50.00%)');
+      expect(plainOutput).toContain('5 passed (50.00%; 95% CI 23.7–76.3%)');
       expect(plainOutput).toContain('5 failed (50.00%)');
       expect(plainOutput).toContain('0 errors (0%)');
     });
@@ -559,7 +559,7 @@ describe('generateEvalSummary', () => {
       const hasLineMatching = (pattern: RegExp) => outputLines.some((line) => pattern.test(line));
 
       expect(plainOutput).toContain('Results:');
-      expect(hasLineMatching(/^\s*(✓\s+)?8 passed \(80\.00%\)$/)).toBe(true);
+      expect(hasLineMatching(/^\s*(✓\s+)?8 passed \(80\.00%; 95% CI 49\.0–94\.3%\)$/)).toBe(true);
       expect(hasLineMatching(/^\s*(✗\s+)?1 failed \(10\.00%\)$/)).toBe(true);
       expect(hasLineMatching(/^\s*(✗\s+)?1 error \(10\.00%\)$/)).toBe(true);
       expect(plainOutput).not.toContain('1 errors');
@@ -586,7 +586,7 @@ describe('generateEvalSummary', () => {
       const lines = generateEvalSummary(params);
 
       expect(lines).toContain(
-        `  ${chalk.green('✓')} ${chalk.white.bold('8')} ${chalk.white('passed')} ${chalk.gray('(80.00%)')}`,
+        `  ${chalk.green('✓')} ${chalk.white.bold('8')} ${chalk.white('passed')} ${chalk.gray('(80.00%; 95% CI 49.0–94.3%)')}`,
       );
       expect(lines).toContain(
         `  ${chalk.red('✗')} ${chalk.white.bold('1')} ${chalk.white('failed')} ${chalk.gray('(10.00%)')}`,


### PR DESCRIPTION
## Why

An observed pass rate is a point estimate: 17/20 and 850/1000 both print 85%, but they support very different conclusions about whether a prompt change actually helped. promptfoo currently reports pass rates as bare percentages everywhere; there is no statistical machinery in the repo (every `stderr` hit is process plumbing).

## What

The eval summary's passed line now carries a **Wilson score interval**:

```
Results:
  ✓ 17 passed (85.00%; 95% CI 64.0–94.8%)
  ✗ 3 failed (15.00%)
```

Wilson rather than the naive normal interval because it stays honest at the boundaries where users most need it: `5 passed (100%; 95% CI 56.6–100.0%)` tells the user that five tests cannot prove a prompt is fixed, where the naive interval would collapse to ±0.

- `src/util/eval/passRateStats.ts` — `wilsonInterval()`, closed form, **no new dependencies**.
- `summary.ts` — only the passed line changes; failed/error lines untouched.
- Tests: parity at 1e-9 against statsmodels' `proportion_confint(method="wilson")`, boundary behavior (0%, 100%), monotonic narrowing with sample size, invalid-input guard. Existing summary assertions updated to the new format.

Ran with `LC_ALL=en_US.UTF-8`: the only failures in `test/util/eval/summary.test.ts` are 6 pre-existing locale-dependent `toLocaleString` assertions that fail identically on the untouched base (Finnish-locale machine renders `1 000`); all new and touched assertions pass.

## Follow-up I'd like your opinion on

Since the same test set runs against every prompt, A-vs-B prompt comparisons are **paired by construction** — an exact McNemar test on the discordant counts would say whether "prompt B beats prompt A" is signal or noise, which point-estimate pass rates can't. I have the math ready (same reference-implementation parity approach); the open question is where you'd want the paired data pulled from (the results table vs. a direct query). Happy to send that as a second PR if the direction is welcome.