### PR TITLE
fix: preserve escaped Nunjucks placeholders in test vars

### DIFF
--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -71,14 +71,17 @@ export function resolveVariables(
         continue;
       }
       const value = variables[key] as string;
-      const match = regex.exec(value);
+      const { protectedValue, restore } = protectNunjucksBlocks(value);
+      const match = regex.exec(protectedValue);
       if (match) {
         const [placeholder, varName] = match;
         if (variables[varName] === undefined) {
           // Do nothing - final nunjucks render will fail if necessary.
           // logger.warn(`Variable "${varName}" not found for substitution.`);
         } else {
-          variables[key] = value.replace(placeholder, variables[varName] as string);
+          variables[key] = restore(
+            protectedValue.replace(placeholder, variables[varName] as string),
+          );
           if (skipResolveVars?.includes(varName) || varsResolvedFromSkipped?.has(varName)) {
             varsResolvedFromSkipped?.add(key);
           }
@@ -90,6 +93,42 @@ export function resolveVariables(
   } while (!resolved && iterations < 5);
 
   return variables;
+}
+
+/**
+ * Protect Nunjucks constructs whose contents must remain literal while resolving
+ * variable-to-variable mappings. They are rendered later by renderPrompt, where
+ * Nunjucks can correctly distinguish raw blocks and string literal expressions
+ * from actual variable references.
+ */
+function protectNunjucksBlocks(value: string): {
+  protectedValue: string;
+  restore: (value: string) => string;
+} {
+  const protectedBlocks: string[] = [];
+  let protectedValue = value;
+  const patterns = [
+    /\{%\s*raw\s*%\}[\s\S]*?\{%\s*endraw\s*%\}/g,
+    /\{#[\s\S]*?#\}/g,
+    /\{\{\s*(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')\s*\}\}/g,
+  ];
+
+  for (const pattern of patterns) {
+    protectedValue = protectedValue.replace(pattern, (block) => {
+      const placeholder = `\u0000promptfoo-nunjucks-block-${protectedBlocks.length}\u0000`;
+      protectedBlocks.push(block);
+      return placeholder;
+    });
+  }
+
+  return {
+    protectedValue,
+    restore: (renderedValue: string) =>
+      renderedValue.replace(
+        /\u0000promptfoo-nunjucks-block-(\d+)\u0000/g,
+        (_placeholder, index: string) => protectedBlocks[Number(index)] ?? _placeholder,
+      ),
+  };
 }
 
 // Utility: Detect partial/unclosed Nunjucks tags and wrap in {% raw %} if needed

--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -71,7 +71,7 @@ export function resolveVariables(
         continue;
       }
       const value = variables[key] as string;
-      const { protectedValue, restore } = protectNunjucksBlocks(value);
+      const { protectedValue, restore } = protectNunjucksBlocks(value, Object.values(variables));
       const match = regex.exec(protectedValue);
       if (match) {
         const [placeholder, varName] = match;
@@ -101,33 +101,72 @@ export function resolveVariables(
  * Nunjucks can correctly distinguish raw blocks and string literal expressions
  * from actual variable references.
  */
-function protectNunjucksBlocks(value: string): {
+function protectNunjucksBlocks(
+  value: string,
+  reservedValues: readonly VarValue[] = [],
+): {
   protectedValue: string;
   restore: (value: string) => string;
 } {
-  const protectedBlocks: string[] = [];
-  let protectedValue = value;
+  const protectedBlocks = new Map<string, string>();
   const patterns = [
-    /\{%\s*raw\s*%\}[\s\S]*?\{%\s*endraw\s*%\}/g,
+    /\{%-?\s*raw\s*-?%\}[\s\S]*?\{%-?\s*endraw\s*-?%\}/g,
     /\{#[\s\S]*?#\}/g,
-    /\{\{\s*(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')\s*\}\}/g,
+    /\{\{\s*(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*')[\s\S]*?\}\}/g,
   ];
 
-  for (const pattern of patterns) {
-    protectedValue = protectedValue.replace(pattern, (block) => {
-      const placeholder = `\u0000promptfoo-nunjucks-block-${protectedBlocks.length}\u0000`;
-      protectedBlocks.push(block);
-      return placeholder;
-    });
+  const ranges = patterns.flatMap((pattern) =>
+    Array.from(value.matchAll(pattern), (match) => ({
+      start: match.index ?? 0,
+      end: (match.index ?? 0) + match[0].length,
+      block: match[0],
+    })),
+  );
+  ranges.sort((a, b) => a.start - b.start || b.end - a.end);
+
+  const selectedRanges = ranges.filter((range, index) => {
+    const previousRanges = ranges.slice(0, index);
+    return !previousRanges.some(
+      (previous) => range.start < previous.end && range.end > previous.start,
+    );
+  });
+  selectedRanges.sort((a, b) => a.start - b.start);
+
+  const reservedStrings = [value, ...reservedValues]
+    .filter((reserved): reserved is string => typeof reserved === 'string')
+    .join('\n');
+  let protectedValue = '';
+  let cursor = 0;
+
+  for (const range of selectedRanges) {
+    protectedValue += value.slice(cursor, range.start);
+    let suffix = 0;
+    let placeholder: string;
+    do {
+      const suffixText = suffix === 0 ? '' : `-${suffix}`;
+      placeholder = `\u0000promptfoo-nunjucks-block-${protectedBlocks.size}${suffixText}\u0000`;
+      suffix++;
+    } while (reservedStrings.includes(placeholder));
+    protectedBlocks.set(placeholder, range.block);
+    protectedValue += placeholder;
+    cursor = range.end;
   }
+  protectedValue += value.slice(cursor);
 
   return {
     protectedValue,
-    restore: (renderedValue: string) =>
-      renderedValue.replace(
-        /\u0000promptfoo-nunjucks-block-(\d+)\u0000/g,
-        (_placeholder, index: string) => protectedBlocks[Number(index)] ?? _placeholder,
-      ),
+    restore: (renderedValue: string) => {
+      let restoredValue = renderedValue;
+      let previousValue;
+      do {
+        previousValue = restoredValue;
+        restoredValue = restoredValue.replace(
+          /\u0000promptfoo-nunjucks-block-\d+(?:-\d+)?\u0000/g,
+          (placeholder) => protectedBlocks.get(placeholder) ?? placeholder,
+        );
+      } while (restoredValue !== previousValue);
+      return restoredValue;
+    },
   };
 }
 

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -433,6 +433,32 @@ describe('evaluatorHelpers', () => {
       expect(renderedPrompt).toBe('{{ var1 }}');
     });
 
+    it('should respect Nunjucks raw tags inside test variables', async () => {
+      const prompt = toPrompt('{{ template }}');
+      const renderedPrompt = await renderPrompt(
+        prompt,
+        {
+          myVar: 'value1',
+          template: '{% raw %}{{ myVar }}{% endraw %}',
+        },
+        {},
+      );
+      expect(renderedPrompt).toBe('{{ myVar }}');
+    });
+
+    it('should respect Nunjucks escaped strings inside test variables', async () => {
+      const prompt = toPrompt('{{ template }}');
+      const renderedPrompt = await renderPrompt(
+        prompt,
+        {
+          myVar: 'value1',
+          template: `{{ '{{ myVar }}' }}`,
+        },
+        {},
+      );
+      expect(renderedPrompt).toBe('{{ myVar }}');
+    });
+
     it('should render variables that are template strings', async () => {
       const prompt = toPrompt('{{ var1 }}');
       const renderedPrompt = await renderPrompt(prompt, { var1: '{{ var2 }}', var2: 'value2' }, {});

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -459,6 +459,58 @@ describe('evaluatorHelpers', () => {
       expect(renderedPrompt).toBe('{{ myVar }}');
     });
 
+    it('should respect whitespace-controlled raw tags inside test variables', async () => {
+      const prompt = toPrompt('{{ template }}');
+      const renderedPrompt = await renderPrompt(
+        prompt,
+        {
+          myVar: 'value1',
+          template: '{% raw -%}{{ myVar }}{% endraw %}',
+        },
+        {},
+      );
+      expect(renderedPrompt).toBe('{{ myVar }}');
+    });
+
+    it('should respect filtered Nunjucks escaped strings inside test variables', async () => {
+      const prompt = toPrompt('{{ template }}');
+      const renderedPrompt = await renderPrompt(
+        prompt,
+        {
+          myVar: 'value1',
+          template: "{{ '{{ myVar }}' | safe }}",
+        },
+        {},
+      );
+      expect(renderedPrompt).toBe('{{ myVar }}');
+    });
+
+    it('should restore nested protected Nunjucks blocks', () => {
+      const variables = {
+        foo: 'FOO',
+        bar: 'BAR',
+        template: '{{ "{% raw %}{{ foo }}{% endraw %}" }} {{ bar }}',
+      };
+      expect(resolveVariables(variables)).toEqual({
+        foo: 'FOO',
+        bar: 'BAR',
+        template: '{{ "{% raw %}{{ foo }}{% endraw %}" }} BAR',
+      });
+    });
+
+    it('should avoid colliding with variable values when protecting Nunjucks blocks', () => {
+      const variables = {
+        foo: 'FOO',
+        payload: '\u0000promptfoo-nunjucks-block-0\u0000',
+        template: '{% raw %}{{ foo }}{% endraw %} {{ payload }}',
+      };
+      expect(resolveVariables(variables)).toEqual({
+        foo: 'FOO',
+        payload: '\u0000promptfoo-nunjucks-block-0\u0000',
+        template: '{% raw %}{{ foo }}{% endraw %} \u0000promptfoo-nunjucks-block-0\u0000',
+      });
+    });
+
     it('should render variables that are template strings', async () => {
       const prompt = toPrompt('{{ var1 }}');
       const renderedPrompt = await renderPrompt(prompt, { var1: '{{ var2 }}', var2: 'value2' }, {});


### PR DESCRIPTION
Fixes #10434

## Summary

- Preserve escaped Nunjucks placeholders when they are supplied through test variables.
- Keep raw blocks, comments, and string-literal expressions intact during variable mapping resolution.

## Root Cause

Variable mapping resolution used a regular expression over the complete variable value. This treated placeholder-looking text inside Nunjucks raw blocks and string-literal expressions as real variable references before Nunjucks rendered the value.

## Verification

- Before/after behavioral verification -> both reported escaping forms failed before the fix and passed after it; ordinary nested variable mapping remains unchanged.
- Source and test syntax checks -> passed.
- `git diff --check` -> passed.
- Dependency-backed repository checks -> delegated to CI because this checkout has no installed project dependencies.

## Notes for Reviewers

The change is limited to variable mapping resolution and adds regression coverage for both escaping forms reported in the issue. The core behavior is verified; dependency-backed repository checks will run in CI after publication.
