### PR TITLE
docs(examples): add Nebius Token Factory recipe

### DIFF
--- a/examples/provider-nebius-token-factory/README.md
+++ b/examples/provider-nebius-token-factory/README.md
@@ -1,0 +1,26 @@
+# provider-nebius-token-factory (Nebius Token Factory)
+
+Use Nebius Token Factory through promptfoo's generic OpenAI-compatible Chat Completions provider. Token Factory needs only its canonical base URL, an API key, and a current model ID, so this example does not add a dedicated provider prefix.
+
+## Setup
+
+1. Create an API key by following the [Token Factory quickstart](https://docs.tokenfactory.nebius.com/quickstart).
+2. Export the key:
+
+   ```bash
+   export NEBIUS_API_KEY=your_api_key_here
+   ```
+
+3. Copy and run the example:
+
+   ```bash
+   npx promptfoo@latest init --example provider-nebius-token-factory
+   cd provider-nebius-token-factory
+   npx promptfoo@latest eval
+   ```
+
+The config uses `openai:chat:moonshotai/Kimi-K2.7-Code` with `apiBaseUrl` set to `https://api.tokenfactory.nebius.com/v1`. Replace the model ID with another current chat model from the [Token Factory catalog](https://tokenfactory.nebius.com/api/public/models_info) if needed.
+
+## API scope
+
+This recipe uses the stateless Chat Completions endpoint. It does not configure promptfoo's OpenAI Responses provider or rely on persisted response state.

--- a/examples/provider-nebius-token-factory/promptfooconfig.yaml
+++ b/examples/provider-nebius-token-factory/promptfooconfig.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: Evaluate coding answers with Nebius Token Factory
+
+prompts:
+  - 'Write a concise {{language}} function that returns the {{n}}th Fibonacci number.'
+
+providers:
+  - id: openai:chat:moonshotai/Kimi-K2.7-Code
+    label: Nebius Token Factory - Kimi K2.7 Code
+    config:
+      apiBaseUrl: https://api.tokenfactory.nebius.com/v1
+      apiKey: '{{env.NEBIUS_API_KEY}}'
+      max_tokens: 512
+      temperature: 0
+
+tests:
+  - vars:
+      language: Python
+      n: 10
+    assert:
+      - type: contains
+        value: 'def '
+      - type: contains-any
+        value: ['55', 'fibonacci', 'Fibonacci']
+
+  - vars:
+      language: TypeScript
+      n: 12
+    assert:
+      - type: contains-any
+        value: ['function', '=>']
+      - type: contains-any
+        value: ['144', 'fibonacci', 'Fibonacci']


### PR DESCRIPTION
## Summary

- add a runnable Nebius Token Factory example using promptfoo's generic `openai:chat` provider
- configure the canonical Token Factory base URL, `NEBIUS_API_KEY`, and current `moonshotai/Kimi-K2.7-Code` model ID
- document setup, model replacement, and the stateless Chat Completions scope
- avoid adding a `nebius:*` prefix or provider registry entry because Token Factory requires only a base URL and API key

## Why

Promptfoo's contribution guide directs OpenAI-compatible services that need only `apiBaseUrl` and an API key to the generic OpenAI provider. This recipe makes that supported path discoverable without adding provider-specific maintenance surface.

The public Token Factory catalog was checked on 2026-08-13 to confirm `moonshotai/Kimi-K2.7-Code` remains current and advertises function calling.

## Validation

- `npm run local -- validate -c examples/provider-nebius-token-factory/promptfooconfig.yaml` — configuration valid
- `npx vitest run test/examples/readme.test.ts` — 1,758 passed
- `npm run l` — passed for changed files
- `npm run f` — passed for changed files
- Prettier check for the new README and YAML — passed
- `git diff --check` — passed

The broader `test/types/index.test.ts` run passed 386 of 388 tests; two unrelated JSON Schema tests could not load `site/static/config-schema.json` because this isolated checkout is sparse. The new config was validated directly through the local CLI.

No Token Factory credential was available, so this PR does not claim a live authenticated eval.
