### PR TITLE
fix(providers): return a clean error on empty choices in localai and OpenAI completions

### DIFF
--- a/src/providers/localai.ts
+++ b/src/providers/localai.ts
@@ -86,6 +86,16 @@ export class LocalAiChatProvider extends LocalAiGenericProvider {
       };
     }
 
+    // A 200 with an empty or missing choices array (soft moderation block or
+    // upstream hiccup) must surface as a clean malformed-response error, not
+    // an opaque TypeError from choices[0].message. Mirrors the sibling fix in
+    // openrouter.ts / snowflake.ts (#10418).
+    if (!data.choices?.[0]?.message) {
+      return {
+        error: `Malformed response data: ${JSON.stringify(data)}`,
+      };
+    }
+
     try {
       return {
         output: data.choices[0].message.content,
@@ -167,6 +177,12 @@ export class LocalAiCompletionProvider extends LocalAiGenericProvider {
     } catch (err) {
       return {
         error: `API call error: ${String(err)}`,
+      };
+    }
+
+    if (!data.choices?.[0]) {
+      return {
+        error: `Malformed response data: ${JSON.stringify(data)}`,
       };
     }
 

--- a/src/providers/localai.ts
+++ b/src/providers/localai.ts
@@ -86,10 +86,6 @@ export class LocalAiChatProvider extends LocalAiGenericProvider {
       };
     }
 
-    // A 200 with an empty or missing choices array (soft moderation block or
-    // upstream hiccup) must surface as a clean malformed-response error, not
-    // an opaque TypeError from choices[0].message. Mirrors the sibling fix in
-    // openrouter.ts / snowflake.ts (#10418).
     if (!data.choices?.[0]?.message) {
       return {
         error: `Malformed response data: ${JSON.stringify(data)}`,

--- a/src/providers/openai/completion.ts
+++ b/src/providers/openai/completion.ts
@@ -144,10 +144,6 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
         error: formatOpenAiError(data),
       };
     }
-    // A 200 with an empty choices array (soft moderation block, upstream
-    // hiccup) must surface as a clean malformed-response error, not an opaque
-    // TypeError from choices[0]. Mirrors the sibling fix in openrouter.ts /
-    // snowflake.ts (#10418).
     if (!data.choices?.[0]) {
       return {
         error: `Malformed response data: ${JSON.stringify(data)}`,

--- a/src/providers/openai/completion.ts
+++ b/src/providers/openai/completion.ts
@@ -144,6 +144,16 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
         error: formatOpenAiError(data),
       };
     }
+    // A 200 with an empty choices array (soft moderation block, upstream
+    // hiccup) must surface as a clean malformed-response error, not an opaque
+    // TypeError from choices[0]. Mirrors the sibling fix in openrouter.ts /
+    // snowflake.ts (#10418).
+    if (!data.choices?.[0]) {
+      return {
+        error: `Malformed response data: ${JSON.stringify(data)}`,
+        cached,
+      };
+    }
     try {
       return {
         output: data.choices[0].text,

--- a/test/providers/localai.test.ts
+++ b/test/providers/localai.test.ts
@@ -124,8 +124,6 @@ describe('LocalAI empty choices handling', () => {
   });
 
   it('returns a clean malformed-response error on empty choices (chat)', async () => {
-    // A 200 with an empty choices array (soft moderation block or upstream
-    // hiccup) must not become an opaque TypeError from choices[0].message.
     vi.mocked(fetchWithCache).mockResolvedValue({ data: { choices: [] } } as any);
 
     const provider = new LocalAiChatProvider('test-model', { config: {} });

--- a/test/providers/localai.test.ts
+++ b/test/providers/localai.test.ts
@@ -117,3 +117,29 @@ describe('LocalAI temperature handling', () => {
     expect(callBody.temperature).toBe(0.7);
   });
 });
+
+describe('LocalAI empty choices handling', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns a clean malformed-response error on empty choices (chat)', async () => {
+    // A 200 with an empty choices array (soft moderation block or upstream
+    // hiccup) must not become an opaque TypeError from choices[0].message.
+    vi.mocked(fetchWithCache).mockResolvedValue({ data: { choices: [] } } as any);
+
+    const provider = new LocalAiChatProvider('test-model', { config: {} });
+    const result = await provider.callApi('Test prompt');
+
+    expect(result.error).toContain('Malformed response data');
+  });
+
+  it('returns a clean malformed-response error on empty choices (completion)', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({ data: { choices: [] } } as any);
+
+    const provider = new LocalAiCompletionProvider('test-model', { config: {} });
+    const result = await provider.callApi('Test prompt');
+
+    expect(result.error).toContain('Malformed response data');
+  });
+});

