### PR TITLE
fix(webui): include errors in pass rates

### DIFF
--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { Chart } from 'chart.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import ResultsCharts from './ResultsCharts';
+import ResultsCharts, { getPassRate } from './ResultsCharts';
 import { useTableStore } from './store';
 
 // Mock Chart.js
@@ -58,6 +58,64 @@ describe('ResultsCharts', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('includes errors in performance-history pass rates', () => {
+    expect(getPassRate({ testPassCount: 1, testFailCount: 0, testErrorCount: 1, score: 1 })).toBe(
+      50,
+    );
+    expect(getPassRate({ testPassCount: 7, testFailCount: 3, testErrorCount: 0, score: 0.7 })).toBe(
+      70,
+    );
+    expect(getPassRate({ testPassCount: 0, testFailCount: 0, testErrorCount: 0, score: 0 })).toBe(
+      0,
+    );
+  });
+
+  it('includes errors in the pass-rate chart denominator', () => {
+    const mockTable = {
+      head: {
+        prompts: [
+          {
+            provider: 'provider-with-error',
+            metrics: {
+              testPassCount: 1,
+              testFailCount: 0,
+              testErrorCount: 1,
+              namedScores: {},
+            },
+          },
+          {
+            provider: 'provider-without-errors',
+            metrics: {
+              testPassCount: 7,
+              testFailCount: 3,
+              testErrorCount: 0,
+              namedScores: {},
+            },
+          },
+        ],
+        vars: [],
+      },
+      body: [],
+    };
+
+    vi.mocked(useTableStore).mockReturnValue({
+      table: mockTable,
+      evalId: 'test-eval',
+      config: { description: 'test config' },
+      setTable: vi.fn(),
+      fetchEvalData: vi.fn(),
+    });
+
+    render(<ResultsCharts scores={[]} />);
+
+    const passRateConfig = vi
+      .mocked(Chart)
+      .mock.calls.map(([, config]) => config)
+      .find((config) => config.data?.labels?.[0] === 'Pass Rate (%)');
+
+    expect(passRateConfig?.data?.datasets.map((dataset) => dataset.data)).toEqual([[50], [70]]);
   });
 
   it('renders chart canvases without a close button', () => {

--- a/src/app/src/pages/eval/components/ResultsCharts.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.test.tsx
@@ -60,6 +60,10 @@ describe('ResultsCharts', () => {
     vi.clearAllMocks();
   });
 
+  it('preserves legacy performance-history pass rates without an error count', () => {
+    expect(getPassRate({ testPassCount: 7, testFailCount: 3, score: 0.7 })).toBe(70);
+  });
+
   it('includes errors in performance-history pass rates', () => {
     expect(getPassRate({ testPassCount: 1, testFailCount: 0, testErrorCount: 1, score: 1 })).toBe(
       50,

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -513,12 +513,13 @@ interface ProgressData {
   metrics: {
     testPassCount: number;
     testFailCount: number;
+    testErrorCount: number;
     score: number;
   };
 }
 
-function getPassRate(metrics: ProgressData['metrics']): number {
-  const totalTests = metrics.testPassCount + metrics.testFailCount;
+export function getPassRate(metrics: ProgressData['metrics']): number {
+  const totalTests = metrics.testPassCount + metrics.testFailCount + metrics.testErrorCount;
   return totalTests === 0 ? 0 : (metrics.testPassCount / totalTests) * 100;
 }
 

--- a/src/app/src/pages/eval/components/ResultsCharts.tsx
+++ b/src/app/src/pages/eval/components/ResultsCharts.tsx
@@ -513,13 +513,13 @@ interface ProgressData {
   metrics: {
     testPassCount: number;
     testFailCount: number;
-    testErrorCount: number;
+    testErrorCount?: number;
     score: number;
   };
 }
 
 export function getPassRate(metrics: ProgressData['metrics']): number {
-  const totalTests = metrics.testPassCount + metrics.testFailCount + metrics.testErrorCount;
+  const totalTests = metrics.testPassCount + metrics.testFailCount + (metrics.testErrorCount ?? 0);
   return totalTests === 0 ? 0 : (metrics.testPassCount / totalTests) * 100;
 }
 

--- a/src/app/src/pages/eval/components/hooks.test.ts
+++ b/src/app/src/pages/eval/components/hooks.test.ts
@@ -398,6 +398,36 @@ describe('useTestCounts', () => {
     ]);
   });
 
+  it('should include errors in total and filtered test counts', () => {
+    const mockTable: EvaluateTable = {
+      head: {
+        prompts: [
+          {
+            raw: 'Test prompt',
+            label: 'Test prompt',
+            provider: 'test-provider',
+            metrics: {
+              testPassCount: 1,
+              testFailCount: 0,
+              testErrorCount: 1,
+            } as EvaluateTable['head']['prompts'][number]['metrics'],
+          },
+        ],
+        vars: [],
+      },
+      body: [],
+    };
+
+    mockedUseTableStore.mockReturnValue({
+      table: mockTable,
+      filteredMetrics: [{ testPassCount: 1, testFailCount: 1, testErrorCount: 2 }],
+    });
+
+    const { result } = renderHook(() => useTestCounts());
+
+    expect(result.current).toEqual([{ total: 2, filtered: 4 }]);
+  });
+
   it('should treat missing testPassCount or testFailCount as zero and return the correct total for each prompt', () => {
     const mockTable: EvaluateTable = {
       head: {
@@ -832,6 +862,52 @@ describe('usePassRates', () => {
       { total: 50, filtered: null },
       { total: 100, filtered: null },
       { total: 0, filtered: null },
+    ]);
+  });
+
+  it('should include errors in total and filtered pass-rate denominators', () => {
+    const mockTable: EvaluateTable = {
+      head: {
+        prompts: [
+          {
+            raw: 'Errored prompt',
+            label: 'Errored prompt',
+            provider: 'provider-with-error',
+            metrics: {
+              testPassCount: 1,
+              testFailCount: 0,
+              testErrorCount: 1,
+            } as EvaluateTable['head']['prompts'][number]['metrics'],
+          },
+          {
+            raw: 'Zero-error prompt',
+            label: 'Zero-error prompt',
+            provider: 'provider-without-errors',
+            metrics: {
+              testPassCount: 7,
+              testFailCount: 3,
+              testErrorCount: 0,
+            } as EvaluateTable['head']['prompts'][number]['metrics'],
+          },
+        ],
+        vars: [],
+      },
+      body: [],
+    };
+
+    mockedUseTableStore.mockReturnValue({
+      table: mockTable,
+      filteredMetrics: [
+        { testPassCount: 1, testFailCount: 1, testErrorCount: 2 },
+        { testPassCount: 7, testFailCount: 3, testErrorCount: 0 },
+      ],
+    });
+
+    const { result } = renderHook(() => usePassRates());
+
+    expect(result.current).toEqual([
+      { total: 50, filtered: 25 },
+      { total: 70, filtered: 70 },
     ]);
   });
 

--- a/src/app/src/pages/eval/components/hooks.ts
+++ b/src/app/src/pages/eval/components/hooks.ts
@@ -56,9 +56,13 @@ export function useTestCounts(): MetricValue[] {
     return table
       ? table.head.prompts.map((prompt, idx) => {
           const totalCount =
-            (prompt.metrics?.testPassCount ?? 0) + (prompt.metrics?.testFailCount ?? 0);
+            (prompt.metrics?.testPassCount ?? 0) +
+            (prompt.metrics?.testFailCount ?? 0) +
+            (prompt.metrics?.testErrorCount ?? 0);
           const filteredCount = filteredMetrics?.[idx]
-            ? (filteredMetrics[idx].testPassCount ?? 0) + (filteredMetrics[idx].testFailCount ?? 0)
+            ? (filteredMetrics[idx].testPassCount ?? 0) +
+              (filteredMetrics[idx].testFailCount ?? 0) +
+              (filteredMetrics[idx].testErrorCount ?? 0)
             : null;
 
           return {

--- a/src/app/src/pages/history/History.test.tsx
+++ b/src/app/src/pages/history/History.test.tsx
@@ -108,7 +108,7 @@ describe('History', () => {
     const promptLink2 = row2Cells.getByRole('link', { name: '[def456]' });
     expect(promptLink2).toHaveAttribute('href', '/prompts?id=def456prompt');
     expect(row2Cells.getByText('Summarize the following text.')).toBeInTheDocument();
-    expect(row2Cells.getByText('77.78%')).toBeInTheDocument();
+    expect(row2Cells.getByText('70.00%')).toBeInTheDocument();
     // Pass count is rendered as a Badge, not gridcell
     expect(row2Cells.getByText('7')).toBeInTheDocument();
     expect(row2Cells.getByText('2')).toBeInTheDocument();

--- a/src/app/src/pages/history/History.tsx
+++ b/src/app/src/pages/history/History.tsx
@@ -29,7 +29,8 @@ interface HistoryProps {
 const calculatePassRate = (evalItem: StandaloneEval): string => {
   const testPassCount = evalItem.metrics?.testPassCount ?? 0;
   const testFailCount = evalItem.metrics?.testFailCount ?? 0;
-  const totalCount = testPassCount + testFailCount;
+  const testErrorCount = evalItem.metrics?.testErrorCount ?? 0;
+  const totalCount = testPassCount + testFailCount + testErrorCount;
   const passRate = totalCount > 0 ? (testPassCount / totalCount) * 100 : 0;
   return passRate?.toFixed(2) ?? '0.00';
 };


### PR DESCRIPTION
## Summary

- include runtime errors in the remaining WebUI pass-rate denominators
- align Results, performance history, and History with the existing server, CLI, and dialog calculations
- add total, filtered, chart-dataset, visible-history, zero-error, and zero-denominator regressions

For an eval with one pass and one runtime error, every surface now reports `50%` instead of some WebUI pages reporting `100%`.

## Testing

- `npm run test:app -- src/pages/eval/components/hooks.test.ts src/pages/eval/components/ResultsCharts.test.tsx src/pages/history/History.test.tsx --run` (74 tests)
- related app regression set (342 tests)
- `npm --prefix src/app run tsc -- --noEmit`
- `npm run build:app`
- changed-file Biome and `git diff --check`
