### PR TITLE
fix(deps): patch vulnerable transitive js-yaml releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8920,9 +8920,9 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -9594,9 +9594,9 @@
       }
     },
     "node_modules/@docusaurus/utils-validation/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -9689,9 +9689,9 @@
       }
     },
     "node_modules/@docusaurus/utils/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -17404,9 +17404,9 @@
       }
     },
     "node_modules/@svgr/core/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -17530,9 +17530,9 @@
       }
     },
     "node_modules/@svgr/plugin-svgo/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -27084,9 +27084,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -35538,9 +35538,9 @@
       }
     },
     "node_modules/postcss-loader/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/site/src/utils/yaml.test.ts
+++ b/site/src/utils/yaml.test.ts
@@ -23,6 +23,26 @@ describe('loadYaml', () => {
     expect(() => loadYaml('!!set {a: not-null}')).toThrow(/cannot resolve a set item/);
   });
 
+  it('does not read inherited values from YAML mapping tags', () => {
+    const mapping = Object.create({ inherited: 'prototype value' }) as Record<string, unknown>;
+    mapping.own = 'own value';
+
+    for (const tag of [yaml.mapTag, yaml.legacyMapTag]) {
+      expect(tag.get(mapping, 'inherited')).toBeNull();
+      expect(tag.get(mapping, 'own')).toBe('own value');
+    }
+  });
+
+  it('preserves timestamps from the first century', () => {
+    expect(loadYaml('0001-01-01')).toEqual(new Date('0001-01-01T00:00:00.000Z'));
+    expect(loadYaml('0050-06-15T12:30:00Z')).toEqual(new Date('0050-06-15T12:30:00.000Z'));
+    expect(loadYaml('0001-02-29')).toBe('0001-02-29');
+  });
+
+  it('preserves implicit null values before a document end marker', () => {
+    expect(loadYaml('optional:\n...\n')).toEqual({ optional: null });
+  });
+
   it('supports large and Map-backed ordered maps while rejecting duplicate keys', () => {
     const entries = Array.from({ length: 2048 }, (_, index) => `{key${index}: ${index}}`);
     expect(loadYaml(`!!omap [${entries.join(', ')}]`)).toHaveLength(2048);

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -752,7 +752,14 @@ describe('package manifests', () => {
       expect(declaredVersion, `${manifestPath} must declare js-yaml`).toBeDefined();
       expect(packageLock.packages[lockPath]?.[field]?.['js-yaml']).toBe(declaredVersion);
       expect(
-        satisfies(minVersion(declaredVersion as string)!, PATCHED_JS_YAML_RANGE),
+        validRange(declaredVersion as string),
+        `${manifestPath} must declare a valid js-yaml semver range`,
+      ).not.toBeNull();
+
+      const minimumVersion = minVersion(declaredVersion as string);
+      expect(minimumVersion, `${manifestPath} must have a minimum js-yaml version`).not.toBeNull();
+      expect(
+        minimumVersion !== null && satisfies(minimumVersion, PATCHED_JS_YAML_RANGE),
         `${manifestPath} must not allow vulnerable js-yaml ${declaredVersion}`,
       ).toBe(true);
       directVersions.push(declaredVersion as string);

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -19,6 +19,7 @@ function readPackageJson<T>(relativePath: string): T {
 
 const SOURCE_FILE_EXTENSIONS = /\.(ts|tsx|mts|cts|js|mjs|cjs)$/;
 const EXPECTED_SHARP_VERSION = '^0.35.3';
+const PATCHED_JS_YAML_RANGE = '^3.15.1 || ^4.3.1 || >=5.2.3';
 const PATCHED_UNDICI_RANGE = '^6.28.0 || ^7.29.0 || >=8.9.0';
 const OPENAI_PACKAGE_NAMES = ['@openai/agents', '@openai/codex-sdk', 'openai'] as const;
 const SWC_PACKAGE_NAMES = [
@@ -731,6 +732,47 @@ describe('package manifests', () => {
     }
 
     expect(lockfile.packages?.['']?.dependencies?.ws).toBe(rootPackageJson.dependencies?.ws);
+  });
+
+  it('keeps every direct and transitive js-yaml installation patched', () => {
+    const packageLock = readPackageJson<{
+      packages: Record<string, PackageManifest & { version?: string }>;
+    }>('package-lock.json');
+    const workspaceManifests = [
+      { path: 'package.json', lockPath: '', field: 'dependencies' },
+      { path: 'site/package.json', lockPath: 'site', field: 'dependencies' },
+      { path: 'src/app/package.json', lockPath: 'src/app', field: 'devDependencies' },
+    ] as const;
+    const directVersions: string[] = [];
+
+    for (const { path: manifestPath, lockPath, field } of workspaceManifests) {
+      const manifest = readPackageJson<PackageManifest>(manifestPath);
+      const declaredVersion = manifest[field]?.['js-yaml'];
+
+      expect(declaredVersion, `${manifestPath} must declare js-yaml`).toBeDefined();
+      expect(packageLock.packages[lockPath]?.[field]?.['js-yaml']).toBe(declaredVersion);
+      expect(
+        satisfies(minVersion(declaredVersion as string)!, PATCHED_JS_YAML_RANGE),
+        `${manifestPath} must not allow vulnerable js-yaml ${declaredVersion}`,
+      ).toBe(true);
+      directVersions.push(declaredVersion as string);
+    }
+
+    expect(new Set(directVersions).size, 'direct js-yaml versions must stay aligned').toBe(1);
+
+    const installations = Object.entries(packageLock.packages).filter(
+      ([packagePath]) =>
+        packagePath === 'node_modules/js-yaml' || packagePath.endsWith('/node_modules/js-yaml'),
+    );
+
+    expect(installations, 'the root lockfile must resolve js-yaml').not.toHaveLength(0);
+    for (const [packagePath, installation] of installations) {
+      expect(installation.version, `${packagePath} must have a version`).toBeDefined();
+      expect(
+        satisfies(installation.version as string, PATCHED_JS_YAML_RANGE),
+        `${packagePath} resolves vulnerable js-yaml ${installation.version}`,
+      ).toBe(true);
+    }
   });
 
   it('keeps the JSON Schema ref parser and its HTTP transport on patched versions', () => {

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { minVersion, satisfies, validRange } from 'semver';
+import { minVersion, satisfies, subset, validRange } from 'semver';
 import { describe, expect, it } from 'vitest';
 import { extractModuleSpecifiers } from '../scripts/architectureUtils';
 
@@ -755,11 +755,8 @@ describe('package manifests', () => {
         validRange(declaredVersion as string),
         `${manifestPath} must declare a valid js-yaml semver range`,
       ).not.toBeNull();
-
-      const minimumVersion = minVersion(declaredVersion as string);
-      expect(minimumVersion, `${manifestPath} must have a minimum js-yaml version`).not.toBeNull();
       expect(
-        minimumVersion !== null && satisfies(minimumVersion, PATCHED_JS_YAML_RANGE),
+        subset(declaredVersion as string, PATCHED_JS_YAML_RANGE),
         `${manifestPath} must not allow vulnerable js-yaml ${declaredVersion}`,
       ).toBe(true);
       directVersions.push(declaredVersion as string);

--- a/test/util/yamlLoad.test.ts
+++ b/test/util/yamlLoad.test.ts
@@ -35,6 +35,26 @@ describe('loadYaml', () => {
     expect(() => loadYaml('!!set {a: not-null}')).toThrow(/cannot resolve a set item/);
   });
 
+  it('does not read inherited values from YAML mapping tags', () => {
+    const mapping = Object.create({ inherited: 'prototype value' }) as Record<string, unknown>;
+    mapping.own = 'own value';
+
+    for (const tag of [yaml.mapTag, yaml.legacyMapTag]) {
+      expect(tag.get(mapping, 'inherited')).toBeNull();
+      expect(tag.get(mapping, 'own')).toBe('own value');
+    }
+  });
+
+  it('preserves timestamps from the first century', () => {
+    expect(loadYaml('0001-01-01')).toEqual(new Date('0001-01-01T00:00:00.000Z'));
+    expect(loadYaml('0050-06-15T12:30:00Z')).toEqual(new Date('0050-06-15T12:30:00.000Z'));
+    expect(loadYaml('0001-02-29')).toBe('0001-02-29');
+  });
+
+  it('preserves implicit null values before a document end marker', () => {
+    expect(loadYaml('optional:\n...\n')).toEqual({ optional: null });
+  });
+
   it('supports large and Map-backed ordered maps while rejecting duplicate keys', () => {
     const entries = Array.from({ length: 2048 }, (_, index) => `{key${index}: ${index}}`);
     expect(loadYaml(`!!omap [${entries.join(', ')}]`)).toHaveLength(2048);


### PR DESCRIPTION
## Summary
- Follow up on #10354 by upgrading all seven vulnerable transitive js-yaml installations: six 4.2.0 -> 4.3.1 and one 3.14.2 -> 3.15.1.
- Add a manifest/lockfile regression gate that keeps root, docs, and web-UI js-yaml declarations aligned and rejects vulnerable resolved copies across every supported major.
- Cover inherited mapping lookups, first-century timestamps, and implicit null values before document-end markers in both YAML compatibility loaders.
- Clear all js-yaml audit findings and reduce the full audit from 185 to 175 findings (170 -> 161 high severity).

## Validation
- Clean npm ci; exact installed and locked versions match for all eight js-yaml installations.
- Backend suite split around local listener contention: 21,731 non-route tests + 415 route tests passed.
- All 4,848 web-UI tests and all 267 docs-site tests passed.
- Production CLI/web build, docs production build, TypeScript check, lint, format check, and dependency-version consistency passed.
- Source and built CLI no-cache echo-provider evals both passed 10/10 with score 1 and zero errors.
- npm audit reports no remaining js-yaml vulnerability.