### PR TITLE
test(providers/http): cover and document multipart file:// paths

### DIFF
--- a/site/docs/providers/http.md
+++ b/site/docs/providers/http.md
@@ -141,6 +141,13 @@ Structured multipart requests bypass the HTTP response cache by default.
 `multipart` is mutually exclusive with `request` and `body`, and it cannot be
 used with `GET` or `HEAD`.
 
+A `file://` path with a host, like `file://fixtures/sample-report45.pdf`, is a
+path relative to the config directory on every platform. Use `file:///` for an
+absolute path. On Windows, write a network share either as a plain
+`\\server\share\report.pdf` with no scheme or as
+`file:////server/share/report.pdf`, since `file://server/share/report.pdf` is
+indistinguishable from a relative path and is read as one.
+
 ## Sending a raw HTTP request
 
 You can also send a raw HTTP request by specifying the `request` property in the provider configuration. This allows you to have full control over the request, including headers and body.

--- a/src/providers/httpMultipart.ts
+++ b/src/providers/httpMultipart.ts
@@ -154,17 +154,37 @@ function createGeneratedFile(
   };
 }
 
-function normalizeFilePath(filePath: string): string {
+export function normalizeFilePath(filePath: string): string {
   if (!filePath.startsWith('file://')) {
     return filePath;
   }
 
+  // Only a file URL with an empty authority (file:///abs/path) names an absolute
+  // local path. Anything else is promptfoo's long-standing shorthand for a
+  // relative path -- file://fixtures/a.pdf, or file://./fixtures/a.pdf once the
+  // var holding it has been rendered.
+  //
+  // The authority has to be checked before handing the URL to fileURLToPath,
+  // because that function disagrees with itself across platforms: POSIX throws
+  // ERR_INVALID_FILE_URL_HOST on a non-empty host, but Windows happily converts
+  // it to a UNC/device path (\\.\fixtures\a.pdf), which is never a valid local
+  // path and reaches the filesystem as an ENOENT.
+  let hasEmptyAuthority = false;
   try {
-    return fileURLToPath(filePath);
+    hasEmptyAuthority = new URL(filePath).host === '';
   } catch {
-    // Preserve promptfoo's long-standing shorthand: file://relative/path.ext
-    return filePath.slice('file://'.length);
+    hasEmptyAuthority = false;
   }
+
+  if (hasEmptyAuthority) {
+    try {
+      return fileURLToPath(filePath);
+    } catch {
+      // Fall through to the relative shorthand below.
+    }
+  }
+
+  return filePath.slice('file://'.length);
 }
 
 function resolvePath(filePath: string): string {

--- a/src/providers/httpMultipart.ts
+++ b/src/providers/httpMultipart.ts
@@ -162,13 +162,23 @@ export function normalizeFilePath(filePath: string): string {
   // Only a file URL with an empty authority (file:///abs/path) names an absolute
   // local path. Anything else is promptfoo's long-standing shorthand for a
   // relative path -- file://fixtures/a.pdf, or file://./fixtures/a.pdf once the
-  // var holding it has been rendered.
+  // var holding it has been rendered. That matches `parseFileUrl`, which every
+  // other `file://` consumer in promptfoo goes through and which strips the
+  // scheme unconditionally.
   //
   // The authority has to be checked before handing the URL to fileURLToPath,
   // because that function disagrees with itself across platforms: POSIX throws
   // ERR_INVALID_FILE_URL_HOST on a non-empty host, but Windows happily converts
   // it to a UNC/device path (\\.\fixtures\a.pdf), which is never a valid local
   // path and reaches the filesystem as an ENOENT.
+  //
+  // A hosted file URL is therefore always read as the shorthand, because
+  // `file://server/share/a.pdf` and `file://fixtures/a.pdf` are syntactically
+  // identical and only the second has a documented meaning. A genuine UNC path
+  // stays reachable through either spelling that is unambiguous -- a plain
+  // `\\server\share\a.pdf` with no scheme, or the empty-authority
+  // `file:////server/share/a.pdf` -- both of which `path.isAbsolute` accepts on
+  // win32 and neither of which collides with a relative path.
   let hasEmptyAuthority = false;
   try {
     hasEmptyAuthority = new URL(filePath).host === '';

--- a/test/providers/http-multipart.test.ts
+++ b/test/providers/http-multipart.test.ts
@@ -466,6 +466,21 @@ describe('normalizeFilePath', () => {
     expect(normalizeFilePath(input)).toBe(expected);
   });
 
+  it.each([
+    // Empty authority, so it is not the relative shorthand. POSIX resolves it directly;
+    // on Windows fileURLToPath rejects the leading `//` and the fallback yields the same
+    // string, which path.win32.isAbsolute accepts as a UNC path either way.
+    ['file:////server/share/report.pdf', '//server/share/report.pdf'],
+    // No scheme at all, so it is returned untouched and stays absolute on win32.
+    ['\\\\server\\share\\report.pdf', '\\\\server\\share\\report.pdf'],
+  ])('keeps %s usable as a UNC path', (input, expected) => {
+    expect(normalizeFilePath(input)).toBe(expected);
+  });
+
+  it('falls back to the shorthand when the file URL cannot be parsed', () => {
+    expect(normalizeFilePath('file://[')).toBe('[');
+  });
+
   it('keeps the shorthand relative when fileURLToPath converts it, as it does on Windows', async () => {
     // fileURLToPath disagrees with itself across platforms for a non-empty
     // authority: POSIX throws ERR_INVALID_FILE_URL_HOST, but Windows returns a

--- a/test/providers/http-multipart.test.ts
+++ b/test/providers/http-multipart.test.ts
@@ -4,9 +4,12 @@ import { createServer, type Server } from 'http';
 import { AddressInfo } from 'net';
 import os from 'os';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import cliState from '../../src/cliState';
 import { HttpProvider } from '../../src/providers/http';
+import { normalizeFilePath } from '../../src/providers/httpMultipart';
 
 interface MockFileSummary {
   filename: string;
@@ -438,5 +441,113 @@ describe('HttpProvider structured multipart requests', () => {
     });
     expect(result.metadata?.multipart.files[0]).not.toHaveProperty('sha256');
     expect(JSON.stringify(result.metadata)).not.toContain('Benign generated report');
+  });
+});
+
+describe('normalizeFilePath', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('converts an absolute file URL to a local path', () => {
+    const absolute = process.platform === 'win32' ? 'C:\\tmp\\report.pdf' : '/tmp/report.pdf';
+    expect(normalizeFilePath(pathToFileURL(absolute).toString())).toBe(absolute);
+  });
+
+  it('leaves paths without the file:// scheme alone', () => {
+    expect(normalizeFilePath('./fixtures/sample.pdf')).toBe('./fixtures/sample.pdf');
+  });
+
+  it.each([
+    ['file://fixtures/sample.pdf', 'fixtures/sample.pdf'],
+    ['file://./fixtures/sample.pdf', './fixtures/sample.pdf'],
+    ['file://../fixtures/sample.pdf', '../fixtures/sample.pdf'],
+  ])('treats %s as promptfoo relative-path shorthand', (input, expected) => {
+    expect(normalizeFilePath(input)).toBe(expected);
+  });
+
+  it('keeps the shorthand relative when fileURLToPath converts it, as it does on Windows', async () => {
+    // fileURLToPath disagrees with itself across platforms for a non-empty
+    // authority: POSIX throws ERR_INVALID_FILE_URL_HOST, but Windows returns a
+    // UNC/device path such as \\.\fixtures\sample.pdf, which is never a valid
+    // local path and reaches the filesystem as an ENOENT. Stand in for the
+    // Windows conversion so the guard is exercised on every platform.
+    vi.resetModules();
+    vi.doMock('url', async () => {
+      const actual = await vi.importActual<typeof import('url')>('url');
+      return {
+        ...actual,
+        default: actual,
+        fileURLToPath: (input: string | URL) => {
+          const parsed = typeof input === 'string' ? new URL(input) : input;
+          if (parsed.host !== '') {
+            return `\\\\${parsed.host}${parsed.pathname.replace(/\//g, '\\')}`;
+          }
+          return actual.fileURLToPath(input);
+        },
+      };
+    });
+
+    try {
+      const { normalizeFilePath: normalizeOnWindows } = await import(
+        '../../src/providers/httpMultipart'
+      );
+      expect(normalizeOnWindows('file://./fixtures/sample.pdf')).toBe('./fixtures/sample.pdf');
+      expect(normalizeOnWindows('file://fixtures/sample.pdf')).toBe('fixtures/sample.pdf');
+    } finally {
+      vi.doUnmock('url');
+      vi.resetModules();
+    }
+  });
+});
+
+describe('HttpProvider multipart relative file:// sources', () => {
+  const originalBasePath = cliState.basePath;
+
+  afterEach(() => {
+    cliState.basePath = originalBasePath;
+  });
+
+  it('resolves a relative file:// path from the config directory', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-multipart-relative-'));
+    tempDirs.push(tempDir);
+    fs.mkdirSync(path.join(tempDir, 'fixtures'));
+    fs.writeFileSync(path.join(tempDir, 'fixtures', 'sample.txt'), 'sample contents');
+    cliState.basePath = tempDir;
+
+    const mockServer = await createMultipartDocumentSummarizerServer();
+    const provider = new HttpProvider('http', {
+      config: {
+        url: mockServer.url,
+        headers: { 'X-API-Key': 'test-api-key' },
+        multipart: {
+          parts: [
+            {
+              kind: 'file',
+              name: 'files',
+              source: { type: 'path', path: 'file://{{documentPath}}' },
+            },
+            {
+              kind: 'field',
+              name: 'documentQuery',
+              value: '{{prompt}}',
+            },
+          ],
+        },
+        transformResponse: 'json.summary',
+      },
+    });
+
+    for (const documentPath of ['./fixtures/sample.txt', 'fixtures/sample.txt']) {
+      await provider.callApi('Summarize local fixture', {
+        prompt: { raw: 'Summarize local fixture', label: 'query' },
+        vars: { documentPath },
+      });
+
+      expect(mockServer.getLastRequest()?.files[0]).toMatchObject({
+        filename: 'sample.txt',
+        sizeBytes: Buffer.byteLength('sample contents'),
+      });
+    }
   });
 });


### PR DESCRIPTION
Fixes #10337.

An HTTP provider multipart file source using promptfoo's relative `file://` shorthand fails on Windows: `./fixtures/sample.pdf` becomes `\\.\fixtures\sample.pdf` and throws `ENOENT`.

## Root cause

`normalizeFilePath` in `src/providers/httpMultipart.ts` handed every `file://` string to `fileURLToPath`, relying on it to *throw* for anything that wasn't an absolute file URL:

```ts
try {
  return fileURLToPath(filePath);
} catch {
  // Preserve promptfoo's long-standing shorthand: file://relative/path.ext
  return filePath.slice('file://'.length);
}
```

That works on POSIX, where a non-empty authority is rejected with `ERR_INVALID_FILE_URL_HOST` and the shorthand branch runs. On Windows the same call *succeeds* and converts the authority into a UNC/device path, so the shorthand branch is never reached:

| input | parsed host | POSIX | Windows |
|---|---|---|---|
| `file://./fixtures/x.pdf` | `.` | throws → `./fixtures/x.pdf` | `\\.\fixtures\x.pdf` |
| `file://fixtures/x.pdf` | `fixtures` | throws → `fixtures/x.pdf` | `\\fixtures\x.pdf` |
| `file:///C:/x.pdf` | `` (empty) | `/C:/x.pdf` | `C:\x.pdf` |

Both of the first two are relative paths per the documented shorthand (`site/docs/providers/http.md` uses `file://fixtures/sample-report45.pdf`), and neither is a network share.

## Fix

Check the authority before converting, and only call `fileURLToPath` when it's empty — the one form that names an absolute local path. Everything else keeps the existing relative behavior, now identically on every platform.

On POSIX this is a no-op: the hosted URLs it now skips are exactly the ones `fileURLToPath` was already throwing on.

## Tests

Added to `test/providers/http-multipart.test.ts`:

- `normalizeFilePath` unit coverage — absolute file URLs, non-`file://` paths, and the `file://fixtures/…` / `file://./…` / `file://../…` shorthands.
- A regression test that substitutes a `fileURLToPath` behaving the way Windows does (returning the UNC path instead of throwing) via `vi.doMock` + dynamic import, so the guard is exercised on Linux and macOS CI too. This one fails against the old implementation and passes with the fix.
- An end-to-end test through `HttpProvider` that resolves `./fixtures/sample.txt` and `fixtures/sample.txt` from `cliState.basePath` and asserts the file actually reaches the server.

`normalizeFilePath` is now exported so the unit tests can reach it directly.

Whole http provider suite passes: `npx vitest run test/providers/http test/providers/http-multipart.test.ts test/providers/httpTransforms.test.ts` → 416 passed. Biome and Prettier clean.

I don't have a Windows box, so the platform-specific half is covered by the simulated `fileURLToPath` rather than a real Windows run — worth a sanity check on Windows CI.


---

**Updated after merging `main` (scope changed).** The `src/providers/httpMultipart.ts` fix described above landed independently on main in #10566 (`22468f45be`, merged 2026-09-01), which also closed #10337. Main's version is a superset: it exports `normalizeFilePath`/`resolvePath`, reads a hosted `file://` URL as the relative shorthand on every platform, and additionally handles Windows drive letters (`file://C:/…`, `file:///C:\…`), the `file://localhost/…` form, and percent-decoding. So **no `src/` change remains in this diff**, and the "Root cause"/"Fix" sections above describe code that is already on main.

What this PR still contributes, on top of main:

- `test/providers/http-multipart.test.ts` (+69) — three cases main's tests don't cover:
  - `normalizeFilePath('file:////server/share/report.pdf')` → `//server/share/report.pdf`, i.e. the empty-authority spelling stays usable as a UNC path;
  - `normalizeFilePath('file://[')` → `[`, the shorthand fallback for a value that isn't a parseable URL;
  - an end-to-end `HttpProvider` test that uploads `./fixtures/sample.txt` and `fixtures/sample.txt` resolved from `cliState.basePath` and asserts the bytes reach the server.
- `site/docs/providers/http.md` (+9) — documents the `file://` resolution rules for multipart sources (hosted URL = relative to the config dir; `file:///`, `file://C:/…` and `file://localhost/…` = absolute; UNC shares as plain `\\server\share\…` or `file:////server/share/…`). #10566 shipped no docs, so this is still new.

Two claims in the "Tests" section above are now stale: the `vi.doMock` + dynamic-import Windows simulation was dropped in the merge (main's implementation never hands a hosted URL to `fileURLToPath`, so there is nothing left to simulate), and `normalizeFilePath` is exported by main rather than by this PR.

Verified against main's implementation: `npx vitest run test/providers/http-multipart.test.ts` → 23 passed.

Title updated from `fix(providers/http): resolve relative multipart file:// paths on Windows` to reflect that this is now test + docs coverage rather than a fix.
