### PR TITLE
test(providers): cover HTTP cache usage in traces

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -12,7 +12,11 @@ import cliState from '../cliState';
 import { getEnvString } from '../envars';
 import { importModule } from '../esm';
 import logger from '../logger';
-import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
+import {
+  extractProviderResponseAttributes,
+  type GenAISpanContext,
+  withGenAISpan,
+} from '../tracing/genaiTracer';
 import { stripDecompressionHeaders } from '../util/fetch/stripDecompressionHeaders';
 import {
   maybeLoadConfigFromExternalFile,
@@ -2588,23 +2592,10 @@ export class HttpProvider implements ApiProvider {
       traceparent: context?.traceparent,
     };
 
-    // Result extractor to set response attributes on the span
-    const resultExtractor = (response: ProviderResponse): GenAISpanResult => {
-      const result: GenAISpanResult = {};
-      if (response.tokenUsage) {
-        result.tokenUsage = {
-          prompt: response.tokenUsage.prompt,
-          completion: response.tokenUsage.completion,
-          total: response.tokenUsage.total,
-        };
-      }
-      return result;
-    };
-
     return withGenAISpan(
       spanContext,
       () => this.callApiInternal(prompt, context, options),
-      resultExtractor,
+      extractProviderResponseAttributes,
     );
   }
 

--- a/test/providers/http/request.test.ts
+++ b/test/providers/http/request.test.ts
@@ -3,6 +3,7 @@ import './setup';
 
 import path from 'path';
 
+import { trace } from '@opentelemetry/api';
 import dedent from 'dedent';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
@@ -1922,6 +1923,61 @@ describe('HttpProvider with token estimation', () => {
     expect(result.tokenUsage!.prompt).toBe(100);
     expect(result.tokenUsage!.completion).toBe(200);
     expect(result.tokenUsage!.total).toBe(300);
+  });
+
+  it('should preserve HTTP token usage cache details on tracing spans', async () => {
+    const spanAttributes: Record<string, unknown> = {};
+    const getTracerSpy = vi.spyOn(trace, 'getTracer').mockReturnValue({
+      startActiveSpan: (_name: string, _options: unknown, _context: unknown, callback: any) =>
+        callback({
+          setAttribute: (key: string, value: unknown) => {
+            spanAttributes[key] = value;
+          },
+          setStatus: vi.fn(),
+          recordException: vi.fn(),
+          end: vi.fn(),
+        }),
+    } as any);
+    const provider = new HttpProvider('http://test.com', {
+      config: {
+        method: 'POST',
+        body: { prompt: '{{prompt}}' },
+        transformResponse: () => ({
+          output: 'Test response',
+          tokenUsage: {
+            prompt: 100,
+            completion: 200,
+            cached: 40,
+            total: 300,
+            completionDetails: {
+              cacheReadInputTokens: 40,
+              cacheCreationInputTokens: 15,
+            },
+          },
+        }),
+      },
+    });
+
+    vi.mocked(fetchWithCache).mockResolvedValueOnce({
+      data: JSON.stringify({ result: 'Hello world' }),
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    });
+
+    try {
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.tokenUsage?.completionDetails).toEqual({
+        cacheReadInputTokens: 40,
+        cacheCreationInputTokens: 15,
+      });
+      expect(spanAttributes['gen_ai.usage.cached_tokens']).toBe(40);
+      expect(spanAttributes['gen_ai.usage.cache_read_input_tokens']).toBe(40);
+      expect(spanAttributes['gen_ai.usage.cache_creation_input_tokens']).toBe(15);
+    } finally {
+      getTracerSpy.mockRestore();
+    }
   });
 
   it('should work with raw request mode', async () => {


### PR DESCRIPTION
## Summary

- use the shared provider-response tracing extractor for the generic HTTP provider
- preserve `tokenUsage.completionDetails` when HTTP/custom providers report cache-read or cache-creation token details
- add a regression test that verifies HTTP span attributes include cached, cache-read, and cache-creation token counts

## Why

The HTTP provider already lets custom targets return structured `tokenUsage`, including cache-aware completion details. The local tracing extractor only copied prompt/completion/total tokens, so cache-read and cache-write details were dropped before they reached GenAI span attributes.

Preserving the full token usage object keeps custom HTTP providers consistent with OpenAI/Responses providers and makes downstream cost accounting possible without changing provider response shape.

## Validation

- `npm run test -- test/providers/http/request.test.ts` -> 95 passed
- `npm run tsc`
- `npx @biomejs/biome lint src/providers/http.ts test/providers/http/request.test.ts` -> existing complexity warnings in `src/providers/http.ts`, no errors
- `git diff --check`

Context: this is part of a broader open-source effort to make prompt-cache costs measurable across eval and agent frameworks: https://github.com/Tanisha-Katara/cacheeconomics


---

**Updated after merging `main` (audit note, not a change by the author):** the scope of this PR has changed
materially, so the summary above no longer matches the diff.

- The `src/providers/http.ts` change is **gone from this diff**, but it was not superseded by an equivalent fix.
  `feat(tracing): align spans with OpenTelemetry GenAI conventions` (#10361, `e6f44f8b04`) **removed GenAI span
  creation from `HttpProvider.callApi` entirely** — it now just delegates to `this.callApiInternal(...)`. The local
  `resultExtractor` this PR replaced no longer exists, so there is nothing left to swap for
  `extractProviderResponseAttributes`.
- What remains is **56 lines of test** in `test/providers/http/request.test.ts` (one case,
  `should preserve HTTP token usage cache details on tracing spans`).
- **That test currently fails against `main`.** Because `HttpProvider` no longer opens a span, the mocked
  `trace.getTracer` is never called and `spanAttributes` stays empty:
  `AssertionError: expected undefined to be 40` at the `gen_ai.usage.cached_tokens` assertion. This is the cause of
  the red `Test on Node …` jobs on this PR.
- The asserted attribute names were also renamed by #10361 and are now stale: `gen_ai.usage.cache_read_input_tokens`
  → `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation_input_tokens` →
  `gen_ai.usage.cache_creation.input_tokens`, and `tokenUsage.cached` is emitted as
  `promptfoo.usage.cached_response_tokens` on a cache hit.
- The response-level half of the test still holds on `main`: `HttpProvider` returns the transform's
  `tokenUsage.completionDetails` untouched, and that assertion passes.
- **The underlying gap may still be real, just in a different place.** HTTP targets are now traced by
  `withTargetSpan` in `src/tracing/targetTracer.ts`, which sets `promptfoo.cache_hit` but no token-usage attributes
  at all. The cache-detail attributes (`gen_ai.usage.cache_read.input_tokens`,
  `gen_ai.usage.cache_creation.input_tokens`) are only emitted by `setGenAIResponseAttributes`, which is reached from
  `withGenAISpan` — used by the OpenAI chat/responses/completion/assistant providers, the Azure Foundry agent, and
  embeddings calls, but not by the plain HTTP target path.

Maintainer decision needed: either rework this coverage against the current tracing architecture (assert the
cache-detail attributes on the evaluator-level target span in `src/tracing/targetTracer.ts`, and update the
attribute names), or close this PR as obsoleted by #10361. No code has been changed by this note.
