### PR TITLE
fix(providers): return clean errors for empty choices in Snowflake and OpenRouter

### DIFF
--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -180,6 +180,12 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
       };
     }
 
+    if (!data.choices || data.choices.length === 0) {
+      return {
+        error: `No choices in OpenRouter response: ${JSON.stringify(data)}`,
+      };
+    }
+
     // Process the response with special handling for Gemini
     const message: any = data.choices[0].message;
     const finishReason = normalizeFinishReason(data.choices[0].finish_reason);

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -183,6 +183,7 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
     if (!data.choices || data.choices.length === 0) {
       return {
         error: `No choices in OpenRouter response: ${JSON.stringify(data)}`,
+        cached,
       };
     }
 

--- a/src/providers/snowflake.ts
+++ b/src/providers/snowflake.ts
@@ -166,6 +166,7 @@ export class SnowflakeCortexProvider extends OpenAiChatCompletionProvider {
     if (!data.choices || data.choices.length === 0) {
       return {
         error: `No choices in Snowflake Cortex response: ${JSON.stringify(data)}`,
+        cached,
       };
     }
 

--- a/src/providers/snowflake.ts
+++ b/src/providers/snowflake.ts
@@ -163,6 +163,12 @@ export class SnowflakeCortexProvider extends OpenAiChatCompletionProvider {
       };
     }
 
+    if (!data.choices || data.choices.length === 0) {
+      return {
+        error: `No choices in Snowflake Cortex response: ${JSON.stringify(data)}`,
+      };
+    }
+
     // Process the response (should be OpenAI-compatible)
     const message = data.choices[0].message;
     const finishReason = normalizeFinishReason(data.choices[0].finish_reason);

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -940,6 +940,21 @@ describe('OpenRouter', () => {
         expect(result.error).toContain('400 Bad Request');
       });
 
+      it('should return a clean error when the response has no choices', async () => {
+        const provider = new OpenRouterProvider('google/gemini-2.5-pro', {
+          config: { apiKeyEnvar: 'OPENROUTER_API_KEY' },
+        });
+
+        const response = new Response(JSON.stringify({ choices: [] }), {
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        });
+        mockedFetchWithRetries.mockResolvedValueOnce(response);
+
+        const result = await provider.callApi('Test prompt');
+        expect(result.error).toContain('No choices');
+      });
       it('should pass through OpenRouter-specific options', async () => {
         const providerWithOptions = new OpenRouterProvider('google/gemini-2.5-pro', {
           config: {

--- a/test/providers/snowflake.test.ts
+++ b/test/providers/snowflake.test.ts
@@ -175,6 +175,24 @@ describe('Snowflake Cortex Provider', () => {
       expect(result.error).toContain('400 Bad Request');
     });
 
+    it('should return a clean error when the response has no choices', async () => {
+      const provider = new SnowflakeCortexProvider('mistral-large2', {
+        config: {
+          accountIdentifier: 'myorg-myaccount',
+          apiKey: 'test-key',
+        },
+      });
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        data: { choices: [] },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+      expect(result.error).toContain('No choices');
+    });
     it('should handle network errors', async () => {
       const provider = new SnowflakeCortexProvider('mistral-large2', {
         config: {


### PR DESCRIPTION
## Summary

`SnowflakeCortexProvider` and `OpenRouterProvider` read `data.choices[0].message` immediately after the `data.error` check, without guarding an empty or missing `choices` array. A 200 response with `{ "choices": [] }` (soft moderation block, upstream hiccup) makes `choices[0]` undefined and the following `.message` access throws a `TypeError`, which surfaces to users as an opaque error.

Both sites follow the shape fixed earlier for other providers (#10124 completion path, #9867 chat path): the sibling error guards exist, but the `choices[0]` access was left unguarded.

**Fix:** guard the choices array and return a clean, actionable error (`No choices in Snowflake Cortex response: ...` / `No choices in OpenRouter response: ...`), matching the repo's existing empty-response error style.

## Test

- New cases in `test/providers/snowflake.test.ts` and `test/providers/openrouter.test.ts`: a mocked 200 with `{ choices: [] }` returns an error containing `No choices`.
- Pre-fix: both new tests fail (opaque TypeError path); post-fix: pass.
- `npx vitest run test/providers/snowflake.test.ts test/providers/openrouter.test.ts` — 45 passed.
- `npx @biomejs/biome check` on the four touched files — clean (the one complexity warning in openrouter's `callApi` pre-exists; the guard adds one branch to an already-over-threshold function).

## Issues

Resolves #10412