### PR TITLE
fix(assertions): avoid regex backtracking in GLEU and SQL parsing

### DIFF
--- a/src/assertions/gleu.ts
+++ b/src/assertions/gleu.ts
@@ -8,7 +8,13 @@ function tokenizeForGleu(text: string): string[] {
     .toLowerCase()
     .trim()
     .split(/\s+/)
-    .map((word) => word.replace(/\.+$/, ''));
+    .map((word) => {
+      let end = word.length;
+      while (end > 0 && word[end - 1] === '.') {
+        end--;
+      }
+      return word.slice(0, end);
+    });
 
   return words.some(Boolean) ? words : [];
 }

--- a/src/assertions/sql.ts
+++ b/src/assertions/sql.ts
@@ -281,8 +281,49 @@ export const handleIsSql = async ({
   };
 };
 
-const FENCE_START_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})[ \t]*([^\r\n]*)$/;
-const FENCE_END_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/;
+interface CodeFence {
+  character: string;
+  length: number;
+  info: string;
+  hasOnlyTrailingWhitespace: boolean;
+}
+
+function parseCodeFence(line: string): CodeFence | undefined {
+  let index = 0;
+  while (index < 3 && (line[index] === ' ' || line[index] === '\t')) {
+    index++;
+  }
+
+  const character = line[index];
+  if (character !== '`' && character !== '~') {
+    return undefined;
+  }
+
+  const fenceStart = index;
+  while (line[index] === character) {
+    index++;
+  }
+  const length = index - fenceStart;
+  if (length < 3) {
+    return undefined;
+  }
+
+  const info = line.slice(index);
+  let whitespaceIndex = 0;
+  while (
+    whitespaceIndex < info.length &&
+    (info[whitespaceIndex] === ' ' || info[whitespaceIndex] === '\t')
+  ) {
+    whitespaceIndex++;
+  }
+
+  return {
+    character,
+    length,
+    info,
+    hasOnlyTrailingWhitespace: whitespaceIndex === info.length,
+  };
+}
 
 function extractSqlCodeBlocks(output: string): string[] {
   const sqlBlocks: string[] = [];
@@ -291,14 +332,13 @@ function extractSqlCodeBlocks(output: string): string[] {
     | undefined;
 
   for (const line of output.split(/\r\n?|\n/)) {
+    const fence = parseCodeFence(line);
     if (!activeBlock) {
-      const openingFence = FENCE_START_PATTERN.exec(line);
-      if (openingFence) {
-        const fence = openingFence[1];
-        const language = openingFence[2].trim().toLowerCase();
+      if (fence) {
+        const language = fence.info.trim().toLowerCase();
         activeBlock = {
           body: [],
-          fenceCharacter: fence[0],
+          fenceCharacter: fence.character,
           fenceLength: fence.length,
           isSql: language === '' || language === 'sql',
         };
@@ -306,10 +346,10 @@ function extractSqlCodeBlocks(output: string): string[] {
       continue;
     }
 
-    const closingFence = FENCE_END_PATTERN.exec(line)?.[1];
     if (
-      closingFence?.[0] === activeBlock.fenceCharacter &&
-      closingFence.length >= activeBlock.fenceLength
+      fence?.hasOnlyTrailingWhitespace &&
+      fence.character === activeBlock.fenceCharacter &&
+      fence.length >= activeBlock.fenceLength
     ) {
       if (activeBlock.isSql) {
         sqlBlocks.push(activeBlock.body.join('\n').trim());

--- a/test/assertions/gleu.test.ts
+++ b/test/assertions/gleu.test.ts
@@ -20,6 +20,20 @@ describe('GLEU score calculation', () => {
     expect(score).toBeGreaterThan(0.95);
   });
 
+  it('removes long trailing period runs without changing the score', () => {
+    const trailingPeriods = '.'.repeat(50_000);
+
+    expect(calculateGleuScore(`The cat${trailingPeriods}`, ['The cat'])).toBe(1);
+    expect(calculateGleuScore('The cat', [`The cat${trailingPeriods}`])).toBe(1);
+  });
+
+  it('preserves long period runs that are followed by other punctuation', () => {
+    const punctuation = `${'.'.repeat(50_000)}!`;
+
+    expect(calculateGleuScore(`The cat${punctuation}`, [`The cat${punctuation}`])).toBe(1);
+    expect(calculateGleuScore(`The cat${punctuation}`, ['The cat!'])).toBeLessThan(1);
+  });
+
   it('should handle the infamous "the the the … " example', () => {
     const references = ['The cat sat on the mat'];
     const candidate = 'the the the the the the the';

--- a/test/assertions/sql.test.ts
+++ b/test/assertions/sql.test.ts
@@ -777,8 +777,25 @@ describe('contains-sql assertion', () => {
     ['a four-backtick fence', '````sql\nSELECT `id` FROM `users`;\n````'],
     ['a tilde fence', '~~~sql\nSELECT 1;\n~~~'],
     ['a longer closing fence', '```sql\nSELECT 1;\n````'],
+    ['an unlabeled fence', '```\nSELECT 1;\n```'],
+    ['a case-insensitive SQL label', '``` SQL \nSELECT 1;\n```'],
+    ['a three-space indentation', '   ```sql\nSELECT 1;\n   ```'],
+    ['tab-padded fence labels', '```\t\tsql\t\nSELECT 1;\n```\t\t'],
   ])('should extract SQL from %s', async (_description, outputString) => {
     await expect(runContainsSql(outputString)).resolves.toMatchObject({ pass: true, score: 1 });
+  });
+
+  it('parses fence labels with long whitespace runs in linear time', async () => {
+    const padding = '\t'.repeat(50_000);
+    const outputString = `\`\`\`${padding}sql\nSELECT 1;\n\`\`\`${padding}`;
+
+    await expect(runContainsSql(outputString)).resolves.toMatchObject({ pass: true, score: 1 });
+  });
+
+  it('does not close a fence with a different character or a shorter fence', async () => {
+    const outputString = '````sql\nSELECT 1;\n~~~\n```\n````';
+
+    await expect(runContainsSql(outputString)).resolves.toMatchObject({ pass: false, score: 0 });
   });
 
   it.each([
@@ -789,6 +806,8 @@ describe('contains-sql assertion', () => {
     ['an unclosed fenced block', `${fence}sql\nSELECT 1;`],
     ['a non-SQL fenced block', `${fence}python\nprint('hello')\n${fence}`],
     ['a tag that merely starts with sql', `${fence}sqlSELECT\nSELECT 1;\n${fence}`],
+    ['a four-space indentation', `    ${fence}sql\nSELECT 1;\n    ${fence}`],
+    ['a closing fence with an info string', `${fence}sql\nSELECT 1;\n${fence}sql`],
   ])('should reject %s', async (_description, outputString) => {
     const result = await runContainsSql(outputString);
 


### PR DESCRIPTION
## Summary
- replace GLEU trailing-period normalization with a linear backward scan
- parse SQL Markdown fences deterministically while preserving indentation, backtick/tilde fences, language labels, and longer closing fences
- add regression coverage for long punctuation/whitespace runs and supported fence variants

## Validation
- 1,354 assertion tests passing across 60 files
- npm run tsc
- Biome checks on changed files; existing complexity warning in unchanged SQL validation code remains
- local Promptfoo eval passed both contains-sql and gleu assertions with score 1