### PR TITLE
fix(assertions): reject partially numeric script scores

### DIFF
--- a/src/assertions/scriptResultNormalization.ts
+++ b/src/assertions/scriptResultNormalization.ts
@@ -149,8 +149,9 @@ export function normalizeScriptResult(
     return normalizeScriptObjectResult(assertion, result, inverse, labels, reasonSuffix);
   }
 
-  const score = Number.parseFloat(String(result));
-  if (Number.isNaN(score)) {
+  const rawScore = String(result).trim();
+  const score = rawScore === '' ? Number.NaN : Number(rawScore);
+  if (!Number.isFinite(score)) {
     throw new Error(
       `${labels.language} assertion must return a boolean, number, or {pass, score, reason} object. Instead got:\n${result}`,
     );

--- a/test/assertions/python.test.ts
+++ b/test/assertions/python.test.ts
@@ -300,6 +300,32 @@ describe('Python file references', { timeout: 15000 }, () => {
     });
   });
 
+  it('should reject a partially numeric Python result', async () => {
+    vi.mocked(runPythonCode).mockResolvedValueOnce('0.8oops');
+
+    const assertion: Assertion = {
+      type: 'python',
+      value: "'0.8oops'",
+      threshold: 0.5,
+    };
+
+    const result = await runAssertion({
+      prompt: 'Some prompt',
+      provider: new OpenAiChatCompletionProvider('gpt-4o-mini'),
+      assertion,
+      test: {} as AtomicTestCase,
+      providerResponse: { output: 'Expected output' },
+    });
+
+    expect(result).toMatchObject({
+      pass: false,
+      score: 0,
+      reason: expect.stringContaining(
+        'Python assertion must return a boolean, number, or {pass, score, reason} object',
+      ),
+    });
+  });
+
   it.each([
     ['boolean', false, 0, 'Python code returned false', false, undefined],
     ['number', 0, 0, 'Python code returned false', false, undefined],


### PR DESCRIPTION
## Summary

Python and Ruby assertions share a result normalizer that accepts numeric strings such as `"0.5"`. It currently uses `Number.parseFloat()`, which also accepts a numeric prefix and silently ignores trailing characters. As a result, a malformed script result such as `"0.8oops"` is normalized to `0.8` and can incorrectly pass a `0.5` threshold.

This change requires the complete trimmed result to represent a finite number. It preserves valid numeric strings while rejecting trailing junk, empty strings, `NaN`, and infinities through the existing script-error path.

## Verification

- Added a public Python assertion-path regression test. Before the fix it receives `pass: true, score: 0.8`; after the fix it receives `pass: false, score: 0` with the existing invalid-return explanation.
- Ran a real local CLI evaluation with the echo provider and an inline Python assertion returning `"0.8oops"`; it exits with the expected failed evaluation and exports `pass: false, score: 0`.
- `npx vitest run test/assertions --sequence.shuffle=false` — 60 files, 1370 tests passed.
- `npm run tsc` — passed.
- `npm run architecture:check` — passed.
- `npm run l` and `npm run f` — passed with no rewrites.

AI assistance disclosure: OpenAI Codex helped identify the parsing edge case and prepare the focused implementation and regression test. The production path, behavior, and test results were verified locally.
