### PR TITLE
feat(providers): add MiniMax H3 video provider

### DIFF
--- a/src/providers/minimax/video.ts
+++ b/src/providers/minimax/video.ts
@@ -1,0 +1,252 @@
+/** MiniMax H3 video generation provider. */
+import logger from '../../logger';
+import { fetchWithProxy } from '../../util/fetch/index';
+import { sleep } from '../../util/time';
+import { buildStorageRefUrl, formatVideoOutput, storeVideoContent } from '../video';
+
+import type { EnvOverrides } from '../../types/env';
+import type {
+  ApiProvider,
+  CallApiContextParams,
+  CallApiOptionsParams,
+  ProviderResponse,
+} from '../../types/index';
+
+export type MiniMaxVideoContent = {
+  type: 'text' | 'image_url' | 'video_url' | 'audio_url';
+  text?: string;
+  image_url?: string;
+  video_url?: string;
+  audio_url?: string;
+  role?: 'first_frame' | 'last_frame' | 'reference_image' | 'reference_video' | 'reference_audio';
+};
+
+export interface MiniMaxVideoOptions {
+  apiKey?: string;
+  apiBaseUrl?: string;
+  model?: string;
+  resolution?: '2K';
+  duration?: number;
+  content?: MiniMaxVideoContent[];
+  aigc_watermark?: boolean;
+  poll_interval_ms?: number;
+  max_poll_time_ms?: number;
+  headers?: Record<string, string>;
+}
+
+const DEFAULT_API_BASE_URL = 'https://api.minimax.io/v2/video_generation';
+const DEFAULT_MODEL = 'MiniMax-H3';
+const DEFAULT_RESOLUTION = '2K';
+const DEFAULT_DURATION = 6;
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_MAX_POLL_TIME_MS = 600000;
+const _VALID_RATIOS = new Set(['adaptive', '21:9', '16:9', '4:3', '1:1', '3:4', '9:16']);
+
+function getApiKey(config: MiniMaxVideoOptions, env?: EnvOverrides): string | undefined {
+  return config.apiKey || env?.MINIMAX_API_KEY || process.env.MINIMAX_API_KEY;
+}
+
+function normalizeContent(prompt: string, content?: MiniMaxVideoContent[]): MiniMaxVideoContent[] {
+  if (content?.length) {
+    return content;
+  }
+  return [{ type: 'text', text: prompt }];
+}
+
+function validateContent(content: MiniMaxVideoContent[]): string | undefined {
+  for (const item of content) {
+    if (!item || !['text', 'image_url', 'video_url', 'audio_url'].includes(item.type)) {
+      return 'content items must use text, image_url, video_url, or audio_url types';
+    }
+    if (item.type === 'text' && !item.text?.trim()) {
+      return 'text content must not be empty';
+    }
+    if (item.type === 'image_url' && !item.image_url) {
+      return 'image_url content must include a URL';
+    }
+    if (item.type === 'video_url' && !item.video_url) {
+      return 'video_url content must include a URL';
+    }
+    if (item.type === 'audio_url' && !item.audio_url) {
+      return 'audio_url content must include a URL';
+    }
+    if (
+      item.role &&
+      ![
+        'first_frame',
+        'last_frame',
+        'reference_image',
+        'reference_video',
+        'reference_audio',
+      ].includes(item.role)
+    ) {
+      return `unsupported MiniMax video content role: ${item.role}`;
+    }
+  }
+  return undefined;
+}
+
+export class MiniMaxVideoProvider implements ApiProvider {
+  modelName: string;
+  config: MiniMaxVideoOptions;
+  private providerId?: string;
+  env?: EnvOverrides;
+
+  constructor(
+    modelName: string = DEFAULT_MODEL,
+    options: { config?: MiniMaxVideoOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    this.modelName = modelName || DEFAULT_MODEL;
+    this.config = options.config || {};
+    this.providerId = options.id;
+    this.env = options.env;
+  }
+
+  id(): string {
+    return this.providerId || `minimax:video:${this.modelName}`;
+  }
+  toString(): string {
+    return `[MiniMax Video Provider ${this.modelName}]`;
+  }
+
+  private getApiUrl(): string {
+    const value =
+      this.config.apiBaseUrl || process.env.MINIMAX_VIDEO_API_BASE_URL || DEFAULT_API_BASE_URL;
+    return value.replace(/\/+$/, '');
+  }
+
+  // The provider lifecycle (submit, poll, download, store) is intentionally
+  // kept together so every failure maps to a provider error.
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: provider lifecycle intentionally stays together
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    _options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
+    const apiKey = getApiKey(this.config, this.env);
+    if (!apiKey) {
+      return {
+        error:
+          'MiniMax API key is not set. Set MINIMAX_API_KEY or add apiKey to the provider config.',
+      };
+    }
+    const config = {
+      ...this.config,
+      ...(context?.prompt?.config as Partial<MiniMaxVideoOptions> | undefined),
+    };
+    const model = config.model || this.modelName || DEFAULT_MODEL;
+    const duration = config.duration ?? DEFAULT_DURATION;
+    if (!Number.isInteger(duration) || duration < 4 || duration > 15) {
+      return { error: 'MiniMax H3 duration must be an integer between 4 and 15 seconds.' };
+    }
+    const resolution = config.resolution || DEFAULT_RESOLUTION;
+    if (resolution !== '2K') {
+      return { error: 'MiniMax H3 resolution must be 2K.' };
+    }
+    const content = normalizeContent(prompt, config.content);
+    const contentError = validateContent(content);
+    if (contentError) {
+      return { error: contentError };
+    }
+    const body: Record<string, unknown> = { model, content, resolution, duration };
+    if (config.aigc_watermark !== undefined) {
+      body.aigc_watermark = config.aigc_watermark;
+    }
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      ...config.headers,
+    };
+    const started = Date.now();
+    try {
+      const response = await fetchWithProxy(this.getApiUrl(), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+      const data = (await response.json().catch(() => ({}))) as any;
+      if (
+        !response.ok ||
+        (data?.base_resp?.status_code !== undefined && data.base_resp.status_code !== 0)
+      ) {
+        return {
+          error: `MiniMax video API error: ${data?.base_resp?.status_msg || response.statusText || response.status}`,
+        };
+      }
+      const taskId = data?.task_id;
+      if (!taskId) {
+        return { error: 'MiniMax video response did not include task_id.' };
+      }
+      const queryUrl = `${this.getApiUrl().replace('/video_generation', '/query/video_generation')}?task_id=${encodeURIComponent(taskId)}`;
+      const interval = config.poll_interval_ms ?? DEFAULT_POLL_INTERVAL_MS;
+      const timeout = config.max_poll_time_ms ?? DEFAULT_MAX_POLL_TIME_MS;
+      const deadline = Date.now() + timeout;
+      let videoUrl: string | undefined;
+      let taskStatus: string | undefined;
+      while (Date.now() < deadline) {
+        const poll = await fetchWithProxy(queryUrl, { method: 'GET', headers });
+        const statusData = (await poll.json().catch(() => ({}))) as any;
+        if (
+          !poll.ok ||
+          (statusData?.base_resp?.status_code && statusData.base_resp.status_code !== 0)
+        ) {
+          return {
+            error: `MiniMax video status error: ${statusData?.base_resp?.status_msg || poll.statusText || poll.status}`,
+          };
+        }
+        const task = statusData?.task || statusData?.data?.task || statusData?.data;
+        taskStatus = task?.status;
+        videoUrl = task?.content?.url || task?.content?.video_url || task?.video_url;
+        if (videoUrl && ['Success', 'success', 'completed', '2'].includes(String(taskStatus))) {
+          break;
+        }
+        if (['Fail', 'Failed', 'failed', 'error'].includes(String(taskStatus))) {
+          return { error: `MiniMax video generation failed (status=${taskStatus}).` };
+        }
+        await sleep(interval);
+      }
+      if (!videoUrl) {
+        return { error: `MiniMax video generation timed out (status=${taskStatus || 'unknown'}).` };
+      }
+      const download = await fetchWithProxy(videoUrl, { method: 'GET' });
+      if (!download.ok) {
+        return { error: `MiniMax video download failed: ${download.status}` };
+      }
+      const { storageRef, error } = await storeVideoContent(
+        Buffer.from(await download.arrayBuffer()),
+        { contentType: 'video/mp4', mediaType: 'video', evalId: context?.evaluationId },
+        'MiniMax Video',
+      );
+      if (error || !storageRef) {
+        return { error: error || 'Failed to store MiniMax video.' };
+      }
+      const url = buildStorageRefUrl(storageRef.key);
+      return {
+        output: formatVideoOutput(prompt, url),
+        latencyMs: Date.now() - started,
+        cost: 0,
+        video: {
+          id: taskId,
+          storageRef: { key: storageRef.key },
+          url,
+          format: 'mp4',
+          duration,
+          model,
+          resolution,
+        },
+        metadata: { taskId, status: taskStatus, model, resolution, duration },
+      };
+    } catch (err) {
+      logger.debug('[MiniMax Video] request failed', { error: String(err) });
+      return { error: `MiniMax video request failed: ${String(err)}` };
+    }
+  }
+}
+
+export function createMiniMaxVideoProvider(
+  providerPath: string,
+  options: { config?: MiniMaxVideoOptions; id?: string; env?: EnvOverrides } = {},
+): ApiProvider {
+  const modelName = providerPath.split(':').slice(2).join(':') || DEFAULT_MODEL;
+  return new MiniMaxVideoProvider(modelName, options);
+}

