### PR TITLE
fix(tracing): keep numeric token counters readable

### DIFF
--- a/site/docs/tracing.md
+++ b/site/docs/tracing.md
@@ -593,7 +593,7 @@ Click the expand icon on any span to reveal a detailed attributes panel showing:
 
 This is useful for inspecting the full request/response bodies (`promptfoo.request.body` and `promptfoo.response.body`) and debugging provider behavior.
 
-Trace reads redact credential-like attribute keys such as authorization headers, cookies, API keys, tokens, secrets, and passwords before displaying or exporting spans. GenAI token counters such as `gen_ai.usage.input_tokens` and application token counters such as `llm.usage.prompt_tokens` and `llm.usage.completion_tokens` remain visible. Avoid placing secrets in custom span attributes because raw attributes may still be retained in the local trace store for internal evaluation workflows.
+Trace reads redact credential-like attribute keys such as authorization headers, cookies, API keys, tokens, secrets, and passwords before displaying or exporting spans. Token counters stay visible as long as their value is a number, so GenAI counters such as `gen_ai.usage.input_tokens` and application counters such as `llm.usage.prompt_tokens`, `llm.token_count.prompt`, and `prompt.tokens` are all readable. A token attribute holding anything other than a number is treated as a credential and redacted. Avoid placing secrets in custom span attributes because raw attributes may still be retained in the local trace store for internal evaluation workflows.
 
 ### Exporting Traces
 

--- a/site/docs/tracing.md
+++ b/site/docs/tracing.md
@@ -593,7 +593,7 @@ Click the expand icon on any span to reveal a detailed attributes panel showing:
 
 This is useful for inspecting the full request/response bodies (`promptfoo.request.body` and `promptfoo.response.body`) and debugging provider behavior.
 
-Trace reads redact credential-like attribute keys such as authorization headers, cookies, API keys, tokens, secrets, and passwords before displaying or exporting spans. Token counters stay visible as long as their value is a number, so GenAI counters such as `gen_ai.usage.input_tokens` and application counters such as `llm.usage.prompt_tokens`, `llm.token_count.prompt`, and `prompt.tokens` are all readable. A token attribute holding anything other than a number is treated as a credential and redacted. Avoid placing secrets in custom span attributes because raw attributes may still be retained in the local trace store for internal evaluation workflows.
+Trace reads redact credential-like attribute keys such as authorization headers, cookies, API keys, tokens, secrets, and passwords before displaying or exporting spans. Token counters stay visible as long as their value is a number, so GenAI counters such as `gen_ai.usage.input_tokens` and application counters such as `llm.usage.prompt_tokens`, `llm.token_count.prompt`, `prompt.tokens`, and `promptTokenCount` are all readable. A token attribute holding anything other than a number is treated as a credential and redacted, and a key that also names an authorization header, an API key, a secret, or a password stays redacted whatever its value. Avoid placing secrets in custom span attributes because raw attributes may still be retained in the local trace store for internal evaluation workflows.
 
 ### Exporting Traces
 

--- a/src/tracing/sanitizeAttributes.ts
+++ b/src/tracing/sanitizeAttributes.ts
@@ -45,9 +45,22 @@ const SAFE_TOKEN_ATTRIBUTE_KEYS = new Set([
   'gen_ai.usage.cache_creation_input_tokens',
 ]);
 
