### PR TITLE
feat(redteam): account for test generation token usage

### DIFF
--- a/site/docs/red-team/configuration.md
+++ b/site/docs/red-team/configuration.md
@@ -38,6 +38,33 @@ shared.
 promptfoo redteam run --tag ci.run-id="$CI_RUN_ID" --tag git.sha="$GIT_SHA"
 ```
 
+### Generation token accounting
+
+Generated configurations include `metadata.generation`, which identifies when the test suite was
+created and, when available, records the model requests and tokens used to create it:
+
+```yaml
+metadata:
+  generation:
+    id: 4d2f4d7f-9b99-4a51-85c5-7fc5f6c03f88
+    generatedAt: '2026-08-17T12:00:00.000Z'
+    tokenUsage:
+      total: 1200
+      prompt: 900
+      completion: 300
+      numRequests: 4
+```
+
+Generation usage includes system-purpose extraction, entity extraction, attack-goal extraction,
+and test generation. A failed request still increments `numRequests` when its token count is
+unavailable. Reusing a complete cached response adds neither requests nor newly consumed tokens;
+provider-side prompt caching during an actual model request still counts that request.
+
+`promptfoo redteam run` attributes generation tokens to the evaluation only when it generated the
+suite during that run. Running an existing generated suite does not charge its historical
+generation usage again. `metadata.generationAccounting` is reserved for internally persisted
+current-run accounting and should not be added to reusable configurations.
+
 ## Configuration Structure
 
 The red team configuration uses the following YAML structure:

--- a/src/contracts/shared.ts
+++ b/src/contracts/shared.ts
@@ -20,12 +20,15 @@ const TokenUsageCoreSchema = z.object({
   completionDetails: CompletionTokenDetailsSchema.optional(),
 });
 
-/** Token usage statistics. The optional `assertions` mirrors the top-level fields for model-graded assertion accounting. */
+/** Target usage with independent generation and assertion breakdowns. */
 export const BaseTokenUsageSchema = TokenUsageCoreSchema.extend({
   assertions: TokenUsageCoreSchema.optional(),
+  generation: TokenUsageCoreSchema.optional(),
 });
 
 export type TokenUsage = z.infer<typeof BaseTokenUsageSchema>;
+export type NormalizedTokenUsage = Required<Omit<TokenUsage, 'generation'>> &
+  Pick<TokenUsage, 'generation'>;
 
 export type NunjucksFilterMap = Record<string, (...args: any[]) => string>;
 

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -43,7 +43,11 @@ import { isNonTransientHttpStatus, NON_TRANSIENT_HTTP_STATUSES } from '../util/f
 import invariant from '../util/invariant';
 import { sanitizeRuntimeOptions, sanitizeTracingConfigForPersistence } from '../util/sanitizer';
 import { getCurrentTimestamp } from '../util/time';
-import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageUtils';
+import {
+  accumulateGenerationTokenUsage,
+  accumulateTokenUsage,
+  createEmptyTokenUsage,
+} from '../util/tokenUsageUtils';
 import {
   invalidateEvaluationCache,
   notifyEvaluationChanged,
@@ -1413,6 +1417,11 @@ export default class Eval {
 
       accumulateTokenUsage(stats.tokenUsage, prompt.metrics?.tokenUsage);
     }
+
+    accumulateGenerationTokenUsage(
+      stats.tokenUsage,
+      this.config.metadata?.generationAccounting?.tokenUsage,
+    );
 
     return stats;
   }

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -529,6 +529,8 @@ export async function doEval(
         ...evaluateOptions,
         ...config.evaluateOptions,
         eventSource: evaluateOptions.eventSource,
+        generationEventId: evaluateOptions.generationEventId,
+        generationTokenUsage: evaluateOptions.generationTokenUsage,
       };
     }
 
@@ -786,6 +788,19 @@ export async function doEval(
       ...(providerFilter ? { providerFilter } : {}),
     };
 
+    if (evaluateOptions.generationTokenUsage) {
+      config = {
+        ...config,
+        metadata: {
+          ...(config.metadata ?? {}),
+          generationAccounting: {
+            id: evaluateOptions.generationEventId,
+            tokenUsage: evaluateOptions.generationTokenUsage,
+          },
+        },
+      };
+    }
+
     // Create or load eval record
     const author = getAuthor();
     const evalRecord = resumeEval
@@ -950,6 +965,10 @@ export async function doEval(
         errors += prompt.metrics.testErrorCount;
       }
       accumulateTokenUsage(tokenUsage, prompt.metrics?.tokenUsage);
+    }
+    const generationTokenUsage = evalRecord.getStats().tokenUsage.generation;
+    if (generationTokenUsage) {
+      tokenUsage.generation = generationTokenUsage;
     }
     const totalTests = successes + failures + errors;
     const passRate = (successes / totalTests) * 100;

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -788,7 +788,12 @@ export async function doEval(
       ...(providerFilter ? { providerFilter } : {}),
     };
 
-    if (evaluateOptions.generationTokenUsage) {
+    if (!resumeEval && config.metadata && 'generationAccounting' in config.metadata) {
+      const { generationAccounting: _staleGenerationAccounting, ...metadata } = config.metadata;
+      config = { ...config, metadata };
+    }
+
+    if (!resumeEval && evaluateOptions.generationTokenUsage) {
       config = {
         ...config,
         metadata: {

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -12,6 +12,7 @@ import {
 } from '../redteam/remoteGeneration';
 import { getRemoteMaterializationContextFromVars } from '../redteam/remoteMaterialization';
 import { fetchWithRetries } from '../util/fetch/index';
+import { getErrorTokenUsage } from '../util/tokenUsageUtils';
 import { getRequestTimeoutMs } from './shared';
 
 import type { EnvOverrides } from '../types/env';
@@ -114,7 +115,17 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
       );
 
       if (!response.ok) {
-        throw new Error(`API call failed with status ${response.status}: ${await response.text()}`);
+        const body = await response.text();
+        const error = new Error(`API call failed with status ${response.status}: ${body}`);
+        try {
+          const parsed = JSON.parse(body) as { tokenUsage?: TokenUsage };
+          if (parsed.tokenUsage) {
+            Object.assign(error, { tokenUsage: parsed.tokenUsage });
+          }
+        } catch {
+          // Preserve the original error for non-JSON responses.
+        }
+        throw error;
       }
 
       const data = await response.json();
@@ -128,6 +139,7 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
 
       return {
         output: validOutputs,
+        ...(data.tokenUsage ? { tokenUsage: data.tokenUsage as TokenUsage } : {}),
       };
     } catch (err) {
       // Re-throw abort errors to properly cancel the operation
@@ -135,8 +147,10 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
         throw err;
       }
       logger.info(`[HarmfulCompletionProvider] ${err}`);
+      const tokenUsage = getErrorTokenUsage(err);
       return {
         error: `[HarmfulCompletionProvider] ${err}`,
+        ...(tokenUsage ? { tokenUsage } : {}),
       };
     }
   }

--- a/src/providers/promptfoo.ts
+++ b/src/providers/promptfoo.ts
@@ -11,15 +11,15 @@ import {
   providerRemoteGenerationContextPayload,
 } from '../redteam/remoteGeneration';
 import { getRemoteMaterializationContextFromVars } from '../redteam/remoteMaterialization';
+import { BaseTokenUsageSchema } from '../types/shared';
 import { fetchWithRetries } from '../util/fetch/index';
-import { getErrorTokenUsage } from '../util/tokenUsageUtils';
 import { getRequestTimeoutMs } from './shared';
 
-import type { EnvOverrides } from '../types/env';
 import type {
   ApiProvider,
   CallApiContextParams,
   CallApiOptionsParams,
+  EnvOverrides,
   Inputs,
   PluginConfig,
   ProviderResponse,
@@ -147,7 +147,11 @@ export class PromptfooHarmfulCompletionProvider implements ApiProvider {
         throw err;
       }
       logger.info(`[HarmfulCompletionProvider] ${err}`);
-      const tokenUsage = getErrorTokenUsage(err);
+      const parsedTokenUsage =
+        err && typeof err === 'object' && 'tokenUsage' in err
+          ? BaseTokenUsageSchema.safeParse(err.tokenUsage)
+          : undefined;
+      const tokenUsage = parsedTokenUsage?.success ? parsedTokenUsage.data : undefined;
       return {
         error: `[HarmfulCompletionProvider] ${err}`,
         ...(tokenUsage ? { tokenUsage } : {}),

--- a/src/redteam/commands/generate.ts
+++ b/src/redteam/commands/generate.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -839,6 +839,11 @@ async function doGenerateRedteamInternal(
       ...(contexts && contexts.length > 0 ? { contexts } : {}),
     };
     const generationRequestCount = generationTokenUsage.numRequests ?? 0;
+    const generation = {
+      id: options.generationRunId ?? randomUUID(),
+      generatedAt: new Date().toISOString(),
+      ...(generationRequestCount > 0 ? { tokenUsage: generationTokenUsage } : {}),
+    };
     if (generationRequestCount > 0) {
       const hasReportedGenerationTokens =
         (generationTokenUsage.total ?? 0) > 0 ||
@@ -882,6 +887,8 @@ async function doGenerateRedteamInternal(
         typeof existingYaml.defaultTest === 'object' ? existingYaml.defaultTest : {};
       const existingMetadata = { ...(existingYaml.metadata || {}) };
       delete existingMetadata.generationTokenUsage;
+      delete existingMetadata.generation;
+      delete existingMetadata.generationAccounting;
       const updatedYaml: Partial<UnifiedConfig> = {
         ...existingYaml,
         ...(options.description ? { description: options.description } : {}),
@@ -901,6 +908,7 @@ async function doGenerateRedteamInternal(
             ? { configHash: await getConfigHash(configPath, options) }
             : { configHash: 'force-regenerate' }),
           ...((generationTokenUsage.numRequests ?? 0) > 0 && { generationTokenUsage }),
+          generation,
           ...(pluginSeverityOverridesId ? { pluginSeverityOverridesId } : {}),
         },
       };
@@ -963,11 +971,14 @@ async function doGenerateRedteamInternal(
       existingConfig.redteam = { ...(existingConfig.redteam || {}), ...updatedRedteamConfig };
       const existingMetadata = { ...(existingConfig.metadata || {}) };
       delete existingMetadata.generationTokenUsage;
+      delete existingMetadata.generation;
+      delete existingMetadata.generationAccounting;
       // Add the config hash to metadata
       existingConfig.metadata = {
         ...existingMetadata,
         configHash: await getConfigHash(configPath, options),
         ...((generationTokenUsage.numRequests ?? 0) > 0 && { generationTokenUsage }),
+        generation,
       };
       const author = getAuthor();
       const userEmail = getUserEmail();
@@ -1008,9 +1019,10 @@ async function doGenerateRedteamInternal(
       ret = writePromptfooConfig(
         {
           ...(options.description ? { description: options.description } : {}),
-          ...((generationTokenUsage.numRequests ?? 0) > 0
-            ? { metadata: { generationTokenUsage } }
-            : {}),
+          metadata: {
+            ...((generationTokenUsage.numRequests ?? 0) > 0 ? { generationTokenUsage } : {}),
+            generation,
+          },
           tests: redteamTests,
         },
         'redteam.yaml',

--- a/src/redteam/extraction/entities.ts
+++ b/src/redteam/extraction/entities.ts
@@ -17,6 +17,7 @@ export async function extractEntities(
         'entities' as RedTeamTask,
         prompts,
         generationContext,
+        provider,
       );
       return result as string[];
     } catch (error) {

--- a/src/redteam/extraction/purpose.ts
+++ b/src/redteam/extraction/purpose.ts
@@ -27,6 +27,7 @@ export async function extractSystemPurpose(
         'purpose' as RedTeamTask,
         prompts,
         generationContext,
+        provider,
       );
       return result as string;
     } catch (error) {

--- a/src/redteam/extraction/util.ts
+++ b/src/redteam/extraction/util.ts
@@ -7,6 +7,8 @@ import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
 import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
+import { getErrorTokenUsage } from '../../util/tokenUsageUtils';
+import { recordGenerationTokenUsage } from '../generationTokenUsage';
 import { normalizeMcpToolCall, stringifyMcpToolCall } from '../mcpToolCall';
 import {
   getRemoteGenerationHeaders,
@@ -45,6 +47,7 @@ interface PromptfooMcpMaterializationOptions {
  * @param task - The type of task to perform ('purpose' or 'entities').
  * @param prompts - An array of prompts to process.
  * @param generationContext - Resolved target context for routing the remote task.
+ * @param provider - Optional tracked generation provider used to account for the remote request.
  * @returns A Promise that resolves to either a string or an array of strings, depending on the task.
  * @throws Will throw an error if the remote generation fails.
  *
@@ -58,11 +61,13 @@ export async function fetchRemoteGeneration(
   task: RedTeamTask,
   prompts: string[],
   generationContext?: RemoteGenerationContext,
+  provider?: ApiProvider,
 ): Promise<string | string[]> {
   invariant(
     !getEnvBool('PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION'),
     'fetchRemoteGeneration should never be called when remote generation is disabled',
   );
+  let responseRecorded = false;
   try {
     const body = {
       task,
@@ -83,9 +88,20 @@ export async function fetchRemoteGeneration(
       'json',
     );
 
+    if (provider) {
+      recordGenerationTokenUsage(provider, {
+        tokenUsage: (response.data as { tokenUsage?: ProviderResponse['tokenUsage'] })?.tokenUsage,
+        cached: response.cached,
+      });
+      responseRecorded = true;
+    }
+
     const parsedResponse = RedTeamGenerationResponse.parse(response.data);
     return parsedResponse.result;
   } catch (error) {
+    if (provider && !responseRecorded) {
+      recordGenerationTokenUsage(provider, { tokenUsage: getErrorTokenUsage(error) });
+    }
     logger.warn(`Error using remote generation for task '${task}': ${error}`);
     throw error;
   }

--- a/src/redteam/generationTokenUsage.ts
+++ b/src/redteam/generationTokenUsage.ts
@@ -1,10 +1,10 @@
-import { accumulateResponseTokenUsage } from '../util/tokenUsageUtils';
+import { accumulateResponseTokenUsage, getErrorTokenUsage } from '../util/tokenUsageUtils';
 
 import type { ApiProvider, TokenUsage } from '../types/index';
 
 const generationUsageRecorder = Symbol('generationUsageRecorder');
 
-type GenerationUsageResponse = { tokenUsage?: Partial<TokenUsage> };
+type GenerationUsageResponse = { tokenUsage?: Partial<TokenUsage>; cached?: boolean };
 type GenerationUsageRecorder = (response: GenerationUsageResponse) => void;
 type TrackedGenerationProvider = ApiProvider & {
   [generationUsageRecorder]?: GenerationUsageRecorder;
@@ -13,9 +13,14 @@ type TrackedGenerationProvider = ApiProvider & {
 function trackProvider<T extends ApiProvider>(provider: T, record: GenerationUsageRecorder): T {
   const callApi = provider.callApi.bind(provider);
   const trackedCallApi: ApiProvider['callApi'] = async (...args) => {
-    const response = await callApi(...args);
-    record(response);
-    return response;
+    try {
+      const response = await callApi(...args);
+      record(response);
+      return response;
+    } catch (error) {
+      record({ tokenUsage: getErrorTokenUsage(error) });
+      throw error;
+    }
   };
   trackedCallApi.label = provider.callApi.label;
 
@@ -39,7 +44,11 @@ export function trackGenerationTokenUsage<T extends ApiProvider>(
   provider: T,
   tokenUsage: TokenUsage,
 ): T {
-  return trackProvider(provider, (response) => accumulateResponseTokenUsage(tokenUsage, response));
+  return trackProvider(provider, (response) => {
+    if (!response.cached) {
+      accumulateResponseTokenUsage(tokenUsage, response);
+    }
+  });
 }
 
 /** Attach a specialized generation provider to its parent's accounting scope. */

--- a/src/redteam/generationTokenUsage.ts
+++ b/src/redteam/generationTokenUsage.ts
@@ -1,0 +1,60 @@
+import { accumulateResponseTokenUsage } from '../util/tokenUsageUtils';
+
+import type { ApiProvider, TokenUsage } from '../types/index';
+
+const generationUsageRecorder = Symbol('generationUsageRecorder');
+
+type GenerationUsageResponse = { tokenUsage?: Partial<TokenUsage> };
+type GenerationUsageRecorder = (response: GenerationUsageResponse) => void;
+type TrackedGenerationProvider = ApiProvider & {
+  [generationUsageRecorder]?: GenerationUsageRecorder;
+};
+
+function trackProvider<T extends ApiProvider>(provider: T, record: GenerationUsageRecorder): T {
+  const callApi = provider.callApi.bind(provider);
+  const trackedCallApi: ApiProvider['callApi'] = async (...args) => {
+    const response = await callApi(...args);
+    record(response);
+    return response;
+  };
+  trackedCallApi.label = provider.callApi.label;
+
+  return new Proxy(provider, {
+    get(target, property) {
+      if (property === 'callApi') {
+        return trackedCallApi;
+      }
+      if (property === generationUsageRecorder) {
+        return record;
+      }
+
+      const value = Reflect.get(target, property, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+/** Observe generation provider calls without changing provider behavior. */
+export function trackGenerationTokenUsage<T extends ApiProvider>(
+  provider: T,
+  tokenUsage: TokenUsage,
+): T {
+  return trackProvider(provider, (response) => accumulateResponseTokenUsage(tokenUsage, response));
+}
+
+/** Attach a specialized generation provider to its parent's accounting scope. */
+export function trackAdditionalGenerationProvider<T extends ApiProvider>(
+  provider: T,
+  parent: ApiProvider,
+): T {
+  const record = (parent as TrackedGenerationProvider)[generationUsageRecorder];
+  return record ? trackProvider(provider, record) : provider;
+}
+
+/** Record remote generation that bypassed the configured provider's callApi method. */
+export function recordGenerationTokenUsage(
+  provider: ApiProvider,
+  response: GenerationUsageResponse,
+): void {
+  (provider as TrackedGenerationProvider)[generationUsageRecorder]?.(response);
+}

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -11,7 +11,6 @@ import { checkRemoteHealth } from '../util/apiHealth';
 import { maybeLoadFromExternalFile } from '../util/file';
 import invariant from '../util/invariant';
 import { extractVariablesFromTemplates } from '../util/templates';
-import { accumulateResponseTokenUsage } from '../util/tokenUsageUtils';
 import { loadYaml } from '../util/yamlLoad';
 import {
   ALIASED_PLUGIN_MAPPINGS,
@@ -38,6 +37,7 @@ import {
 import { CODING_AGENT_CORE_PLUGINS, CODING_AGENT_PLUGINS } from './constants/codingAgents';
 import { extractEntities } from './extraction/entities';
 import { extractSystemPurpose } from './extraction/purpose';
+import { trackGenerationTokenUsage } from './generationTokenUsage';
 import { CustomPlugin } from './plugins/custom';
 import { Plugins } from './plugins/index';
 import { isValidPolicyObject, makeInlinePolicyIdSync } from './plugins/policy/utils';
@@ -74,27 +74,6 @@ import type {
 } from './types';
 
 const MATERIALIZED_MULTI_INPUT_PROMPT_METADATA_KEY = '__promptfooMaterializedMultiInputPrompt';
-
-function trackGenerationTokenUsage(provider: ApiProvider, tokenUsage: TokenUsage): ApiProvider {
-  const callApi = provider.callApi.bind(provider);
-  const trackedCallApi: ApiProvider['callApi'] = async (...args) => {
-    const response = await callApi(...args);
-    accumulateResponseTokenUsage(tokenUsage, response);
-    return response;
-  };
-  trackedCallApi.label = provider.callApi.label;
-
-  return new Proxy(provider, {
-    get(target, property) {
-      if (property === 'callApi') {
-        return trackedCallApi;
-      }
-
-      const value = Reflect.get(target, property, target);
-      return typeof value === 'function' ? value.bind(target) : value;
-    },
-  });
-}
 
 function getMaterializedMultiInputPromptSnapshot(
   metadata: TestCase['metadata'] | undefined,

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -61,8 +61,7 @@ import {
   getShortPluginId,
 } from './util';
 
-import type { ApiProvider, TestCase, TestCaseWithPlugin } from '../types/index';
-import type { Inputs, TokenUsage } from '../types/shared';
+import type { ApiProvider, Inputs, TestCase, TestCaseWithPlugin, TokenUsage } from '../types/index';
 import type { RedteamProviderSelection } from './providers/shared';
 import type {
   FailedPluginInfo,

--- a/src/redteam/index.ts
+++ b/src/redteam/index.ts
@@ -1500,6 +1500,7 @@ export async function synthesize({
               plugin.id,
               policy,
               cloudTargetId,
+              redteamProvider,
             );
 
             (testCase.metadata as any).goal = extractedGoal;
@@ -1638,6 +1639,7 @@ export async function synthesize({
               plugin.id,
               policy,
               cloudTargetId,
+              redteamProvider,
             );
 
             (testCase.metadata as any).goal = extractedGoal;

--- a/src/redteam/plugins/harmful/unaligned.ts
+++ b/src/redteam/plugins/harmful/unaligned.ts
@@ -3,6 +3,7 @@ import logger from '../../../logger';
 import { PromptfooHarmfulCompletionProvider } from '../../../providers/promptfoo';
 import { retryWithDeduplication, sampleArray } from '../../../util/generation';
 import { sleep } from '../../../util/time';
+import { trackAdditionalGenerationProvider } from '../../generationTokenUsage';
 import {
   extractMaterializedVariablesFromJsonWithMetadata,
   extractPromptFromTags,
@@ -74,17 +75,20 @@ async function processPromptForInputs(
 }
 
 export async function getHarmfulTests(
-  { purpose, injectVar, n, delayMs = 0, config, targetId }: PluginActionParams,
+  { provider, purpose, injectVar, n, delayMs = 0, config, targetId }: PluginActionParams,
   plugin: keyof typeof UNALIGNED_PROVIDER_HARM_PLUGINS,
 ): Promise<TestCase[]> {
   const maxHarmfulTests = getEnvInt('PROMPTFOO_MAX_HARMFUL_TESTS_PER_REQUEST', 5);
-  const unalignedProvider = new PromptfooHarmfulCompletionProvider({
-    purpose,
-    n: Math.min(n, maxHarmfulTests),
-    harmCategory: plugin,
-    config,
-    targetId,
-  });
+  const unalignedProvider = trackAdditionalGenerationProvider(
+    new PromptfooHarmfulCompletionProvider({
+      purpose,
+      n: Math.min(n, maxHarmfulTests),
+      harmCategory: plugin,
+      config,
+      targetId,
+    }),
+    provider,
+  );
 
   const generatePrompts = async (): Promise<string[]> => {
     const result = await unalignedProvider.callApi('');

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -398,6 +398,7 @@ async function fetchRemoteTestCases(
     tokenUsage?: TokenUsage;
   }
 
+  let responseRecorded = false;
   try {
     const { cached, data, status, statusText } = await fetchWithCache<PluginGenerationResponse>(
       getRemoteGenerationUrl(),
@@ -408,8 +409,9 @@ async function fetchRemoteTestCases(
       },
       getRequestTimeoutMs(),
     );
-    if (provider && !cached) {
-      recordGenerationTokenUsage(provider, { tokenUsage: data?.tokenUsage });
+    if (provider) {
+      recordGenerationTokenUsage(provider, { tokenUsage: data?.tokenUsage, cached });
+      responseRecorded = true;
     }
     if (status !== 200 || !data || !data.result || !Array.isArray(data.result)) {
       logger.error(`Error generating test cases for ${key}: ${statusText} ${JSON.stringify(data)}`);
@@ -422,9 +424,8 @@ async function fetchRemoteTestCases(
     logger.debug(`Received remote generation for ${key}:\n${JSON.stringify(ret)}`);
     return ret;
   } catch (err) {
-    const errorTokenUsage = getErrorTokenUsage(err);
-    if (provider && errorTokenUsage) {
-      recordGenerationTokenUsage(provider, { tokenUsage: errorTokenUsage });
+    if (provider && !responseRecorded) {
+      recordGenerationTokenUsage(provider, { tokenUsage: getErrorTokenUsage(err) });
     }
     logger.error(`Error generating test cases for ${key}: ${err}`);
     return [];

--- a/src/redteam/plugins/index.ts
+++ b/src/redteam/plugins/index.ts
@@ -8,6 +8,7 @@ import { getRequestTimeoutMs } from '../../providers/shared';
 import { checkRemoteHealth } from '../../util/apiHealth';
 import { retryWithDeduplication } from '../../util/generation';
 import invariant from '../../util/invariant';
+import { getErrorTokenUsage } from '../../util/tokenUsageUtils';
 import {
   BIAS_PLUGINS,
   CANARY_BREAKING_STRATEGY_IDS,
@@ -16,6 +17,7 @@ import {
   REMOTE_ONLY_PLUGIN_IDS,
   UNALIGNED_PROVIDER_HARM_PLUGINS,
 } from '../constants';
+import { recordGenerationTokenUsage } from '../generationTokenUsage';
 import { buildPromptInputDescriptions } from '../inputVariables';
 import {
   getRemoteGenerationExplicitlyDisabledError,
@@ -80,7 +82,13 @@ import { VLGuardPlugin } from './vlguard';
 import { VLSUPlugin } from './vlsu';
 import { XSTestPlugin } from './xstest';
 
-import type { ApiProvider, PluginActionParams, PluginConfig, TestCase } from '../../types/index';
+import type {
+  ApiProvider,
+  PluginActionParams,
+  PluginConfig,
+  TestCase,
+  TokenUsage,
+} from '../../types/index';
 import type { HarmPlugin } from '../constants';
 
 export interface PluginFactory {
@@ -345,6 +353,7 @@ async function fetchRemoteTestCases(
   n: number,
   config: PluginConfig,
   redteamGenerationContext?: RedteamGenerationContext | string,
+  provider?: ApiProvider,
 ): Promise<TestCase[]> {
   invariant(
     !getEnvBool('PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION'),
@@ -386,10 +395,11 @@ async function fetchRemoteTestCases(
 
   interface PluginGenerationResponse extends RemoteMaterializationResponse {
     result?: TestCase[];
+    tokenUsage?: TokenUsage;
   }
 
   try {
-    const { data, status, statusText } = await fetchWithCache<PluginGenerationResponse>(
+    const { cached, data, status, statusText } = await fetchWithCache<PluginGenerationResponse>(
       getRemoteGenerationUrl(),
       {
         method: 'POST',
@@ -398,6 +408,9 @@ async function fetchRemoteTestCases(
       },
       getRequestTimeoutMs(),
     );
+    if (provider && !cached) {
+      recordGenerationTokenUsage(provider, { tokenUsage: data?.tokenUsage });
+    }
     if (status !== 200 || !data || !data.result || !Array.isArray(data.result)) {
       logger.error(`Error generating test cases for ${key}: ${statusText} ${JSON.stringify(data)}`);
       return [];
@@ -409,6 +422,10 @@ async function fetchRemoteTestCases(
     logger.debug(`Received remote generation for ${key}:\n${JSON.stringify(ret)}`);
     return ret;
   } catch (err) {
+    const errorTokenUsage = getErrorTokenUsage(err);
+    if (provider && errorTokenUsage) {
+      recordGenerationTokenUsage(provider, { tokenUsage: errorTokenUsage });
+    }
     logger.error(`Error generating test cases for ${key}: ${err}`);
     return [];
   }
@@ -452,6 +469,7 @@ function createPluginFactory<T extends PluginConfig>(
         n,
         configWithDefaults ?? {},
         redteamGenerationContext ?? targetId,
+        provider,
       );
       const computedModifiers = computeModifiersFromConfig(configWithDefaults);
 
@@ -578,6 +596,7 @@ const piiPlugins: PluginFactory[] = PII_PLUGINS.map((category: string) => ({
         params.n,
         params.config ?? {},
         params.targetId,
+        params.provider,
       );
       const computedModifiers = computeModifiersFromConfig(params.config);
       return testCases.map((testCase) => ({
@@ -620,6 +639,7 @@ const biasPlugins: PluginFactory[] = BIAS_PLUGINS.map((category: string) => ({
       params.n,
       params.config ?? {},
       params.targetId,
+      params.provider,
     );
     const computedModifiers = computeModifiersFromConfig(params.config);
     return testCases.map((testCase) => ({
@@ -644,6 +664,7 @@ function createRemotePlugin<T extends PluginConfig>(
     key,
     validate: validate as ((config: PluginConfig) => void) | undefined,
     action: async ({
+      provider,
       purpose,
       injectVar,
       n,
@@ -665,6 +686,7 @@ function createRemotePlugin<T extends PluginConfig>(
         n,
         configWithDefaults ?? {},
         redteamGenerationContext ?? targetId,
+        provider,
       );
       const computedModifiers = computeModifiersFromConfig(configWithDefaults);
       const testsWithMetadata = testCases.map((testCase) => ({

--- a/src/redteam/plugins/intent.ts
+++ b/src/redteam/plugins/intent.ts
@@ -64,6 +64,7 @@ export class IntentPlugin extends RedteamPluginBase {
           this.id,
           undefined,
           this.targetId,
+          this.provider,
         );
 
         testCases.push({
@@ -85,6 +86,7 @@ export class IntentPlugin extends RedteamPluginBase {
           this.id,
           undefined,
           this.targetId,
+          this.provider,
         );
 
         testCases.push({

--- a/src/redteam/shared.ts
+++ b/src/redteam/shared.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
@@ -94,6 +95,7 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
     const { maxConcurrency, tags: _runtimeTags, ...passThroughOptions } = options;
 
     let redteamConfig;
+    const generationRunId = randomUUID();
     const generationStartTime = Date.now();
     try {
       redteamConfig = await doGenerateRedteam({
@@ -106,6 +108,7 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
         verbose: options.verbose,
         delay: options.delay,
         inRedteamRun: true,
+        generationRunId,
         abortSignal: options.abortSignal,
         progressBar: options.progressBar,
       });
@@ -133,6 +136,8 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
     const { defaultConfig } = await loadDefaultConfig();
     // Exclude 'description' from options to avoid conflict with Commander's description method
     const { description: _description, ...evalOptions } = options;
+    const generation = redteamConfig.metadata?.generation;
+    const generatedDuringRun = generation?.id === generationRunId;
     const evalResult = await doEval(
       {
         ...evalOptions,
@@ -151,6 +156,9 @@ export async function doRedteamRun(options: RedteamRunOptions): Promise<Eval | u
         abortSignal: options.abortSignal,
         progressCallback: options.progressCallback,
         eventSource: options.eventSource,
+        ...(generatedDuringRun && generation.tokenUsage
+          ? { generationEventId: generation.id, generationTokenUsage: generation.tokenUsage }
+          : {}),
       },
     );
 

--- a/src/redteam/types.ts
+++ b/src/redteam/types.ts
@@ -273,6 +273,8 @@ export interface RedteamCliGenerateOptions extends CommonOptions {
   force?: boolean;
   write: boolean;
   inRedteamRun?: boolean;
+  /** Internal run identifier used to distinguish fresh generation from suite reuse. */
+  generationRunId?: string;
   verbose?: boolean;
   abortSignal?: AbortSignal;
   burpEscapeJson?: boolean;

--- a/src/redteam/util.ts
+++ b/src/redteam/util.ts
@@ -4,8 +4,10 @@ import { getRequestTimeoutMs } from '../providers/shared';
 import { type Inputs } from '../types/shared';
 import { safeJsonStringify } from '../util/json';
 import { escapeRegExp } from '../util/text';
+import { getErrorTokenUsage } from '../util/tokenUsageUtils';
 import { pluginDescriptions } from './constants';
 import { DATASET_PLUGINS } from './constants/strategies';
+import { recordGenerationTokenUsage } from './generationTokenUsage';
 import {
   type InputMaterializationContext,
   type MaterializedInputVariablesResult,
@@ -19,7 +21,7 @@ import {
 } from './remoteGeneration';
 import { remoteGenerationContextPayload } from './remoteGenerationContext';
 
-import type { CallApiContextParams, ProviderResponse } from '../types/index';
+import type { ApiProvider, CallApiContextParams, ProviderResponse } from '../types/index';
 
 /**
  * Regex pattern for matching <Prompt> tags in multi-input redteam generation output.
@@ -340,6 +342,7 @@ export function getShortPluginId(pluginId: string): string {
  * @param pluginId - Optional plugin ID to provide context about the attack type.
  * @param policy - Optional policy text for custom policy tests to improve intent extraction.
  * @param targetId - Optional cloud target database ID used by remote task handlers to resolve target-owned provider context.
+ * @param provider - Optional tracked generation provider used to account for the remote request.
  * @returns The extracted goal, or null if extraction fails.
  */
 export async function extractGoalFromPrompt(
@@ -348,6 +351,7 @@ export async function extractGoalFromPrompt(
   pluginId?: string,
   policy?: string,
   targetId?: string,
+  provider?: ApiProvider,
 ): Promise<string | null> {
   if (neverGenerateRemote()) {
     logger.debug('Remote generation disabled, skipping goal extraction');
@@ -380,10 +384,12 @@ export async function extractGoalFromPrompt(
 
   interface ExtractIntentResponse {
     intent?: string;
+    tokenUsage?: ProviderResponse['tokenUsage'];
   }
 
+  let responseRecorded = false;
   try {
-    const { data, status, statusText } = await fetchWithCache<ExtractIntentResponse>(
+    const { cached, data, status, statusText } = await fetchWithCache<ExtractIntentResponse>(
       getRemoteGenerationUrl(),
       {
         method: 'POST',
@@ -392,6 +398,11 @@ export async function extractGoalFromPrompt(
       },
       getRequestTimeoutMs(),
     );
+
+    if (provider) {
+      recordGenerationTokenUsage(provider, { tokenUsage: data?.tokenUsage, cached });
+      responseRecorded = true;
+    }
 
     logger.debug(
       `Goal extraction response - Status: ${status} ${statusText || ''}, Data: ${JSON.stringify(data)}`,
@@ -411,6 +422,9 @@ export async function extractGoalFromPrompt(
 
     return data.intent;
   } catch (error) {
+    if (provider && !responseRecorded) {
+      recordGenerationTokenUsage(provider, { tokenUsage: getErrorTokenUsage(error) });
+    }
     logger.warn(`Error extracting goal: ${error}`);
     return null;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { ProviderEnvOverridesSchema } from '../contracts/env';
 import {
   BaseTokenUsageSchema,
+  type NormalizedTokenUsage,
   type NunjucksFilterMap,
   type TokenUsage,
   type VarValue,
@@ -407,7 +408,7 @@ export interface EvaluateResult {
   namedScores: Record<string, number>;
   cost?: number;
   metadata?: Record<string, any>;
-  tokenUsage?: Required<TokenUsage>;
+  tokenUsage?: NormalizedTokenUsage;
   /**
    * Eval ID this result belongs to, surfaced when tracing is enabled so consumers
    * can pass it to `/api/traces/evaluation/:evaluationId` without re-deriving it.
@@ -483,7 +484,7 @@ export interface EvaluateStats {
   successes: number;
   failures: number;
   errors: number;
-  tokenUsage: Required<TokenUsage>;
+  tokenUsage: NormalizedTokenUsage;
   durationMs?: number;
   generationDurationMs?: number;
   evaluationDurationMs?: number;

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -1,5 +1,6 @@
 import type { EventSource } from './eventSource';
 import type { EvaluateOptions } from './index';
+import type { TokenUsage } from './shared';
 
 /**
  * Internal orchestration metadata that should not be accepted from reusable
@@ -8,4 +9,6 @@ import type { EvaluateOptions } from './index';
  */
 export type InternalEvaluateOptions = EvaluateOptions & {
   eventSource?: EventSource;
+  generationEventId?: string;
+  generationTokenUsage?: TokenUsage;
 };

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -1,6 +1,7 @@
 import {
   BaseTokenUsageSchema,
   type CompletionTokenDetails,
+  type NormalizedTokenUsage,
   type TokenUsage,
 } from '../types/shared';
 
@@ -46,7 +47,7 @@ export function createEmptyAssertions(): NonNullable<TokenUsage['assertions']> {
 /**
  * Create an empty token usage object with all fields initialized to zero.
  */
-export function createEmptyTokenUsage(): Required<TokenUsage> {
+export function createEmptyTokenUsage(): NormalizedTokenUsage {
   return {
     prompt: 0,
     completion: 0,
@@ -155,6 +156,11 @@ export function accumulateTokenUsage(
       );
     }
   }
+
+  if (update.generation) {
+    target.generation ??= createEmptyAssertions();
+    accumulateTokenUsage(target.generation, update.generation);
+  }
 }
 
 /**
@@ -243,8 +249,8 @@ export function accumulateResponseTokenUsage(
 }
 
 /**
- * Fold generation-time provider tokens into evaluation totals without treating
- * internal generation calls as target probes. Returns whether the payload was valid.
+ * Record generation-time provider tokens separately from target usage and probes.
+ * Returns whether the payload contained observable generation usage.
  */
 export function accumulateGenerationTokenUsage(target: TokenUsage, update: unknown): boolean {
   const parsed = BaseTokenUsageSchema.safeParse(update);
@@ -252,14 +258,15 @@ export function accumulateGenerationTokenUsage(target: TokenUsage, update: unkno
     return false;
   }
 
-  const { assertions: _assertions, numRequests: _numRequests, ...tokenTotals } = parsed.data;
-  const hasTokenTotals =
-    Object.values(tokenTotals).some((value) => typeof value === 'number' && value !== 0) ||
-    Object.values(tokenTotals.completionDetails ?? {}).some((value) => value !== 0);
-  if (!hasTokenTotals) {
+  const { assertions: _assertions, generation: _generation, ...generationUsage } = parsed.data;
+  const hasUsage =
+    Object.values(generationUsage).some((value) => typeof value === 'number' && value !== 0) ||
+    Object.values(generationUsage.completionDetails ?? {}).some((value) => value !== 0);
+  if (!hasUsage) {
     return false;
   }
-  accumulateTokenUsage(target, tokenTotals);
+  target.generation ??= createEmptyAssertions();
+  accumulateTokenUsage(target.generation, generationUsage);
   return true;
 }
 
@@ -271,7 +278,7 @@ export function accumulateGenerationTokenUsage(target: TokenUsage, update: unkno
  */
 export function normalizeTokenUsage(
   tokenUsage: Partial<TokenUsage> | undefined,
-): Required<TokenUsage> {
+): NormalizedTokenUsage {
   return {
     total: tokenUsage?.total || 0,
     prompt: tokenUsage?.prompt || 0,
@@ -280,5 +287,6 @@ export function normalizeTokenUsage(
     numRequests: tokenUsage?.numRequests || 0,
     completionDetails: tokenUsage?.completionDetails || createEmptyCompletionDetails(),
     assertions: tokenUsage?.assertions || createEmptyAssertions(),
+    ...(tokenUsage?.generation ? { generation: tokenUsage.generation } : {}),
   };
 }

--- a/test/commands/eval/evaluateOptions.test.ts
+++ b/test/commands/eval/evaluateOptions.test.ts
@@ -133,6 +133,86 @@ describe('evaluateOptions behavior', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  describe('generation accounting provenance', () => {
+    function generationConfig(metadata: Record<string, unknown>) {
+      return {
+        metadata,
+        providers: [{ id: 'echo' }],
+        prompts: ['Hello'],
+        tests: [{ vars: {} }],
+      };
+    }
+
+    it('removes copied generation charges from a newly created evaluation', async () => {
+      const configFile = writeTempConfig(
+        tmpDir,
+        'test-stale-generation-accounting.yaml',
+        generationConfig({
+          owner: 'preserved metadata',
+          generationAccounting: {
+            id: 'previous-generation',
+            tokenUsage: { total: 40, numRequests: 4 },
+          },
+        }),
+      );
+
+      await doEval({ table: false, write: false, config: [configFile] }, {}, undefined, {});
+
+      const evalRecord = evaluateMock.mock.calls.at(-1)?.[1] as Eval;
+      expect(evalRecord.config.metadata).toEqual({ owner: 'preserved metadata' });
+      expect(evalRecord.getStats().tokenUsage.generation).toBeUndefined();
+    });
+
+    it('replaces copied generation charges with accounting from the current run', async () => {
+      const configFile = writeTempConfig(
+        tmpDir,
+        'test-current-generation-accounting.yaml',
+        generationConfig({
+          generationAccounting: {
+            id: 'previous-generation',
+            tokenUsage: { total: 40, numRequests: 4 },
+          },
+        }),
+      );
+      const currentUsage = { total: 12, prompt: 8, completion: 4, numRequests: 1 };
+
+      await doEval({ table: false, write: false, config: [configFile] }, {}, undefined, {
+        generationEventId: 'current-generation',
+        generationTokenUsage: currentUsage,
+      });
+
+      const evalRecord = evaluateMock.mock.calls.at(-1)?.[1] as Eval;
+      expect(evalRecord.config.metadata?.generationAccounting).toEqual({
+        id: 'current-generation',
+        tokenUsage: currentUsage,
+      });
+      expect(evalRecord.getStats().tokenUsage.generation).toMatchObject(currentUsage);
+    });
+
+    it('preserves existing generation charges when resuming the same evaluation', async () => {
+      const generationAccounting = {
+        id: 'original-generation',
+        tokenUsage: { total: 40, prompt: 25, completion: 15, numRequests: 4 },
+      };
+      const resumeEval = new Eval(generationConfig({ generationAccounting }), {
+        id: 'eval-resume-generation-accounting',
+        persisted: true,
+      });
+      const findByIdSpy = vi.spyOn(Eval, 'findById').mockResolvedValue(resumeEval);
+
+      try {
+        await doEval({ table: false, resume: resumeEval.id } as any, {}, undefined, {});
+
+        expect(resumeEval.config.metadata?.generationAccounting).toEqual(generationAccounting);
+        expect(resumeEval.getStats().tokenUsage.generation).toMatchObject(
+          generationAccounting.tokenUsage,
+        );
+      } finally {
+        findByIdSpy.mockRestore();
+      }
+    });
+  });
+
   describe('Reading values from config file', () => {
     it('should read evaluateOptions.maxConcurrency', async () => {
       const options = await runEvalAndGetOptions({

--- a/test/contracts/index.test.ts
+++ b/test/contracts/index.test.ts
@@ -135,8 +135,12 @@ describe('contracts leaf surface', () => {
           numRequests: 1,
           completionDetails: { reasoning: 1 },
         },
+        generation: { prompt: 12, completion: 4, total: 16, numRequests: 2 },
       });
       expect(parsed.success).toBe(true);
+      expect(parsed).toMatchObject({
+        data: { generation: { prompt: 12, completion: 4, total: 16, numRequests: 2 } },
+      });
     });
 
     it('parses CompletionTokenDetailsSchema with all fields', () => {

--- a/test/factories/provider.ts
+++ b/test/factories/provider.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 import type { ApiProvider, ProviderResponse, TokenUsage } from '../../src/types/index';
+import type { NormalizedTokenUsage } from '../../src/types/shared';
 
 export type MockApiProvider = ApiProvider & {
   id: ReturnType<typeof vi.fn<() => string>>;
@@ -41,7 +42,7 @@ export function createTokenUsage(overrides: TokenUsage = {}): TokenUsage {
  * defaults the caller didn't mention. This is the right behavior for fixtures
  * flowing into type-strict slots (e.g. EvaluateResult.tokenUsage).
  */
-export function createRequiredTokenUsage(overrides: TokenUsage = {}): Required<TokenUsage> {
+export function createRequiredTokenUsage(overrides: TokenUsage = {}): NormalizedTokenUsage {
   return {
     total: 10,
     prompt: 5,

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -1114,6 +1114,40 @@ describe('evaluator', () => {
   });
 
   describe('getStats', () => {
+    it('attributes generation metadata once without increasing target tokens or probes', () => {
+      const eval1 = new Eval({
+        metadata: {
+          generationAccounting: {
+            id: 'generation-1',
+            tokenUsage: { total: 40, prompt: 25, completion: 15, numRequests: 4 },
+          },
+        },
+      });
+      eval1.prompts = [
+        { metrics: { tokenUsage: { total: 10, numRequests: 1 } } },
+        { metrics: { tokenUsage: { total: 20, numRequests: 1 } } },
+      ] as any;
+
+      const stats = eval1.getStats();
+
+      expect(stats.tokenUsage).toMatchObject({
+        total: 30,
+        numRequests: 2,
+        generation: { total: 40, prompt: 25, completion: 15, numRequests: 4 },
+      });
+    });
+
+    it('does not attribute historical suite generation metadata without a run charge', () => {
+      const eval1 = new Eval({
+        metadata: {
+          generation: { id: 'old-generation', tokenUsage: { total: 40, numRequests: 4 } },
+          generationTokenUsage: { total: 40, numRequests: 4 },
+        },
+      });
+
+      expect(eval1.getStats().tokenUsage.generation).toBeUndefined();
+    });
+
     it('should accumulate assertion token usage correctly', () => {
       const eval1 = new Eval({});
       eval1.prompts = [

--- a/test/providers/promptfoo.test.ts
+++ b/test/providers/promptfoo.test.ts
@@ -79,6 +79,30 @@ describe('PromptfooHarmfulCompletionProvider', () => {
     expect(result).toEqual({ output: ['test output'] });
   });
 
+  it('preserves token usage returned by harmful generation', async () => {
+    const tokenUsage = { total: 18, prompt: 11, completion: 7 };
+    vi.mocked(fetchWithRetries).mockResolvedValue(
+      new Response(JSON.stringify({ output: 'test output', tokenUsage }), { status: 200 }),
+    );
+
+    await expect(provider.callApi('test prompt')).resolves.toEqual({
+      output: ['test output'],
+      tokenUsage,
+    });
+  });
+
+  it('preserves reported token usage when harmful generation fails', async () => {
+    const tokenUsage = { total: 18, prompt: 11, completion: 7 };
+    vi.mocked(fetchWithRetries).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Generation failed', tokenUsage }), { status: 500 }),
+    );
+
+    await expect(provider.callApi('test prompt')).resolves.toMatchObject({
+      error: expect.stringContaining('Generation failed'),
+      tokenUsage,
+    });
+  });
+
   it('should include target context in harmful generation requests', async () => {
     provider = new PromptfooHarmfulCompletionProvider({
       ...options,

--- a/test/redteam/commands/generate.test.ts
+++ b/test/redteam/commands/generate.test.ts
@@ -512,6 +512,11 @@ describe('doGenerateRedteam', () => {
             prompt: 13,
             total: 20,
           },
+          generation: expect.objectContaining({
+            id: expect.any(String),
+            generatedAt: expect.any(String),
+            tokenUsage: { cached: 0, completion: 7, numRequests: 2, prompt: 13, total: 20 },
+          }),
         }),
       }),
       'output.yaml',

--- a/test/redteam/extraction/entities.test.ts
+++ b/test/redteam/extraction/entities.test.ts
@@ -3,6 +3,7 @@ import { fetchWithCache } from '../../../src/cache';
 import { VERSION } from '../../../src/constants';
 import logger from '../../../src/logger';
 import { extractEntities } from '../../../src/redteam/extraction/entities';
+import { trackGenerationTokenUsage } from '../../../src/redteam/generationTokenUsage';
 import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
 import {
   createMockProvider,
@@ -111,6 +112,26 @@ describe('Entities Extractor', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('Error using remote generation'),
     );
+  });
+
+  it('attributes remote entity extraction to the tracked generation provider', async () => {
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'false' });
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: {
+        task: 'entities',
+        result: ['Tracked entity'],
+        tokenUsage: { total: 13, prompt: 8, completion: 5 },
+      },
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    });
+    const usage = {};
+
+    await extractEntities(trackGenerationTokenUsage(provider, usage), ['prompt']);
+
+    expect(usage).toMatchObject({ total: 13, prompt: 8, completion: 5, numRequests: 1 });
   });
 
   it('should use local extraction when remote generation is disabled', async () => {

--- a/test/redteam/extraction/purpose.test.ts
+++ b/test/redteam/extraction/purpose.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { fetchWithCache } from '../../../src/cache';
 import { VERSION } from '../../../src/constants';
 import { DEFAULT_PURPOSE, extractSystemPurpose } from '../../../src/redteam/extraction/purpose';
+import { trackGenerationTokenUsage } from '../../../src/redteam/generationTokenUsage';
 import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
 import {
   createMockProvider,
@@ -98,6 +99,26 @@ describe('System Purpose Extractor', () => {
     expect(result).toBe('');
     expect(provider.callApi).not.toHaveBeenCalled();
     mockProcessEnv({ OPENAI_API_KEY: originalOpenaiKey });
+  });
+
+  it('attributes remote purpose extraction to the tracked generation provider', async () => {
+    mockProcessEnv({ OPENAI_API_KEY: undefined });
+    mockProcessEnv({ PROMPTFOO_DISABLE_REDTEAM_REMOTE_GENERATION: 'false' });
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: {
+        task: 'purpose',
+        result: 'Tracked remote purpose',
+        tokenUsage: { total: 11, prompt: 7, completion: 4 },
+      },
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    });
+    const usage = {};
+
+    await extractSystemPurpose(trackGenerationTokenUsage(provider, usage), ['prompt']);
+
+    expect(usage).toMatchObject({ total: 11, prompt: 7, completion: 4, numRequests: 1 });
   });
 
   it('should use local extraction when remote generation is disabled', async () => {

--- a/test/redteam/extraction/util.test.ts
+++ b/test/redteam/extraction/util.test.ts
@@ -9,6 +9,7 @@ import {
   formatPrompts,
   RedTeamGenerationResponse,
 } from '../../../src/redteam/extraction/util';
+import { trackGenerationTokenUsage } from '../../../src/redteam/generationTokenUsage';
 import { getRemoteGenerationUrl } from '../../../src/redteam/remoteGeneration';
 import {
   createMockProvider,
@@ -121,6 +122,72 @@ describe('fetchRemoteGeneration', () => {
       getRequestTimeoutMs(),
       'json',
     );
+  });
+
+  it('records token usage from uncached remote extraction requests', async () => {
+    const tokenUsage = { total: 18, prompt: 12, completion: 6 };
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: { task: 'purpose', result: 'Tracked purpose', tokenUsage },
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    });
+    const generationUsage = {};
+    const provider = trackGenerationTokenUsage(createMockProvider(), generationUsage);
+
+    await expect(fetchRemoteGeneration('purpose', ['prompt'], undefined, provider)).resolves.toBe(
+      'Tracked purpose',
+    );
+
+    expect(generationUsage).toMatchObject({ ...tokenUsage, numRequests: 1 });
+  });
+
+  it('does not count cached remote extraction responses', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: {
+        task: 'entities',
+        result: ['cached entity'],
+        tokenUsage: { total: 18, numRequests: 1 },
+      },
+      status: 200,
+      statusText: 'OK',
+      cached: true,
+    });
+    const generationUsage = {};
+    const provider = trackGenerationTokenUsage(createMockProvider(), generationUsage);
+
+    await fetchRemoteGeneration('entities', ['prompt'], undefined, provider);
+
+    expect(generationUsage).toEqual({});
+  });
+
+  it('counts failed remote extraction requests without token usage', async () => {
+    vi.mocked(fetchWithCache).mockRejectedValueOnce(new Error('extraction timed out'));
+    const generationUsage = {};
+    const provider = trackGenerationTokenUsage(createMockProvider(), generationUsage);
+
+    await expect(fetchRemoteGeneration('purpose', ['prompt'], undefined, provider)).rejects.toThrow(
+      'extraction timed out',
+    );
+
+    expect(generationUsage).toEqual({ numRequests: 1 });
+  });
+
+  it('does not count an invalid remote extraction response twice', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: { task: 'purpose', tokenUsage: { total: 12 } },
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    });
+    const generationUsage = {};
+    const provider = trackGenerationTokenUsage(createMockProvider(), generationUsage);
+
+    await expect(
+      fetchRemoteGeneration('purpose', ['prompt'], undefined, provider),
+    ).rejects.toThrow();
+
+    expect(generationUsage).toMatchObject({ total: 12, numRequests: 1 });
   });
 
   it('should include the resolved cloud target in the remote generation payload', async () => {

--- a/test/redteam/generationTokenUsage.test.ts
+++ b/test/redteam/generationTokenUsage.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  recordGenerationTokenUsage,
+  trackAdditionalGenerationProvider,
+  trackGenerationTokenUsage,
+} from '../../src/redteam/generationTokenUsage';
+
+import type { ApiProvider, TokenUsage } from '../../src/types/index';
+
+function createProvider(callApi: ApiProvider['callApi']): ApiProvider {
+  return { id: () => 'generation-provider', callApi };
+}
+
+describe('generation token usage', () => {
+  it('does not count cached provider responses or their historical token usage', async () => {
+    const usage: TokenUsage = {};
+    const provider = trackGenerationTokenUsage(
+      createProvider(
+        vi.fn().mockResolvedValue({
+          output: 'cached generation',
+          cached: true,
+          tokenUsage: { total: 30, prompt: 20, completion: 10, numRequests: 1 },
+        }),
+      ),
+      usage,
+    );
+
+    await provider.callApi('generate a test');
+
+    expect(usage).toEqual({});
+  });
+
+  it('counts actual provider requests that contain prompt-cache token details', async () => {
+    const usage: TokenUsage = {};
+    const provider = trackGenerationTokenUsage(
+      createProvider(
+        vi.fn().mockResolvedValue({
+          output: 'fresh generation',
+          cached: false,
+          tokenUsage: { total: 30, prompt: 20, completion: 10, cached: 15 },
+        }),
+      ),
+      usage,
+    );
+
+    await provider.callApi('generate a test');
+
+    expect(usage).toMatchObject({
+      total: 30,
+      prompt: 20,
+      completion: 10,
+      cached: 15,
+      numRequests: 1,
+    });
+  });
+
+  it('counts failed provider requests even when token usage is unavailable', async () => {
+    const usage: TokenUsage = {};
+    const provider = trackGenerationTokenUsage(
+      createProvider(vi.fn().mockRejectedValue(new Error('generation timed out'))),
+      usage,
+    );
+
+    await expect(provider.callApi('generate a test')).rejects.toThrow('generation timed out');
+
+    expect(usage).toEqual({ numRequests: 1 });
+  });
+
+  it('preserves token usage from failed provider requests exactly once', async () => {
+    const usage: TokenUsage = {};
+    const error = Object.assign(new Error('generation failed'), {
+      tokenUsage: { total: 14, prompt: 9, completion: 5 },
+    });
+    const provider = trackGenerationTokenUsage(
+      createProvider(vi.fn().mockRejectedValue(error)),
+      usage,
+    );
+
+    await expect(provider.callApi('generate a test')).rejects.toThrow('generation failed');
+
+    expect(usage).toMatchObject({ total: 14, prompt: 9, completion: 5, numRequests: 1 });
+  });
+
+  it('applies the same cache rules to specialized generation providers', async () => {
+    const usage: TokenUsage = {};
+    const parent = trackGenerationTokenUsage(
+      createProvider(vi.fn().mockResolvedValue({ output: 'unused' })),
+      usage,
+    );
+    const specialized = trackAdditionalGenerationProvider(
+      createProvider(
+        vi.fn().mockResolvedValue({
+          output: 'cached specialized generation',
+          cached: true,
+          tokenUsage: { total: 45, numRequests: 1 },
+        }),
+      ),
+      parent,
+    );
+
+    await specialized.callApi('generate a specialized test');
+
+    expect(usage).toEqual({});
+  });
+
+  it('ignores cached direct remote generation responses', () => {
+    const usage: TokenUsage = {};
+    const provider = trackGenerationTokenUsage(
+      createProvider(vi.fn().mockResolvedValue({ output: 'unused' })),
+      usage,
+    );
+
+    recordGenerationTokenUsage(provider, {
+      cached: true,
+      tokenUsage: { total: 40, numRequests: 2 },
+    });
+
+    expect(usage).toEqual({});
+  });
+});

--- a/test/redteam/plugins/harmful/unaligned.test.ts
+++ b/test/redteam/plugins/harmful/unaligned.test.ts
@@ -5,6 +5,7 @@ import {
   LLAMA_GUARD_REPLICATE_PROVIDER,
   UNALIGNED_PROVIDER_HARM_PLUGINS,
 } from '../../../../src/redteam/constants';
+import { trackGenerationTokenUsage } from '../../../../src/redteam/generationTokenUsage';
 import { REDTEAM_MODEL_CATEGORIES } from '../../../../src/redteam/plugins/harmful/constants';
 import { getHarmfulTests } from '../../../../src/redteam/plugins/harmful/unaligned';
 import { createMockProvider, type MockApiProvider } from '../../../factories/provider';
@@ -37,6 +38,41 @@ describe('harmful plugin', () => {
   });
 
   describe('getHarmfulTests', () => {
+    it('records harmful generation calls and retries in the parent generation scope', async () => {
+      mockCallApi
+        .mockResolvedValueOnce({
+          output: ['Repeated prompt'],
+          tokenUsage: { total: 10, prompt: 6, completion: 4 },
+        })
+        .mockResolvedValueOnce({
+          output: ['Repeated prompt'],
+          tokenUsage: { total: 8, prompt: 5, completion: 3 },
+        })
+        .mockResolvedValueOnce({
+          output: ['Second prompt'],
+          tokenUsage: { total: 12, prompt: 7, completion: 5 },
+        });
+      const generationUsage = {};
+
+      await getHarmfulTests(
+        {
+          provider: trackGenerationTokenUsage(mockProvider, generationUsage),
+          purpose: 'test purpose',
+          injectVar: 'testVar',
+          n: 2,
+          delayMs: 0,
+        },
+        'harmful:sex-crime',
+      );
+
+      expect(generationUsage).toMatchObject({
+        total: 30,
+        prompt: 18,
+        completion: 12,
+        numRequests: 3,
+      });
+    });
+
     it('should handle unaligned provider plugins with multiple prompts', async () => {
       const unalignedPlugin = Object.keys(UNALIGNED_PROVIDER_HARM_PLUGINS)[0];
 

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -12,6 +12,7 @@ import {
   REDTEAM_PROVIDER_HARM_PLUGINS,
   UNALIGNED_PROVIDER_HARM_PLUGINS,
 } from '../../../src/redteam/constants';
+import { trackGenerationTokenUsage } from '../../../src/redteam/generationTokenUsage';
 import { Plugins } from '../../../src/redteam/plugins/index';
 import { neverGenerateRemote, shouldGenerateRemote } from '../../../src/redteam/remoteGeneration';
 import { getShortPluginId } from '../../../src/redteam/util';
@@ -169,6 +170,84 @@ describe('Plugins', () => {
       expect(() => ragPlugin?.validate?.({ intendedResults: [] })).toThrow(
         'config.intendedResults',
       );
+    });
+  });
+
+  describe('remote generation token accounting', () => {
+    it('records usage returned by uncached remote plugin generation', async () => {
+      vi.mocked(shouldGenerateRemote).mockReturnValue(true);
+      vi.mocked(neverGenerateRemote).mockReturnValue(false);
+      const tokenUsage = { total: 28, prompt: 18, completion: 10, numRequests: 2 };
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { result: [{ vars: { testVar: 'generated prompt' } }], tokenUsage },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+      const generationUsage = {};
+      const provider = trackGenerationTokenUsage(mockProvider, generationUsage);
+      const plugin = Plugins.find((candidate) => candidate.key === 'ssrf');
+
+      await plugin?.action({
+        provider,
+        purpose: 'test',
+        injectVar: 'testVar',
+        n: 1,
+        config: {},
+        delayMs: 0,
+      });
+
+      expect(generationUsage).toMatchObject(tokenUsage);
+    });
+
+    it('does not charge cached remote plugin responses again', async () => {
+      vi.mocked(shouldGenerateRemote).mockReturnValue(true);
+      vi.mocked(neverGenerateRemote).mockReturnValue(false);
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: {
+          result: [{ vars: { testVar: 'cached prompt' } }],
+          tokenUsage: { total: 28, numRequests: 2 },
+        },
+        cached: true,
+        status: 200,
+        statusText: 'OK',
+      });
+      const generationUsage = {};
+      const provider = trackGenerationTokenUsage(mockProvider, generationUsage);
+      const plugin = Plugins.find((candidate) => candidate.key === 'ssrf');
+
+      await plugin?.action({
+        provider,
+        purpose: 'test',
+        injectVar: 'testVar',
+        n: 1,
+        config: {},
+        delayMs: 0,
+      });
+
+      expect(generationUsage).toEqual({});
+    });
+
+    it('preserves usage reported by failed remote generation requests', async () => {
+      vi.mocked(shouldGenerateRemote).mockReturnValue(true);
+      vi.mocked(neverGenerateRemote).mockReturnValue(false);
+      const tokenUsage = { total: 16, prompt: 10, completion: 6 };
+      vi.mocked(fetchWithCache).mockRejectedValueOnce(
+        Object.assign(new Error('remote generation failed'), { tokenUsage }),
+      );
+      const generationUsage = {};
+      const plugin = Plugins.find((candidate) => candidate.key === 'ssrf');
+
+      await plugin?.action({
+        provider: trackGenerationTokenUsage(mockProvider, generationUsage),
+        purpose: 'test',
+        injectVar: 'testVar',
+        n: 1,
+        config: {},
+        delayMs: 0,
+      });
+
+      expect(generationUsage).toMatchObject({ ...tokenUsage, numRequests: 1 });
     });
   });
 

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -249,6 +249,25 @@ describe('Plugins', () => {
 
       expect(generationUsage).toMatchObject({ ...tokenUsage, numRequests: 1 });
     });
+
+    it('counts failed remote generation requests when token usage is unavailable', async () => {
+      vi.mocked(shouldGenerateRemote).mockReturnValue(true);
+      vi.mocked(neverGenerateRemote).mockReturnValue(false);
+      vi.mocked(fetchWithCache).mockRejectedValueOnce(new Error('remote generation timed out'));
+      const generationUsage = {};
+      const plugin = Plugins.find((candidate) => candidate.key === 'ssrf');
+
+      await plugin?.action({
+        provider: trackGenerationTokenUsage(mockProvider, generationUsage),
+        purpose: 'test',
+        injectVar: 'testVar',
+        n: 1,
+        config: {},
+        delayMs: 0,
+      });
+
+      expect(generationUsage).toEqual({ numRequests: 1 });
+    });
   });
 
   describe('max chars retries', () => {

--- a/test/redteam/plugins/intent.test.ts
+++ b/test/redteam/plugins/intent.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { matchesLlmRubric } from '../../../src/matchers/llmGrading';
+import { trackGenerationTokenUsage } from '../../../src/redteam/generationTokenUsage';
 import { IntentGrader, IntentPlugin } from '../../../src/redteam/plugins/intent';
 import { createMockProvider } from '../../factories/provider';
 
@@ -105,6 +106,33 @@ describe('IntentPlugin', () => {
     expect(tests[0].metadata).toHaveProperty('goal', 'Access unauthorized customer data');
     expect(tests[1].vars).toHaveProperty('prompt', 'intent2');
     expect(tests[2].vars).toHaveProperty('prompt', 'intent3');
+  });
+
+  it('accounts for every remote intent extraction exactly once', async () => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce({
+        data: { intent: 'First goal', tokenUsage: { total: 9, prompt: 6, completion: 3 } },
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      })
+      .mockResolvedValueOnce({
+        data: { intent: 'Second goal', tokenUsage: { total: 11, prompt: 7, completion: 4 } },
+        status: 200,
+        statusText: 'OK',
+        cached: false,
+      });
+    const usage = {};
+    const plugin = new IntentPlugin(
+      trackGenerationTokenUsage(mockProvider, usage),
+      'test-purpose',
+      'prompt',
+      { intent: ['intent1', 'intent2'] },
+    );
+
+    await plugin.generateTests(1, 0);
+
+    expect(usage).toMatchObject({ total: 20, prompt: 13, completion: 7, numRequests: 2 });
   });
 
   it('should initialize with a list of list of strings', async () => {

--- a/test/redteam/shared.test.ts
+++ b/test/redteam/shared.test.ts
@@ -212,6 +212,42 @@ describe('doRedteamRun', () => {
     );
   });
 
+  it('attributes generation usage only when this run generated the test suite', async () => {
+    const tokenUsage = { total: 42, prompt: 30, completion: 12, numRequests: 3 };
+    vi.mocked(doGenerateRedteam).mockImplementation(async (options) => ({
+      metadata: {
+        generation: { id: options.generationRunId, tokenUsage },
+      },
+    }));
+
+    await doRedteamRun({});
+
+    expect(doEval).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        generationEventId: expect.any(String),
+        generationTokenUsage: tokenUsage,
+      }),
+    );
+  });
+
+  it('does not charge an evaluation for a reused generated test suite', async () => {
+    vi.mocked(doGenerateRedteam).mockResolvedValue({
+      metadata: {
+        generation: {
+          id: 'previous-generation',
+          tokenUsage: { total: 42, numRequests: 3 },
+        },
+      },
+    });
+
+    await doRedteamRun({});
+
+    expect(vi.mocked(doEval).mock.calls[0][3]).not.toHaveProperty('generationTokenUsage');
+  });
+
   describe('liveRedteamConfig temporary file handling', () => {
     const mockConfig = {
       prompts: ['Test prompt'],

--- a/test/redteam/util.test.ts
+++ b/test/redteam/util.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../src/cache';
+import { trackGenerationTokenUsage } from '../../src/redteam/generationTokenUsage';
 import {
   extractAllPromptsFromTags,
   extractGoalFromPrompt,
@@ -164,6 +165,82 @@ describe('extractGoalFromPrompt', () => {
 
     const result = await extractGoalFromPrompt('test prompt', 'test purpose');
     expect(result).toBe('test goal');
+  });
+
+  it('records token usage from fresh goal extraction requests', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data: { intent: 'tracked goal', tokenUsage: { total: 17, prompt: 10, completion: 7 } },
+      deleteFromCache: async () => {},
+    });
+    const usage = {};
+    const provider = trackGenerationTokenUsage(
+      { id: () => 'generation-provider', callApi: vi.fn().mockResolvedValue({ output: 'unused' }) },
+      usage,
+    );
+
+    const result = await extractGoalFromPrompt(
+      'test prompt',
+      'test purpose',
+      undefined,
+      undefined,
+      undefined,
+      provider,
+    );
+
+    expect(result).toBe('tracked goal');
+    expect(usage).toMatchObject({ total: 17, prompt: 10, completion: 7, numRequests: 1 });
+  });
+
+  it('does not count cached goal extraction responses', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: true,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      data: { intent: 'cached goal', tokenUsage: { total: 17, numRequests: 1 } },
+      deleteFromCache: async () => {},
+    });
+    const usage = {};
+    const provider = trackGenerationTokenUsage(
+      { id: () => 'generation-provider', callApi: vi.fn().mockResolvedValue({ output: 'unused' }) },
+      usage,
+    );
+
+    await extractGoalFromPrompt(
+      'test prompt',
+      'test purpose',
+      undefined,
+      undefined,
+      undefined,
+      provider,
+    );
+
+    expect(usage).toEqual({});
+  });
+
+  it('counts failed goal extraction requests without reported token usage', async () => {
+    vi.mocked(fetchWithCache).mockRejectedValueOnce(new Error('goal extraction timed out'));
+    const usage = {};
+    const provider = trackGenerationTokenUsage(
+      { id: () => 'generation-provider', callApi: vi.fn().mockResolvedValue({ output: 'unused' }) },
+      usage,
+    );
+
+    const result = await extractGoalFromPrompt(
+      'test prompt',
+      'test purpose',
+      undefined,
+      undefined,
+      undefined,
+      provider,
+    );
+
+    expect(result).toBeNull();
+    expect(usage).toEqual({ numRequests: 1 });
   });
 
   it('should return null on HTTP error', async () => {

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -310,7 +310,7 @@ describe('tokenUsageUtils', () => {
   });
 
   describe('accumulateGenerationTokenUsage', () => {
-    it('adds generation totals without inflating target request counts', () => {
+    it('keeps generation usage separate from target tokens and request counts', () => {
       const target = createEmptyTokenUsage();
       target.numRequests = 2;
 
@@ -325,11 +325,12 @@ describe('tokenUsageUtils', () => {
       ).toBe(true);
 
       expect(target).toMatchObject({
-        total: 15,
-        prompt: 9,
-        completion: 6,
+        total: 0,
+        prompt: 0,
+        completion: 0,
         numRequests: 2,
         assertions: { total: 0, numRequests: 0 },
+        generation: { total: 15, prompt: 9, completion: 6, numRequests: 3 },
       });
     });
 
@@ -337,8 +338,16 @@ describe('tokenUsageUtils', () => {
       const target = createEmptyTokenUsage();
 
       expect(accumulateGenerationTokenUsage(target, 'invalid')).toBe(false);
-      expect(accumulateGenerationTokenUsage(target, { numRequests: 3 })).toBe(false);
+      expect(accumulateGenerationTokenUsage(target, {})).toBe(false);
       expect(target.total).toBe(0);
+    });
+
+    it('preserves generation request counts when a provider reports no token totals', () => {
+      const target = createEmptyTokenUsage();
+
+      expect(accumulateGenerationTokenUsage(target, { numRequests: 3 })).toBe(true);
+      expect(target.generation).toMatchObject({ total: 0, numRequests: 3 });
+      expect(target.numRequests).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- Capture generation usage from successful and failed harmful-test generation requests.
- Persist generation accounting events and attribute each event once, including reused or regenerated test suites.
- Keep generation tokens and requests separate from target usage and probe counts.

## Verification

- 440 focused tests passed across generation, plugins, providers, persistence, schemas, grading, and token utilities.
- `npm run tsc` passed.

Stack 2 of 4; review against the grading-correctness branch. Companion Cloud PR: https://github.com/promptfoo/promptfoo-cloud/pull/4499