### PR TITLE
fix(deps): hold jsdom below the release our Node floor cannot install

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -219,8 +219,9 @@
       "groupName": "socket.io"
     },
     {
-      "description": "Keep jsdom in sync across all workspaces",
+      "description": "Keep jsdom in sync across all workspaces, and hold it below 30. jsdom 30 requires node ^22.22.2 || ^24.15.0 || >=26.0.0, but this package publishes engines.node >=22.22.0 and .npmrc sets engine-strict=true, so `npm ci` fails EBADENGINE on the Node 22.22.0 lanes that exist precisely to test that floor (see the closed #10311). jsdom is a dev-only Vitest environment, so raising the published runtime floor for it would make promptfoo refuse to start on Node 22.22.0/22.22.1 for no user-facing gain. Lift this cap when engines.node moves past 22.22.2 for an independent reason.",
       "matchPackageNames": ["jsdom"],
+      "allowedVersions": "<30",
       "groupName": "jsdom"
     },
     {

--- a/src/app/src/pages/eval/components/ResultsTable.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.test.tsx
@@ -3169,7 +3169,7 @@ describe('ResultsTable Filtered Metrics Display', () => {
 
     const filteredCostElement = screen.getByText('($0.6173 filtered)');
     expect(filteredCostElement).toBeInTheDocument();
-    expect(filteredCostElement).toHaveStyle('font-size: 0.9em');
+    expect(filteredCostElement.style.fontSize).toBe('0.9em');
     expect(filteredCostElement).toHaveStyle('color: #666');
     expect(filteredCostElement).toHaveStyle('margin-left: 4px');
 
@@ -3178,7 +3178,7 @@ describe('ResultsTable Filtered Metrics Display', () => {
 
     const filteredTokensElement = screen.getByText('(500 filtered)');
     expect(filteredTokensElement).toBeInTheDocument();
-    expect(filteredTokensElement).toHaveStyle('font-size: 0.9em');
+    expect(filteredTokensElement.style.fontSize).toBe('0.9em');
     expect(filteredTokensElement).toHaveStyle('color: #666');
     expect(filteredTokensElement).toHaveStyle('margin-left: 4px');
 
@@ -3187,7 +3187,7 @@ describe('ResultsTable Filtered Metrics Display', () => {
     expect(screen.getByLabelText('200 ms')).toBeInTheDocument();
     const filteredLatencyElement = screen.getByText('(200ms filtered)');
     expect(filteredLatencyElement).toBeInTheDocument();
-    expect(filteredLatencyElement).toHaveStyle('font-size: 0.9em');
+    expect(filteredLatencyElement.style.fontSize).toBe('0.9em');
   });
 });
 

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -218,6 +218,45 @@ describe('package manifests', () => {
     ).toBe(true);
   });
 
+  it('keeps jsdom on a release the supported Node floor can install', () => {
+    const rootPackageJson = readPackageJson<PackageManifest & { engines?: Record<string, string> }>(
+      'package.json',
+    );
+    const renovateConfig = readPackageJson<{
+      packageRules?: Array<{
+        allowedVersions?: string;
+        matchPackageNames?: string[];
+      }>;
+    }>('renovate.json');
+    // jsdom 30 requires node ^22.22.2 || ^24.15.0 || >=26.0.0. With engine-strict=true and a
+    // published floor of >=22.22.0, `npm ci` fails EBADENGINE on the Node 22.22.0 lanes that
+    // exist to test that floor. jsdom is a dev-only Vitest environment, so the cap moves only
+    // after engines.node does.
+    const nodeFloor = minVersion(rootPackageJson.engines?.node as string);
+    const jsdomCap = renovateConfig.packageRules?.find((rule) =>
+      rule.matchPackageNames?.includes('jsdom'),
+    )?.allowedVersions;
+
+    expect(nodeFloor, 'the root manifest must declare a Node floor').toBeDefined();
+
+    if (nodeFloor!.compare('22.22.2') < 0) {
+      expect(
+        jsdomCap,
+        'Renovate must hold jsdom below 30 while the Node floor is below 22.22.2',
+      ).toBe('<30');
+
+      for (const manifestPath of ['src/app/package.json', 'site/package.json']) {
+        const range = readPackageJson<PackageManifest>(manifestPath).devDependencies?.jsdom;
+
+        expect(range, `${manifestPath} must declare jsdom`).toBeDefined();
+        expect(
+          satisfies('30.0.0', range as string),
+          `${manifestPath} resolves a jsdom the Node floor cannot install`,
+        ).toBe(false);
+      }
+    }
+  });
+
   it('keeps CLI smoke tests on the real unsupported and minimum-supported Node releases', () => {
     const workflow = fs.readFileSync(
       path.join(process.cwd(), '.github/workflows/main.yml'),


### PR DESCRIPTION
## Summary

Renovate keeps proposing jsdom 30 (#10311), and it cannot land as-is.

jsdom 30 declares `engines.node: ^22.22.2 || ^24.15.0 || >=26.0.0`. This package publishes `engines.node: ">=22.22.0"`, `.npmrc` sets `engine-strict=true`, and `.github/workflows/main.yml` deliberately installs **exactly** 22.22.0 on five lanes so they test the declared floor rather than the latest 22.22.x. The result is a hard `npm ci` failure before any test runs:

```
npm error code EBADENGINE
npm error engine Not compatible with your version of node/npm: jsdom@30.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"node":"v22.22.0","npm":"11.11.0"}
```

jsdom is a dev-only Vitest environment. Clearing this by raising the published floor would make `promptfoo` refuse to start on Node 22.22.0/22.22.1 — `src/entrypoint.ts` hard-errors below `engines.node` — for a package that never reaches users. So the cap is the right side to move.

- Cap Renovate at `<30` on the existing jsdom rule, with the reason inline.
- Assert the cap holds **while** the floor is below 22.22.2, so it lifts on its own once `engines.node` moves for an independent reason instead of becoming a stale pin nobody remembers.

## Also: a jsdom-version-independent test fix

jsdom 30 fixed `getComputedStyle()` to resolve lengths into pixels, so `toHaveStyle('font-size: 0.9em')` reports `10.8px` there and `ResultsTable.test.tsx` fails. Asserting the declared inline style is what the component actually promises (`<span style={{ fontSize: '0.9em', ... }}>`) and holds on either version, so that lands here rather than waiting on the bump.

## Validation

- `npx vitest run test/package-manifests.test.ts` — 30 passed
- Guard verified negatively: dropping `allowedVersions` fails with `Renovate must hold jsdom below 30 while the Node floor is below 22.22.2`
- `npx vitest run --root src/app src/pages/eval/components/ResultsTable.test.tsx` — passes on the installed jsdom 29.0.2
- `renovate-config-validator renovate.json` — `Config validated successfully`