-function isSensitiveAttributeKey(key: string): boolean {
+/**
+ * Matches keys that count tokens rather than carry one, so counters from any
+ * instrumentation stay readable: `prompt.tokens` and `response.tokens` from the tracing
+ * docs, `ai.usage.promptTokens` (Vercel AI SDK) and `llm.token_count.prompt`
+ * (OpenInference).
+ */
+const TOKEN_COUNT_KEY_PATTERN = /tokens$|(?:^|[^a-z0-9])token_?counts?(?:[^a-z0-9]|$)/;
+
+function isTokenCountAttribute(lowerKey: string, value: unknown): boolean {
+  // A count is a number. Anything else under the same key could be a credential.
+  return typeof value === 'number' && TOKEN_COUNT_KEY_PATTERN.test(lowerKey);
+}
+
+function isSensitiveAttributeKey(key: string, value: unknown): boolean {
   const lowerKey = key.toLowerCase();
-  if (SAFE_TOKEN_ATTRIBUTE_KEYS.has(lowerKey)) {
+  if (SAFE_TOKEN_ATTRIBUTE_KEYS.has(lowerKey) || isTokenCountAttribute(lowerKey, value)) {
     return false;
   }
 
@@ -101,7 +114,7 @@ export function sanitizeTraceAttributes(
       sanitized[key] = '[REDACTED]';
       continue;
     }
-    if (sanitizeSensitiveAttributes && isSensitiveAttributeKey(key)) {
+    if (sanitizeSensitiveAttributes && isSensitiveAttributeKey(key, value)) {
       sanitized[key] = '<redacted>';
       continue;
     }

--- a/src/tracing/sanitizeAttributes.ts
+++ b/src/tracing/sanitizeAttributes.ts
@@ -59,9 +59,16 @@ const TOKEN_COUNT_KEY_PATTERN = /tokens$|(?:^|[^a-z0-9])token_?counts?(?:[^a-z0-
  * Lowercasing on its own destroys the camel-case boundary, so `promptTokenCount`
  * would read as `prompttokencount` and match neither branch of the pattern. Insert the
  * boundary first.
+ *
+ * Two passes, because an acronym needs the opposite rule: the first splits a lower or
+ * digit followed by an upper (`promptToken`), the second splits an upper run followed by
+ * a capitalised word (`LLMToken`, `OpenAIToken`).
  */
 function toBoundaryKey(key: string): string {
-  return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
+    .toLowerCase();
 }
 
 function isTokenCountAttribute(key: string, lowerKey: string, value: unknown): boolean {

--- a/src/tracing/sanitizeAttributes.ts
+++ b/src/tracing/sanitizeAttributes.ts
@@ -45,6 +45,8 @@ const SAFE_TOKEN_ATTRIBUTE_KEYS = new Set([
   'gen_ai.usage.cache_creation_input_tokens',
 ]);
 
+const TOKEN_MARKER = 'token';
+
 /**
  * Matches keys that count tokens rather than carry one, so counters from any
  * instrumentation stay readable: `prompt.tokens` and `response.tokens` from the tracing
@@ -53,25 +55,48 @@ const SAFE_TOKEN_ATTRIBUTE_KEYS = new Set([
  */
 const TOKEN_COUNT_KEY_PATTERN = /tokens$|(?:^|[^a-z0-9])token_?counts?(?:[^a-z0-9]|$)/;
 
-function isTokenCountAttribute(lowerKey: string, value: unknown): boolean {
-  // A count is a number. Anything else under the same key could be a credential.
-  return typeof value === 'number' && TOKEN_COUNT_KEY_PATTERN.test(lowerKey);
+/**
+ * Lowercasing on its own destroys the camel-case boundary, so `promptTokenCount`
+ * would read as `prompttokencount` and match neither branch of the pattern. Insert the
+ * boundary first.
+ */
+function toBoundaryKey(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+}
+
+function isTokenCountAttribute(key: string, lowerKey: string, value: unknown): boolean {
+  // A count is a number. Anything else under the same key could be a credential,
+  // including under a well-known usage key.
+  if (typeof value !== 'number') {
+    return false;
+  }
+  return (
+    SAFE_TOKEN_ATTRIBUTE_KEYS.has(lowerKey) || TOKEN_COUNT_KEY_PATTERN.test(toBoundaryKey(key))
+  );
 }
 
 function isSensitiveAttributeKey(key: string, value: unknown): boolean {
   const lowerKey = key.toLowerCase();
-  if (SAFE_TOKEN_ATTRIBUTE_KEYS.has(lowerKey) || isTokenCountAttribute(lowerKey, value)) {
+  const normalizedKey = lowerKey.replace(/[^a-z0-9]/g, '');
+
+  const matchedMarkers = SENSITIVE_ATTRIBUTE_KEYS.filter(
+    (sensitiveKey, index) =>
+      lowerKey.includes(sensitiveKey) ||
+      normalizedKey.includes(NORMALIZED_SENSITIVE_ATTRIBUTE_KEYS[index]),
+  );
+
+  if (matchedMarkers.length === 0) {
     return false;
   }
 
-  const normalizedKey = lowerKey.replace(/[^a-z0-9]/g, '');
+  // Only the `token` marker can be waived, and only for a count. A key such as
+  // `authorization.tokens` or `api_key.token_count` also names credential material, so it
+  // stays redacted whatever its value.
+  if (matchedMarkers.some((marker) => marker !== TOKEN_MARKER)) {
+    return true;
+  }
 
-  return SENSITIVE_ATTRIBUTE_KEYS.some((sensitiveKey, index) => {
-    return (
-      lowerKey.includes(sensitiveKey) ||
-      normalizedKey.includes(NORMALIZED_SENSITIVE_ATTRIBUTE_KEYS[index])
-    );
-  });
+  return !isTokenCountAttribute(key, lowerKey, value);
 }
 
 export function sanitizeTraceAttributes(

--- a/test/tracing/sanitizeAttributes.test.ts
+++ b/test/tracing/sanitizeAttributes.test.ts
@@ -41,6 +41,49 @@ describe('sanitizeTraceAttributes', () => {
     });
   });
 
+  it('preserves numeric token counters from application instrumentation', () => {
+    expect(
+      sanitizeTraceAttributes({
+        'prompt.tokens': 150,
+        'response.tokens': 85,
+        'llm.token_count.prompt': 150,
+        'llm.token_count.total': 235,
+        'ai.usage.promptTokens': 150,
+        'ai.usage.completionTokens': 85,
+      }),
+    ).toEqual({
+      'prompt.tokens': 150,
+      'response.tokens': 85,
+      'llm.token_count.prompt': 150,
+      'llm.token_count.total': 235,
+      'ai.usage.promptTokens': 150,
+      'ai.usage.completionTokens': 85,
+    });
+  });
+
+  it('redacts token attributes that do not hold a count', () => {
+    expect(
+      sanitizeTraceAttributes({
+        'session.tokens': 'sk-live-1234567890',
+        'auth.token_count': ['sk-a', 'sk-b'],
+        refresh_token: 'rt-1234567890',
+      }),
+    ).toEqual({
+      'session.tokens': '<redacted>',
+      'auth.token_count': '<redacted>',
+      refresh_token: '<redacted>',
+    });
+  });
+
+  it('lets explicit redactions override token counters', () => {
+    expect(
+      sanitizeTraceAttributes(
+        { 'prompt.tokens': 150, 'gen_ai.usage.input_tokens': 150 },
+        { redactAttributes: ['tokens'] },
+      ),
+    ).toEqual({ 'prompt.tokens': '[REDACTED]', 'gen_ai.usage.input_tokens': '[REDACTED]' });
+  });
+
   it('applies explicit evaluation redactions even when generic sanitization is disabled', () => {
     expect(
       sanitizeTraceAttributes(

--- a/test/tracing/sanitizeAttributes.test.ts
+++ b/test/tracing/sanitizeAttributes.test.ts
@@ -99,6 +99,16 @@ describe('sanitizeTraceAttributes', () => {
     ).toEqual({ promptTokenCount: 150, completionTokenCount: 85, totalTokenCount: 235 });
   });
 
+  it('preserves acronym-prefixed token counters', () => {
+    expect(
+      sanitizeTraceAttributes({
+        LLMTokenCount: 150,
+        OpenAITokenCount: 85,
+        LLMTokens: 235,
+      }),
+    ).toEqual({ LLMTokenCount: 150, OpenAITokenCount: 85, LLMTokens: 235 });
+  });
+
   it('redacts well-known usage keys that do not hold a number', () => {
     expect(
       sanitizeTraceAttributes({

--- a/test/tracing/sanitizeAttributes.test.ts
+++ b/test/tracing/sanitizeAttributes.test.ts
@@ -75,6 +75,39 @@ describe('sanitizeTraceAttributes', () => {
     });
   });
 
+  it('keeps redacting keys that name other credential material', () => {
+    expect(
+      sanitizeTraceAttributes({
+        'authorization.tokens': 150,
+        'api_key.token_count': 42,
+        'secret.tokens': 7,
+      }),
+    ).toEqual({
+      'authorization.tokens': '<redacted>',
+      'api_key.token_count': '<redacted>',
+      'secret.tokens': '<redacted>',
+    });
+  });
+
+  it('preserves camelCase token counters', () => {
+    expect(
+      sanitizeTraceAttributes({
+        promptTokenCount: 150,
+        completionTokenCount: 85,
+        totalTokenCount: 235,
+      }),
+    ).toEqual({ promptTokenCount: 150, completionTokenCount: 85, totalTokenCount: 235 });
+  });
+
+  it('redacts well-known usage keys that do not hold a number', () => {
+    expect(
+      sanitizeTraceAttributes({
+        'gen_ai.usage.input_tokens': '150',
+        'gen_ai.usage.output_tokens': 85,
+      }),
+    ).toEqual({ 'gen_ai.usage.input_tokens': '<redacted>', 'gen_ai.usage.output_tokens': 85 });
+  });
+
   it('lets explicit redactions override token counters', () => {
     expect(
       sanitizeTraceAttributes(


### PR DESCRIPTION
## What changed

The trace sanitizer masks any attribute key containing "token" unless that exact key
is on an allowlist in `src/tracing/sanitizeAttributes.ts`. A key now escapes redaction
when two things hold: its name reads as a count (ends in `tokens`, or has a
`token_count` segment) and its value is a number. The allowlist stays, so nothing that
is readable today becomes redacted.

## Why

The allowlist misses token counters that this repo tells people to send.

`site/docs/tracing.md` shows `'prompt.tokens': tokenCount` under "Add Relevant
Attributes" and `generateSpan.setAttribute('response.tokens', response.tokenCount)` in
the RAG pipeline example. Follow either and the trace viewer and the trace export show
`<redacted>` instead of the count.

The same happens to two conventions promptfoo already ingests: OpenInference
`llm.token_count.prompt` (Arize Phoenix and its instrumentors) and Vercel AI SDK
`ai.usage.promptTokens`, whose spans are recognised elsewhere in the codebase through
`ai.model.id` and `ai.toolCall.*`.

`<redacted>` on a plain integer is also misleading in the other direction. It tells the
reader a credential was found where there was only a number.

I checked the value type as well as the key name because the key alone is not enough. A
string under `session.tokens` could be a real credential, so only numbers are exempt.

## How tested

Before, on `3bd40b5`:

    {
      "prompt.tokens": "<redacted>",
      "response.tokens": "<redacted>",
      "llm.token_count.prompt": "<redacted>",
      "llm.token_count.total": "<redacted>",
      "ai.usage.promptTokens": "<redacted>",
      "gen_ai.usage.input_tokens": 150,
      "access_token": "<redacted>",
      "authorization": "<redacted>"
    }

After:

    {
      "prompt.tokens": 150,
      "response.tokens": 85,
      "llm.token_count.prompt": 150,
      "llm.token_count.total": 235,
      "ai.usage.promptTokens": 150,
      "gen_ai.usage.input_tokens": 150,
      "access_token": "<redacted>",
      "authorization": "<redacted>"
    }

Reproduce either side by calling `sanitizeTraceAttributes()` from
`src/tracing/sanitizeAttributes.ts` with that object.

Suites run locally:

    npx vitest run test/tracing test/evaluator/trace-integration.test.ts test/assertions/trace.test.ts test/assertions/trajectory.test.ts
    28 files, 711 tests passed

    npx vitest run test/util/azureBlob.test.ts test/util/testCaseReader.test.ts
    2 files, 102 tests passed

    npx tsc --noEmit    # clean
    npx biome check src/tracing/sanitizeAttributes.ts test/tracing/sanitizeAttributes.test.ts    # clean
    npx prettier --check on the three changed files    # clean

The other redaction tests, `test/tracing/store.test.ts` included, pass unchanged, which
is what shows the allowlisted keys still behave as before.

## Tradeoffs

- A numeric attribute such as `user.tokens: 5` is now visible. It is a count, so this
  reads as correct, but it is a behaviour change worth naming.
- A counter sent as a string, for example `'prompt.tokens': '150'`, stays redacted. The
  OTLP receiver converts `intValue` to a number, so ingested spans are unaffected.
- Explicit `redactAttributes` patterns still take priority over everything here, and
  there is a test for that.
