### PR TITLE
fix(deps): keep Renovate on the supported npm major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "rangeStrategy": "auto",
   "postUpdateOptions": [],
   "constraints": {
-    "npm": ">= 11"
+    "npm": ">=11.18.0 <12"
   },
   "npmrc": "registry=https://registry.npmjs.org/\nengine-strict=true",
   "lockFileMaintenance": {

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -193,6 +193,19 @@ describe('package manifests', () => {
     ).toBe(true);
   });
 
+  it('keeps Renovate on the npm major used by CI', () => {
+    const renovateConfig = readPackageJson<{
+      constraints?: {
+        npm?: string;
+      };
+    }>('renovate.json');
+    const npmConstraint = renovateConfig.constraints?.npm;
+
+    expect(npmConstraint, 'Renovate must constrain its npm version').toBeDefined();
+    expect(satisfies('11.18.0', npmConstraint as string)).toBe(true);
+    expect(satisfies('12.0.0', npmConstraint as string)).toBe(false);
+  });
+
   it('keeps jsdom on a release the supported Node floor can install', () => {
     const rootPackageJson = readPackageJson<PackageManifest & { engines?: Record<string, string> }>(
       'package.json',

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -202,6 +202,8 @@ describe('package manifests', () => {
     const npmConstraint = renovateConfig.constraints?.npm;
 
     expect(npmConstraint, 'Renovate must constrain its npm version').toBeDefined();
+    expect(validRange(npmConstraint)).not.toBeNull();
+    expect(satisfies('11.17.0', npmConstraint as string)).toBe(false);
     expect(satisfies('11.18.0', npmConstraint as string)).toBe(true);
     expect(satisfies('12.0.0', npmConstraint as string)).toBe(false);
   });


### PR DESCRIPTION
## Summary

- constrain Renovate to npm `>=11.18.0 <12`, matching the npm 11.18.0 version already pinned throughout Promptfoo CI
- prevent npm 12's `--package-lock-only` / bundled-dependency `EALLOWREMOTE` bug from blocking Renovate lockfile maintenance
- add a manifest regression test that accepts the supported CI npm version and rejects npm 12

Renovate PR #10391 currently fails `renovate/artifacts` because npm 12 rejects the registry-hosted `@tailwindcss/oxide-wasm32-wasi` tarball. npm/cli#9800 documents the exact `--package-lock-only` failure and explains why setting `allow-remote=root` does not fix it. Restricting Renovate to the repository's already-supported npm 11 major avoids weakening the remote-dependency guard.

## Validation

- `npx vitest run test/package-manifests.test.ts test/code-scan-action --sequence.shuffle=false` — 112 tests passed
- `npm run tsc`
- `npm run l`
- `npm run f`
- `npx prettier --check renovate.json`
- confirmed npm 11.18.0 and 11.19.0 satisfy the constraint; npm 12.0.0 and npm 11.6.2 do not
