### PR TITLE
fix(deps): enforce npm release age during lockfile maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "constraints": {
     "npm": ">=11.18.0 <12"
   },
-  "npmrc": "registry=https://registry.npmjs.org/\nengine-strict=true",
+  "npmrc": "registry=https://registry.npmjs.org/\nengine-strict=true\nmin-release-age=10",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
@@ -26,6 +26,13 @@
     {
       "description": "Disable major Node.js version updates",
       "matchPackageNames": ["node"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Keep Renovate's npm tool constraint on the CI-supported major; npm 12 breaks bundled lockfile maintenance",
+      "matchFileNames": ["renovate.json"],
+      "matchPackageNames": ["npm"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -198,6 +198,12 @@ describe('package manifests', () => {
       constraints?: {
         npm?: string;
       };
+      packageRules?: Array<{
+        enabled?: boolean;
+        matchFileNames?: string[];
+        matchPackageNames?: string[];
+        matchUpdateTypes?: string[];
+      }>;
     }>('renovate.json');
     const npmConstraint = renovateConfig.constraints?.npm;
 
@@ -206,6 +212,31 @@ describe('package manifests', () => {
     expect(satisfies('11.17.0', npmConstraint as string)).toBe(false);
     expect(satisfies('11.18.0', npmConstraint as string)).toBe(true);
     expect(satisfies('12.0.0', npmConstraint as string)).toBe(false);
+    expect(
+      renovateConfig.packageRules?.some(
+        (rule) =>
+          rule.enabled === false &&
+          rule.matchFileNames?.includes('renovate.json') &&
+          rule.matchPackageNames?.includes('npm') &&
+          rule.matchUpdateTypes?.includes('major'),
+      ),
+    ).toBe(true);
+  });
+
+  it('applies the npm release-age policy to Renovate lockfile maintenance', () => {
+    const renovateConfig = readPackageJson<{
+      npmrc?: string;
+      packageRules?: Array<{
+        matchDatasources?: string[];
+        minimumReleaseAge?: string;
+      }>;
+    }>('renovate.json');
+    const npmReleaseAgeRule = renovateConfig.packageRules?.find((rule) =>
+      rule.matchDatasources?.includes('npm'),
+    );
+
+    expect(npmReleaseAgeRule?.minimumReleaseAge).toBe('10 days');
+    expect(renovateConfig.npmrc).toMatch(/^min-release-age=10$/m);
   });
 
   it('keeps jsdom on a release the supported Node floor can install', () => {


### PR DESCRIPTION
## Summary

- Apply the existing ten-day npm stabilization window inside Renovate's npm configuration so lockfile maintenance cannot pull freshly published transitive dependencies that bypass `packageRules.minimumReleaseAge` and fail the Socket security policy.
- Disable major updates of Renovate's own npm tool constraint while npm 12 remains incompatible with the supported CI floor and bundled lockfile maintenance.
- Add manifest regression coverage for the npm release-age configuration, its matching Renovate package rule, and the npm-major guard.

## Why

The regenerated lockfile-maintenance PR updated 673 packages, including dozens of packages published within the last five days. The configured Socket registry rejected those packages despite the existing ten-day Renovate package rules because npm performs lockfile resolution independently. Renovate also immediately opened a separate PR that would undo the npm-11 constraint and restore the previously diagnosed npm-12 lockfile failure.

## Validation

- `npx vitest run test/package-manifests.test.ts test/scripts/architectureUtils.test.ts test/code-scan-action` — 172 tests passed.
- `npm run tsc`
- `npx @biomejs/biome check renovate.json test/package-manifests.test.ts`
- `npx check-dependency-version-consistency`
- `npm run l && npm run f`
- Confirmed npm parses Renovate's generated configuration as `min-release-age=10`.
