### PR TITLE
refactor(tracing): simplify redaction and stabilize regression tests

### DIFF
--- a/src/tracing/genaiTracer.ts
+++ b/src/tracing/genaiTracer.ts
@@ -541,10 +541,14 @@ function buildRequestAttributes(
  * Redacts API keys, secrets, tokens, and other sensitive patterns.
  */
 export function sanitizeBody(body: string): string {
+  const replace = String.prototype.replace as (
+    this: string,
+    pattern: RegExp,
+    replacement: (typeof SENSITIVE_PATTERNS)[number]['replacement'],
+  ) => string;
   let sanitized = body;
   for (const { pattern, replacement } of SENSITIVE_PATTERNS) {
-    // Both replacement types are valid, but TypeScript models them as separate overloads.
-    sanitized = sanitized.replace(pattern, replacement as string);
+    sanitized = replace.call(sanitized, pattern, replacement);
   }
   return sanitized;
 }

--- a/src/tracing/genaiTracer.ts
+++ b/src/tracing/genaiTracer.ts
@@ -543,11 +543,8 @@ function buildRequestAttributes(
 export function sanitizeBody(body: string): string {
   let sanitized = body;
   for (const { pattern, replacement } of SENSITIVE_PATTERNS) {
-    if (typeof replacement === 'function') {
-      sanitized = sanitized.replace(pattern, replacement);
-    } else {
-      sanitized = sanitized.replace(pattern, replacement);
-    }
+    // Both replacement types are valid, but TypeScript models them as separate overloads.
+    sanitized = sanitized.replace(pattern, replacement as string);
   }
   return sanitized;
 }

--- a/test/assertions/sql.test.ts
+++ b/test/assertions/sql.test.ts
@@ -487,7 +487,7 @@ describe('is-sql assertion', () => {
 
   // ------------------------------------------ Allowed Table/Column List Tests ------------------------------------------ //
   describe('Allowed Table/Column List Tests', () => {
-    it('should fail if the output SQL statement violate allowedTables', async () => {
+    it('should fail if the output SQL statement violates allowedTables', async () => {
       const renderedValue = {
         databaseType: 'MySQL',
         allowedTables: ['(select|update|insert|delete)::null::departments'],
@@ -527,7 +527,7 @@ describe('is-sql assertion', () => {
       });
     });
 
-    it('should fail if the output SQL statement violate allowedColumns', async () => {
+    it('should fail if the output SQL statement violates allowedColumns', async () => {
       const renderedValue = {
         databaseType: 'MySQL',
         allowedColumns: ['select::null::name', 'update::null::id'],

--- a/test/providers/openai/completion.test.ts
+++ b/test/providers/openai/completion.test.ts
@@ -380,7 +380,7 @@ describe('OpenAI Provider', () => {
       const result = await provider.callApi('Test prompt');
 
       expect(mockFetchWithCache).toHaveBeenCalledTimes(1);
-      expect(result.error).toContain('Cannot destructure property');
+      expect(result.error).toEqual(expect.stringMatching(/\S/));
     });
 
     it('should pass custom headers from config', async () => {

--- a/test/providers/openai/completion.test.ts
+++ b/test/providers/openai/completion.test.ts
@@ -380,7 +380,7 @@ describe('OpenAI Provider', () => {
       const result = await provider.callApi('Test prompt');
 
       expect(mockFetchWithCache).toHaveBeenCalledTimes(1);
-      expect(result.error).toEqual(expect.stringMatching(/\S/));
+      expect(result.error).toMatch(/^API call error:/);
     });
 
     it('should pass custom headers from config', async () => {

--- a/test/tracing/evaluatorTracing.test.ts
+++ b/test/tracing/evaluatorTracing.test.ts
@@ -52,13 +52,8 @@ vi.mock('../../src/tracing/otlpReceiver', () => ({
 describe('evaluatorTracing', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    mockStartOTLPReceiver.mockReset();
     mockStartOTLPReceiver.mockResolvedValue(undefined);
-    mockStopOTLPReceiver.mockReset();
     mockStopOTLPReceiver.mockResolvedValue(undefined);
-    mockUpdateOTLPReceiverOptions.mockReset();
-    mockRegisterOTLPReceiverTracePolicy.mockReset();
-    mockCreateTrace.mockReset();
     mockCreateTrace.mockResolvedValue(undefined);
     vi.mocked(getTraceStore).mockReturnValue({
       createTrace: mockCreateTrace,

--- a/test/tracing/genaiTracer.test.ts
+++ b/test/tracing/genaiTracer.test.ts
@@ -8,6 +8,7 @@ import {
   getCurrentTraceId,
   getTraceparent,
   PromptfooAttributes,
+  sanitizeBody,
   setGenAIResponseAttributes,
   withGenAISpan,
   withGenAIToolSpan,
@@ -784,6 +785,15 @@ describe('genaiTracer', () => {
       providerId: 'openai:gpt-4',
       sanitizeBodies: true, // Enable sanitization for these tests
     };
+
+    it('supports both capture-group and functional secret replacements', () => {
+      const encodedSecret = `${'a'.repeat(20)}/${'b'.repeat(19)}`;
+      const ordinaryText = 'c'.repeat(40);
+
+      expect(sanitizeBody(`password=hunter2 ${encodedSecret} ${ordinaryText}`)).toBe(
+        `password=<REDACTED> <REDACTED_SECRET> ${ordinaryText}`,
+      );
+    });
 
     it('should redact OpenAI API keys from request body', async () => {
       const contextWithBody = {

--- a/test/tracing/storePersistence.test.ts
+++ b/test/tracing/storePersistence.test.ts
@@ -339,6 +339,7 @@ describe('span uniqueness migration', () => {
     const directory = await mkdtemp(join(tmpdir(), 'promptfoo-span-migration-'));
 
     try {
+      // Pin the migration that removes duplicate spans before adding its unique index.
       const migration = await readFile(
         new URL('../../drizzle/0025_broken_emma_frost.sql', import.meta.url),
         'utf8',


### PR DESCRIPTION
## Summary

- Simplify tracing-body redaction while preserving string and callback replacements, with focused regression coverage.
- Make OpenAI completion error assertions independent of JavaScript engine wording and remove redundant tracing mock resets.
- Correct SQL assertion test descriptions and document why the span-uniqueness migration test targets a specific historical migration.
- Resolve all six currently visible code-quality AI findings across five reported files.

## Validation

- `node node_modules/vitest/vitest.mjs run test/tracing/genaiTracer.test.ts test/tracing/evaluatorTracing.test.ts test/tracing/storePersistence.test.ts test/providers/openai/completion.test.ts test/assertions/sql.test.ts --sequence.shuffle=false --configLoader runner` — 221 tests passed
- `node node_modules/vitest/vitest.mjs run test/tracing test/evaluator/trace-integration.test.ts test/assertions/trace.test.ts test/assertions/trajectory.test.ts --sequence.shuffle=false --configLoader runner` — 627 tests passed
- `npm run tsc`
- `npm run l`
- `npm run f`
