### PR TITLE
fix(openai): handle empty image responses

### DIFF
--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -578,15 +578,17 @@ export function formatOutput(
   responseFormat?: string,
   outputFormat?: string,
 ): string | { error: string } {
+  const image = Array.isArray(data.data) ? data.data[0] : undefined;
+
   if (responseFormat === 'b64_json') {
-    const b64Json = data.data[0].b64_json;
+    const b64Json = image?.b64_json;
     if (!b64Json) {
       return { error: `No base64 image data found in response: ${JSON.stringify(data)}` };
     }
 
     return `data:${getMimeTypeForOutputFormat(outputFormat)};base64,${b64Json}`;
   } else {
-    const url = data.data[0].url;
+    const url = image?.url;
     if (!url) {
       return { error: `No image URL found in response: ${JSON.stringify(data)}` };
     }

--- a/test/providers/openai/image.functions.test.ts
+++ b/test/providers/openai/image.functions.test.ts
@@ -132,11 +132,43 @@ describe('OpenAI Image Provider Functions', () => {
       expect(result).toHaveProperty('error');
     });
 
+    it('should return error when URL response data array is empty', () => {
+      const data = { data: [] };
+      const result = formatOutput(data, 'prompt');
+      expect(result).toEqual({
+        error: `No image URL found in response: ${JSON.stringify(data)}`,
+      });
+    });
+
+    it('should return error when URL response data field is missing', () => {
+      const data = { created: 123 };
+      const result = formatOutput(data, 'prompt');
+      expect(result).toEqual({
+        error: `No image URL found in response: ${JSON.stringify(data)}`,
+      });
+    });
+
     it('should return error when base64 data is missing', () => {
       const data = { data: [{}] };
       const result = formatOutput(data, 'prompt', 'b64_json');
       expect(typeof result).toBe('object');
       expect(result).toHaveProperty('error');
+    });
+
+    it('should return error when base64 response data array is empty', () => {
+      const data = { data: [] };
+      const result = formatOutput(data, 'prompt', 'b64_json');
+      expect(result).toEqual({
+        error: `No base64 image data found in response: ${JSON.stringify(data)}`,
+      });
+    });
+
+    it('should return error when base64 response data field is missing', () => {
+      const data = { created: 123 };
+      const result = formatOutput(data, 'prompt', 'b64_json');
+      expect(result).toEqual({
+        error: `No base64 image data found in response: ${JSON.stringify(data)}`,
+      });
     });
   });
 
@@ -588,9 +620,8 @@ describe('OpenAI Image Provider Functions', () => {
       );
 
       expect(result).toHaveProperty('error');
-      expect(result.error).toContain('API error: TypeError');
-      expect(result.error).toContain('Cannot read properties of undefined');
-      expect(mockDeleteFromCache).toHaveBeenCalledWith();
+      expect(result.error).toContain('No image URL found in response');
+      expect(mockDeleteFromCache).not.toHaveBeenCalled();
     });
 
     it('should handle a specific error case with malformed response', async () => {
@@ -611,8 +642,8 @@ describe('OpenAI Image Provider Functions', () => {
       );
 
       expect(result).toHaveProperty('error');
-      expect(result.error).toContain('API error:');
-      expect(mockDeleteFromCache).toHaveBeenCalledWith();
+      expect(result.error).toContain('No image URL found in response');
+      expect(mockDeleteFromCache).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Fixes #10262.

OpenAI image responses with an empty or malformed `data` field previously threw an opaque TypeError while formatting output. This now safely returns the existing descriptive “No image URL/base64 image data found in response” errors.

Tested with:

```sh
node node_modules/vitest/vitest.mjs run test/providers/openai/image.functions.test.ts
```


---

**Updated after merging `main` (2026-09-15):** nothing here was superseded. `formatOutput` in `src/providers/openai/image.ts` is still unguarded on `main`, so the 6-line null-safe change in this PR is still the entire production diff. Net diff against `main` today:

```
 src/providers/openai/image.ts                 |  6 ++-
 test/providers/openai/image.functions.test.ts | 64 +++++++++++++++++++++++++--
 test/providers/openai/image.test.ts           | 15 +++++--
```

One behavioral consequence worth flagging for review, which isn't mentioned above: because `formatOutput` now returns an error object instead of throwing, `processApiResponse` no longer reaches its `catch` block for a 200 whose `data` array is empty or missing, and therefore no longer calls `deleteFromCache()` for that response. Eviction on a genuine parse failure is unaffected.

This PR already updated the two affected expectations in `test/providers/openai/image.functions.test.ts`. A follow-up commit pushed to this branch (`700197b8`) updates the third, pre-existing one — `should handle deleteFromCache when response parsing fails` in `test/providers/openai/image.test.ts`, which was still asserting the old eviction and is not covered by the `image.functions.test.ts` command quoted above — and adds direct coverage so that eviction on a real parse failure stays tested.

All 147 tests across `test/providers/openai/image.test.ts` and `test/providers/openai/image.functions.test.ts` pass on the merged branch, and CI is green.
