### PR TITLE
fix(redteam): count fresh unmetered grading calls

### DIFF
--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -205,7 +205,10 @@ export function accumulateGradingResponseTokenUsage(
   const cachedTokens = response.tokenUsage?.cached ?? 0;
   const cachedResponse =
     response.cached === true ||
-    (response.tokenUsage?.numRequests === 0 && reportedTotal <= cachedTokens);
+    (response.cached === undefined &&
+      response.tokenUsage?.numRequests === 0 &&
+      cachedTokens > 0 &&
+      reportedTotal <= cachedTokens);
 
   target.assertions ??= createEmptyAssertions();
   if (cachedResponse) {

--- a/test/redteam/providers/iterative.test.ts
+++ b/test/redteam/providers/iterative.test.ts
@@ -1019,6 +1019,44 @@ describe('RedteamIterativeProvider', () => {
       });
     });
 
+    it.each([false, undefined])(
+      'counts an unmetered internal judge call when cached is %s',
+      async (cached) => {
+        const gradingProvider = createMockProvider({
+          id: 'mock-unmetered-grading-provider',
+          response: createProviderResponse({
+            output: JSON.stringify({
+              currentResponse: { rating: 5, explanation: 'Partially successful' },
+              previousBestResponse: { rating: 0, explanation: 'No previous response' },
+            }),
+            cached,
+            tokenUsage: { total: 0, prompt: 0, completion: 0, cached: 0, numRequests: 0 },
+          }),
+        });
+
+        const result = await runRedteamConversation({
+          context: { prompt: { raw: '', label: '' }, vars: {} },
+          filters: undefined,
+          injectVar: 'test',
+          numIterations: 1,
+          options: {},
+          prompt: { raw: 'test {{test}}', label: 'test' },
+          redteamProvider: mockRedteamProvider,
+          gradingProvider,
+          targetProvider: mockTargetProvider,
+          vars: { test: 'goal' },
+          excludeTargetOutputFromAgenticAttackGeneration: false,
+        });
+
+        expect(gradingProvider.callApi).toHaveBeenCalledOnce();
+        expect(result.tokenUsage.assertions).toMatchObject({
+          total: 0,
+          cached: 0,
+          numRequests: 1,
+        });
+      },
+    );
+
     it('should accumulate token usage across multiple iterations', async () => {
       // Clear the mock to use the target provider directly for this test
       mockGetTargetResponse.mockReset();

--- a/test/redteam/providers/iterative.test.ts
+++ b/test/redteam/providers/iterative.test.ts
@@ -1019,44 +1019,6 @@ describe('RedteamIterativeProvider', () => {
       });
     });
 
-    it.each([false, undefined])(
-      'counts an unmetered internal judge call when cached is %s',
-      async (cached) => {
-        const gradingProvider = createMockProvider({
-          id: 'mock-unmetered-grading-provider',
-          response: createProviderResponse({
-            output: JSON.stringify({
-              currentResponse: { rating: 5, explanation: 'Partially successful' },
-              previousBestResponse: { rating: 0, explanation: 'No previous response' },
-            }),
-            cached,
-            tokenUsage: { total: 0, prompt: 0, completion: 0, cached: 0, numRequests: 0 },
-          }),
-        });
-
-        const result = await runRedteamConversation({
-          context: { prompt: { raw: '', label: '' }, vars: {} },
-          filters: undefined,
-          injectVar: 'test',
-          numIterations: 1,
-          options: {},
-          prompt: { raw: 'test {{test}}', label: 'test' },
-          redteamProvider: mockRedteamProvider,
-          gradingProvider,
-          targetProvider: mockTargetProvider,
-          vars: { test: 'goal' },
-          excludeTargetOutputFromAgenticAttackGeneration: false,
-        });
-
-        expect(gradingProvider.callApi).toHaveBeenCalledOnce();
-        expect(result.tokenUsage.assertions).toMatchObject({
-          total: 0,
-          cached: 0,
-          numRequests: 1,
-        });
-      },
-    );
-
     it('should accumulate token usage across multiple iterations', async () => {
       // Clear the mock to use the target provider directly for this test
       mockGetTargetResponse.mockReset();

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -437,6 +437,34 @@ describe('tokenUsageUtils', () => {
       expect(target.assertions).toMatchObject({ total: 0, numRequests: 0 });
     });
 
+    it.each([false, undefined])('counts unmetered strategy grading when cached is %s', (cached) => {
+      const target = createEmptyTokenUsage();
+
+      accumulateGradingResponseTokenUsage(target, {
+        cached,
+        tokenUsage: createEmptyTokenUsage(),
+      });
+
+      expect(target.assertions).toMatchObject({ total: 0, cached: 0, numRequests: 1 });
+    });
+
+    it('preserves explicitly fresh grading when avoided cached tokens exceed fresh usage', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateGradingResponseTokenUsage(target, {
+        cached: false,
+        tokenUsage: { total: 50, prompt: 30, completion: 20, cached: 97, numRequests: 0 },
+      });
+
+      expect(target.assertions).toMatchObject({
+        total: 50,
+        prompt: 30,
+        completion: 20,
+        cached: 97,
+        numRequests: 1,
+      });
+    });
+
     it('counts fresh strategy grading tasks normalized to zero requests', () => {
       const target = createEmptyTokenUsage();
 


### PR DESCRIPTION
## Summary

- Honor explicit fresh-response provenance when accounting for red-team strategy grading calls.
- Infer a cached response only when cached-token usage provides positive evidence, so zero-token judge calls still count as one request.
- Cover both shared accounting and a complete iterative-redteam conversation, including fresh responses whose cached-token metadata exceeds their current token usage.

## Regression

Before the fix, five focused cases failed: fresh judge responses with `cached: false` or no cache flag were recorded as zero grading requests, and an explicitly fresh response with 50 current tokens plus 97 cached tokens lost all 50 current tokens.

## Validation

- `npx vitest run test/util/tokenUsageUtils.test.ts test/redteam/providers/iterative.test.ts test/redteam/providers/iterativeTree.test.ts test/redteam/providers/iterativeImage.test.ts test/redteam/providers/custom/index.test.ts test/redteam/providers/voiceCrescendo/index.test.ts test/evaluator/tokenUsage.test.ts test/assertions/assertionsResult.test.ts test/models/evalResult.test.ts test/remoteGrading.test.ts --maxWorkers=3` (312 tests passed)
- `npm run tsc`
- `npx @biomejs/biome ci src/util/tokenUsageUtils.ts test/util/tokenUsageUtils.test.ts test/redteam/providers/iterative.test.ts`
- `npm run local -- eval -c test/smoke/fixtures/configs/basic.yaml --no-cache -o /private/tmp/promptfoo-redteam-grading-cache-provenance-eval.json` (1 passed, 0 failed, 0 errors)
