### PR TITLE
fix(providers): avoid crash on empty choices in snowflake and openrouter

### DIFF
--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -180,6 +180,16 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
       };
     }
 
+    // Guard against a 200 response with an empty or missing `choices` array
+    // (soft moderation block, upstream hiccup, or n>1 edge cases). Without this,
+    // `data.choices[0]` is undefined and `.message` throws an opaque TypeError.
+    // Mirrors the sibling OpenAI-compatible providers (mistral.ts, ai21.ts).
+    if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+      return {
+        error: `Malformed response data: ${JSON.stringify(data)}`,
+      };
+    }
+
     // Process the response with special handling for Gemini
     const message: any = data.choices[0].message;
     const finishReason = normalizeFinishReason(data.choices[0].finish_reason);

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -187,6 +187,7 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
     if (!data.choices || !data.choices[0] || !data.choices[0].message) {
       return {
         error: `Malformed response data: ${JSON.stringify(data)}`,
+        cached,
       };
     }
 

--- a/src/providers/snowflake.ts
+++ b/src/providers/snowflake.ts
@@ -170,6 +170,7 @@ export class SnowflakeCortexProvider extends OpenAiChatCompletionProvider {
     if (!data.choices || !data.choices[0] || !data.choices[0].message) {
       return {
         error: `Malformed response data: ${JSON.stringify(data)}`,
+        cached,
       };
     }
 

--- a/src/providers/snowflake.ts
+++ b/src/providers/snowflake.ts
@@ -163,6 +163,16 @@ export class SnowflakeCortexProvider extends OpenAiChatCompletionProvider {
       };
     }
 
+    // Guard against a 200 response with an empty or missing `choices` array
+    // (soft moderation block, upstream hiccup, or n>1 edge cases). Without this,
+    // `data.choices[0]` is undefined and `.message` throws an opaque TypeError.
+    // Mirrors the sibling OpenAI-compatible providers (mistral.ts, ai21.ts).
+    if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+      return {
+        error: `Malformed response data: ${JSON.stringify(data)}`,
+      };
+    }
+
     // Process the response (should be OpenAI-compatible)
     const message = data.choices[0].message;
     const finishReason = normalizeFinishReason(data.choices[0].finish_reason);

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -237,6 +237,61 @@ describe('OpenRouter', () => {
       }
     });
 
