### PR TITLE
fix(redteam): count unmetered generation requests

### DIFF
--- a/src/providers/anthropic/completion.ts
+++ b/src/providers/anthropic/completion.ts
@@ -116,7 +116,7 @@ export class AnthropicCompletionProvider extends AnthropicGenericProvider {
     // already thrown by this point, and createEmptyTokenUsage cannot throw.
     return {
       output: response.completion,
-      tokenUsage: createEmptyTokenUsage(), // Legacy Completion API doesn't expose token usage in its response type
+      tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 }, // Legacy Completion API doesn't expose token usage in its response type
     };
   }
 }

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -972,6 +972,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
           // Could be an old cache item, which was just the text content from TextBlock.
           return {
             output: cachedResponse,
+            cached: true,
             tokenUsage: createEmptyTokenUsage(),
           };
         }

--- a/src/providers/bedrock/knowledgeBase.ts
+++ b/src/providers/bedrock/knowledgeBase.ts
@@ -263,7 +263,7 @@ export class AwsBedrockKnowledgeBaseProvider
       return {
         output,
         metadata: { citations },
-        tokenUsage: createEmptyTokenUsage(), // TODO: Add token usage once Bedrock Knowledge Base API supports it
+        tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 }, // TODO: Add token usage once Bedrock Knowledge Base API supports it
       };
     } catch (err) {
       return {

--- a/src/providers/bedrock/nova-sonic.ts
+++ b/src/providers/bedrock/nova-sonic.ts
@@ -505,7 +505,7 @@ export class NovaSonicProvider extends AwsBedrockGenericProvider implements ApiP
         output: assistantTranscript || '[No response received from API]',
         ...audioOutput,
         // TODO: Add proper token usage tracking
-        tokenUsage: createEmptyTokenUsage(),
+        tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 },
         cached: false,
         metadata: {
           ...audioOutput,

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -274,6 +274,7 @@ export class ReplicateProvider implements ApiProvider {
 
       // If still processing, poll for completion
       if (response.status === 'starting' || response.status === 'processing') {
+        cached = false;
         response = await this.pollForCompletion(response.id);
       }
 

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -234,7 +234,12 @@ export class ReplicateProvider implements ApiProvider {
 
       if (cachedResponse) {
         logger.debug('Returning cached Replicate response', { modelName: this.modelName });
-        return { ...JSON.parse(cachedResponse as string), cached: true };
+        const parsedResponse = JSON.parse(cachedResponse as string);
+        return {
+          ...parsedResponse,
+          tokenUsage: { ...parsedResponse.tokenUsage, numRequests: 0 },
+          cached: true,
+        };
       }
     }
 

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -286,6 +286,7 @@ export class ReplicateProvider implements ApiProvider {
     } catch (err) {
       return {
         error: `API call error: ${String(err)}`,
+        ...(cached && { cached: true, tokenUsage: createEmptyTokenUsage() }),
       };
     }
     logger.debug('Replicate API response received', {

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -237,7 +237,11 @@ export class ReplicateProvider implements ApiProvider {
         const parsedResponse = JSON.parse(cachedResponse as string);
         return {
           ...parsedResponse,
-          tokenUsage: { ...parsedResponse.tokenUsage, numRequests: 0 },
+          tokenUsage: {
+            ...parsedResponse.tokenUsage,
+            cached: parsedResponse.tokenUsage?.total ?? 0,
+            numRequests: 0,
+          },
           cached: true,
         };
       }

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -352,7 +352,7 @@ export class ReplicateProvider implements ApiProvider {
         },
         getRequestTimeoutMs(),
         'json',
-        false, // Don't cache polling requests
+        true, // Don't cache polling requests
       );
 
       const prediction = pollResponse.data as ReplicatePrediction;

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -334,6 +334,7 @@ export class ReplicateProvider implements ApiProvider {
     logger.error('Unsupported response from Replicate: ' + JSON.stringify(response));
     return {
       error: 'Unsupported response from Replicate: ' + JSON.stringify(response),
+      ...responseMetadata,
     };
   }
 

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -249,6 +249,7 @@ export class ReplicateProvider implements ApiProvider {
 
     logger.debug('Calling Replicate', { modelName: this.modelName, promptLength: prompt.length });
     let response;
+    let cached = false;
     try {
       // Create prediction with sync mode (wait up to 60 seconds)
       const createResponse = await fetchWithCache(
@@ -268,6 +269,7 @@ export class ReplicateProvider implements ApiProvider {
         'json',
       );
 
+      cached = createResponse.cached;
       response = createResponse.data as ReplicatePrediction;
 
       // If still processing, poll for completion
@@ -290,11 +292,16 @@ export class ReplicateProvider implements ApiProvider {
       ...getReplicateValueSummary('response', response),
     });
 
+    const responseMetadata = {
+      ...(cached && { cached: true }),
+      tokenUsage: { ...createEmptyTokenUsage(), numRequests: Number(!cached) },
+    };
+
     if (typeof response === 'string') {
       // It's text
       const ret = {
         output: response,
-        tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 },
+        ...responseMetadata,
       };
       if (cache && cacheKey) {
         try {
@@ -310,7 +317,7 @@ export class ReplicateProvider implements ApiProvider {
         const output = response.join('');
         const ret = {
           output,
-          tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 },
+          ...responseMetadata,
         };
         if (cache && cacheKey) {
           try {

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -285,7 +285,7 @@ export class ReplicateProvider implements ApiProvider {
       // It's text
       const ret = {
         output: response,
-        tokenUsage: createEmptyTokenUsage(),
+        tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 },
       };
       if (cache && cacheKey) {
         try {
@@ -301,7 +301,7 @@ export class ReplicateProvider implements ApiProvider {
         const output = response.join('');
         const ret = {
           output,
-          tokenUsage: createEmptyTokenUsage(),
+          tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 },
         };
         if (cache && cacheKey) {
           try {

--- a/src/redteam/generationTokenUsage.ts
+++ b/src/redteam/generationTokenUsage.ts
@@ -47,9 +47,6 @@ export function trackGenerationTokenUsage<T extends ApiProvider>(
   return trackProvider(provider, (response) => {
     if (!response.cached) {
       accumulateResponseTokenUsage(tokenUsage, response);
-      if (response.tokenUsage?.numRequests === 0) {
-        tokenUsage.numRequests = (tokenUsage.numRequests ?? 0) + 1;
-      }
     }
   });
 }

--- a/src/redteam/generationTokenUsage.ts
+++ b/src/redteam/generationTokenUsage.ts
@@ -47,6 +47,9 @@ export function trackGenerationTokenUsage<T extends ApiProvider>(
   return trackProvider(provider, (response) => {
     if (!response.cached) {
       accumulateResponseTokenUsage(tokenUsage, response);
+      if (response.tokenUsage?.numRequests === 0) {
+        tokenUsage.numRequests = (tokenUsage.numRequests ?? 0) + 1;
+      }
     }
   });
 }

--- a/test/providers/anthropic/completion.test.ts
+++ b/test/providers/anthropic/completion.test.ts
@@ -45,7 +45,7 @@ describe('AnthropicCompletionProvider', () => {
       expect(provider.anthropic.completions.create).toHaveBeenCalledTimes(1);
       expect(result).toMatchObject({
         output: 'Test output',
-        tokenUsage: {},
+        tokenUsage: { numRequests: 1 },
       });
     });
 
@@ -63,7 +63,7 @@ describe('AnthropicCompletionProvider', () => {
       expect(provider.anthropic.completions.create).toHaveBeenCalledTimes(1);
       expect(result).toMatchObject({
         output: 'Test output',
-        tokenUsage: {},
+        tokenUsage: { numRequests: 1 },
       });
 
       vi.mocked(provider.anthropic.completions.create).mockClear();
@@ -73,7 +73,7 @@ describe('AnthropicCompletionProvider', () => {
       expect(cachedResult.cached).toBe(true);
       expect(cachedResult).toMatchObject({
         output: 'Test output',
-        tokenUsage: {},
+        tokenUsage: { numRequests: 0 },
       });
     });
 

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -742,9 +742,9 @@ describe('AnthropicMessagesProvider', () => {
       await getCache().set(cacheKey, 'Test output');
 
       const result = await provider.callApi('What is the forecast in San Francisco?');
-      // Legacy cache items (plain strings) don't get the cached flag
       expect(result).toMatchObject({
         output: 'Test output',
+        cached: true,
         tokenUsage: {},
       });
       expect(provider.anthropic.messages.create).toHaveBeenCalledTimes(0);

--- a/test/providers/bedrock/knowledgeBase.test.ts
+++ b/test/providers/bedrock/knowledgeBase.test.ts
@@ -311,7 +311,7 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
     expect(result).toEqual({
       output: 'This is the response from the knowledge base',
       metadata: { citations: mockResponse.citations },
-      tokenUsage: createEmptyTokenUsage(),
+      tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 },
     });
   });
 

--- a/test/providers/bedrock/nova-sonic.test.ts
+++ b/test/providers/bedrock/nova-sonic.test.ts
@@ -269,6 +269,15 @@ describe('NovaSonic Provider', () => {
   });
 
   describe('API Interactions', () => {
+    it('counts the request when a successful stream does not report token usage', async () => {
+      vi.spyOn(NovaSonicProvider.prototype, 'callApi').mockRestore();
+
+      const result = await provider.callApi('Test prompt');
+
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(result.tokenUsage).toMatchObject({ total: 0, numRequests: 1 });
+    });
+
     it('should successfully call API and handle text response', async () => {
       const result = await provider.callApi('Test prompt');
 

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -171,39 +171,44 @@ describe('ReplicateProvider', () => {
     );
   });
 
-  it('should poll for completion when prediction is still processing', async () => {
-    // First call returns processing status
-    mockedFetchWithCache.mockResolvedValueOnce({
-      data: {
-        id: 'test-id',
-        status: 'processing',
-        output: null,
-      },
-      cached: false,
-      status: 200,
-      statusText: 'OK',
-    });
+  it.each([false, true])(
+    'should count live polling when the cached initial prediction is %s',
+    async (cachedPrediction) => {
+      // First call returns processing status
+      mockedFetchWithCache.mockResolvedValueOnce({
+        data: {
+          id: 'test-id',
+          status: 'processing',
+          output: null,
+        },
+        cached: cachedPrediction,
+        status: 200,
+        statusText: 'OK',
+      });
 
-    // Second call (polling) returns completed
-    mockedFetchWithCache.mockResolvedValueOnce({
-      data: {
-        id: 'test-id',
-        status: 'succeeded',
-        output: 'test response',
-      },
-      cached: false,
-      status: 200,
-      statusText: 'OK',
-    });
+      // Second call (polling) returns completed
+      mockedFetchWithCache.mockResolvedValueOnce({
+        data: {
+          id: 'test-id',
+          status: 'succeeded',
+          output: 'test response',
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
 
-    const provider = new ReplicateProvider('test-model', {
-      config: { apiKey: mockApiKey },
-    });
+      const provider = new ReplicateProvider('test-model', {
+        config: { apiKey: mockApiKey },
+      });
 
-    const result = await provider.callApi('test prompt');
-    expect(result.output).toBe('test response');
-    expect(mockedFetchWithCache).toHaveBeenCalledTimes(2);
-  });
+      const result = await provider.callApi('test prompt');
+      expect(result.output).toBe('test response');
+      expect(result.cached).not.toBe(true);
+      expect(result.tokenUsage).toMatchObject({ total: 0, numRequests: 1 });
+      expect(mockedFetchWithCache).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it('should handle array outputs', async () => {
     mockedFetchWithCache.mockResolvedValue({

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -259,6 +259,30 @@ describe('ReplicateProvider', () => {
     expect(result.error).toBe('API call error: Error: Model error');
   });
 
+  it('does not count a cached failed prediction as a new request', async () => {
+    mockedFetchWithCache.mockResolvedValue({
+      data: {
+        id: 'test-id',
+        status: 'failed',
+        error: 'Model error',
+      },
+      cached: true,
+      status: 200,
+      statusText: 'OK',
+    });
+
+    const provider = new ReplicateProvider('test-model', {
+      config: { apiKey: mockApiKey },
+    });
+    const result = await provider.callApi('test prompt');
+
+    expect(result).toMatchObject({
+      error: 'API call error: Error: Model error',
+      cached: true,
+      tokenUsage: { total: 0, cached: 0, numRequests: 0 },
+    });
+  });
+
   it('should use versioned endpoint for models with version IDs', async () => {
     mockedFetchWithCache.mockResolvedValue({
       data: {

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -355,6 +355,29 @@ describe('ReplicateProvider', () => {
     },
   );
 
+  it.each([{ unsupported: true }, [{ unsupported: true }]])(
+    'preserves cache accounting for unsupported cached output %o',
+    async (output) => {
+      mockedFetchWithCache.mockResolvedValue({
+        data: { id: 'test-id', status: 'succeeded', output },
+        cached: true,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const provider = new ReplicateProvider('test-model', {
+        config: { apiKey: mockApiKey },
+      });
+      const result = await provider.callApi('test prompt');
+
+      expect(result).toMatchObject({
+        error: expect.stringContaining('Unsupported response from Replicate'),
+        cached: true,
+        tokenUsage: { total: 0, cached: 0, numRequests: 0 },
+      });
+    },
+  );
+
   it('should cache successful string responses', async () => {
     mockedFetchWithCache.mockResolvedValue({
       data: {

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -305,6 +305,43 @@ describe('ReplicateProvider', () => {
     expect(mockedFetchWithCache).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { output: 'cached prediction', expectedOutput: 'cached prediction' },
+    { output: ['cached', ' ', 'prediction'], expectedOutput: 'cached prediction' },
+  ])(
+    'does not count an inner cached prediction for output $output',
+    async ({ output, expectedOutput }) => {
+      mockedFetchWithCache.mockResolvedValue({
+        data: { id: 'test-id', status: 'succeeded', output },
+        cached: true,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const mockCache = {
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn(),
+      } as any;
+      vi.mocked(isCacheEnabled).mockReturnValue(true);
+      vi.mocked(getCache).mockResolvedValue(mockCache);
+
+      const provider = new ReplicateProvider('test-model', {
+        config: { apiKey: mockApiKey },
+      });
+      const result = await provider.callApi('test prompt');
+
+      expect(result).toMatchObject({
+        output: expectedOutput,
+        cached: true,
+        tokenUsage: { total: 0, cached: 0, numRequests: 0 },
+      });
+      expect(JSON.parse(mockCache.set.mock.calls[0][1])).toMatchObject({
+        cached: true,
+        tokenUsage: { numRequests: 0 },
+      });
+    },
+  );
+
   it('should cache successful string responses', async () => {
     mockedFetchWithCache.mockResolvedValue({
       data: {

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -295,7 +295,7 @@ describe('ReplicateProvider', () => {
     const result = await provider.callApi('test prompt');
 
     expect(result.cached).toBe(true);
-    expect(result.tokenUsage).toEqual({ total: 100, numRequests: 0 });
+    expect(result.tokenUsage).toEqual({ total: 100, cached: 100, numRequests: 0 });
     expect(result.output).toBe('cached PFQA_REPLICATE_CACHED_OUTPUT_SECRET response');
     expect(mockCache.get).toHaveBeenCalled();
     const debugLogs = vi.mocked(logger.debug).mock.calls.map((call) => JSON.stringify(call));

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -207,6 +207,14 @@ describe('ReplicateProvider', () => {
       expect(result.cached).not.toBe(true);
       expect(result.tokenUsage).toMatchObject({ total: 0, numRequests: 1 });
       expect(mockedFetchWithCache).toHaveBeenCalledTimes(2);
+      expect(mockedFetchWithCache).toHaveBeenNthCalledWith(
+        2,
+        'https://api.replicate.com/v1/predictions/test-id',
+        expect.objectContaining({ method: 'GET' }),
+        expect.any(Number),
+        'json',
+        true,
+      );
     },
   );
 

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -59,6 +59,7 @@ describe('ReplicateProvider', () => {
 
     const result = await provider.callApi('test prompt');
     expect(result.output).toBe('test response');
+    expect(result.tokenUsage).toMatchObject({ total: 0, numRequests: 1 });
     const requestBody = JSON.parse(
       (mockedFetchWithCache.mock.calls[0][1] as { body: string }).body,
     );
@@ -222,6 +223,7 @@ describe('ReplicateProvider', () => {
 
     const result = await provider.callApi('test prompt');
     expect(result.output).toBe('Hello World');
+    expect(result.tokenUsage).toMatchObject({ total: 0, numRequests: 1 });
   });
 
   it('should handle failed predictions', async () => {
@@ -339,7 +341,7 @@ describe('ReplicateProvider', () => {
     expect(mockCache.set).toHaveBeenCalledWith(cacheKey, expect.any(String));
     expect(JSON.parse(mockCache.set.mock.calls[0][1])).toEqual({
       output: 'test response',
-      tokenUsage: createEmptyTokenUsage(),
+      tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 },
     });
   });
 
@@ -573,7 +575,7 @@ describe('ReplicateModerationProvider', () => {
 
     const result = await provider.callModerationApi('unsafe prompt', 'unsafe response');
     expect(result.flags).toHaveLength(1);
-    expect(result.tokenUsage).toEqual(createEmptyTokenUsage());
+    expect(result.tokenUsage).toEqual({ ...createEmptyTokenUsage(), numRequests: 1 });
   });
 
   it('should forward provider-reported token usage with upstream errors', async () => {

--- a/test/providers/replicate.test.ts
+++ b/test/providers/replicate.test.ts
@@ -277,7 +277,7 @@ describe('ReplicateProvider', () => {
   it('should set cached flag when returning cached response', async () => {
     const mockCachedResponse = {
       output: 'cached PFQA_REPLICATE_CACHED_OUTPUT_SECRET response',
-      tokenUsage: { total: 100 },
+      tokenUsage: { total: 100, numRequests: 1 },
     };
 
     const mockCache = {
@@ -295,6 +295,7 @@ describe('ReplicateProvider', () => {
     const result = await provider.callApi('test prompt');
 
     expect(result.cached).toBe(true);
+    expect(result.tokenUsage).toEqual({ total: 100, numRequests: 0 });
     expect(result.output).toBe('cached PFQA_REPLICATE_CACHED_OUTPUT_SECRET response');
     expect(mockCache.get).toHaveBeenCalled();
     const debugLogs = vi.mocked(logger.debug).mock.calls.map((call) => JSON.stringify(call));

--- a/test/redteam/generationTokenUsage.test.ts
+++ b/test/redteam/generationTokenUsage.test.ts
@@ -4,6 +4,7 @@ import {
   trackAdditionalGenerationProvider,
   trackGenerationTokenUsage,
 } from '../../src/redteam/generationTokenUsage';
+import { createEmptyTokenUsage } from '../../src/util/tokenUsageUtils';
 
 import type { ApiProvider, TokenUsage } from '../../src/types/index';
 
@@ -29,6 +30,33 @@ describe('generation token usage', () => {
 
     expect(usage).toEqual({});
   });
+
+  it.each([false, undefined])(
+    'counts fresh generation requests with normalized zero usage when cached is %s',
+    async (cached) => {
+      const usage: TokenUsage = {};
+      const provider = trackGenerationTokenUsage(
+        createProvider(
+          vi.fn().mockResolvedValue({
+            output: 'unmetered generation',
+            cached,
+            tokenUsage: createEmptyTokenUsage(),
+          }),
+        ),
+        usage,
+      );
+
+      await provider.callApi('generate a test');
+
+      expect(usage).toMatchObject({
+        total: 0,
+        prompt: 0,
+        completion: 0,
+        cached: 0,
+        numRequests: 1,
+      });
+    },
+  );
 
   it('counts actual provider requests that contain prompt-cache token details', async () => {
     const usage: TokenUsage = {};

--- a/test/redteam/generationTokenUsage.test.ts
+++ b/test/redteam/generationTokenUsage.test.ts
@@ -32,7 +32,28 @@ describe('generation token usage', () => {
   });
 
   it.each([false, undefined])(
-    'counts fresh generation requests with normalized zero usage when cached is %s',
+    'counts reported zero-token generation requests when cached is %s',
+    async (cached) => {
+      const usage: TokenUsage = {};
+      const provider = trackGenerationTokenUsage(
+        createProvider(
+          vi.fn().mockResolvedValue({
+            output: 'unmetered generation',
+            cached,
+            tokenUsage: { ...createEmptyTokenUsage(), numRequests: 1 },
+          }),
+        ),
+        usage,
+      );
+
+      await provider.callApi('generate a test');
+
+      expect(usage).toMatchObject({ total: 0, numRequests: 1 });
+    },
+  );
+
+  it.each([false, undefined])(
+    'preserves explicit zero-request generation usage when cached is %s',
     async (cached) => {
       const usage: TokenUsage = {};
       const provider = trackGenerationTokenUsage(
@@ -53,7 +74,7 @@ describe('generation token usage', () => {
         prompt: 0,
         completion: 0,
         cached: 0,
-        numRequests: 1,
+        numRequests: 0,
       });
     },
   );


### PR DESCRIPTION
## Summary

- Report real Anthropic Completion, Bedrock Knowledge Base, Bedrock Nova Sonic, and Replicate requests even when their APIs do not expose token counts.
- Preserve intentional zero-request responses, provider-reported cumulative request counts, and both provider-level and lower-level Replicate HTTP cache hits; classify historical cached tokens without counting replayed requests.
- Add provider regressions for fresh responses, both cache layers, cache-bypassing live prediction polls, failed and unsupported cached predictions, Replicate string and array outputs, moderation, and Nova Sonic streams.

These providers previously returned `numRequests: 0` after real API calls, so requests disappeared from `metadata.generation.tokenUsage` and generated-suite accounting. Reporting the request at the source fixes both red-team generation and other accounting consumers without overriding legitimate explicit zeroes.

## Validation

- 948 focused backend tests across red-team generation, token accounting, Anthropic, Bedrock, Nova Sonic, Replicate, Watsonx, Claude Agent SDK, and package manifests.
- 132 evaluation-output frontend tests.
- 279 affected-provider and accounting tests on the minimum supported Node 22.22.0.
- `npm run tsc`
- `npm run architecture:check`
- `npm run l` and `npm run f`
- Two offline `npm run local -- redteam generate ... --force --no-cache` runs: counted both real zero-token requests, while a provider explicitly reporting zero requests remained uncounted.
- Offline `npm run local -- eval ... --no-cache -o ...`: one passing test, score 1, and no failures or errors.

Provider accounting, explicit-zero, Anthropic cache-hit, both Replicate cache layers, cached-token classification, prediction polling, and cached error-path regressions were observed failing before their fixes and passing afterward.
