### PR TITLE
fix(providers): normalize OpenRouter URLs and validate SDK ranges

### DIFF
--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -3,7 +3,12 @@ import logger from '../logger';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
 import { normalizeFinishReason } from '../util/finishReason';
 import { OpenAiChatCompletionProvider } from './openai/chat';
-import { calculateOpenAICost, formatOpenAiError, getTokenUsage } from './openai/util';
+import {
+  appendOpenAiApiPath,
+  calculateOpenAICost,
+  formatOpenAiError,
+  getTokenUsage,
+} from './openai/util';
 import { getRequestTimeoutMs } from './shared';
 import type OpenAI from 'openai';
 
@@ -146,7 +151,7 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
     try {
       ({ data, cached, status, statusText } =
         await fetchWithCache<OpenRouterChatCompletionResponse>(
-          `${this.getApiUrl()}/chat/completions`,
+          appendOpenAiApiPath(this.getApiUrl(), 'chat/completions'),
           {
             method: 'POST',
             headers: {

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -449,7 +449,9 @@ describe('package manifests', () => {
     expect(packageLock.packages[''].dependencies?.[sdkName]).toBe(sdkVersion);
     expect(packageLock.packages[''].devDependencies?.[agentName]).toBe(agentVersion);
     expect(packageLock.packages[''].optionalDependencies?.[agentName]).toBe(agentVersion);
-    expect(packageLock.packages[`node_modules/${sdkName}`].version).toBe(sdkVersion);
+    const resolvedSdkVersion = packageLock.packages[`node_modules/${sdkName}`].version;
+    expect(resolvedSdkVersion).toBeDefined();
+    expect(satisfies(resolvedSdkVersion!, sdkVersion!)).toBe(true);
     expect(agentPackage.version).toBe(agentVersion);
 
     for (const [binaryName, binaryVersion] of Object.entries(

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -180,41 +180,41 @@ describe('OpenRouter', () => {
         expectedUrl:
           'https://proxy.example.com/openrouter/api/v1/chat/completions?api-version=2026-08-18',
       },
-    ])('should normalize the request URL for apiBaseUrl $apiBaseUrl', async ({
-      apiBaseUrl,
-      expectedUrl,
-    }) => {
-      const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
+    ])(
+      'should normalize the request URL for apiBaseUrl $apiBaseUrl',
+      async ({ apiBaseUrl, expectedUrl }) => {
+        const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
 
-      try {
-        const provider = new OpenRouterProvider('google/gemini-2.5-pro', {
-          config: {
-            apiBaseUrl,
-          },
-        });
+        try {
+          const provider = new OpenRouterProvider('google/gemini-2.5-pro', {
+            config: {
+              apiBaseUrl,
+            },
+          });
 
-        const response = new Response(
-          JSON.stringify({
-            choices: [{ message: { content: 'Test output' }, finish_reason: 'stop' }],
-            usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
-          }),
-          {
-            status: 200,
-            statusText: 'OK',
-            headers: new Headers({ 'Content-Type': 'application/json' }),
-          },
-        );
-        mockedFetchWithRetries.mockResolvedValueOnce(response);
+          const response = new Response(
+            JSON.stringify({
+              choices: [{ message: { content: 'Test output' }, finish_reason: 'stop' }],
+              usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+            }),
+            {
+              status: 200,
+              statusText: 'OK',
+              headers: new Headers({ 'Content-Type': 'application/json' }),
+            },
+          );
+          mockedFetchWithRetries.mockResolvedValueOnce(response);
 
-        await provider.callApi('Test prompt');
+          await provider.callApi('Test prompt');
 
-        const [url] = mockedFetchWithRetries.mock.calls[0] ?? [];
-        expect(provider.config.apiBaseUrl).toBe(apiBaseUrl);
-        expect(url).toBe(expectedUrl);
-      } finally {
-        restoreEnv();
-      }
-    });
+          const [url] = mockedFetchWithRetries.mock.calls[0] ?? [];
+          expect(provider.config.apiBaseUrl).toBe(apiBaseUrl);
+          expect(url).toBe(expectedUrl);
+        } finally {
+          restoreEnv();
+        }
+      },
+    );
 
     it('should combine apiBaseUrl override with passthrough options on the request body', async () => {
       const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -166,14 +166,30 @@ describe('OpenRouter', () => {
       }
     });
 
-    it('should preserve a trailing slash on the configured apiBaseUrl as-is', async () => {
+    it.each([
+      {
+        apiBaseUrl: 'https://proxy.example.com/openrouter/api/v1/',
+        expectedUrl: 'https://proxy.example.com/openrouter/api/v1/chat/completions',
+      },
+      {
+        apiBaseUrl: 'https://proxy.example.com/openrouter/api/v1///',
+        expectedUrl: 'https://proxy.example.com/openrouter/api/v1/chat/completions',
+      },
+      {
+        apiBaseUrl: 'https://proxy.example.com/openrouter/api/v1/?api-version=2026-08-18',
+        expectedUrl:
+          'https://proxy.example.com/openrouter/api/v1/chat/completions?api-version=2026-08-18',
+      },
+    ])('should normalize the request URL for apiBaseUrl $apiBaseUrl', async ({
+      apiBaseUrl,
+      expectedUrl,
+    }) => {
       const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
 
       try {
-        const customApiBaseUrl = 'https://proxy.example.com/openrouter/api/v1/';
         const provider = new OpenRouterProvider('google/gemini-2.5-pro', {
           config: {
-            apiBaseUrl: customApiBaseUrl,
+            apiBaseUrl,
           },
         });
 
@@ -193,7 +209,8 @@ describe('OpenRouter', () => {
         await provider.callApi('Test prompt');
 
         const [url] = mockedFetchWithRetries.mock.calls[0] ?? [];
-        expect(url).toBe(`${customApiBaseUrl}/chat/completions`);
+        expect(provider.config.apiBaseUrl).toBe(apiBaseUrl);
+        expect(url).toBe(expectedUrl);
       } finally {
         restoreEnv();
       }


### PR DESCRIPTION
## Summary

- Build OpenRouter chat completion URLs with the shared OpenAI-compatible path helper so trailing slashes do not create invalid proxy paths and query parameters remain intact.
- Cover single trailing slashes, repeated trailing slashes, and query-bearing OpenRouter proxy URLs without changing the configured base URL.
- Validate the resolved Anthropic SDK lockfile version against its declared semver range instead of comparing a resolved version to a range string.

## Validation

- `node node_modules/vitest/vitest.mjs run test/package-manifests.test.ts test/providers/openrouter.test.ts test/providers/openai/util.test.ts test/providers/openai/chat.test.ts --sequence.shuffle=false --reporter=dot --maxWorkers=1` (4 files, 322 tests passed)
- `node node_modules/typescript/bin/tsc --noEmit`
- `npm run l && npm run f`
- `npm run local -- eval -c /private/tmp/promptfoo-ai-findings-pr-10433/promptfooconfig.yaml --no-cache -o /private/tmp/promptfoo-ai-findings-pr-10433/result.json` against a local mock OpenRouter proxy (1 passed, 0 failed, 0 errors; observed `POST /openrouter/api/v1/chat/completions?tenant=qa`)
