### PR TITLE
docs(providers): add Claude 4.1 Opus and clarify per-platform availability

### DIFF
--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -82,8 +82,10 @@ Anthropic does not publish `-latest` aliases — `claude-sonnet-4-5-latest` retu
 parentheses above: `claude-sonnet-4-5` resolves to `claude-sonnet-4-5-20250929`.
 Claude 4.6 and newer are already unversioned IDs, so there is nothing to shorten.
 
-Rows without a parenthetical have no alias; several of them are retired on the direct
-Anthropic API and remain listed for cost attribution on historical evals.
+Rows without a parenthetical have no alias. Availability also differs by platform:
+Claude 4, 4.1, 3.7, and 3.5 no longer resolve on the direct Anthropic API, while several
+of them are still served by Bedrock, Vertex, and OpenRouter. The rows stay listed both
+for those platforms and for cost attribution on historical evals.
 
 :::
 
@@ -104,6 +106,7 @@ Claude models are available across multiple platforms. Here's how the model name
 | Claude 4.5 Opus   | claude-opus-4-5-20251101 (claude-opus-4-5)     | claude-opus-4-5-20251101                                              | anthropic.claude-opus-4-5-20251101-v1:0           | claude-opus-4-5@20251101                       |
 | Claude 4.5 Sonnet | claude-sonnet-4-5-20250929 (claude-sonnet-4-5) | claude-sonnet-4-5-20250929                                            | anthropic.claude-sonnet-4-5-20250929-v1:0         | claude-sonnet-4-5@20250929                     |
 | Claude 4.5 Haiku  | claude-haiku-4-5-20251001 (claude-haiku-4-5)   | claude-haiku-4-5-20251001                                             | anthropic.claude-haiku-4-5-20251001-v1:0          | claude-haiku-4-5@20251001                      |
+| Claude 4.1 Opus   | Retired on the direct API                      | claude-opus-4-1-20250805                                              | anthropic.claude-opus-4-1-20250805-v1:0           | claude-opus-4-1@20250805                       |
 | Claude 4 Opus     | claude-opus-4-20250514                         | claude-opus-4-20250514                                                | anthropic.claude-opus-4-20250514-v1:0             | claude-opus-4@20250514                         |
 | Claude 4 Sonnet   | claude-sonnet-4-20250514                       | claude-sonnet-4-20250514                                              | anthropic.claude-sonnet-4-20250514-v1:0           | claude-sonnet-4@20250514                       |
 | Claude 3.7 Sonnet | claude-3-7-sonnet-20250219                     | claude-3-7-sonnet-20250219                                            | anthropic.claude-3-7-sonnet-20250219-v1:0         | claude-3-7-sonnet@20250219                     |


### PR DESCRIPTION
## Summary

Completes the Vertex leg of the model-ID audit started in #10483. Verified the Vertex column against the live Model Garden publisher list (`publishers/anthropic/models`, swept across five regional endpoints with pagination).

## Findings

**Claude 4.1 Opus was missing from the cross-platform table entirely**, despite being live on three of the four platforms:

| Platform | Status |
| --- | --- |
| Anthropic direct | `not_found_error` — retired |
| Vertex AI | `claude-opus-4-1@20250805` — live |
| AWS Bedrock | `anthropic.claude-opus-4-1-20250805-v1:0` — live |
| OpenRouter | `anthropic/claude-opus-4.1` — live |

It is already in `ANTHROPIC_MODELS` and the Bedrock registry, so only the docs table omitted it.

**Availability differs by platform, and the note didn't say so.** The retirement note added in #10483 said "several of them are retired on the direct Anthropic API" without naming which, and implied the rows were dead everywhere. Claude 4, 4.1, 3.7, and 3.5 no longer resolve on the direct API, while Bedrock, Vertex, and OpenRouter still serve several of them — so the rows are load-bearing for those platforms, not just history.

## Live Vertex catalog (for the record)

```
claude-3-opus@20240229      claude-opus-4-6@default
claude-fable-5@default      claude-opus-4-7@default
claude-haiku-4-5@20251001   claude-opus-4-8@default
claude-opus-4-1@20250805    claude-opus-5@default
claude-opus-4-5@20251101    claude-sonnet-4-5@20250929
claude-sonnet-4-6@default   claude-sonnet-5@default
```

Every other ID in the Vertex column matches. The Claude 3.x/4 entries no longer appear in Model Garden, consistent with the direct-API retirements.

## Validation

- `npx docusaurus build` — succeeds.
- Vertex list read with the `logs-reader` service account; the `rawPredict` probes returned `403 PERMISSION_DENIED` (not 404), so availability was confirmed from the publisher listing rather than by invoking the models.