+    it('returns a clean error instead of crashing on an empty choices array', async () => {
+      const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
+
+      try {
+        const provider = new OpenRouterProvider('google/gemini-2.5-pro', {});
+
+        // A 200 response with an empty `choices` array (soft moderation block,
+        // upstream hiccup, or n>1 edge cases). Before the fix this made
+        // `data.choices[0]` undefined and `.message` threw an opaque TypeError.
+        const response = new Response(
+          JSON.stringify({
+            choices: [],
+            usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
+          }),
+          {
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        );
+        mockedFetchWithRetries.mockResolvedValueOnce(response);
+
+        const result = await provider.callApi('Test prompt');
+        expect(result.error).toContain('Malformed response data');
+        expect(result.output).toBeUndefined();
+      } finally {
+        restoreEnv();
+      }
+    });
+
+    it('returns a clean error instead of crashing when the response has no choices field', async () => {
+      const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
+
+      try {
+        const provider = new OpenRouterProvider('google/gemini-2.5-pro', {});
+
+        const response = new Response(
+          JSON.stringify({
+            usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
+          }),
+          {
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers({ 'Content-Type': 'application/json' }),
+          },
+        );
+        mockedFetchWithRetries.mockResolvedValueOnce(response);
+
+        const result = await provider.callApi('Test prompt');
+        expect(result.error).toContain('Malformed response data');
+      } finally {
+        restoreEnv();
+      }
+    });
+
     describe('Thinking tokens handling', () => {
       beforeEach(() => {
         mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -262,6 +262,9 @@ describe('OpenRouter', () => {
         const result = await provider.callApi('Test prompt');
         expect(result.error).toContain('Malformed response data');
         expect(result.output).toBeUndefined();
+        // The malformed-response return must carry the cache-hit status so
+        // downstream doesn't treat a cached failure as a live provider call.
+        expect(result.cached).toBe(false);
       } finally {
         restoreEnv();
       }
@@ -287,6 +290,7 @@ describe('OpenRouter', () => {
 
         const result = await provider.callApi('Test prompt');
         expect(result.error).toContain('Malformed response data');
+        expect(result.cached).toBe(false);
       } finally {
         restoreEnv();
       }

--- a/test/providers/snowflake.test.ts
+++ b/test/providers/snowflake.test.ts
@@ -232,5 +232,51 @@ describe('Snowflake Cortex Provider', () => {
         },
       ]);
     });
+
+    it('returns a clean error instead of crashing on an empty choices array', async () => {
+      const provider = new SnowflakeCortexProvider('mistral-large2', {
+        config: {
+          accountIdentifier: 'myorg-myaccount',
+          apiKey: 'test-key',
+        },
+      });
+
+      // A 200 response with an empty `choices` array (soft moderation block,
+      // upstream hiccup, or n>1 edge cases). Before the fix this made
+      // `data.choices[0]` undefined and `.message` threw an opaque TypeError.
+      mockFetchWithCache.mockResolvedValueOnce({
+        data: {
+          choices: [],
+          usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+      expect(result.error).toContain('Malformed response data');
+    });
+
+    it('returns a clean error instead of crashing when the response has no choices field', async () => {
+      const provider = new SnowflakeCortexProvider('mistral-large2', {
+        config: {
+          accountIdentifier: 'myorg-myaccount',
+          apiKey: 'test-key',
+        },
+      });
+
+      mockFetchWithCache.mockResolvedValueOnce({
+        data: {
+          usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('Test prompt');
+      expect(result.error).toContain('Malformed response data');
+    });
   });
 });

--- a/test/providers/snowflake.test.ts
+++ b/test/providers/snowflake.test.ts
@@ -249,13 +249,16 @@ describe('Snowflake Cortex Provider', () => {
           choices: [],
           usage: { total_tokens: 5, prompt_tokens: 5, completion_tokens: 0 },
         },
-        cached: false,
+        // Served from cache: the malformed-response return must preserve the
+        // cached flag so downstream skips provider delays / live-call metrics.
+        cached: true,
         status: 200,
         statusText: 'OK',
       });
 
       const result = await provider.callApi('Test prompt');
       expect(result.error).toContain('Malformed response data');
+      expect(result.cached).toBe(true);
     });
 
     it('returns a clean error instead of crashing when the response has no choices field', async () => {
@@ -277,6 +280,7 @@ describe('Snowflake Cortex Provider', () => {
 
       const result = await provider.callApi('Test prompt');
       expect(result.error).toContain('Malformed response data');
+      expect(result.cached).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #10412.

`SnowflakeCortexProvider` and `OpenRouterProvider` read `data.choices[0].message`
immediately after the `data.error` check, without guarding an empty or missing
`choices` array. A `200` response with `{ "choices": [] }` (soft moderation block,
upstream hiccup, or `n > 1` edge cases) makes `choices[0]` undefined, so the
subsequent `.message` access throws an opaque
`TypeError: Cannot read properties of undefined (reading 'message')` instead of a
usable error. Both sites are the same shape fixed earlier for the Azure providers
(#10124 completion path, #9867 chat path).

## Fix

Add the guard the sibling OpenAI-compatible providers already use
([`mistral.ts`](https://github.com/promptfoo/promptfoo/blob/main/src/providers/mistral.ts)
and [`ai21.ts`](https://github.com/promptfoo/promptfoo/blob/main/src/providers/ai21.ts)):
right after the `data.error` check, return `Malformed response data: <body>` when
`choices` is missing/empty, before dereferencing it. This turns the crash into the
same clean, actionable error those providers already emit. The happy path and the
tool-call / reasoning branches are unchanged.

## Tests

Added a regression test to each provider suite covering (a) an empty `choices`
array and (b) a response with no `choices` field.

- **Without the fix:** all 4 new tests fail with the reported
  `TypeError: Cannot read properties of undefined` (`reading 'message'` /
  `reading '0'`).
- **With the fix:** they pass.

```
$ npx vitest run test/providers/snowflake.test.ts test/providers/openrouter.test.ts
 Test Files  2 passed (2)
      Tests  47 passed (47)
```

- `tsc --noEmit`: 0 errors.
- `biome ci .`: exit 0. (The pre-existing `noExcessiveCognitiveComplexity` warning
  on `executeOpenRouterCall` is `level: "warn"` and was already over the threshold
  before this change; I left the function structure alone to keep the diff minimal.)

Net: 2 source files (+10 each, guard + comment), 2 test files. No behavior change
on valid responses.