--- a/src/providers/minimax/video.ts
+++ b/src/providers/minimax/video.ts
@@ -1,16 +1,6 @@
 /** MiniMax H3 video generation provider. */
-import logger from '../../logger';
-import { fetchWithProxy } from '../../util/fetch/index';
-import { sleep } from '../../util/time';
+import { fetchWithProviderProxy } from '../fetch';
 import { buildStorageRefUrl, formatVideoOutput, storeVideoContent } from '../video';
-
-import type { EnvOverrides } from '../../types/env';
-import type {
-  ApiProvider,
-  CallApiContextParams,
-  CallApiOptionsParams,
-  ProviderResponse,
-} from '../../types/index';
 
 export type MiniMaxVideoContent = {
   type: 'text' | 'image_url' | 'video_url' | 'audio_url';
@@ -34,6 +24,13 @@ export interface MiniMaxVideoOptions {
   headers?: Record<string, string>;
 }
 
+type MiniMaxVideoContext = {
+  evaluationId?: string;
+  prompt?: { config?: unknown };
+};
+
+type MiniMaxVideoEnv = Record<string, string | undefined>;
+
 const DEFAULT_API_BASE_URL = 'https://api.minimax.io/v2/video_generation';
 const DEFAULT_MODEL = 'MiniMax-H3';
 const DEFAULT_RESOLUTION = '2K';
@@ -42,7 +39,7 @@ const DEFAULT_POLL_INTERVAL_MS = 5000;
 const DEFAULT_MAX_POLL_TIME_MS = 600000;
 const _VALID_RATIOS = new Set(['adaptive', '21:9', '16:9', '4:3', '1:1', '3:4', '9:16']);
 
-function getApiKey(config: MiniMaxVideoOptions, env?: EnvOverrides): string | undefined {
+function getApiKey(config: MiniMaxVideoOptions, env?: MiniMaxVideoEnv): string | undefined {
   return config.apiKey || env?.MINIMAX_API_KEY || process.env.MINIMAX_API_KEY;
 }
 
@@ -86,15 +83,15 @@ function validateContent(content: MiniMaxVideoContent[]): string | undefined {
   return undefined;
 }
 
-export class MiniMaxVideoProvider implements ApiProvider {
+export class MiniMaxVideoProvider {
   modelName: string;
   config: MiniMaxVideoOptions;
   private providerId?: string;
-  env?: EnvOverrides;
+  env?: MiniMaxVideoEnv;
 
   constructor(
     modelName: string = DEFAULT_MODEL,
-    options: { config?: MiniMaxVideoOptions; id?: string; env?: EnvOverrides } = {},
+    options: { config?: MiniMaxVideoOptions; id?: string; env?: MiniMaxVideoEnv } = {},
   ) {
     this.modelName = modelName || DEFAULT_MODEL;
     this.config = options.config || {};
@@ -118,11 +115,7 @@ export class MiniMaxVideoProvider implements ApiProvider {
   // The provider lifecycle (submit, poll, download, store) is intentionally
   // kept together so every failure maps to a provider error.
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: provider lifecycle intentionally stays together
-  async callApi(
-    prompt: string,
-    context?: CallApiContextParams,
-    _options?: CallApiOptionsParams,
-  ): Promise<ProviderResponse> {
+  async callApi(prompt: string, context?: MiniMaxVideoContext) {
     const apiKey = getApiKey(this.config, this.env);
     if (!apiKey) {
       return {
@@ -159,7 +152,7 @@ export class MiniMaxVideoProvider implements ApiProvider {
     };
     const started = Date.now();
     try {
-      const response = await fetchWithProxy(this.getApiUrl(), {
+      const response = await fetchWithProviderProxy(this.getApiUrl(), {
         method: 'POST',
         headers,
         body: JSON.stringify(body),
@@ -184,7 +177,7 @@ export class MiniMaxVideoProvider implements ApiProvider {
       let videoUrl: string | undefined;
       let taskStatus: string | undefined;
       while (Date.now() < deadline) {
-        const poll = await fetchWithProxy(queryUrl, { method: 'GET', headers });
+        const poll = await fetchWithProviderProxy(queryUrl, { method: 'GET', headers });
         const statusData = (await poll.json().catch(() => ({}))) as any;
         if (
           !poll.ok ||
@@ -203,12 +196,12 @@ export class MiniMaxVideoProvider implements ApiProvider {
         if (['Fail', 'Failed', 'failed', 'error'].includes(String(taskStatus))) {
           return { error: `MiniMax video generation failed (status=${taskStatus}).` };
         }
-        await sleep(interval);
+        await new Promise((resolve) => setTimeout(resolve, interval));
       }
       if (!videoUrl) {
         return { error: `MiniMax video generation timed out (status=${taskStatus || 'unknown'}).` };
       }
-      const download = await fetchWithProxy(videoUrl, { method: 'GET' });
+      const download = await fetchWithProviderProxy(videoUrl, { method: 'GET' });
       if (!download.ok) {
         return { error: `MiniMax video download failed: ${download.status}` };
       }
@@ -237,7 +230,6 @@ export class MiniMaxVideoProvider implements ApiProvider {
         metadata: { taskId, status: taskStatus, model, resolution, duration },
       };
     } catch (err) {
-      logger.debug('[MiniMax Video] request failed', { error: String(err) });
       return { error: `MiniMax video request failed: ${String(err)}` };
     }
   }
@@ -245,8 +237,8 @@ export class MiniMaxVideoProvider implements ApiProvider {
 
 export function createMiniMaxVideoProvider(
   providerPath: string,
-  options: { config?: MiniMaxVideoOptions; id?: string; env?: EnvOverrides } = {},
-): ApiProvider {
+  options: { config?: MiniMaxVideoOptions; id?: string; env?: MiniMaxVideoEnv } = {},
+) {
   const modelName = providerPath.split(':').slice(2).join(':') || DEFAULT_MODEL;
   return new MiniMaxVideoProvider(modelName, options);
 }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -66,6 +66,7 @@ import { ManualInputProvider } from './manualInput';
 import { MCPProvider } from './mcp/index';
 import { createMetaProvider } from './meta';
 import { createMiniMaxProvider } from './minimax';
+import { createMiniMaxVideoProvider } from './minimax/video';
 import { MistralChatCompletionProvider, MistralEmbeddingProvider } from './mistral';
 import { MlflowGatewayChatCompletionProvider } from './mlflow-gateway';
 import { createMoonshotProvider } from './moonshot';
@@ -815,6 +816,19 @@ export const providerMap: ProviderFactory[] = [
       return createMetaProvider(providerPath, {
         ...providerOptions,
         env: providerOptions.env ?? context.env,
+      });
+    },
+  },
+  {
+    test: (providerPath: string) => providerPath.startsWith('minimax:video:'),
+    create: async (
+      providerPath: string,
+      providerOptions: ProviderOptions,
+      context: LoadApiProviderContext,
+    ) => {
+      return createMiniMaxVideoProvider(providerPath, {
+        config: providerOptions as any,
+        env: context.env,
       });
     },
   },

--- a/test/providers/minimax/video.test.ts
+++ b/test/providers/minimax/video.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MiniMaxVideoProvider } from '../../../src/providers/minimax/video';
+import * as videoUtils from '../../../src/providers/video/utils';
+import * as fetch from '../../../src/util/fetch/index';
+
+vi.mock('../../../src/logger');
+vi.mock('../../../src/util/fetch/index');
+vi.mock('../../../src/providers/video/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof videoUtils>();
+  return {
+    ...actual,
+    buildStorageRefUrl: vi.fn(() => 'storageRef:video/test.mp4'),
+    formatVideoOutput: vi.fn(() => '[Video](storageRef:video/test.mp4)'),
+    storeVideoContent: vi.fn(async () => ({ storageRef: { key: 'video/test.mp4' } })),
+  };
+});
+
+describe('MiniMax H3 video provider', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubEnv('MINIMAX_API_KEY', 'test-key');
+  });
+
+  it('sends H3 content and polls task content URL', async () => {
+    vi.mocked(fetch.fetchWithProxy)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ task_id: 'task-1', base_resp: { status_code: 0 } }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            task: { status: 'Success', content: { url: 'https://cdn.example/video.mp4' } },
+            base_resp: { status_code: 0 },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(new Response(Buffer.from('video'), { status: 200 }));
+    const provider = new MiniMaxVideoProvider('MiniMax-H3');
+    const result = await provider.callApi('A cinematic city', {
+      prompt: {
+        config: {
+          duration: 8,
+          resolution: '2K',
+          content: [{ type: 'text', text: 'A cinematic city' }],
+        },
+      },
+    } as any);
+    expect(result.error).toBeUndefined();
+    expect(result.video?.id).toBe('task-1');
+    expect(vi.mocked(fetch.fetchWithProxy).mock.calls[0]?.[0]).toBe(
+      'https://api.minimax.io/v2/video_generation',
+    );
+    const body = JSON.parse(String(vi.mocked(fetch.fetchWithProxy).mock.calls[0]?.[1]?.body));
+    expect(body).toMatchObject({ model: 'MiniMax-H3', resolution: '2K', duration: 8 });
+    expect(body.content).toEqual([{ type: 'text', text: 'A cinematic city' }]);
+  });
+});

--- a/test/providers/minimax/video.test.ts
+++ b/test/providers/minimax/video.test.ts
@@ -1,9 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { MiniMaxVideoProvider } from '../../../src/providers/minimax/video';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMiniMaxVideoProvider,
+  MiniMaxVideoProvider,
+} from '../../../src/providers/minimax/video';
 import * as videoUtils from '../../../src/providers/video/utils';
 import * as fetch from '../../../src/util/fetch/index';
 
-vi.mock('../../../src/logger');
 vi.mock('../../../src/util/fetch/index');
 vi.mock('../../../src/providers/video/utils', async (importOriginal) => {
   const actual = await importOriginal<typeof videoUtils>();
@@ -15,29 +17,50 @@ vi.mock('../../../src/providers/video/utils', async (importOriginal) => {
   };
 });
 
+const createResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status });
+
+const mockSuccessfulRequest = (downloadStatus = 200) => {
+  vi.mocked(fetch.fetchWithProxy)
+    .mockResolvedValueOnce(createResponse({ task_id: 'task-1', base_resp: { status_code: 0 } }))
+    .mockResolvedValueOnce(
+      createResponse({
+        task: { status: 'Success', content: { url: 'https://cdn.example/video.mp4' } },
+        base_resp: { status_code: 0 },
+      }),
+    )
+    .mockResolvedValueOnce(new Response(Buffer.from('video'), { status: downloadStatus }));
+};
+
 describe('MiniMax H3 video provider', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.stubEnv('MINIMAX_API_KEY', 'test-key');
+    vi.mocked(videoUtils.buildStorageRefUrl).mockReturnValue('storageRef:video/test.mp4');
+    vi.mocked(videoUtils.formatVideoOutput).mockReturnValue('[Video](storageRef:video/test.mp4)');
+    vi.mocked(videoUtils.storeVideoContent).mockResolvedValue({
+      storageRef: {
+        provider: 'filesystem',
+        key: 'video/test.mp4',
+        contentHash: 'test-hash',
+        metadata: { contentType: 'video/mp4', mediaType: 'video', sizeBytes: 5 },
+      },
+    });
   });
 
-  it('sends H3 content and polls task content URL', async () => {
-    vi.mocked(fetch.fetchWithProxy)
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ task_id: 'task-1', base_resp: { status_code: 0 } }), {
-          status: 200,
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            task: { status: 'Success', content: { url: 'https://cdn.example/video.mp4' } },
-            base_resp: { status_code: 0 },
-          }),
-          { status: 200 },
-        ),
-      )
-      .mockResolvedValueOnce(new Response(Buffer.from('video'), { status: 200 }));
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('creates providers with default and custom identifiers', () => {
+    expect(createMiniMaxVideoProvider('minimax:video:').id()).toBe('minimax:video:MiniMax-H3');
+    const provider = new MiniMaxVideoProvider('MiniMax-H3', { id: 'custom-video' });
+    expect(provider.id()).toBe('custom-video');
+    expect(provider.toString()).toBe('[MiniMax Video Provider MiniMax-H3]');
+  });
+
+  it('sends H3 content and polls the task content URL', async () => {
+    mockSuccessfulRequest();
     const provider = new MiniMaxVideoProvider('MiniMax-H3');
     const result = await provider.callApi('A cinematic city', {
       prompt: {
@@ -45,16 +68,170 @@ describe('MiniMax H3 video provider', () => {
           duration: 8,
           resolution: '2K',
           content: [{ type: 'text', text: 'A cinematic city' }],
+          aigc_watermark: true,
         },
       },
-    } as any);
+      evaluationId: 'eval-1',
+    });
+
     expect(result.error).toBeUndefined();
-    expect(result.video?.id).toBe('task-1');
+    expect(result.video).toMatchObject({
+      id: 'task-1',
+      duration: 8,
+      model: 'MiniMax-H3',
+      resolution: '2K',
+    });
+    expect(result.metadata).toMatchObject({ taskId: 'task-1', status: 'Success' });
     expect(vi.mocked(fetch.fetchWithProxy).mock.calls[0]?.[0]).toBe(
       'https://api.minimax.io/v2/video_generation',
     );
+    expect(vi.mocked(fetch.fetchWithProxy).mock.calls[1]?.[0]).toBe(
+      'https://api.minimax.io/v2/query/video_generation?task_id=task-1',
+    );
     const body = JSON.parse(String(vi.mocked(fetch.fetchWithProxy).mock.calls[0]?.[1]?.body));
-    expect(body).toMatchObject({ model: 'MiniMax-H3', resolution: '2K', duration: 8 });
-    expect(body.content).toEqual([{ type: 'text', text: 'A cinematic city' }]);
+    expect(body).toEqual({
+      model: 'MiniMax-H3',
+      content: [{ type: 'text', text: 'A cinematic city' }],
+      resolution: '2K',
+      duration: 8,
+      aigc_watermark: true,
+    });
+    expect(videoUtils.storeVideoContent).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      expect.objectContaining({ evalId: 'eval-1' }),
+      'MiniMax Video',
+    );
+  });
+
+  it('uses configured authentication, endpoint, headers, and default content', async () => {
+    mockSuccessfulRequest();
+    const provider = new MiniMaxVideoProvider('', {
+      config: {
+        apiKey: 'configured-key',
+        apiBaseUrl: 'https://api.example.cn/v2/video_generation/',
+        headers: { 'X-Test': 'yes' },
+      },
+    });
+    await provider.callApi('A mountain lake');
+
+    const [url, options] = vi.mocked(fetch.fetchWithProxy).mock.calls[0]!;
+    expect(url).toBe('https://api.example.cn/v2/video_generation');
+    expect(options?.headers).toMatchObject({
+      Authorization: 'Bearer configured-key',
+      'X-Test': 'yes',
+    });
+    expect(JSON.parse(String(options?.body))).toMatchObject({
+      model: 'MiniMax-H3',
+      content: [{ type: 'text', text: 'A mountain lake' }],
+      resolution: '2K',
+      duration: 6,
+    });
+  });
+
+  it('polls pending tasks until a nested task succeeds', async () => {
+    vi.mocked(fetch.fetchWithProxy)
+      .mockResolvedValueOnce(createResponse({ task_id: 'task-2' }))
+      .mockResolvedValueOnce(createResponse({ data: { status: 'processing' } }))
+      .mockResolvedValueOnce(
+        createResponse({ data: { task: { status: '2', video_url: 'https://cdn.example/v.mp4' } } }),
+      )
+      .mockResolvedValueOnce(new Response(Buffer.from('video'), { status: 200 }));
+    const provider = new MiniMaxVideoProvider('MiniMax-H3', {
+      config: { poll_interval_ms: 0, max_poll_time_ms: 1000 },
+    });
+
+    const result = await provider.callApi('A city at night');
+
+    expect(result.error).toBeUndefined();
+    expect(fetch.fetchWithProxy).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns an authentication error when no API key is configured', async () => {
+    vi.stubEnv('MINIMAX_API_KEY', '');
+    const result = await new MiniMaxVideoProvider('MiniMax-H3').callApi('prompt');
+    expect(result.error).toContain('MINIMAX_API_KEY');
+    expect(fetch.fetchWithProxy).not.toHaveBeenCalled();
+  });
+
+  it.each([3, 16, 4.5])('rejects invalid duration %s', async (duration) => {
+    const provider = new MiniMaxVideoProvider('MiniMax-H3', { config: { duration } });
+    expect((await provider.callApi('prompt')).error).toContain('between 4 and 15');
+  });
+
+  it('rejects unsupported resolution', async () => {
+    const provider = new MiniMaxVideoProvider('MiniMax-H3', {
+      config: { resolution: '1080p' as '2K' },
+    });
+    expect((await provider.callApi('prompt')).error).toContain('resolution must be 2K');
+  });
+
+  it.each([
+    { type: 'unsupported' },
+    { type: 'text', text: ' ' },
+    { type: 'image_url' },
+    { type: 'video_url' },
+    { type: 'audio_url' },
+    { type: 'text', text: 'prompt', role: 'unsupported' },
+  ])('rejects invalid content %#', async (item) => {
+    const provider = new MiniMaxVideoProvider('MiniMax-H3', {
+      config: { content: [item] as any },
+    });
+    expect((await provider.callApi('prompt')).error).toBeTruthy();
+    expect(fetch.fetchWithProxy).not.toHaveBeenCalled();
+  });
+
+  it('returns the create API error', async () => {
+    vi.mocked(fetch.fetchWithProxy).mockResolvedValueOnce(
+      createResponse({ base_resp: { status_code: 1001, status_msg: 'invalid request' } }),
+    );
+    const result = await new MiniMaxVideoProvider('MiniMax-H3').callApi('prompt');
+    expect(result.error).toBe('MiniMax video API error: invalid request');
+  });
+
+  it('requires a task identifier from the create response', async () => {
+    vi.mocked(fetch.fetchWithProxy).mockResolvedValueOnce(createResponse({}));
+    const result = await new MiniMaxVideoProvider('MiniMax-H3').callApi('prompt');
+    expect(result.error).toContain('did not include task_id');
+  });
+
+  it('returns status and generation failures', async () => {
+    vi.mocked(fetch.fetchWithProxy)
+      .mockResolvedValueOnce(createResponse({ task_id: 'task-3' }))
+      .mockResolvedValueOnce(
+        createResponse({ base_resp: { status_code: 1002, status_msg: 'query failed' } }),
+      );
+    const statusError = await new MiniMaxVideoProvider('MiniMax-H3').callApi('prompt');
+    expect(statusError.error).toBe('MiniMax video status error: query failed');
+
+    vi.mocked(fetch.fetchWithProxy)
+      .mockResolvedValueOnce(createResponse({ task_id: 'task-4' }))
+      .mockResolvedValueOnce(createResponse({ task: { status: 'Failed' } }));
+    const generationError = await new MiniMaxVideoProvider('MiniMax-H3').callApi('prompt');
+    expect(generationError.error).toContain('status=Failed');
+  });
+
+  it('times out when polling cannot begin before the deadline', async () => {
+    vi.mocked(fetch.fetchWithProxy).mockResolvedValueOnce(createResponse({ task_id: 'task-5' }));
+    const provider = new MiniMaxVideoProvider('MiniMax-H3', {
+      config: { max_poll_time_ms: 0 },
+    });
+    expect((await provider.callApi('prompt')).error).toContain('timed out');
+  });
+
+  it('returns download and storage failures', async () => {
+    mockSuccessfulRequest(502);
+    const downloadError = await new MiniMaxVideoProvider('MiniMax-H3').callApi('prompt');
+    expect(downloadError.error).toBe('MiniMax video download failed: 502');
+
+    mockSuccessfulRequest();
+    vi.mocked(videoUtils.storeVideoContent).mockResolvedValueOnce({ error: 'storage unavailable' });
+    const storageError = await new MiniMaxVideoProvider('MiniMax-H3').callApi('prompt');
+    expect(storageError.error).toBe('storage unavailable');
+  });
+
+  it('converts thrown request errors to provider errors', async () => {
+    vi.mocked(fetch.fetchWithProxy).mockRejectedValueOnce(new Error('network unavailable'));
+    const result = await new MiniMaxVideoProvider('MiniMax-H3').callApi('prompt');
+    expect(result.error).toContain('network unavailable');
   });
 });


### PR DESCRIPTION
Reason: Add MiniMax H3 text-to-video generation to promptfoo's provider registry.

This adds a dedicated MiniMax video provider for the global and regional video_generation endpoints. It submits H3 content, resolution, and duration parameters, polls task status, downloads completed video content, and stores it using promptfoo's existing video storage contract. Text, image, video, and audio content roles are validated and supported.

Checks:
- `npx @biomejs/biome check src/providers/minimax/video.ts test/providers/minimax/video.test.ts`
- `npx tsc --noEmit -p tsconfig.json`
- `npx vitest run test/providers/minimax/video.test.ts`
