### PR TITLE
docs(site): use absolute model grading link in HLE benchmark guide

### DIFF
--- a/site/docs/guides/hle-benchmark.md
+++ b/site/docs/guides/hle-benchmark.md
@@ -263,5 +263,5 @@ Promptfoo provides HLE eval capabilities through automated dataset integration, 
 ### Promptfoo Integration
 
 - [HuggingFace Provider Guide](../providers/huggingface.md) - Set up dataset access
-- [Model Grading Setup](../../configuration/expected-outputs/model-graded/) - Configure automated grading
+- [Model Grading Setup](../configuration/expected-outputs/model-graded/) - Configure automated grading
 - [Anthropic Provider](../providers/anthropic.md) - Configure Claude 4


### PR DESCRIPTION
Fixes a broken internal documentation link in `site/docs/guides/hle-benchmark.md`.

The "Model Grading Setup" link used `../../configuration/expected-outputs/model-graded/`, which resolves two levels up from `docs/guides/` (escaping the docs root to `/configuration/...` instead of `/docs/configuration/...`) and 404s on the built site. All sibling links in the same file use a single `../` (e.g. `../providers/huggingface.md`), and other guides link to the same page as `../configuration/expected-outputs/model-graded/` (see `evaluate-rag.md`).

Changed to `../configuration/expected-outputs/model-graded/`, which resolves to the existing page.

---

**Updated after merging `main`:** the change on this branch is no longer the one described above, and the original diagnosis did not hold. Correcting the record, without touching the analysis above:

- **The `../../` link on `main` is not broken.** `site/docusaurus.config.ts` sets `trailingSlash: true`, so the page is served at `/docs/guides/hle-benchmark/` and `../../configuration/expected-outputs/model-graded/` resolves to `/docs/configuration/expected-outputs/model-graded/`. The live page renders it as `href="/docs/configuration/expected-outputs/model-graded/"`, that URL returns HTTP 200, and `onBrokenLinks: 'throw'` has never flagged it.
- **The originally proposed `../configuration/...` target broke the docs build.** "Build Docs" failed on `d545433f` with:

  ```text
  - Broken link on source page path = /docs/guides/hle-benchmark/:
     -> linking to ../configuration/expected-outputs/model-graded/ (resolved as: /docs/guides/configuration/expected-outputs/model-graded/)
  ```

  The sibling-link comparison doesn't carry over: `../providers/huggingface.md` is a `.md` link, which Docusaurus resolves against the **file** path at build time, whereas an extension-less URL such as `.../model-graded/` is resolved against the **page URL**. The links to this same index page in `evaluate-rag.md` use `/docs/configuration/expected-outputs/model-graded/`, not `../configuration/...`.
- **What the branch contains now:** `19d4e662` retargeted the link to the site-absolute `/docs/configuration/expected-outputs/model-graded/` — the form already used by `evaluate-rag.md`, `llm-as-a-judge.md`, and `gpt-5.2-vs-o3.md` (7 occurrences), and one that is immune to trailing-slash resolution. CI is green.

Net diff against `main` is one line in `site/docs/guides/hle-benchmark.md`. Since it swaps a working relative link for an equivalent absolute one, it is a consistency/robustness cleanup rather than a broken-link fix, and the title has been updated to say so. **Maintainer note:** nothing was actually broken, so whether this is worth landing is a judgement call.