--- a/test/providers/openai/completion.test.ts
+++ b/test/providers/openai/completion.test.ts
@@ -233,25 +233,22 @@ describe('OpenAI Provider', () => {
       ['davinci-002', 2, 2],
       ['ft:babbage-002:company::model', 1.6, 1.6],
       ['ft:davinci-002:company::model', 12, 12],
-    ])(
-      'should call and price supported Completions model %s',
-      async (model, inputRate, outputRate) => {
-        mockFetchWithCache.mockResolvedValueOnce({
-          ...mockResponse,
-          data: {
-            choices: [{ text: 'Test output' }],
-            usage: { total_tokens: 3_000, prompt_tokens: 2_000, completion_tokens: 1_000 },
-          },
-        });
+    ])('should call and price supported Completions model %s', async (model, inputRate, outputRate) => {
+      mockFetchWithCache.mockResolvedValueOnce({
+        ...mockResponse,
+        data: {
+          choices: [{ text: 'Test output' }],
+          usage: { total_tokens: 3_000, prompt_tokens: 2_000, completion_tokens: 1_000 },
+        },
+      });
 
-        const result = await new OpenAiCompletionProvider(model).callApi('Test prompt');
-        const request = mockFetchWithCache.mock.calls[0] as [string, { body: string }];
+      const result = await new OpenAiCompletionProvider(model).callApi('Test prompt');
+      const request = mockFetchWithCache.mock.calls[0] as [string, { body: string }];
 
-        expect(request[0]).toContain('/completions');
-        expect(JSON.parse(request[1].body)).toMatchObject({ model, prompt: 'Test prompt' });
-        expect(result.cost).toBeCloseTo((2_000 * inputRate + 1_000 * outputRate) / 1e6, 10);
-      },
-    );
+      expect(request[0]).toContain('/completions');
+      expect(JSON.parse(request[1].body)).toMatchObject({ model, prompt: 'Test prompt' });
+      expect(result.cost).toBeCloseTo((2_000 * inputRate + 1_000 * outputRate) / 1e6, 10);
+    });
 
     it('should handle API errors', async () => {
       mockFetchWithCache.mockResolvedValue({
@@ -281,6 +278,24 @@ describe('OpenAI Provider', () => {
 
       expect(result.error).toBeDefined();
       expect(result.error).toContain('Network error');
+    });
+
+    it('returns a clean error on an empty choices array instead of an opaque TypeError', async () => {
+      // A 200 with empty choices (soft moderation block or upstream hiccup)
+      // must not surface as "API error: TypeError: Cannot read ...".
+      mockFetchWithCache.mockResolvedValue({
+        data: { choices: [] },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+        severity: 'info',
+      });
+
+      const provider = new OpenAiCompletionProvider('text-davinci-003');
+      const result = await provider.callApi('Test prompt');
+
+      expect(result.error).toContain('Malformed response data');
+      expect(result.error).not.toContain('TypeError');
     });
 
     it('should handle missing API key', async () => {
@@ -441,7 +456,9 @@ describe('OpenAI Provider', () => {
       const provider = new OpenAiCompletionProvider('text-davinci-003');
       const result = await provider.callApi('Test prompt');
 
-      expect(result.error).toMatch(/API error:/);
+      // A missing choices array now reads as a clean malformed-response error
+      // rather than an opaque "API error: TypeError: ..." from choices[0].
+      expect(result.error).toContain('Malformed response data');
     });
 
     it('should handle invalid OPENAI_STOP env var', async () => {

--- a/test/providers/openai/completion.test.ts
+++ b/test/providers/openai/completion.test.ts
@@ -233,22 +233,25 @@ describe('OpenAI Provider', () => {
       ['davinci-002', 2, 2],
       ['ft:babbage-002:company::model', 1.6, 1.6],
       ['ft:davinci-002:company::model', 12, 12],
-    ])('should call and price supported Completions model %s', async (model, inputRate, outputRate) => {
-      mockFetchWithCache.mockResolvedValueOnce({
-        ...mockResponse,
-        data: {
-          choices: [{ text: 'Test output' }],
-          usage: { total_tokens: 3_000, prompt_tokens: 2_000, completion_tokens: 1_000 },
-        },
-      });
+    ])(
+      'should call and price supported Completions model %s',
+      async (model, inputRate, outputRate) => {
+        mockFetchWithCache.mockResolvedValueOnce({
+          ...mockResponse,
+          data: {
+            choices: [{ text: 'Test output' }],
+            usage: { total_tokens: 3_000, prompt_tokens: 2_000, completion_tokens: 1_000 },
+          },
+        });
 
-      const result = await new OpenAiCompletionProvider(model).callApi('Test prompt');
-      const request = mockFetchWithCache.mock.calls[0] as [string, { body: string }];
+        const result = await new OpenAiCompletionProvider(model).callApi('Test prompt');
+        const request = mockFetchWithCache.mock.calls[0] as [string, { body: string }];
 
-      expect(request[0]).toContain('/completions');
-      expect(JSON.parse(request[1].body)).toMatchObject({ model, prompt: 'Test prompt' });
-      expect(result.cost).toBeCloseTo((2_000 * inputRate + 1_000 * outputRate) / 1e6, 10);
-    });
+        expect(request[0]).toContain('/completions');
+        expect(JSON.parse(request[1].body)).toMatchObject({ model, prompt: 'Test prompt' });
+        expect(result.cost).toBeCloseTo((2_000 * inputRate + 1_000 * outputRate) / 1e6, 10);
+      },
+    );
 
     it('should handle API errors', async () => {
       mockFetchWithCache.mockResolvedValue({
@@ -281,8 +284,6 @@ describe('OpenAI Provider', () => {
     });
 
     it('returns a clean error on an empty choices array instead of an opaque TypeError', async () => {
-      // A 200 with empty choices (soft moderation block or upstream hiccup)
-      // must not surface as "API error: TypeError: Cannot read ...".
       mockFetchWithCache.mockResolvedValue({
         data: { choices: [] },
         cached: false,
@@ -455,8 +456,6 @@ describe('OpenAI Provider', () => {
       const provider = new OpenAiCompletionProvider('text-davinci-003');
       const result = await provider.callApi('Test prompt');
 
-      // A missing choices array now reads as a clean malformed-response error
-      // rather than an opaque "API error: TypeError: ..." from choices[0].
       expect(result.error).toContain('Malformed response data');
     });
 

--- a/test/providers/openai/completion.test.ts
+++ b/test/providers/openai/completion.test.ts
@@ -288,7 +288,6 @@ describe('OpenAI Provider', () => {
         cached: false,
         status: 200,
         statusText: 'OK',
-        severity: 'info',
       });
 
       const provider = new OpenAiCompletionProvider('text-davinci-003');


### PR DESCRIPTION
## What

Same empty-`choices` treatment that just landed for openrouter/snowflake in #10418, applied to the two remaining unguarded OpenAI-compatible readers: `localai.ts` (chat + legacy completions paths) and `openai/completion.ts`.

A 200 response with an empty or missing `choices` array currently falls into these files' catch-all `try/catch` and comes back as an opaque `API response error: TypeError: Cannot read properties of undefined`. With this change it surfaces as a clean `Malformed response data: …` error, same as the siblings.

The guards check for the choice object's presence (not text truthiness), so a legitimate empty-string completion still passes through.

## Tests

- `test/providers/localai.test.ts`: both LocalAI providers return the clean error on `choices: []`.
- `test/providers/openai/completion.test.ts`: new empty-choices case plus the existing missing-choices parsing test updated to the new message (its old expectation pinned the opaque TypeError text).
- 32/32 pass across both files; biome/eslint/prettier clean.
