### PR TITLE
fix(providers): future-proof Claude sampling parameters

### DIFF
--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -249,6 +249,18 @@ function withMergedAnthropicUsage(
   return usage ? { ...response, usage } : response;
 }
 
+function isOfficialAnthropicApiBaseUrl(apiBaseUrl: string | undefined): boolean {
+  if (!apiBaseUrl) {
+    return true;
+  }
+
+  try {
+    return new URL(apiBaseUrl).hostname === 'api.anthropic.com';
+  } catch {
+    return false;
+  }
+}
+
 function getAnthropicCostFromMessage(
   modelName: string,
   config: AnthropicMessageOptions,
@@ -722,7 +734,10 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
     // (`thinking: { type: 'enabled', budget_tokens }`) returns a 400. Keep this
     // capability separate from the forward-looking sampling-parameter fallback:
     // a new family may reject sampling controls before its thinking behavior is known.
-    const samplingParamsDeprecated = isSamplingParamsDeprecatedClaudeModel(this.modelName);
+    const samplingParamsDeprecated = isSamplingParamsDeprecatedClaudeModel(this.modelName, {
+      // Anthropic-compatible gateways may use arbitrary routing aliases rather than model IDs.
+      allowUnknownFamilyFallback: isOfficialAnthropicApiBaseUrl(this.getApiBaseUrl()),
+    });
     const manualThinkingDeprecated = isManualThinkingDeprecatedClaudeModel(this.modelName);
     const alwaysOnAdaptiveThinking = isAlwaysOnAdaptiveThinkingClaudeModel(this.modelName);
     const modelWarningName = getClaudeModelWarningName(this.modelName) ?? 'this Claude model';

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -297,6 +297,15 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
   // their model ids don't trigger the unknown-Anthropic-model warning.
   static readonly WARNS_ON_UNKNOWN_MODEL: boolean = true;
 
+  /**
+   * Whether this provider's model name is authoritative enough for the forward-looking Claude 5+
+   * sampling fallback. Compatible gateways may use arbitrary aliases; forwarding providers can
+   * override this when they preserve the upstream Anthropic model ID.
+   */
+  protected usesAuthoritativeModelIds(): boolean {
+    return isOfficialAnthropicApiBaseUrl(this.getApiBaseUrl());
+  }
+
   constructor(
     modelName: string,
     options: { id?: string; config?: AnthropicMessageOptions; env?: EnvOverrides } = {},
@@ -735,8 +744,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
     // capability separate from the forward-looking sampling-parameter fallback:
     // a new family may reject sampling controls before its thinking behavior is known.
     const samplingParamsDeprecated = isSamplingParamsDeprecatedClaudeModel(this.modelName, {
-      // Anthropic-compatible gateways may use arbitrary routing aliases rather than model IDs.
-      allowUnknownFamilyFallback: isOfficialAnthropicApiBaseUrl(this.getApiBaseUrl()),
+      allowUnknownFamilyFallback: this.usesAuthoritativeModelIds(),
     });
     const manualThinkingDeprecated = isManualThinkingDeprecatedClaudeModel(this.modelName);
     const alwaysOnAdaptiveThinking = isAlwaysOnAdaptiveThinkingClaudeModel(this.modelName);

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -32,6 +32,7 @@ import {
   getTokenUsage,
   isAlwaysOnAdaptiveThinkingClaudeModel,
   isDisabledThinkingRejectedAtEffort,
+  isManualThinkingDeprecatedClaudeModel,
   isSamplingParamsDeprecatedClaudeModel,
   normalizeAnthropicModelName,
   normalizeClaudeThinkingConfig,
@@ -583,7 +584,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
     requested: Anthropic.Messages.ThinkingConfigParam | undefined,
     effort: ClaudeEffort | undefined,
     flags: {
-      samplingParamsDeprecated: boolean;
+      manualThinkingDeprecated: boolean;
       alwaysOnAdaptiveThinking: boolean;
       modelWarningName: string;
     },
@@ -602,9 +603,9 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
      */
     thinkingConsumesTokens: boolean;
   } {
-    const { samplingParamsDeprecated, alwaysOnAdaptiveThinking, modelWarningName } = flags;
+    const { manualThinkingDeprecated, alwaysOnAdaptiveThinking, modelWarningName } = flags;
 
-    if (samplingParamsDeprecated && requested?.type === 'enabled') {
+    if (manualThinkingDeprecated && requested?.type === 'enabled') {
       if (!this.manualThinkingConversionWarned) {
         logger.warn(
           alwaysOnAdaptiveThinking
@@ -717,11 +718,12 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
       context?.vars,
     );
 
-    // Newer Claude models are adaptive-only — manual budget-based thinking
-    // (`thinking: { type: 'enabled', budget_tokens }`) returns a 400. Translate a
-    // migrated Opus 4.6 config to adaptive thinking so it keeps working; effort
-    // controls reasoning depth on these models.
+    // Some newer Claude models are adaptive-only — manual budget-based thinking
+    // (`thinking: { type: 'enabled', budget_tokens }`) returns a 400. Keep this
+    // capability separate from the forward-looking sampling-parameter fallback:
+    // a new family may reject sampling controls before its thinking behavior is known.
     const samplingParamsDeprecated = isSamplingParamsDeprecatedClaudeModel(this.modelName);
+    const manualThinkingDeprecated = isManualThinkingDeprecatedClaudeModel(this.modelName);
     const alwaysOnAdaptiveThinking = isAlwaysOnAdaptiveThinkingClaudeModel(this.modelName);
     const modelWarningName = getClaudeModelWarningName(this.modelName) ?? 'this Claude model';
     const {
@@ -732,7 +734,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
       // Provider config wins over a thinking block embedded in the prompt.
       config.thinking ?? thinking,
       config.effort,
-      { samplingParamsDeprecated, alwaysOnAdaptiveThinking, modelWarningName },
+      { manualThinkingDeprecated, alwaysOnAdaptiveThinking, modelWarningName },
     );
 
     // Validate and warn about thinking-incompatible params. Skip when the model

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -197,9 +197,11 @@ const CLAUDE_OPUS_48_PATTERN = /(^|[^a-z0-9])claude-opus-4-8(?![0-9])/i;
 const CLAUDE_OPUS_47_PATTERN = /(^|[^a-z0-9])claude-opus-4-7(?![0-9])/i;
 // Anthropic deprecates non-default sampling controls on models released after Opus 4.6. Keep a
 // forward-compatible fallback for Claude 5+ family names so providers do not send rejected
-// parameters while waiting for a model-specific capability row.
+// parameters while waiting for a model-specific capability row. Limit the generation token to
+// one or two digits so date-stamped deployment aliases (for example, `claude-prod-20260811`) are
+// not mistaken for future Claude generations.
 const CLAUDE_5_OR_LATER_PATTERN =
-  /(^|[^a-z0-9])claude-[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*-(?:[5-9]|[1-9][0-9]+)(?![a-z0-9])/i;
+  /(^|[^a-z0-9])claude-[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*-(?:[5-9]|[1-9][0-9])(?![a-z0-9])/i;
 // Opus/Sonnet 4.5 and 4.6, and Haiku 4.5 — regional premium only (no other deprecations).
 const CLAUDE_4_5_AND_4_6_REGIONAL_PREMIUM_PATTERN =
   /(^|[^a-z0-9])claude-(?:opus|sonnet|haiku)-4-(?:5|6)(?![0-9])/i;
@@ -211,6 +213,8 @@ interface ClaudeModelFamily {
   warningName?: string;
   /** Rejects `temperature`/`top_p`/`top_k` at the model level (the API returns 400). */
   samplingParamsDeprecated?: boolean;
+  /** Rejects manual budget thinking (`thinking.type: 'enabled'`) in favor of adaptive thinking. */
+  manualThinkingDeprecated?: boolean;
   /** Thinking is always on; `thinking: { type: 'disabled' }` is rejected. */
   alwaysOnAdaptiveThinking?: boolean;
   /**
@@ -240,6 +244,7 @@ const CLAUDE_MODEL_FAMILIES: readonly ClaudeModelFamily[] = [
     match: CLAUDE_FABLE_MYTHOS_5_PATTERN,
     warningName: 'Claude Fable 5 and Claude Mythos 5',
     samplingParamsDeprecated: true,
+    manualThinkingDeprecated: true,
     alwaysOnAdaptiveThinking: true,
     regionalPremium: true,
   },
@@ -249,6 +254,7 @@ const CLAUDE_MODEL_FAMILIES: readonly ClaudeModelFamily[] = [
     match: CLAUDE_OPUS_5_PATTERN,
     warningName: 'Claude Opus 5',
     samplingParamsDeprecated: true,
+    manualThinkingDeprecated: true,
     thinkingOnByDefault: true,
     disabledThinkingEffortCapped: true,
     regionalPremium: true,
@@ -257,6 +263,7 @@ const CLAUDE_MODEL_FAMILIES: readonly ClaudeModelFamily[] = [
     match: CLAUDE_SONNET_5_PATTERN,
     warningName: 'Claude Sonnet 5',
     samplingParamsDeprecated: true,
+    manualThinkingDeprecated: true,
     regionalPremium: true,
   },
   // Opus 4.7 and 4.8 share behavior and warning wording.
@@ -264,12 +271,14 @@ const CLAUDE_MODEL_FAMILIES: readonly ClaudeModelFamily[] = [
     match: CLAUDE_OPUS_48_PATTERN,
     warningName: 'Claude Opus 4.7 and 4.8',
     samplingParamsDeprecated: true,
+    manualThinkingDeprecated: true,
     regionalPremium: true,
   },
   {
     match: CLAUDE_OPUS_47_PATTERN,
     warningName: 'Claude Opus 4.7 and 4.8',
     samplingParamsDeprecated: true,
+    manualThinkingDeprecated: true,
     regionalPremium: true,
   },
   { match: CLAUDE_4_5_AND_4_6_REGIONAL_PREMIUM_PATTERN, regionalPremium: true },
@@ -390,6 +399,11 @@ export function isSamplingParamsDeprecatedClaudeModel(modelId: string): boolean 
   );
 }
 
+/** True when the model rejects manual budget thinking and requires adaptive thinking instead. */
+export function isManualThinkingDeprecatedClaudeModel(modelId: string): boolean {
+  return hasClaudeCapability(modelId, 'manualThinkingDeprecated');
+}
+
 /**
  * Normalize a Claude thinking config for models that deprecate manual
  * budget-based thinking: an `enabled` budget converts to adaptive thinking
@@ -407,7 +421,7 @@ export function normalizeClaudeThinkingConfig<
   thinking: T | undefined,
   effort: ClaudeEffort | null | undefined,
 ): T | { type: 'adaptive'; display?: 'summarized' | 'omitted' } | undefined {
-  if (thinking?.type === 'enabled' && isSamplingParamsDeprecatedClaudeModel(modelId)) {
+  if (thinking?.type === 'enabled' && isManualThinkingDeprecatedClaudeModel(modelId)) {
     return { type: 'adaptive', ...(thinking.display ? { display: thinking.display } : {}) };
   }
   if (

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -196,12 +196,12 @@ const CLAUDE_SONNET_5_PATTERN = /(^|[^a-z0-9])claude-sonnet-5(?![a-z0-9])/i;
 const CLAUDE_OPUS_48_PATTERN = /(^|[^a-z0-9])claude-opus-4-8(?![0-9])/i;
 const CLAUDE_OPUS_47_PATTERN = /(^|[^a-z0-9])claude-opus-4-7(?![0-9])/i;
 // Anthropic deprecates non-default sampling controls on models released after Opus 4.6. Keep a
-// forward-compatible fallback for Claude 5+ family names so providers do not send rejected
-// parameters while waiting for a model-specific capability row. Limit the generation token to
-// one or two digits so date-stamped deployment aliases (for example, `claude-prod-20260811`) are
-// not mistaken for future Claude generations.
-const CLAUDE_5_OR_LATER_PATTERN =
-  /(^|[^a-z0-9])claude-[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*-(?:[5-9]|[1-9][0-9])(?![a-z0-9])/i;
+// forward-compatible fallback for post-4.6 Claude 4.x and Claude 5+ family names so providers do
+// not send rejected parameters while waiting for a model-specific capability row. Limit 4.x to
+// the one-digit minors after 4.6, and later major generations to one or two digits, so lookalikes
+// such as `claude-opus-4-80` and date-stamped aliases are not mistaken for future models.
+const CLAUDE_POST_46_OR_5_PLUS_PATTERN =
+  /(^|[^a-z0-9])claude-[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*-(?:4-[7-9]|[5-9]|[1-9][0-9])(?![a-z0-9])/i;
 // Opus/Sonnet 4.5 and 4.6, and Haiku 4.5 — regional premium only (no other deprecations).
 const CLAUDE_4_5_AND_4_6_REGIONAL_PREMIUM_PATTERN =
   /(^|[^a-z0-9])claude-(?:opus|sonnet|haiku)-4-(?:5|6)(?![0-9])/i;
@@ -386,16 +386,16 @@ export function normalizeAnthropicModelName(modelName: string): string {
 }
 
 interface SamplingParamsDeprecationOptions {
-  /** Apply the forward-looking Claude 5+ family matcher to values known to be model IDs. */
+  /** Apply the forward-looking post-4.6 family matcher to values known to be model IDs. */
   allowUnknownFamilyFallback?: boolean;
 }
 
 /**
- * Claude Opus 4.7/4.8 and Claude 5+ models deprecate manual sampling controls at the model
+ * Claude models released after Opus 4.6 deprecate manual sampling controls at the model
  * level — `temperature`, `top_p`, and `top_k` return 400 `invalid_request_error` (including
  * promptfoo's built-in `temperature` default of 0). Shared by the Anthropic, Bedrock, Vertex,
  * and Azure providers. Known families use the capability table above; the generation fallback
- * keeps newly released Claude 5+ family names safe before their model-specific rows land.
+ * keeps newly released post-4.6 family names safe before their model-specific rows land.
  */
 export function isSamplingParamsDeprecatedClaudeModel(
   modelId: string,
@@ -403,7 +403,7 @@ export function isSamplingParamsDeprecatedClaudeModel(
 ): boolean {
   return (
     hasClaudeCapability(modelId, 'samplingParamsDeprecated') ||
-    (allowUnknownFamilyFallback && CLAUDE_5_OR_LATER_PATTERN.test(modelId))
+    (allowUnknownFamilyFallback && CLAUDE_POST_46_OR_5_PLUS_PATTERN.test(modelId))
   );
 }
 

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -385,6 +385,11 @@ export function normalizeAnthropicModelName(modelName: string): string {
   return modelName.replace(/^(?:(?:global|us|eu|jp|au)\.)?anthropic\./, '');
 }
 
+interface SamplingParamsDeprecationOptions {
+  /** Apply the forward-looking Claude 5+ family matcher to values known to be model IDs. */
+  allowUnknownFamilyFallback?: boolean;
+}
+
 /**
  * Claude Opus 4.7/4.8 and Claude 5+ models deprecate manual sampling controls at the model
  * level — `temperature`, `top_p`, and `top_k` return 400 `invalid_request_error` (including
@@ -392,10 +397,13 @@ export function normalizeAnthropicModelName(modelName: string): string {
  * and Azure providers. Known families use the capability table above; the generation fallback
  * keeps newly released Claude 5+ family names safe before their model-specific rows land.
  */
-export function isSamplingParamsDeprecatedClaudeModel(modelId: string): boolean {
+export function isSamplingParamsDeprecatedClaudeModel(
+  modelId: string,
+  { allowUnknownFamilyFallback = true }: SamplingParamsDeprecationOptions = {},
+): boolean {
   return (
     hasClaudeCapability(modelId, 'samplingParamsDeprecated') ||
-    CLAUDE_5_OR_LATER_PATTERN.test(modelId)
+    (allowUnknownFamilyFallback && CLAUDE_5_OR_LATER_PATTERN.test(modelId))
   );
 }
 

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -186,15 +186,20 @@ export const ANTHROPIC_MODELS = [
 
 // Model-ID matchers for each Claude family, across Anthropic, Bedrock (incl. the
 // `us.`/`eu.`/`jp.`/`global.` inference-profile prefixes), Vertex, and Azure deployment
-// names. The leading `(^|[^a-z0-9])` boundary and a trailing lookahead guard (`(?![0-9])`,
-// or `(?![a-z0-9])` for the dateless Fable/Mythos IDs) keep a family from matching a longer
-// neighbor (e.g. `claude-opus-4-80` is not Opus 4.8, and `claude-sonnet-4-5` is not Sonnet 5)
-// while still matching dated snapshots like `claude-opus-4-8-20260528`.
+// names. The leading `(^|[^a-z0-9])` boundary and trailing lookahead guards keep a family
+// from matching a longer neighbor (e.g. `claude-opus-4-80` is not Opus 4.8, and
+// `claude-sonnet-5x` is not Sonnet 5) while still matching dated snapshots like
+// `claude-opus-4-8-20260528`.
 const CLAUDE_FABLE_MYTHOS_5_PATTERN = /(^|[^a-z0-9])claude-(?:fable|mythos)-5(?![a-z0-9])/i;
-const CLAUDE_OPUS_5_PATTERN = /(^|[^a-z0-9])claude-opus-5(?![0-9])/i;
-const CLAUDE_SONNET_5_PATTERN = /(^|[^a-z0-9])claude-sonnet-5(?![0-9])/i;
+const CLAUDE_OPUS_5_PATTERN = /(^|[^a-z0-9])claude-opus-5(?![a-z0-9])/i;
+const CLAUDE_SONNET_5_PATTERN = /(^|[^a-z0-9])claude-sonnet-5(?![a-z0-9])/i;
 const CLAUDE_OPUS_48_PATTERN = /(^|[^a-z0-9])claude-opus-4-8(?![0-9])/i;
 const CLAUDE_OPUS_47_PATTERN = /(^|[^a-z0-9])claude-opus-4-7(?![0-9])/i;
+// Anthropic deprecates non-default sampling controls on models released after Opus 4.6. Keep a
+// forward-compatible fallback for Claude 5+ family names so providers do not send rejected
+// parameters while waiting for a model-specific capability row.
+const CLAUDE_5_OR_LATER_PATTERN =
+  /(^|[^a-z0-9])claude-[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*-(?:[5-9]|[1-9][0-9]+)(?![a-z0-9])/i;
 // Opus/Sonnet 4.5 and 4.6, and Haiku 4.5 — regional premium only (no other deprecations).
 const CLAUDE_4_5_AND_4_6_REGIONAL_PREMIUM_PATTERN =
   /(^|[^a-z0-9])claude-(?:opus|sonnet|haiku)-4-(?:5|6)(?![0-9])/i;
@@ -372,14 +377,17 @@ export function normalizeAnthropicModelName(modelName: string): string {
 }
 
 /**
- * Claude Opus 4.7/4.8, Claude Opus 5, Claude Sonnet 5, and Claude 5 Fable/Mythos deprecate manual sampling
- * controls at the model level — `temperature`, `top_p`, and `top_k` return 400
- * `invalid_request_error` (including promptfoo's built-in `temperature` default of 0). Shared
- * by the Anthropic, Bedrock, Vertex, and Azure providers; support for a new model lands as a
- * row in CLAUDE_MODEL_FAMILIES above.
+ * Claude Opus 4.7/4.8 and Claude 5+ models deprecate manual sampling controls at the model
+ * level — `temperature`, `top_p`, and `top_k` return 400 `invalid_request_error` (including
+ * promptfoo's built-in `temperature` default of 0). Shared by the Anthropic, Bedrock, Vertex,
+ * and Azure providers. Known families use the capability table above; the generation fallback
+ * keeps newly released Claude 5+ family names safe before their model-specific rows land.
  */
 export function isSamplingParamsDeprecatedClaudeModel(modelId: string): boolean {
-  return hasClaudeCapability(modelId, 'samplingParamsDeprecated');
+  return (
+    hasClaudeCapability(modelId, 'samplingParamsDeprecated') ||
+    CLAUDE_5_OR_LATER_PATTERN.test(modelId)
+  );
 }
 
 /**

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -197,11 +197,11 @@ const CLAUDE_OPUS_48_PATTERN = /(^|[^a-z0-9])claude-opus-4-8(?![0-9])/i;
 const CLAUDE_OPUS_47_PATTERN = /(^|[^a-z0-9])claude-opus-4-7(?![0-9])/i;
 // Anthropic deprecates non-default sampling controls on models released after Opus 4.6. Keep a
 // forward-compatible fallback for post-4.6 Claude 4.x and Claude 5+ family names so providers do
-// not send rejected parameters while waiting for a model-specific capability row. Limit 4.x to
-// the one-digit minors after 4.6, and later major generations to one or two digits, so lookalikes
-// such as `claude-opus-4-80` and date-stamped aliases are not mistaken for future models.
+// not send rejected parameters while waiting for a model-specific capability row. Accept every
+// numeric 4.x minor after 4.6, while keeping later major generations to one or two digits so
+// date-stamped aliases are not mistaken for future models.
 const CLAUDE_POST_46_OR_5_PLUS_PATTERN =
-  /(^|[^a-z0-9])claude-[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*-(?:4-[7-9]|[5-9]|[1-9][0-9])(?![a-z0-9])/i;
+  /(^|[^a-z0-9])claude-[a-z][a-z0-9]*(?:-[a-z][a-z0-9]*)*-(?:4-(?:[7-9]|[1-9][0-9]+)|[5-9]|[1-9][0-9])(?![a-z0-9])/i;
 // Opus/Sonnet 4.5 and 4.6, and Haiku 4.5 — regional premium only (no other deprecations).
 const CLAUDE_4_5_AND_4_6_REGIONAL_PREMIUM_PATTERN =
   /(^|[^a-z0-9])claude-(?:opus|sonnet|haiku)-4-(?:5|6)(?![0-9])/i;

--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -120,7 +120,10 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
   protected isSamplingParamsDeprecatedClaudeModel(): boolean {
     return (
       Boolean(this.config.isClaudeOpus47OrLater) ||
-      isSamplingParamsDeprecatedClaudeModel(this.deploymentName)
+      isSamplingParamsDeprecatedClaudeModel(this.deploymentName, {
+        // Azure deployment names are arbitrary aliases, not authoritative model IDs.
+        allowUnknownFamilyFallback: false,
+      })
     );
   }
 

--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -761,6 +761,13 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
     return `[AWS Bedrock Converse Provider ${this.modelName}]`;
   }
 
+  private isSamplingParamsDeprecatedClaudeModel(): boolean {
+    return isSamplingParamsDeprecatedClaudeModel(this.modelName, {
+      // Application inference profile names are user-defined aliases, not model IDs.
+      allowUnknownFamilyFallback: !this.modelName.includes(':application-inference-profile/'),
+    });
+  }
+
   private async initializeMCP(): Promise<void> {
     if (!this.config.mcp) {
       return;
@@ -962,7 +969,7 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
     // level — a request that pins `temperature` or `topP` on Bedrock returns
     // ValidationException. Drop both regardless of where they came from (config
     // or AWS_BEDROCK_TEMPERATURE / AWS_BEDROCK_TOP_P).
-    const samplingParamsDeprecated = isSamplingParamsDeprecatedClaudeModel(this.modelName);
+    const samplingParamsDeprecated = this.isSamplingParamsDeprecatedClaudeModel();
     const temperature = reasoningEnabled || samplingParamsDeprecated ? undefined : temperatureValue;
     const topP = reasoningEnabled || samplingParamsDeprecated ? undefined : topPValue;
 
@@ -1090,7 +1097,7 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
     // sampling-deprecated Claude model (Fable/Mythos 5, Sonnet 5, Opus 4.7/4.8) rejects
     // temperature/top_p/top_k, so strip them from the raw fields too; normalizeClaudeThinkingConfig
     // then converts enabled -> adaptive and drops disabled only on the always-on Fable/Mythos models.
-    if (isSamplingParamsDeprecatedClaudeModel(this.modelName)) {
+    if (this.isSamplingParamsDeprecatedClaudeModel()) {
       delete fields.temperature;
       delete fields.top_p;
       delete fields.top_k;

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -1627,7 +1627,10 @@ export const BEDROCK_MODEL = {
       // so we normalize silently here; the Anthropic Messages provider surfaces
       // the one-time heads-up and the provider docs document the behavior.
       const samplingParamsDeprecated = modelName
-        ? isSamplingParamsDeprecatedClaudeModel(modelName)
+        ? isSamplingParamsDeprecatedClaudeModel(modelName, {
+            // Application inference profile names are user-defined aliases, not model IDs.
+            allowUnknownFamilyFallback: !modelName.includes(':application-inference-profile/'),
+          })
         : false;
       if (!samplingParamsDeprecated) {
         addConfigParam(params, 'temperature', config?.temperature, undefined, 0);

--- a/src/providers/cloudflare-gateway.ts
+++ b/src/providers/cloudflare-gateway.ts
@@ -420,6 +420,11 @@ export class CloudflareGatewayAnthropicProvider extends AnthropicMessagesProvide
     });
   }
 
+  protected override usesAuthoritativeModelIds(): boolean {
+    // Cloudflare forwards this provider's model ID to Anthropic unchanged.
+    return true;
+  }
+
   id(): string {
     return `cloudflare-gateway:anthropic:${this.modelName}`;
   }

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -3117,7 +3117,7 @@ describe('AnthropicMessagesProvider', () => {
       expect(params).toHaveProperty('temperature', 0.5);
     });
 
-    it.each(['claude-haiku-5', 'claude-opus-4-9'])(
+    it.each(['claude-haiku-5', 'claude-opus-4-9', 'claude-opus-4-10'])(
       'keeps the fallback for %s on an explicitly configured official Anthropic endpoint',
       async (modelName) => {
         const provider = createProvider(modelName, {

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -3086,7 +3086,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('keeps sampling params for a custom gateway alias configured with apiBaseUrl', async () => {
-      const provider = createProvider('claude-prod-5', {
+      const provider = createProvider('claude-prod-4-9', {
         config: {
           apiBaseUrl: 'https://gateway.example.com/anthropic',
           temperature: 0.5,
@@ -3094,7 +3094,7 @@ describe('AnthropicMessagesProvider', () => {
       });
       const createSpy = vi
         .spyOn(provider.anthropic.messages, 'create')
-        .mockResolvedValue({ ...mockResp, model: 'claude-prod-5' });
+        .mockResolvedValue({ ...mockResp, model: 'claude-prod-4-9' });
 
       await provider.callApi('Hello');
 
@@ -3117,19 +3117,22 @@ describe('AnthropicMessagesProvider', () => {
       expect(params).toHaveProperty('temperature', 0.5);
     });
 
-    it('keeps the fallback for an explicitly configured official Anthropic endpoint', async () => {
-      const provider = createProvider('claude-haiku-5', {
-        config: { apiBaseUrl: 'https://api.anthropic.com', temperature: 0.5 },
-      });
-      const createSpy = vi
-        .spyOn(provider.anthropic.messages, 'create')
-        .mockResolvedValue({ ...mockResp, model: 'claude-haiku-5' });
+    it.each(['claude-haiku-5', 'claude-opus-4-9'])(
+      'keeps the fallback for %s on an explicitly configured official Anthropic endpoint',
+      async (modelName) => {
+        const provider = createProvider(modelName, {
+          config: { apiBaseUrl: 'https://api.anthropic.com', temperature: 0.5 },
+        });
+        const createSpy = vi
+          .spyOn(provider.anthropic.messages, 'create')
+          .mockResolvedValue({ ...mockResp, model: modelName });
 
-      await provider.callApi('Hello');
+        await provider.callApi('Hello');
 
-      const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
-      expect(params).not.toHaveProperty('temperature');
-    });
+        const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
+        expect(params).not.toHaveProperty('temperature');
+      },
+    );
 
     it('omits the built-in temperature default for Sonnet 5 (no explicit config)', async () => {
       // Regression for the live-API 400: `temperature` is deprecated for this model.

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -3085,6 +3085,52 @@ describe('AnthropicMessagesProvider', () => {
       expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Manual extended thinking'));
     });
 
+    it('keeps sampling params for a custom gateway alias configured with apiBaseUrl', async () => {
+      const provider = createProvider('claude-prod-5', {
+        config: {
+          apiBaseUrl: 'https://gateway.example.com/anthropic',
+          temperature: 0.5,
+        },
+      });
+      const createSpy = vi
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValue({ ...mockResp, model: 'claude-prod-5' });
+
+      await provider.callApi('Hello');
+
+      const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
+      expect(params).toHaveProperty('temperature', 0.5);
+    });
+
+    it('keeps sampling params for a custom gateway alias configured from the environment', async () => {
+      const provider = createProvider('claude-prod-5', {
+        config: { temperature: 0.5 },
+        env: { ANTHROPIC_BASE_URL: 'https://gateway.example.com/anthropic' },
+      });
+      const createSpy = vi
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValue({ ...mockResp, model: 'claude-prod-5' });
+
+      await provider.callApi('Hello');
+
+      const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
+      expect(params).toHaveProperty('temperature', 0.5);
+    });
+
+    it('keeps the fallback for an explicitly configured official Anthropic endpoint', async () => {
+      const provider = createProvider('claude-haiku-5', {
+        config: { apiBaseUrl: 'https://api.anthropic.com', temperature: 0.5 },
+      });
+      const createSpy = vi
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValue({ ...mockResp, model: 'claude-haiku-5' });
+
+      await provider.callApi('Hello');
+
+      const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
+      expect(params).not.toHaveProperty('temperature');
+    });
+
     it('omits the built-in temperature default for Sonnet 5 (no explicit config)', async () => {
       // Regression for the live-API 400: `temperature` is deprecated for this model.
       const provider = createProvider('claude-sonnet-5', { config: {} });

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -3065,6 +3065,26 @@ describe('AnthropicMessagesProvider', () => {
       expect(params.thinking?.budget_tokens).toBe(5000);
     });
 
+    it('preserves manual thinking for an unlisted Claude 5 family', async () => {
+      const provider = createProvider('claude-haiku-5', {
+        config: { thinking: { type: 'enabled', budget_tokens: 5000 }, max_tokens: 10000 },
+      });
+      const createSpy = vi
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValue({ ...mockResp, model: 'claude-haiku-5' });
+      const warnSpy = vi.spyOn(logger, 'warn');
+
+      await provider.callApi('Hello');
+
+      const params = createSpy.mock.calls[0][0] as unknown as {
+        thinking?: { type?: string; budget_tokens?: number };
+        temperature?: number;
+      };
+      expect(params.thinking).toEqual({ type: 'enabled', budget_tokens: 5000 });
+      expect(params).not.toHaveProperty('temperature');
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Manual extended thinking'));
+    });
+
     it('omits the built-in temperature default for Sonnet 5 (no explicit config)', async () => {
       // Regression for the live-API 400: `temperature` is deprecated for this model.
       const provider = createProvider('claude-sonnet-5', { config: {} });

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -2045,8 +2045,19 @@ describe('Anthropic utilities', () => {
       }
     });
 
+    it('future-proofs sampling deprecation for post-4.6 Claude 4.x families', () => {
+      for (const id of [
+        'claude-opus-4-9',
+        'anthropic:messages:claude-haiku-4-9-20260901',
+        'us.anthropic.claude-research-preview-4-9',
+        'vertex:claude-sonnet-4-9',
+      ]) {
+        expect(isSamplingParamsDeprecatedClaudeModel(id)).toBe(true);
+      }
+    });
+
     it('can disable the unknown-family fallback for alias-based providers', () => {
-      for (const alias of ['claude-prod-5', 'claude-prod-25']) {
+      for (const alias of ['claude-prod-4-9', 'claude-prod-5', 'claude-prod-25']) {
         expect(
           isSamplingParamsDeprecatedClaudeModel(alias, {
             allowUnknownFamilyFallback: false,

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -1985,9 +1985,10 @@ describe('Anthropic utilities', () => {
       ]) {
         expect(getClaudeModelWarningName(id)).not.toBe('Claude Opus 4.7 and 4.8');
       }
-      // `claude-opus-4-80` is not a recognized family at all, and keeps sampling params.
+      // `claude-opus-4-80` is not a recognized capability-table family, so it has no
+      // family-specific warning even though the forward-compatible sampling fallback covers it.
       expect(getClaudeModelWarningName('claude-opus-4-80')).toBeUndefined();
-      expect(isSamplingParamsDeprecatedClaudeModel('claude-opus-4-80')).toBe(false);
+      expect(isSamplingParamsDeprecatedClaudeModel('claude-opus-4-80')).toBe(true);
     });
 
     it('still detects dated Opus 4.8 snapshots', () => {
@@ -2048,6 +2049,8 @@ describe('Anthropic utilities', () => {
     it('future-proofs sampling deprecation for post-4.6 Claude 4.x families', () => {
       for (const id of [
         'claude-opus-4-9',
+        'claude-opus-4-10',
+        'claude-opus-4-50',
         'anthropic:messages:claude-haiku-4-9-20260901',
         'us.anthropic.claude-research-preview-4-9',
         'vertex:claude-sonnet-4-9',
@@ -2072,10 +2075,9 @@ describe('Anthropic utilities', () => {
       ).toBe(true);
     });
 
-    it('does not mistake legacy or lookalike model IDs for Claude 5+', () => {
+    it('does not mistake legacy or lookalike IDs for sampling-deprecated models', () => {
       for (const id of [
         'claude-3-5-sonnet-20241022',
-        'claude-opus-4-50',
         'claude-sonnet-5x',
         'claude-prod-20260811',
         'notclaude-opus-5',

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -2045,6 +2045,22 @@ describe('Anthropic utilities', () => {
       }
     });
 
+    it('can disable the unknown-family fallback for alias-based providers', () => {
+      for (const alias of ['claude-prod-5', 'claude-prod-25']) {
+        expect(
+          isSamplingParamsDeprecatedClaudeModel(alias, {
+            allowUnknownFamilyFallback: false,
+          }),
+        ).toBe(false);
+      }
+
+      expect(
+        isSamplingParamsDeprecatedClaudeModel('claude-opus-5', {
+          allowUnknownFamilyFallback: false,
+        }),
+      ).toBe(true);
+    });
+
     it('does not mistake legacy or lookalike model IDs for Claude 5+', () => {
       for (const id of [
         'claude-3-5-sonnet-20241022',

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -2033,6 +2033,29 @@ describe('Anthropic utilities', () => {
       }
     });
 
+    it('future-proofs sampling deprecation for unlisted Claude 5+ model families', () => {
+      for (const id of [
+        'claude-haiku-5',
+        'anthropic:messages:claude-haiku-5-20260801',
+        'us.anthropic.claude-research-preview-5',
+        'vertex:claude-sonnet-6',
+        'global.anthropic.claude-opus-10',
+      ]) {
+        expect(isSamplingParamsDeprecatedClaudeModel(id)).toBe(true);
+      }
+    });
+
+    it('does not mistake legacy or lookalike model IDs for Claude 5+', () => {
+      for (const id of [
+        'claude-3-5-sonnet-20241022',
+        'claude-opus-4-50',
+        'claude-sonnet-5x',
+        'notclaude-opus-5',
+      ]) {
+        expect(isSamplingParamsDeprecatedClaudeModel(id)).toBe(false);
+      }
+    });
+
     it('detects Claude Sonnet 5 across provider naming schemes', () => {
       for (const id of [
         'claude-sonnet-5',

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -2050,6 +2050,7 @@ describe('Anthropic utilities', () => {
         'claude-3-5-sonnet-20241022',
         'claude-opus-4-50',
         'claude-sonnet-5x',
+        'claude-prod-20260811',
         'notclaude-opus-5',
       ]) {
         expect(isSamplingParamsDeprecatedClaudeModel(id)).toBe(false);
@@ -2198,7 +2199,7 @@ describe('Anthropic utilities', () => {
     });
 
     it('normalizes thinking configs per model family and effort', () => {
-      // Manual budget thinking converts to adaptive on every sampling-deprecated family,
+      // Manual budget thinking converts to adaptive on families known to reject it,
       // preserving `display`.
       expect(
         normalizeClaudeThinkingConfig(
@@ -2207,6 +2208,16 @@ describe('Anthropic utilities', () => {
           undefined,
         ),
       ).toEqual({ type: 'adaptive', display: 'summarized' });
+
+      // The sampling fallback does not imply adaptive-thinking support. Preserve a user's
+      // explicit budget until a new family has a model-specific capability row.
+      expect(
+        normalizeClaudeThinkingConfig(
+          'claude-haiku-5',
+          { type: 'enabled', budget_tokens: 8000 } as any,
+          undefined,
+        ),
+      ).toEqual({ type: 'enabled', budget_tokens: 8000 });
 
       // Fable/Mythos reject `disabled` outright, at any effort.
       expect(

--- a/test/providers/azure/chat.test.ts
+++ b/test/providers/azure/chat.test.ts
@@ -911,20 +911,23 @@ describe('AzureChatCompletionProvider', () => {
       expect(body).toHaveProperty('top_p', 0.9);
     });
 
-    it('keeps sampling params for a date-stamped Claude deployment alias', async () => {
-      const provider = new AzureChatCompletionProvider('claude-prod-20260811', {
-        config: {
-          apiHost: 'test.azure.com',
-          apiKey: 'test-key',
-          max_tokens: 512,
-          temperature: 0.5,
-          top_p: 0.9,
-        },
-      });
-      const { body } = await (provider as any).getOpenAiBody('hi');
-      expect(body).toHaveProperty('temperature', 0.5);
-      expect(body).toHaveProperty('top_p', 0.9);
-    });
+    it.each(['claude-prod-5', 'claude-prod-25', 'claude-prod-20260811'])(
+      'keeps sampling params for custom Claude deployment alias %s',
+      async (deploymentName) => {
+        const provider = new AzureChatCompletionProvider(deploymentName, {
+          config: {
+            apiHost: 'test.azure.com',
+            apiKey: 'test-key',
+            max_tokens: 512,
+            temperature: 0.5,
+            top_p: 0.9,
+          },
+        });
+        const { body } = await (provider as any).getOpenAiBody('hi');
+        expect(body).toHaveProperty('temperature', 0.5);
+        expect(body).toHaveProperty('top_p', 0.9);
+      },
+    );
 
     it('omits sampling params for an opus-4-7-named deployment even without the flag', async () => {
       // Baseline name-match path: deployment name matches opus-4-7, so sampling

--- a/test/providers/azure/chat.test.ts
+++ b/test/providers/azure/chat.test.ts
@@ -911,6 +911,21 @@ describe('AzureChatCompletionProvider', () => {
       expect(body).toHaveProperty('top_p', 0.9);
     });
 
+    it('keeps sampling params for a date-stamped Claude deployment alias', async () => {
+      const provider = new AzureChatCompletionProvider('claude-prod-20260811', {
+        config: {
+          apiHost: 'test.azure.com',
+          apiKey: 'test-key',
+          max_tokens: 512,
+          temperature: 0.5,
+          top_p: 0.9,
+        },
+      });
+      const { body } = await (provider as any).getOpenAiBody('hi');
+      expect(body).toHaveProperty('temperature', 0.5);
+      expect(body).toHaveProperty('top_p', 0.9);
+    });
+
     it('omits sampling params for an opus-4-7-named deployment even without the flag', async () => {
       // Baseline name-match path: deployment name matches opus-4-7, so sampling
       // params are stripped without setting isClaudeOpus47OrLater.

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -1894,6 +1894,37 @@ Third line`;
       expect(call?.inferenceConfig?.maxTokens).toBe(1024);
     });
 
+    it.each(['claude-prod-5', 'claude-prod-25'])(
+      'keeps sampling params for custom application inference profile alias %s',
+      async (profileName) => {
+        const provider = new AwsBedrockConverseProvider(
+          `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/${profileName}`,
+          {
+            config: {
+              region: 'us-east-1',
+              max_tokens: 1024,
+              temperature: 0.5,
+              topP: 0.9,
+            },
+          },
+        );
+
+        mockSend.mockResolvedValueOnce(createMockConverseResponse('Test'));
+
+        await provider.callApi('Test');
+
+        const { ConverseCommand } = (await import(
+          '@aws-sdk/client-bedrock-runtime'
+        )) as unknown as MockBedrockModule;
+        const call = (ConverseCommand as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(
+          -1,
+        )?.[0] as { inferenceConfig?: Record<string, unknown> };
+        expect(call?.inferenceConfig?.temperature).toBe(0.5);
+        expect(call?.inferenceConfig?.topP).toBe(0.9);
+        expect(call?.inferenceConfig?.maxTokens).toBe(1024);
+      },
+    );
+
     it.each(['any', { tool: { name: 'test_tool' } }])(
       'omits forced tool choice for Claude Fable 5 while preserving tools: %j',
       async (toolChoice) => {

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -2433,6 +2433,36 @@ Third line`;
       );
     });
 
+    it('should keep manual thinking enabled for an unlisted Claude 5 family', async () => {
+      const provider = new AwsBedrockConverseProvider('anthropic.claude-haiku-5', {
+        config: {
+          region: 'us-east-1',
+          thinking: {
+            type: 'enabled',
+            budget_tokens: 12000,
+          },
+        },
+      });
+
+      mockSend.mockResolvedValueOnce(createMockConverseResponse('Test'));
+
+      await provider.callApi('Test');
+
+      const { ConverseCommand } = (await import(
+        '@aws-sdk/client-bedrock-runtime'
+      )) as unknown as MockBedrockModule;
+      expect(ConverseCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalModelRequestFields: {
+            thinking: {
+              type: 'enabled',
+              budget_tokens: 12000,
+            },
+          },
+        }),
+      );
+    });
+
     it('should pass through disabled thinking unchanged for Claude Opus 4.8', async () => {
       // Only type: 'enabled' is rewritten to adaptive for deprecated Opus
       // models; a disabled thinking block must be forwarded as-is.

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -703,6 +703,20 @@ describe('AwsBedrockGenericProvider', () => {
       }
     });
 
+    it.each(['claude-prod-5', 'claude-prod-25'])(
+      'keeps temperature for custom application inference profile alias %s',
+      async (profileName) => {
+        const params = await BEDROCK_MODEL.CLAUDE_MESSAGES.params(
+          { region: 'us-east-1', temperature: 0.5 },
+          'hi',
+          undefined,
+          `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/${profileName}`,
+        );
+
+        expect(params.temperature).toBe(0.5);
+      },
+    );
+
     it('gives Claude Opus 5 thinking headroom in the default max_tokens', async () => {
       // Opus 5 spends part of max_tokens on its default adaptive thinking even with no
       // `thinking` field, so the bare 1024 default would truncate ordinary answers.

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -821,6 +821,19 @@ describe('AwsBedrockGenericProvider', () => {
       expect(params.thinking).toEqual({ type: 'enabled', budget_tokens: 5000 });
     });
 
+    it('keeps manual thinking enabled for an unlisted Claude 5 family on Bedrock invokeModel', async () => {
+      const params = await BEDROCK_MODEL.CLAUDE_MESSAGES.params(
+        {
+          region: 'us-east-1',
+          thinking: { type: 'enabled', budget_tokens: 5000 },
+        },
+        'hi',
+        undefined,
+        'us.anthropic.claude-haiku-5',
+      );
+      expect(params.thinking).toEqual({ type: 'enabled', budget_tokens: 5000 });
+    });
+
     it('keeps disabled thinking unchanged for Claude Opus 4.8 on Bedrock invokeModel', async () => {
       const config: BedrockClaudeMessagesCompletionOptions = {
         region: 'us-east-1',

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -676,6 +676,33 @@ describe('AwsBedrockGenericProvider', () => {
       expect(params.temperature).toBeUndefined();
     });
 
+    it('omits temperature for Claude Opus 5 on the reported Bedrock path', async () => {
+      const params = await BEDROCK_MODEL.CLAUDE_MESSAGES.params(
+        { region: 'us-east-1', temperature: 0.5 },
+        'hi',
+        undefined,
+        'us.anthropic.claude-opus-5',
+      );
+
+      expect(params.temperature).toBeUndefined();
+    });
+
+    it('omits temperature for unlisted Claude 5+ models on Bedrock invokeModel', async () => {
+      for (const modelName of [
+        'us.anthropic.claude-haiku-5',
+        'global.anthropic.claude-research-preview-6',
+      ]) {
+        const params = await BEDROCK_MODEL.CLAUDE_MESSAGES.params(
+          { region: 'us-east-1', temperature: 0.5 },
+          'hi',
+          undefined,
+          modelName,
+        );
+
+        expect(params.temperature).toBeUndefined();
+      }
+    });
+
     it('gives Claude Opus 5 thinking headroom in the default max_tokens', async () => {
       // Opus 5 spends part of max_tokens on its default adaptive thinking even with no
       // `thinking` field, so the bare 1024 default would truncate ordinary answers.

--- a/test/providers/cloudflare-gateway.test.ts
+++ b/test/providers/cloudflare-gateway.test.ts
@@ -385,7 +385,7 @@ describe('CloudflareGateway Provider', () => {
       );
     });
 
-    it.each(['claude-haiku-5', 'claude-opus-4-9'])(
+    it.each(['claude-haiku-5', 'claude-opus-4-9', 'claude-opus-4-10'])(
       'applies sampling deprecations to authoritative model ID %s forwarded to Anthropic',
       async (modelName) => {
         const provider = new CloudflareGatewayAnthropicProvider(modelName, {

--- a/test/providers/cloudflare-gateway.test.ts
+++ b/test/providers/cloudflare-gateway.test.ts
@@ -384,6 +384,31 @@ describe('CloudflareGateway Provider', () => {
         expect.any(Object),
       );
     });
+
+    it('applies sampling deprecations to authoritative model IDs forwarded to Anthropic', async () => {
+      const provider = new CloudflareGatewayAnthropicProvider('claude-haiku-5', {
+        config: { ...minimumConfig, temperature: 0.5 },
+      });
+      const responsePayload = {
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Test' }],
+        model: 'claude-haiku-5',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 5, output_tokens: 5 },
+      };
+      mockFetch.mockResolvedValue({
+        ...defaultMockResponse,
+        text: vi.fn().mockResolvedValue(JSON.stringify(responsePayload)),
+        ok: true,
+      });
+
+      await provider.callApi('Test prompt');
+
+      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(requestBody).not.toHaveProperty('temperature');
+    });
   });
 
   describe('Error Handling', () => {

--- a/test/providers/cloudflare-gateway.test.ts
+++ b/test/providers/cloudflare-gateway.test.ts
@@ -385,30 +385,33 @@ describe('CloudflareGateway Provider', () => {
       );
     });
 
-    it('applies sampling deprecations to authoritative model IDs forwarded to Anthropic', async () => {
-      const provider = new CloudflareGatewayAnthropicProvider('claude-haiku-5', {
-        config: { ...minimumConfig, temperature: 0.5 },
-      });
-      const responsePayload = {
-        id: 'msg_123',
-        type: 'message',
-        role: 'assistant',
-        content: [{ type: 'text', text: 'Test' }],
-        model: 'claude-haiku-5',
-        stop_reason: 'end_turn',
-        usage: { input_tokens: 5, output_tokens: 5 },
-      };
-      mockFetch.mockResolvedValue({
-        ...defaultMockResponse,
-        text: vi.fn().mockResolvedValue(JSON.stringify(responsePayload)),
-        ok: true,
-      });
+    it.each(['claude-haiku-5', 'claude-opus-4-9'])(
+      'applies sampling deprecations to authoritative model ID %s forwarded to Anthropic',
+      async (modelName) => {
+        const provider = new CloudflareGatewayAnthropicProvider(modelName, {
+          config: { ...minimumConfig, temperature: 0.5 },
+        });
+        const responsePayload = {
+          id: 'msg_123',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Test' }],
+          model: modelName,
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 5, output_tokens: 5 },
+        };
+        mockFetch.mockResolvedValue({
+          ...defaultMockResponse,
+          text: vi.fn().mockResolvedValue(JSON.stringify(responsePayload)),
+          ok: true,
+        });
 
-      await provider.callApi('Test prompt');
+        await provider.callApi('Test prompt');
 
-      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(requestBody).not.toHaveProperty('temperature');
-    });
+        const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(requestBody).not.toHaveProperty('temperature');
+      },
+    );
   });
 
   describe('Error Handling', () => {

--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -3367,6 +3367,21 @@ describe('VertexChatProvider.callClaudeApi', () => {
       expect(requestData.max_tokens).toBe(6024);
     });
 
+    it('should keep manual thinking enabled for an unlisted Claude 5 family', async () => {
+      provider = new VertexChatProvider('claude-haiku-5', {
+        config: {
+          thinking: { type: 'enabled', budget_tokens: 5000 },
+        },
+      });
+      setupClaudeMocks();
+
+      await provider.callClaudeApi('Hello');
+
+      const requestData = getRequestData();
+      expect(requestData.thinking).toEqual({ type: 'enabled', budget_tokens: 5000 });
+      expect(requestData.max_tokens).toBe(6024);
+    });
+
     it('should not bump max_tokens when adaptive conversion drops budget_tokens for Claude Opus 4.8', async () => {
       provider = new VertexChatProvider('claude-opus-4-8', {
         config: {


### PR DESCRIPTION
## Summary

- add direct regression coverage for the reported Bedrock Claude Opus 5 request path
- recognize well-formed Claude 5+ model IDs as using deprecated sampling controls, even before a model-specific capability row is added
- retain explicit family metadata for model-specific behavior while tightening malformed model-ID boundaries

## Context and root cause

PR #10210 added explicit Claude Opus 5 support before #10307 was opened, so the reported model now has a capability row on `main`. This PR covers that exact Bedrock path with a regression test and closes the remaining structural gap: sampling-parameter suppression otherwise depends entirely on explicit `CLAUDE_MODEL_FAMILIES` rows.

That row-by-row behavior means a newly released Claude 5+ family can still inherit a configured or default `temperature` until Promptfoo adds its metadata. Anthropic documents `temperature`, `top_p`, and `top_k` as deprecated for Claude 4.7-and-later models, with non-default values returning HTTP 400. The generation fallback keeps new Claude 5+ IDs safe while explicit rows continue to provide family-specific behavior.

Reference: https://platform.claude.com/docs/en/about-claude/model-deprecations#api-parameter-deprecations

## Impact

New Claude 5+ model families and later generations omit unsupported `temperature`, `top_p`, and `top_k` parameters across Anthropic-compatible provider paths. Older Claude IDs, including Claude 4.6, retain their existing sampling behavior. Lookalikes such as `claude-sonnet-5x` no longer match the Sonnet 5 capability row.

Fixes #10307

## Verification

- affected provider tests: 981 passed across Anthropic Messages/util, Azure chat, Bedrock Converse/index, and Google Vertex
- TypeScript: `tsc --noEmit`
- changed-file lint/format: `biome check`
- production package, app, and postbuild stages passed
- broader suite: 22,112 tests passed; the remaining unrelated cases require Windows symlink privileges unavailable in this environment
