### PR TITLE
fix(redteam): account for remote strategy generation usage

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -275,6 +275,8 @@ function getEffectiveCacheEnabled() {
 export type FetchWithCacheResult<T> = {
   data: T;
   cached: boolean;
+  /** Another concurrent caller owns the upstream request that produced this response. */
+  coalesced?: boolean;
   status: number;
   statusText: string;
   headers?: Record<string, string>;
@@ -871,6 +873,7 @@ export async function fetchWithCache<T = unknown>(
 
   const inflightCacheKey = getInflightFetchCacheKey(cacheKey, url, options);
   let inflightResponse = inflightFetchResponses.get(inflightCacheKey);
+  const coalesced = inflightResponse !== undefined;
   if (!inflightResponse) {
     inflightResponse = (async () => {
       const preparedResponse = await prepareFetchResponse(
@@ -892,7 +895,8 @@ export async function fetchWithCache<T = unknown>(
   }
 
   const response = await inflightResponse;
-  return deserializeFetchResponse<T>(response, false, cache, cacheKey);
+  const result = deserializeFetchResponse<T>(response, false, cache, cacheKey);
+  return coalesced ? { ...result, coalesced: true } : result;
 }
 
 /**

--- a/src/redteam/generationTokenUsage.ts
+++ b/src/redteam/generationTokenUsage.ts
@@ -67,3 +67,8 @@ export function recordGenerationTokenUsage(
 ): void {
   (provider as TrackedGenerationProvider)[generationUsageRecorder]?.(response);
 }
+
+/** Preserve usage reported by a failed remote generation request. */
+export function recordFailedGenerationTokenUsage(provider: ApiProvider, error: unknown): void {
+  recordGenerationTokenUsage(provider, { tokenUsage: getErrorTokenUsage(error) });
+}

--- a/src/redteam/generationTokenUsage.ts
+++ b/src/redteam/generationTokenUsage.ts
@@ -70,5 +70,8 @@ export function recordGenerationTokenUsage(
 
 /** Preserve usage reported by a failed remote generation request. */
 export function recordFailedGenerationTokenUsage(provider: ApiProvider, error: unknown): void {
-  recordGenerationTokenUsage(provider, { tokenUsage: getErrorTokenUsage(error) });
+  const tokenUsage = getErrorTokenUsage(error);
+  if (tokenUsage) {
+    recordGenerationTokenUsage(provider, { tokenUsage });
+  }
 }

--- a/src/redteam/generationTokenUsage.ts
+++ b/src/redteam/generationTokenUsage.ts
@@ -9,6 +9,7 @@ type GenerationUsageRecorder = (response: GenerationUsageResponse) => void;
 type TrackedGenerationProvider = ApiProvider & {
   [generationUsageRecorder]?: GenerationUsageRecorder;
 };
+const recordedGenerationErrors = new WeakMap<object, WeakSet<GenerationUsageRecorder>>();
 
 function trackProvider<T extends ApiProvider>(provider: T, record: GenerationUsageRecorder): T {
   const callApi = provider.callApi.bind(provider);
@@ -71,7 +72,19 @@ export function recordGenerationTokenUsage(
 /** Preserve usage reported by a failed remote generation request. */
 export function recordFailedGenerationTokenUsage(provider: ApiProvider, error: unknown): void {
   const tokenUsage = getErrorTokenUsage(error);
-  if (tokenUsage) {
-    recordGenerationTokenUsage(provider, { tokenUsage });
+  const record = (provider as TrackedGenerationProvider)[generationUsageRecorder];
+  if (!tokenUsage || !record) {
+    return;
   }
+
+  if (error && typeof error === 'object') {
+    const recorders = recordedGenerationErrors.get(error) ?? new WeakSet<GenerationUsageRecorder>();
+    if (recorders.has(record)) {
+      return;
+    }
+    recorders.add(record);
+    recordedGenerationErrors.set(error, recorders);
+  }
+
+  record({ tokenUsage });
 }

--- a/src/redteam/remoteGenerationTask.ts
+++ b/src/redteam/remoteGenerationTask.ts
@@ -53,7 +53,7 @@ export async function postRemoteGenerationTask<T>(
 
     // Some remote tasks are deterministic, so an absent usage payload cannot be treated as a
     // model request. Only the service knows whether or how many provider calls actually ran.
-    if (provider && data?.tokenUsage) {
+    if (provider && data?.tokenUsage && !response.coalesced) {
       responseRecorded = true;
       recordGenerationTokenUsage(provider, {
         tokenUsage: data.tokenUsage,

--- a/src/redteam/remoteGenerationTask.ts
+++ b/src/redteam/remoteGenerationTask.ts
@@ -1,7 +1,18 @@
 import { fetchWithCache } from '../cache';
 import { getUserEmail } from '../globalConfig/accounts';
 import { getRequestTimeoutMs } from '../providers/shared';
+import {
+  recordFailedGenerationTokenUsage,
+  recordGenerationTokenUsage,
+} from './generationTokenUsage';
 import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from './remoteGeneration';
+
+import type { StrategyRuntimeContext } from './strategies/types';
+
+interface RemoteGenerationTaskOptions {
+  headers?: Record<string, string>;
+  bustCache?: boolean;
+}
 
 /**
  * Sends a task to the remote generation endpoint.
@@ -12,17 +23,49 @@ import { getRemoteGenerationHeaders, getRemoteGenerationUrl } from './remoteGene
  */
 export async function postRemoteGenerationTask<T>(
   payload: Record<string, unknown>,
+  runtimeContext?: StrategyRuntimeContext,
+  options?: RemoteGenerationTaskOptions,
 ): Promise<Awaited<ReturnType<typeof fetchWithCache<T>>>> {
-  return fetchWithCache<T>(
-    getRemoteGenerationUrl(),
-    {
+  const provider = runtimeContext?.generationProviderSelection?.provider;
+  let responseRecorded = false;
+
+  try {
+    const request = {
       method: 'POST',
-      headers: getRemoteGenerationHeaders(),
+      headers: getRemoteGenerationHeaders(options?.headers),
       body: JSON.stringify({
         ...payload,
         email: getUserEmail(),
       }),
-    },
-    getRequestTimeoutMs(),
-  );
+    };
+    const response = options?.bustCache
+      ? await fetchWithCache<T>(
+          getRemoteGenerationUrl(),
+          request,
+          getRequestTimeoutMs(),
+          'json',
+          true,
+        )
+      : await fetchWithCache<T>(getRemoteGenerationUrl(), request, getRequestTimeoutMs());
+    const data = response.data as
+      | { tokenUsage?: Parameters<typeof recordGenerationTokenUsage>[1]['tokenUsage'] }
+      | undefined;
+
+    // Some remote tasks are deterministic, so an absent usage payload cannot be treated as a
+    // model request. Only the service knows whether or how many provider calls actually ran.
+    if (provider && data?.tokenUsage) {
+      responseRecorded = true;
+      recordGenerationTokenUsage(provider, {
+        tokenUsage: data.tokenUsage,
+        cached: response.cached,
+      });
+    }
+
+    return response;
+  } catch (error) {
+    if (provider && !responseRecorded) {
+      recordFailedGenerationTokenUsage(provider, error);
+    }
+    throw error;
+  }
 }

--- a/src/redteam/strategies/citation.ts
+++ b/src/redteam/strategies/citation.ts
@@ -11,11 +11,13 @@ import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import { postRemoteGenerationTask } from '../remoteGenerationTask';
 
 import type { TestCase } from '../../types/index';
+import type { StrategyRuntimeContext } from './types';
 
 async function generateCitations(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, any>,
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   let progressBar: SingleBar | undefined;
   try {
@@ -59,7 +61,10 @@ async function generateCitations(
         };
       }
 
-      const { data } = await postRemoteGenerationTask<CitationGenerationResponse>(payload);
+      const { data } = await postRemoteGenerationTask<CitationGenerationResponse>(
+        payload,
+        runtimeContext,
+      );
 
       logger.debug(
         `Got remote citation generation result for case ${Number(index) + 1}: ${JSON.stringify(data)}`,
@@ -137,12 +142,13 @@ export async function addCitationTestCases(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, unknown>,
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   if (neverGenerateRemote()) {
     throw new Error(getRemoteGenerationExplicitlyDisabledError('Citation strategy'));
   }
 
-  const citationTestCases = await generateCitations(testCases, injectVar, config);
+  const citationTestCases = await generateCitations(testCases, injectVar, config, runtimeContext);
   if (citationTestCases.length === 0) {
     logger.warn('No citation test cases were generated');
   }

--- a/src/redteam/strategies/gcg.ts
+++ b/src/redteam/strategies/gcg.ts
@@ -1,19 +1,17 @@
 import async from 'async';
 import { Presets, SingleBar } from 'cli-progress';
-import { fetchWithCache } from '../../cache';
-import { getUserEmail, isLoggedIntoCloud } from '../../globalConfig/accounts';
+import { isLoggedIntoCloud } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
-  getRemoteGenerationHeaders,
-  getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
 import { remoteGenerationContextPayload } from '../remoteGenerationContext';
+import { postRemoteGenerationTask } from '../remoteGenerationTask';
 
 import type { TestCase } from '../../types/index';
+import type { StrategyRuntimeContext } from './types';
 
 export const CONCURRENCY = 10;
 
@@ -21,6 +19,7 @@ async function generateGcgPrompts(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, any> & { n?: number },
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   let progressBar: SingleBar | undefined;
   try {
@@ -55,7 +54,6 @@ async function generateGcgPrompts(
         query: testCase.vars[injectVar],
         ...(config.n && { n: config.n }),
         ...remoteGenerationContextPayload(config.targetId),
-        email: getUserEmail(),
       };
 
       interface GCGGenerationResponse {
@@ -63,18 +61,13 @@ async function generateGcgPrompts(
         responses?: string[];
       }
 
-      const { data, status, statusText } = await fetchWithCache<GCGGenerationResponse>(
-        getRemoteGenerationUrl(),
+      const { data, status, statusText } = await postRemoteGenerationTask<GCGGenerationResponse>(
+        payload,
+        runtimeContext,
         {
-          method: 'POST',
-          headers: getRemoteGenerationHeaders({
-            'x-promptfoo-silent': 'true',
-          }),
-          body: JSON.stringify(payload),
+          headers: { 'x-promptfoo-silent': 'true' },
+          bustCache: true,
         },
-        getRequestTimeoutMs(),
-        'json',
-        true,
       );
 
       logger.debug('[GCG] Got generation result', {
@@ -149,6 +142,7 @@ export async function addGcgTestCases(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, unknown>,
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   if (!isLoggedIntoCloud()) {
     throw new Error(
@@ -160,7 +154,7 @@ export async function addGcgTestCases(
     throw new Error(getRemoteGenerationExplicitlyDisabledError('GCG strategy'));
   }
 
-  const gcgTestCases = await generateGcgPrompts(testCases, injectVar, config);
+  const gcgTestCases = await generateGcgPrompts(testCases, injectVar, config, runtimeContext);
   if (gcgTestCases.length === 0) {
     logger.warn('No GCG test cases were generated');
   }

--- a/src/redteam/strategies/index.ts
+++ b/src/redteam/strategies/index.ts
@@ -93,9 +93,9 @@ export const Strategies: Strategy[] = [
   },
   {
     id: 'citation',
-    action: async (testCases, injectVar, config) => {
+    action: async (testCases, injectVar, config, _strategyId, runtimeContext) => {
       logger.debug(`Adding Citation to ${testCases.length} test cases`);
-      const newTestCases = await addCitationTestCases(testCases, injectVar, config);
+      const newTestCases = await addCitationTestCases(testCases, injectVar, config, runtimeContext);
       logger.debug(`Added ${newTestCases.length} Citation test cases`);
       return newTestCases;
     },
@@ -131,9 +131,9 @@ export const Strategies: Strategy[] = [
   },
   {
     id: 'gcg',
-    action: async (testCases, injectVar, config) => {
+    action: async (testCases, injectVar, config, _strategyId, runtimeContext) => {
       logger.debug(`Adding GCG test cases to ${testCases.length} test cases`);
-      const newTestCases = await addGcgTestCases(testCases, injectVar, config);
+      const newTestCases = await addGcgTestCases(testCases, injectVar, config, runtimeContext);
       logger.debug(`Added ${newTestCases.length} GCG test cases`);
       return newTestCases;
     },
@@ -206,18 +206,23 @@ export const Strategies: Strategy[] = [
   },
   {
     id: 'jailbreak:composite',
-    action: async (testCases, injectVar, config) => {
+    action: async (testCases, injectVar, config, _strategyId, runtimeContext) => {
       logger.debug(`Adding composite jailbreak test cases to ${testCases.length} test cases`);
-      const newTestCases = await addCompositeTestCases(testCases, injectVar, config);
+      const newTestCases = await addCompositeTestCases(
+        testCases,
+        injectVar,
+        config,
+        runtimeContext,
+      );
       logger.debug(`Added ${newTestCases.length} composite jailbreak test cases`);
       return newTestCases;
     },
   },
   {
     id: 'jailbreak:likert',
-    action: async (testCases, injectVar, config) => {
+    action: async (testCases, injectVar, config, _strategyId, runtimeContext) => {
       logger.debug(`Adding Likert scale jailbreaks to ${testCases.length} test cases`);
-      const newTestCases = await addLikertTestCases(testCases, injectVar, config);
+      const newTestCases = await addLikertTestCases(testCases, injectVar, config, runtimeContext);
       logger.debug(`Added ${newTestCases.length} Likert scale jailbreak test cases`);
       return newTestCases;
     },

--- a/src/redteam/strategies/likert.ts
+++ b/src/redteam/strategies/likert.ts
@@ -10,11 +10,13 @@ import { remoteGenerationContextPayload } from '../remoteGenerationContext';
 import { postRemoteGenerationTask } from '../remoteGenerationTask';
 
 import type { TestCase } from '../../types/index';
+import type { StrategyRuntimeContext } from './types';
 
 async function generateLikertPrompts(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, any>,
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   let progressBar: SingleBar | undefined;
   try {
@@ -54,7 +56,10 @@ async function generateLikertPrompts(
         modifiedPrompts?: string[];
       }
 
-      const { data } = await postRemoteGenerationTask<LikertGenerationResponse>(payload);
+      const { data } = await postRemoteGenerationTask<LikertGenerationResponse>(
+        payload,
+        runtimeContext,
+      );
 
       logger.debug(
         `Got Likert jailbreak generation result for case ${Number(index) + 1}: ${JSON.stringify(
@@ -117,12 +122,13 @@ export async function addLikertTestCases(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, unknown>,
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   if (neverGenerateRemote()) {
     throw new Error(getRemoteGenerationExplicitlyDisabledError('Likert jailbreak strategy'));
   }
 
-  const likertTestCases = await generateLikertPrompts(testCases, injectVar, config);
+  const likertTestCases = await generateLikertPrompts(testCases, injectVar, config, runtimeContext);
   if (likertTestCases.length === 0) {
     logger.warn('No Likert jailbreak test cases were generated');
   }

--- a/src/redteam/strategies/mathPrompt.ts
+++ b/src/redteam/strategies/mathPrompt.ts
@@ -24,6 +24,7 @@ export async function generateMathPrompt(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, any>,
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   try {
     const batchSize = 8;
@@ -65,7 +66,10 @@ export async function generateMathPrompt(
         result?: TestCase[];
       }
 
-      const { data } = await postRemoteGenerationTask<MathPromptGenerationResponse>(payload);
+      const { data } = await postRemoteGenerationTask<MathPromptGenerationResponse>(
+        payload,
+        runtimeContext,
+      );
 
       logger.debug(
         `Got remote MathPrompt generation result for batch ${Number(index) + 1}: ${JSON.stringify(data)}`,
@@ -147,7 +151,12 @@ export async function addMathPrompt(
   // Keep every request-, cache-, or route-selected provider local so this phase
   // cannot silently switch backends.
   if (shouldGenerateRemote() && canGenerateRemoteWithSelection(runtimeContext)) {
-    const mathPromptTestCases = await generateMathPrompt(testCases, injectVar, config);
+    const mathPromptTestCases = await generateMathPrompt(
+      testCases,
+      injectVar,
+      config,
+      runtimeContext,
+    );
     if (mathPromptTestCases.length > 0) {
       return mathPromptTestCases;
     }

--- a/src/redteam/strategies/multilingual.ts
+++ b/src/redteam/strategies/multilingual.ts
@@ -122,6 +122,7 @@ async function processRemoteChunk(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, any>,
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   const payload = {
     task: 'multilingual',
@@ -135,7 +136,7 @@ async function processRemoteChunk(
     ...remoteGenerationContextPayload(config.targetId),
   };
 
-  const resp = await postRemoteGenerationTask(payload);
+  const resp = await postRemoteGenerationTask(payload, runtimeContext);
   const { data, status, statusText } = resp as any;
   const result = (data as any)?.result;
   if (!Array.isArray(result)) {
@@ -158,6 +159,7 @@ async function generateMultilingual(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, any>,
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   try {
     const chunkSize = getRemoteChunkSize(config);
@@ -195,7 +197,7 @@ async function generateMultilingual(
       const chunk = chunkObj.data;
       const chunkNum = chunkObj.chunkNum;
       try {
-        const chunkResults = await processRemoteChunk(chunk, injectVar, config);
+        const chunkResults = await processRemoteChunk(chunk, injectVar, config, runtimeContext);
 
         const languages: string[] =
           Array.isArray(config.languages) && config.languages.length > 0
@@ -229,7 +231,12 @@ async function generateMultilingual(
           // Try individual test cases from failed chunk silently
           for (const testCase of chunk) {
             try {
-              const individualResults = await processRemoteChunk([testCase], injectVar, config);
+              const individualResults = await processRemoteChunk(
+                [testCase],
+                injectVar,
+                config,
+                runtimeContext,
+              );
               allResults.push(...individualResults);
             } catch (error) {
               logger.debug(`Individual test case failed in chunk ${chunkNum}: ${error}`);
@@ -248,7 +255,12 @@ async function generateMultilingual(
 
           for (const testCase of missingTestCases) {
             try {
-              const individualResults = await processRemoteChunk([testCase], injectVar, config);
+              const individualResults = await processRemoteChunk(
+                [testCase],
+                injectVar,
+                config,
+                runtimeContext,
+              );
               allResults.push(...individualResults);
             } catch (error) {
               logger.debug(`Individual retry failed for test case in chunk ${chunkNum}: ${error}`);
@@ -273,7 +285,12 @@ async function generateMultilingual(
         if (chunk.length > 1) {
           for (const testCase of chunk) {
             try {
-              const individualResults = await processRemoteChunk([testCase], injectVar, config);
+              const individualResults = await processRemoteChunk(
+                [testCase],
+                injectVar,
+                config,
+                runtimeContext,
+              );
               allResults.push(...individualResults);
             } catch (individualError) {
               logger.debug(`Individual test case failed: ${individualError}`);
@@ -548,7 +565,12 @@ export async function addMultilingual(
   // Fallback: No language modifiers found - use old translation logic
   // This maintains backward compatibility for users who specify language differently
   if (shouldGenerateRemote() && canGenerateRemoteWithSelection(runtimeContext)) {
-    const multilingualTestCases = await generateMultilingual(testCases, injectVar, config);
+    const multilingualTestCases = await generateMultilingual(
+      testCases,
+      injectVar,
+      config,
+      runtimeContext,
+    );
     if (multilingualTestCases.length > 0) {
       return multilingualTestCases;
     }

--- a/src/redteam/strategies/singleTurnComposite.ts
+++ b/src/redteam/strategies/singleTurnComposite.ts
@@ -1,25 +1,23 @@
 import async from 'async';
 import { Presets, SingleBar } from 'cli-progress';
-import { fetchWithCache } from '../../cache';
-import { getUserEmail } from '../../globalConfig/accounts';
 import logger from '../../logger';
-import { getRequestTimeoutMs } from '../../providers/shared';
 import invariant from '../../util/invariant';
 import {
   getRemoteGenerationExplicitlyDisabledError,
-  getRemoteGenerationHeaders,
-  getRemoteGenerationUrl,
   neverGenerateRemote,
 } from '../remoteGeneration';
 import { remoteGenerationContextPayload } from '../remoteGenerationContext';
+import { postRemoteGenerationTask } from '../remoteGenerationTask';
 
 import type { TestCase } from '../../types/index';
 import type { Inputs } from '../../types/shared';
+import type { StrategyRuntimeContext } from './types';
 
 async function generateCompositePrompts(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, any> & { n?: number; modelFamily?: string },
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   let progressBar: SingleBar | undefined;
   try {
@@ -52,7 +50,6 @@ async function generateCompositePrompts(
       const payload = {
         task: 'jailbreak:composite',
         prompt: testCase.vars[injectVar],
-        email: getUserEmail(),
         ...(config.n && { n: config.n }),
         ...(config.modelFamily && { modelFamily: config.modelFamily }),
         ...(inputs && { inputs }),
@@ -77,14 +74,9 @@ async function generateCompositePrompts(
         modifiedPrompts?: string[];
       }
 
-      const { data } = await fetchWithCache<CompositeGenerationResponse>(
-        getRemoteGenerationUrl(),
-        {
-          method: 'POST',
-          headers: getRemoteGenerationHeaders(),
-          body: JSON.stringify(payload),
-        },
-        getRequestTimeoutMs(),
+      const { data } = await postRemoteGenerationTask<CompositeGenerationResponse>(
+        payload,
+        runtimeContext,
       );
 
       logger.debug(
@@ -145,12 +137,18 @@ export async function addCompositeTestCases(
   testCases: TestCase[],
   injectVar: string,
   config: Record<string, unknown>,
+  runtimeContext?: StrategyRuntimeContext,
 ): Promise<TestCase[]> {
   if (neverGenerateRemote()) {
     throw new Error(getRemoteGenerationExplicitlyDisabledError('Composite jailbreak strategy'));
   }
 
-  const compositeTestCases = await generateCompositePrompts(testCases, injectVar, config);
+  const compositeTestCases = await generateCompositePrompts(
+    testCases,
+    injectVar,
+    config,
+    runtimeContext,
+  );
   if (compositeTestCases.length === 0) {
     logger.warn('No composite  jailbreak test cases were generated');
   }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -540,9 +540,11 @@ describe('fetchWithCache', () => {
       });
       expect(result2).toMatchObject({
         cached: false,
+        coalesced: true,
         data: response,
         status: 200,
       });
+      expect(result1.coalesced).toBeUndefined();
       expect(mockFetchWithRetries).toHaveBeenCalledTimes(1);
 
       const cachedResult = await fetchWithCache(url, {}, 1000);
@@ -643,9 +645,11 @@ describe('fetchWithCache', () => {
       });
       expect(result2).toMatchObject({
         cached: false,
+        coalesced: true,
         status: 200,
         data: { error: 'Rate limit exceeded' },
       });
+      expect(result1.coalesced).toBeUndefined();
       expect(mockFetchWithRetries).toHaveBeenCalledTimes(1);
 
       const result3 = await fetchWithCache(url, {}, 1000);
@@ -680,9 +684,11 @@ describe('fetchWithCache', () => {
       });
       expect(result2).toMatchObject({
         cached: false,
+        coalesced: true,
         status: 400,
         data: { error: 'Bad Request' },
       });
+      expect(result1.coalesced).toBeUndefined();
       expect(mockFetchWithRetries).toHaveBeenCalledTimes(1);
 
       await fetchWithCache(url, {}, 1000);

--- a/test/redteam/remoteGenerationTask.test.ts
+++ b/test/redteam/remoteGenerationTask.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../src/cache';
+import { getUserEmail } from '../../src/globalConfig/accounts';
+import { trackGenerationTokenUsage } from '../../src/redteam/generationTokenUsage';
+import {
+  getRemoteGenerationHeaders,
+  getRemoteGenerationUrl,
+} from '../../src/redteam/remoteGeneration';
+import { postRemoteGenerationTask } from '../../src/redteam/remoteGenerationTask';
+
+import type { StrategyRuntimeContext } from '../../src/redteam/strategies/types';
+import type { ApiProvider, TokenUsage } from '../../src/types/index';
+
+vi.mock('../../src/cache');
+vi.mock('../../src/globalConfig/accounts');
+vi.mock('../../src/redteam/remoteGeneration');
+
+function createTrackedContext(usage: TokenUsage): StrategyRuntimeContext {
+  const provider: ApiProvider = {
+    id: () => 'generation-provider',
+    callApi: vi.fn().mockResolvedValue({ output: 'unused' }),
+  };
+
+  return {
+    generationProviderSelection: {
+      provider: trackGenerationTokenUsage(provider, usage),
+      source: 'default',
+    },
+  };
+}
+
+describe('postRemoteGenerationTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getUserEmail).mockReturnValue('test@example.com');
+    vi.mocked(getRemoteGenerationUrl).mockReturnValue('https://example.com/task');
+    vi.mocked(getRemoteGenerationHeaders).mockImplementation((extra) => ({
+      'Content-Type': 'application/json',
+      ...extra,
+    }));
+  });
+
+  it('records generation usage returned by a fresh remote strategy response', async () => {
+    const usage: TokenUsage = {};
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: false,
+      data: {
+        result: [],
+        tokenUsage: { total: 30, prompt: 20, completion: 10, numRequests: 3 },
+      },
+      status: 200,
+      statusText: 'OK',
+    });
+
+    await postRemoteGenerationTask({ task: 'math-prompt' }, createTrackedContext(usage));
+
+    expect(usage).toMatchObject({ total: 30, prompt: 20, completion: 10, numRequests: 3 });
+  });
+
+  it('does not count historical usage from a cached remote response', async () => {
+    const usage: TokenUsage = {};
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: true,
+      data: { tokenUsage: { total: 45, prompt: 30, completion: 15, numRequests: 2 } },
+      status: 200,
+      statusText: 'OK',
+    });
+
+    await postRemoteGenerationTask({ task: 'citation' }, createTrackedContext(usage));
+
+    expect(usage).toEqual({});
+  });
+
+  it('does not invent model requests for deterministic tasks without reported usage', async () => {
+    const usage: TokenUsage = {};
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: false,
+      data: { modifiedPrompts: ['deterministic result'] },
+      status: 200,
+      statusText: 'OK',
+    });
+
+    await postRemoteGenerationTask({ task: 'jailbreak:likert' }, createTrackedContext(usage));
+
+    expect(usage).toEqual({});
+  });
+
+  it('records reported usage from an unsuccessful remote response exactly once', async () => {
+    const usage: TokenUsage = {};
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: false,
+      data: {
+        error: 'generation failed after calling the provider',
+        tokenUsage: { total: 12, prompt: 8, completion: 4, numRequests: 1 },
+      },
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    await postRemoteGenerationTask({ task: 'citation' }, createTrackedContext(usage));
+
+    expect(usage).toMatchObject({ total: 12, prompt: 8, completion: 4, numRequests: 1 });
+  });
+
+  it('preserves token usage carried by a rejected remote request', async () => {
+    const usage: TokenUsage = {};
+    const error = Object.assign(new Error('generation failed'), {
+      tokenUsage: { total: 14, prompt: 9, completion: 5 },
+    });
+    vi.mocked(fetchWithCache).mockRejectedValue(error);
+
+    await expect(
+      postRemoteGenerationTask({ task: 'citation' }, createTrackedContext(usage)),
+    ).rejects.toThrow('generation failed');
+
+    expect(usage).toMatchObject({ total: 14, prompt: 9, completion: 5, numRequests: 1 });
+  });
+
+  it('counts a failed remote request when no token breakdown is available', async () => {
+    const usage: TokenUsage = {};
+    vi.mocked(fetchWithCache).mockRejectedValue(new Error('generation timed out'));
+
+    await expect(
+      postRemoteGenerationTask({ task: 'citation' }, createTrackedContext(usage)),
+    ).rejects.toThrow('generation timed out');
+
+    expect(usage).toEqual({ numRequests: 1 });
+  });
+
+  it('preserves custom headers and cache-busting for GCG requests', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: false,
+      data: { responses: ['generated'] },
+      status: 200,
+      statusText: 'OK',
+    });
+
+    await postRemoteGenerationTask({ task: 'gcg' }, undefined, {
+      headers: { 'x-promptfoo-silent': 'true' },
+      bustCache: true,
+    });
+
+    expect(fetchWithCache).toHaveBeenCalledWith(
+      'https://example.com/task',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-promptfoo-silent': 'true',
+        },
+        body: JSON.stringify({ task: 'gcg', email: 'test@example.com' }),
+      },
+      expect.any(Number),
+      'json',
+      true,
+    );
+  });
+});

--- a/test/redteam/remoteGenerationTask.test.ts
+++ b/test/redteam/remoteGenerationTask.test.ts
@@ -154,6 +154,40 @@ describe('postRemoteGenerationTask', () => {
     expect(usage).toMatchObject({ total: 14, prompt: 9, completion: 5, numRequests: 1 });
   });
 
+  it('records a coalesced remote generation failure only once', async () => {
+    const usage: TokenUsage = {};
+    const runtimeContext = createTrackedContext(usage);
+    const error = Object.assign(new Error('generation failed'), {
+      tokenUsage: { total: 14, prompt: 9, completion: 5 },
+    });
+    vi.mocked(fetchWithCache).mockRejectedValue(error);
+
+    const results = await Promise.allSettled([
+      postRemoteGenerationTask({ task: 'citation', topic: 'duplicate' }, runtimeContext),
+      postRemoteGenerationTask({ task: 'citation', topic: 'duplicate' }, runtimeContext),
+    ]);
+
+    expect(results.every((result) => result.status === 'rejected')).toBe(true);
+    expect(usage).toMatchObject({ total: 14, prompt: 9, completion: 5, numRequests: 1 });
+  });
+
+  it('tracks the same remote failure separately for independent accounting scopes', async () => {
+    const firstUsage: TokenUsage = {};
+    const secondUsage: TokenUsage = {};
+    const error = Object.assign(new Error('generation failed'), {
+      tokenUsage: { total: 14, prompt: 9, completion: 5 },
+    });
+    vi.mocked(fetchWithCache).mockRejectedValue(error);
+
+    await Promise.allSettled([
+      postRemoteGenerationTask({ task: 'citation' }, createTrackedContext(firstUsage)),
+      postRemoteGenerationTask({ task: 'citation' }, createTrackedContext(secondUsage)),
+    ]);
+
+    expect(firstUsage).toMatchObject({ total: 14, numRequests: 1 });
+    expect(secondUsage).toMatchObject({ total: 14, numRequests: 1 });
+  });
+
   it('does not invent model usage when a remote request fails without a token breakdown', async () => {
     const usage: TokenUsage = {};
     vi.mocked(fetchWithCache).mockRejectedValue(new Error('generation timed out'));

--- a/test/redteam/remoteGenerationTask.test.ts
+++ b/test/redteam/remoteGenerationTask.test.ts
@@ -71,6 +71,30 @@ describe('postRemoteGenerationTask', () => {
     expect(usage).toEqual({});
   });
 
+  it('records coalesced concurrent generation usage only for the request owner', async () => {
+    const usage: TokenUsage = {};
+    const runtimeContext = createTrackedContext(usage);
+    const response = {
+      cached: false,
+      data: {
+        result: [],
+        tokenUsage: { total: 30, prompt: 20, completion: 10, numRequests: 3 },
+      },
+      status: 200,
+      statusText: 'OK',
+    };
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce(response)
+      .mockResolvedValueOnce({ ...response, coalesced: true });
+
+    await Promise.all([
+      postRemoteGenerationTask({ task: 'citation', topic: 'duplicate' }, runtimeContext),
+      postRemoteGenerationTask({ task: 'citation', topic: 'duplicate' }, runtimeContext),
+    ]);
+
+    expect(usage).toMatchObject({ total: 30, prompt: 20, completion: 10, numRequests: 3 });
+  });
+
   it('does not invent model requests for deterministic tasks without reported usage', async () => {
     const usage: TokenUsage = {};
     vi.mocked(fetchWithCache).mockResolvedValue({
@@ -102,6 +126,20 @@ describe('postRemoteGenerationTask', () => {
     expect(usage).toMatchObject({ total: 12, prompt: 8, completion: 4, numRequests: 1 });
   });
 
+  it('does not invent model usage for an unsuccessful HTTP response without usage', async () => {
+    const usage: TokenUsage = {};
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: false,
+      data: { error: 'request was rejected before model execution' },
+      status: 401,
+      statusText: 'Unauthorized',
+    });
+
+    await postRemoteGenerationTask({ task: 'citation' }, createTrackedContext(usage));
+
+    expect(usage).toEqual({});
+  });
+
   it('preserves token usage carried by a rejected remote request', async () => {
     const usage: TokenUsage = {};
     const error = Object.assign(new Error('generation failed'), {
@@ -116,7 +154,7 @@ describe('postRemoteGenerationTask', () => {
     expect(usage).toMatchObject({ total: 14, prompt: 9, completion: 5, numRequests: 1 });
   });
 
-  it('counts a failed remote request when no token breakdown is available', async () => {
+  it('does not invent model usage when a remote request fails without a token breakdown', async () => {
     const usage: TokenUsage = {};
     vi.mocked(fetchWithCache).mockRejectedValue(new Error('generation timed out'));
 
@@ -124,7 +162,7 @@ describe('postRemoteGenerationTask', () => {
       postRemoteGenerationTask({ task: 'citation' }, createTrackedContext(usage)),
     ).rejects.toThrow('generation timed out');
 
-    expect(usage).toEqual({ numRequests: 1 });
+    expect(usage).toEqual({});
   });
 
   it('preserves custom headers and cache-busting for GCG requests', async () => {

--- a/test/redteam/strategies/citation.test.ts
+++ b/test/redteam/strategies/citation.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
 import { getUserEmail } from '../../../src/globalConfig/accounts';
 import logger from '../../../src/logger';
+import { trackGenerationTokenUsage } from '../../../src/redteam/generationTokenUsage';
 import {
   getRemoteGenerationExplicitlyDisabledError,
   getRemoteGenerationHeaders,
@@ -10,7 +11,7 @@ import {
 } from '../../../src/redteam/remoteGeneration';
 import { addCitationTestCases } from '../../../src/redteam/strategies/citation';
 
-import type { TestCase } from '../../../src/types/index';
+import type { ApiProvider, TestCase, TokenUsage } from '../../../src/types/index';
 
 vi.mock('../../../src/cache');
 vi.mock('../../../src/globalConfig/accounts');
@@ -110,6 +111,40 @@ describe('citation strategy', () => {
       },
       expect.any(Number),
     );
+  });
+
+  it('adds remote citation usage to the request-scoped generation provider', async () => {
+    const usage: TokenUsage = {};
+    const provider: ApiProvider = {
+      id: () => 'generation-provider',
+      callApi: vi.fn().mockResolvedValue({ output: 'unused' }),
+    };
+    mockFetchWithCache.mockResolvedValueOnce({
+      data: {
+        result: {
+          citation: { type: 'Journal Article', content: 'Tracked citation' },
+        },
+        tokenUsage: { total: 18, prompt: 12, completion: 6, numRequests: 1 },
+      },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    });
+
+    const result = await addCitationTestCases(
+      testCases,
+      'prompt',
+      {},
+      {
+        generationProviderSelection: {
+          provider: trackGenerationTokenUsage(provider, usage),
+          source: 'default',
+        },
+      },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(usage).toMatchObject({ total: 18, prompt: 12, completion: 6, numRequests: 1 });
   });
 
   it('forwards targetId without serializing unrelated config', async () => {

--- a/test/redteam/strategies/mathPrompt.test.ts
+++ b/test/redteam/strategies/mathPrompt.test.ts
@@ -1,6 +1,7 @@
 import { SingleBar } from 'cli-progress';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
+import { trackGenerationTokenUsage } from '../../../src/redteam/generationTokenUsage';
 import { redteamProviderManager } from '../../../src/redteam/providers/shared';
 import * as remoteGeneration from '../../../src/redteam/remoteGeneration';
 import {
@@ -240,9 +241,14 @@ describe('mathPrompt', () => {
     });
 
     it('keeps remote generation enabled for the built-in default selection', async () => {
+      const generationTokenUsage = {};
       vi.mocked(remoteGeneration.shouldGenerateRemote).mockReturnValue(true);
       vi.mocked(fetchWithCache).mockResolvedValue({
-        data: { result: [{ vars: { prompt: 'remote-default' } }] },
+        cached: false,
+        data: {
+          result: [{ vars: { prompt: 'remote-default' } }],
+          tokenUsage: { total: 45, prompt: 30, completion: 15, numRequests: 3 },
+        },
       } as any);
 
       const result = await addMathPrompt(
@@ -251,7 +257,10 @@ describe('mathPrompt', () => {
         { mathConcepts: ['topology'] },
         {
           generationProviderSelection: {
-            provider: createMockProvider({ id: 'default-regular' }),
+            provider: trackGenerationTokenUsage(
+              createMockProvider({ id: 'default-regular' }),
+              generationTokenUsage,
+            ),
             source: 'default',
           },
         },
@@ -260,6 +269,12 @@ describe('mathPrompt', () => {
       expect(fetchWithCache).toHaveBeenCalledTimes(1);
       expect(redteamProviderManager.getDefaultProvider).not.toHaveBeenCalled();
       expect(result[0]?.vars?.prompt).toBe('remote-default');
+      expect(generationTokenUsage).toMatchObject({
+        total: 45,
+        prompt: 30,
+        completion: 15,
+        numRequests: 3,
+      });
     });
 
     it('uses the request-scoped generation provider for local encoding', async () => {

--- a/test/redteam/strategies/multilingual.test.ts
+++ b/test/redteam/strategies/multilingual.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../../src/cache';
+import { trackGenerationTokenUsage } from '../../../src/redteam/generationTokenUsage';
 import { redteamProviderManager } from '../../../src/redteam/providers/shared';
 import * as remoteGeneration from '../../../src/redteam/remoteGeneration';
 import { addMultilingual } from '../../../src/redteam/strategies/multilingual';
@@ -150,8 +151,10 @@ describe('multilingual', () => {
   });
 
   it('sends only the remote multilingual contract for the default path', async () => {
+    const generationTokenUsage = {};
     vi.mocked(remoteGeneration.shouldGenerateRemote).mockReturnValue(true);
     vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: false,
       data: {
         result: [
           {
@@ -159,6 +162,7 @@ describe('multilingual', () => {
             metadata: { originalText: 'test', language: 'es' },
           },
         ],
+        tokenUsage: { total: 21, prompt: 14, completion: 7, numRequests: 2 },
       },
       status: 200,
       statusText: 'OK',
@@ -179,7 +183,10 @@ describe('multilingual', () => {
       },
       {
         generationProviderSelection: {
-          provider: createMockProvider({ id: 'default-regular' }),
+          provider: trackGenerationTokenUsage(
+            createMockProvider({ id: 'default-regular' }),
+            generationTokenUsage,
+          ),
           source: 'default',
         },
       },
@@ -201,6 +208,12 @@ describe('multilingual', () => {
     expect(body).not.toContain('env-secret');
     expect(body).not.toContain('config-secret');
     expect(body).not.toContain('header-secret');
+    expect(generationTokenUsage).toMatchObject({
+      total: 21,
+      prompt: 14,
+      completion: 7,
+      numRequests: 2,
+    });
   });
 
   it('stays local when a runtime provider has no serializable spec', async () => {


### PR DESCRIPTION
## Summary

- Route citation, math, multilingual, GCG, composite, and Likert strategy requests through the shared remote-generation transport and request-scoped generation tracker.
- Preserve provider-reported request counts and failed-request usage, ignore cached response replays, and avoid inventing model usage for deterministic tasks.
- Preserve GCG authentication headers and cache-busting behavior while keeping provider credentials out of serialized task payloads.

Cloud task handlers must also return `tokenUsage` for model-backed remote work before those production responses can contribute token totals. Existing deterministic responses without usage remain correctly uncounted.

## Verification

- 388 passing tests across remote-generation transport, generation tracking, strategy implementations, synthesis, plugin generation, extraction, and goal generation.
- `npm run build`
- `npm run tsc`
- `npm run architecture:check`
