### PR TITLE
fix(providers): redact AWS SigV4 credentials in sanitized output

### DIFF
--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -125,6 +125,19 @@ export const SECRET_FIELD_NAMES = new Set([
   'webhooksecret',
   'anthropicapikey',
   'awsbearertokenbedrock',
+
+  // AWS SigV4 credentials. Both spellings are needed: normalizeFieldName strips
+  // underscores, so the env var AWS_SECRET_ACCESS_KEY collapses to
+  // 'awssecretaccesskey' while the documented provider config field
+  // `secretAccessKey` collapses to 'secretaccesskey'. These are first-class,
+  // documented Bedrock config fields (see site/docs/providers/aws-bedrock.md),
+  // so an inline credential otherwise reaches logs and shared configs in clear text.
+  'secretaccesskey',
+  'awssecretaccesskey',
+  'sessiontoken',
+  'awssessiontoken',
+  'accesskeyid',
+  'awsaccesskeyid',
   'authorization',
   'auth',
   'bearer',

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -571,6 +571,52 @@ describe('sanitizeObject', () => {
         });
       });
 
+      // AWS SigV4 credentials are documented Bedrock provider config fields and env
+      // vars. Before this coverage they reached logs and shared configs in clear text,
+      // even though bedrock/knowledgeBase.ts already treated them as sensitive locally.
+      it.each([
+        'AWS_SECRET_ACCESS_KEY',
+        'AWS_SESSION_TOKEN',
+        'AWS_ACCESS_KEY_ID',
+        'secretAccessKey',
+        'sessionToken',
+        'accessKeyId',
+      ])('should redact %s', (field) => {
+        expect(sanitizeObject({ [field]: 'aws-credential-value' })).toEqual({
+          [field]: '[REDACTED]',
+        });
+      });
+
+      it('should redact AWS credentials nested in a Bedrock provider config', () => {
+        expect(
+          sanitizeObject({
+            providers: [
+              {
+                id: 'bedrock:anthropic.claude-sonnet-5',
+                config: {
+                  region: 'us-east-1',
+                  accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+                  secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+                  sessionToken: 'FwoGZXIvYXdzEExampleSessionToken',
+                },
+              },
+            ],
+          }),
+        ).toEqual({
+          providers: [
+            {
+              id: 'bedrock:anthropic.claude-sonnet-5',
+              config: {
+                region: 'us-east-1',
+                accessKeyId: '[REDACTED]',
+                secretAccessKey: '[REDACTED]',
+                sessionToken: '[REDACTED]',
+              },
+            },
+          ],
+        });
+      });
+
       it('should redact ANTHROPIC_API_KEY', () => {
         expect(sanitizeObject({ ANTHROPIC_API_KEY: 'anthropic-key' })).toEqual({
           ANTHROPIC_API_KEY: '[REDACTED]',
@@ -1236,8 +1282,10 @@ describe('sanitizeObject', () => {
       const result = sanitizeObject(awsConfig);
       expect(result.region).toBe('us-east-1');
       expect(result.accessKeyId).toBe('[REDACTED]');
-      expect(result.secretAccessKey).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
-      expect(result.sessionToken).toBe('session-token-value');
+      // Previously asserted to pass through in clear text, which contradicted this
+      // test's own name: secretAccessKey and sessionToken are the actual secrets.
+      expect(result.secretAccessKey).toBe('[REDACTED]');
+      expect(result.sessionToken).toBe('[REDACTED]');
     });
 
     it('should sanitize provider response with metadata', () => {


### PR DESCRIPTION
## Problem

`secretAccessKey` and `sessionToken` are documented AWS Bedrock provider config fields (see `site/docs/providers/aws-bedrock.md`), and `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` are the matching environment variables. None of them were in `SECRET_FIELD_NAMES`, so an inline credential reached logs and sanitized config output in clear text.

`src/providers/bedrock/knowledgeBase.ts:196` already carries its own local `sensitiveKeys` list covering exactly `accessKeyId`, `secretAccessKey`, and `sessionToken` — the intent was established, only the shared sanitizer was missing them.

Reproduction on `main`:

```
EXPOSED  AWS_SECRET_ACCESS_KEY   -> awssecretaccesskey
EXPOSED  AWS_SESSION_TOKEN       -> awssessiontoken
EXPOSED  secretAccessKey         -> secretaccesskey
EXPOSED  sessionToken            -> sessiontoken
REDACTED AWS_BEARER_TOKEN_BEDROCK
```

## Fix

Add the AWS SigV4 credential names to `SECRET_FIELD_NAMES`. Both spellings are required because `normalizeFieldName` strips underscores: the env var collapses to `awssecretaccesskey`, the config field to `secretaccesskey`.

The existing `should sanitize AWS credentials` test asserted that `secretAccessKey` and `sessionToken` passed through **unredacted**, contradicting its own name. It now asserts they are redacted.

## Tests

- Per-field coverage for all six spellings.
- A regression test exercising the original vector: AWS credentials nested inside a `bedrock:` provider config, the shape a user actually writes in `promptfooconfig.yaml`.

## Validation

- `npx vitest run` — 23,022 passed, 10 skipped (full backend suite)
- `npx tsc --noEmit` — clean
- `npx @biomejs/biome ci .` — 0 errors

## Context

Found while auditing open Anthropic/Bedrock PRs. This is the sanitizer half of the credential-export blocker raised in review on #10123; landing it separately unblocks that PR and fixes the gap for everyone already using inline Bedrock credentials.