### PR TITLE
fix(vars): respect {% raw %} and nested expressions when pre-resolving placeholders

### DIFF
--- a/src/evaluatorHelpers.ts
+++ b/src/evaluatorHelpers.ts
@@ -57,7 +57,6 @@ export function resolveVariables(
   varsResolvedFromSkipped?: Set<string>,
 ): Record<string, VarValue> {
   let resolved: boolean;
-  const regex = /\{\{\s*(\w+)\s*\}\}/; // Matches {{variableName}}, {{ variableName }}, etc.
 
   let iterations = 0;
   do {
@@ -71,14 +70,17 @@ export function resolveVariables(
         continue;
       }
       const value = variables[key] as string;
-      const match = regex.exec(value);
+      const match = firstUnprotectedPlaceholder(value);
       if (match) {
-        const [placeholder, varName] = match;
+        const { placeholder, varName, index } = match;
         if (variables[varName] === undefined) {
           // Do nothing - final nunjucks render will fail if necessary.
           // logger.warn(`Variable "${varName}" not found for substitution.`);
         } else {
-          variables[key] = value.replace(placeholder, variables[varName] as string);
+          variables[key] =
+            value.slice(0, index) +
+            (variables[varName] as string) +
+            value.slice(index + placeholder.length);
           if (skipResolveVars?.includes(varName) || varsResolvedFromSkipped?.has(varName)) {
             varsResolvedFromSkipped?.add(key);
           }
@@ -90,6 +92,34 @@ export function resolveVariables(
   } while (!resolved && iterations < 5);
 
   return variables;
+}
+
+const RAW_BLOCK_REGEX = /\{%\s*raw\s*%\}.*?\{%\s*endraw\s*%\}/gs;
+const SIMPLE_PLACEHOLDER_REGEX = /\{\{\s*(\w+)\s*\}\}/g;
+
+// Regex substitution cannot see Nunjucks structure, so a placeholder inside a
+// {% raw %} block or nested in another {{ ... }} expression (say a quoted
+// string literal) must be left for the real render pass; replacing it here
+// would defeat the escape.
+function firstUnprotectedPlaceholder(
+  value: string,
+): { placeholder: string; varName: string; index: number } | null {
+  const rawSpans: Array<[number, number]> = [];
+  for (const match of value.matchAll(RAW_BLOCK_REGEX)) {
+    rawSpans.push([match.index, match.index + match[0].length]);
+  }
+  for (const match of value.matchAll(SIMPLE_PLACEHOLDER_REGEX)) {
+    const start = match.index;
+    if (rawSpans.some(([s, e]) => start >= s && start < e)) {
+      continue;
+    }
+    const before = value.slice(0, start);
+    if (before.lastIndexOf('{{') > before.lastIndexOf('}}')) {
+      continue;
+    }
+    return { placeholder: match[0], varName: match[1]!, index: start };
+  }
+  return null;
 }
 
 // Utility: Detect partial/unclosed Nunjucks tags and wrap in {% raw %} if needed

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -633,6 +633,39 @@ describe('evaluatorHelpers', () => {
       };
       expect(resolveVariables(variables)).toEqual(expected);
     });
+
+    it('should leave placeholders inside raw blocks untouched', () => {
+      const variables = {
+        varOne: 'abc',
+        varThree: '{% raw %}{{varOne}}{% endraw %}',
+      };
+      expect(resolveVariables(variables)).toEqual({
+        varOne: 'abc',
+        varThree: '{% raw %}{{varOne}}{% endraw %}',
+      });
+    });
+
+    it('should leave placeholders nested in another expression untouched', () => {
+      const variables = {
+        varOne: 'abc',
+        varTwo: "{{ '{{varOne}}' }}",
+      };
+      expect(resolveVariables(variables)).toEqual({
+        varOne: 'abc',
+        varTwo: "{{ '{{varOne}}' }}",
+      });
+    });
+
+    it('should still substitute simple placeholders around protected spans', () => {
+      const variables = {
+        x: 'yes',
+        mixed: '{{x}} and {% raw %}{{x}}{% endraw %}',
+      };
+      expect(resolveVariables(variables)).toEqual({
+        x: 'yes',
+        mixed: 'yes and {% raw %}{{x}}{% endraw %}',
+      });
+    });
   });
 
   describe('runExtensionHook', () => {


### PR DESCRIPTION
Fixes #10434.

## Summary

`{% raw %}` and quoted-literal escapes in `vars:` values did not survive prompt rendering, because the regex-based pre-resolution pass substituted `{{var}}` placeholders before Nunjucks ever saw them. `{% raw %}{{varOne}}{% endraw %}` became `{% raw %}abc{% endraw %}`, and `{{ '{{varOne}}' }}` became `{{ 'abc' }}`, so both rendered as `abc` instead of the literal placeholder text.

## Root cause

`resolveVariables` matched `/\{\{\s*(\w+)\s*\}\}/` against the raw string with no awareness of Nunjucks structure. A placeholder sitting inside a `{% raw %}...{% endraw %}` span, or nested inside an outer `{{ ... }}` expression, is not a simple placeholder, but the regex replaced it anyway.

## Fix

The pre-resolution pass now picks the first placeholder that is neither inside a raw block nor nested in an unclosed outer expression, and splices by index instead of a global string replace. Anything structural is left for the real Nunjucks render, which already handles both shapes correctly.

## Verification

- Reproduced the issue's exact YAML shapes end to end through `renderPrompt`: before, `three=[abc]`; after, `two=[{{varOne}}] three=[{{varOne}}] one=[abc]`.
- New unit tests pin the raw-block escape, the nested-expression escape, and substitution still working around protected spans. `npx vitest run test/evaluatorHelpers.test.ts`: 106 passed.
- `tsc --noEmit` clean; Biome reports only the pre-existing cognitive-complexity warning on `renderPrompt`.
