### PR TITLE
test(providers): stabilize Gemini Live streaming timeout

### DIFF
--- a/test/providers/google/live.test.ts
+++ b/test/providers/google/live.test.ts
@@ -1779,31 +1779,38 @@ describe('GoogleLiveProvider', () => {
   });
 
   it('keeps a continuously streaming response alive past the idle-timeout window', async () => {
-    provider = new GoogleLiveProvider('gemini-2.0-flash-exp', {
-      config: {
-        generationConfig: { response_modalities: ['text'] },
-        timeoutMs: 120,
-        apiKey: 'test-api-key',
-      },
-    });
-    vi.mocked(WebSocket).mockImplementation(function () {
-      setImmediate(() => {
-        mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
-        simulateSetupMessage(mockWs);
+    vi.useFakeTimers();
+    try {
+      provider = new GoogleLiveProvider('gemini-2.0-flash-exp', {
+        config: {
+          generationConfig: { response_modalities: ['text'] },
+          timeoutMs: 120,
+          apiKey: 'test-api-key',
+        },
       });
-      // Stream for ~300ms total (longer than timeoutMs) with every gap below the
-      // 120ms idle window — the idle guard must re-arm instead of hard-killing.
-      for (let i = 1; i <= 4; i++) {
-        setTimeout(() => simulateTextMessage(mockWs, `chunk${i} `), 60 * i);
-      }
-      setTimeout(() => simulateCompletionMessage(mockWs), 300);
-      return mockWs;
-    });
+      vi.mocked(WebSocket).mockImplementation(function () {
+        setImmediate(() => {
+          mockWs.onopen?.({ type: 'open', target: mockWs } as WebSocket.Event);
+          simulateSetupMessage(mockWs);
+        });
+        // Stream for 300ms total (longer than timeoutMs) with every gap below the
+        // 120ms idle window — the idle guard must re-arm instead of hard-killing.
+        for (let i = 1; i <= 4; i++) {
+          setTimeout(() => simulateTextMessage(mockWs, `chunk${i} `), 60 * i);
+        }
+        setTimeout(() => simulateCompletionMessage(mockWs), 300);
+        return mockWs;
+      });
 
-    const response = await provider.callApi('test prompt');
+      const responsePromise = provider.callApi('test prompt');
+      await vi.runAllTimersAsync();
+      const response = await responsePromise;
 
-    expect(response.error).toBeUndefined();
-    expect(response.output).toMatchObject({ text: 'chunk1 chunk2 chunk3 chunk4 ' });
+      expect(response.error).toBeUndefined();
+      expect(response.output).toMatchObject({ text: 'chunk1 chunk2 chunk3 chunk4 ' });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('should keep the Live request timeout active after a partial text response', async () => {


### PR DESCRIPTION
## Summary

- Replace wall-clock scheduling in the Gemini Live continuous-streaming timeout regression test with Vitest fake timers.
- Preserve the four streamed chunks, 120 ms idle timeout, and 300 ms total stream while removing Windows runner scheduling races.
- Restore real timers in a `finally` block to prevent shuffled test-order pollution.

## Why

The Windows shard in https://github.com/promptfoo/promptfoo/actions/runs/32401546355/job/96530686427 failed because delayed stream callbacks let the real 120 ms idle timeout fire before the next mocked chunk was delivered. The dependency-only PR did not modify provider behavior.

## Validation

- Reproduced the exact CI failure by delaying two mocked WebSocket callbacks; the updated test passes the same injected-stall reproducer.
- Temporarily removed the provider's idle-timeout rearm and verified the fake-timer regression test still fails with the original 120 ms timeout.
- `npx vitest run test/providers/google/live.test.ts test/providers/websocket.test.ts test/util/xlsx.test.ts test/util/xlsxEntities.test.ts test/package-manifests.test.ts test/test-hygiene.test.ts --configLoader runner` (326 tests passed).
- `npx vitest run test/providers/google/live.test.ts --configLoader runner --sequence.seed=1` (92 tests passed).
- `npx vitest run test/providers/google/live.test.ts --configLoader runner --sequence.seed=42` (92 tests passed).
- `npm run tsc`.
- `npm run l && npm run f`.
