### PR TITLE
fix(deps): align Chevrotain CST generator with parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4618,14 +4618,15 @@
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-13.1.0.tgz",
-      "integrity": "sha512-lgsE1yOUf25dB/BdZjhl2hdqqTNd9h2VZ2g7Gn5/eVEwF8zBoATLMctk+qWP015JFUAkBUxgZGJyxH3SwtpAyw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.2.0.tgz",
+      "integrity": "sha512-ssJFvn/UXhQQeICw3SR/fZPmYVj+JM2mP+Lx7bZ51cOeHaMWOKp3AUMuyM3QR82aFFXTfcAp67P5GpPjGmbZWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/gast": "13.1.0",
-        "@chevrotain/types": "13.1.0"
+        "@chevrotain/gast": "11.2.0",
+        "@chevrotain/types": "11.2.0",
+        "lodash-es": "4.17.23"
       }
     },
     "node_modules/@chevrotain/gast": {

--- a/package.json
+++ b/package.json
@@ -195,14 +195,14 @@
     },
     "chevrotain": {
       ".": "11.2.0",
-      "@chevrotain/cst-dts-gen": "13.1.0",
+      "@chevrotain/cst-dts-gen": "11.2.0",
       "@chevrotain/gast": "11.2.0",
       "@chevrotain/regexp-to-ast": "11.2.0",
       "@chevrotain/types": "11.2.0",
       "@chevrotain/utils": "11.2.0"
     },
     "@chevrotain/cst-dts-gen": {
-      ".": "13.1.0",
+      ".": "11.2.0",
       "@chevrotain/gast": "11.2.0",
       "@chevrotain/types": "11.2.0"
     },

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -585,6 +585,12 @@ describe('package manifests', () => {
 
     const parserVersion = chevrotainOverride?.['.'];
     expect(parserVersion, 'Chevrotain must have a pinned parser version').toBeDefined();
+    expect(generatorVersion, `${generatorName} must match the pinned parser version`).toBe(
+      parserVersion,
+    );
+    expect(packageLock.packages['node_modules/chevrotain']?.dependencies?.[generatorName]).toBe(
+      parserVersion,
+    );
 
     for (const dependencyName of ['@chevrotain/gast', '@chevrotain/types']) {
       expect(
@@ -592,6 +598,9 @@ describe('package manifests', () => {
         `${generatorName} must share the parser's ${dependencyName} version`,
       ).toBe(parserVersion);
       expect(packageLock.packages[`node_modules/${dependencyName}`]?.version).toBe(parserVersion);
+      expect(
+        packageLock.packages[`node_modules/${generatorName}`]?.dependencies?.[dependencyName],
+      ).toBe(parserVersion);
       expect(
         packageLock.packages[`node_modules/${generatorName}/node_modules/${dependencyName}`],
       ).toBeUndefined();
@@ -614,20 +623,14 @@ describe('package manifests', () => {
     const parserVersion = chevrotainOverride?.['.'];
     // chevrotain@X declares every @chevrotain/* sub-package at exactly X and all six reach npm
     // within about a minute of each other, so Renovate must not move any of them alone.
-    // @chevrotain/cst-dts-gen is frozen too but is excluded from the version assertion below: it
-    // is currently overridden to 13.1.0 under chevrotain 11.2.0 (#10345) and gets realigned when
-    // the family moves as a set.
     const pinnedGrammarPackages = [
+      '@chevrotain/cst-dts-gen',
       '@chevrotain/gast',
       '@chevrotain/types',
       '@chevrotain/regexp-to-ast',
       '@chevrotain/utils',
     ];
-    const pinnedParserPackages = [
-      'chevrotain',
-      ...pinnedGrammarPackages,
-      '@chevrotain/cst-dts-gen',
-    ];
+    const pinnedParserPackages = ['chevrotain', ...pinnedGrammarPackages];
 
     expect(parserVersion, 'Chevrotain must have a pinned parser version').toBeDefined();
 


### PR DESCRIPTION
## Summary

- Restore `@chevrotain/cst-dts-gen` to `11.2.0`, matching the pinned `chevrotain`, `@chevrotain/gast`, and `@chevrotain/types` packages.
- Fix three violated exact-version dependency contracts introduced when the generator advanced to `13.1.0` while the parser stack stayed on `11.2.0`.
- Extend the existing manifest regression tests to verify the generator version, each package's declared dependencies, and Renovate's complete parser-family lockstep policy.

## Regression proof

Both targeted manifest tests fail on the previous configuration because the generator resolves to `13.1.0` instead of the parser's `11.2.0`; both pass after the manifest and lockfile are realigned.

## Verification

- `npx vitest run test/package-manifests.test.ts test/scripts/architectureUtils.test.ts test/scripts/checkTypeScriptCoverage.test.ts --configLoader runner` — 91 tests passed.
- `npm run tsc`
- `npm run architecture:check`
- `npm run l` and `npm run f`
- Installed the exact `11.2.0` parser/generator family in an isolated directory, parsed a token stream, and generated CST declarations successfully.
- `PROMPTFOO_CONFIG_DIR=/private/tmp/promptfoo-recent-bug-hunt-config npm run local -- eval -c test/smoke/fixtures/configs/basic.yaml --no-cache --no-share -o /private/tmp/promptfoo-recent-bug-hunt-output.json` — one passing result, score `1`, and no errors.
- Verified the resolved package URL and integrity match the previously committed `11.2.0` lockfile entry.
