### PR TITLE
refactor(providers): share the function-tool callback executor

### DIFF
--- a/src/providers/bedrock/converse.ts
+++ b/src/providers/bedrock/converse.ts
@@ -19,19 +19,17 @@ import {
   type GenAISpanContext,
   type GenAISpanResult,
   withGenAISpan,
-  withGenAIToolSpan,
 } from '../../tracing/genaiTracer';
-import {
-  CallbackPathTraversalError,
-  loadCallbackFromFileUrl,
-  wrapError,
-} from '../../util/functions/loadFunction';
 import { maybeLoadToolsFromExternalFile } from '../../util/index';
 import {
   isAlwaysOnAdaptiveThinkingClaudeModel,
   isSamplingParamsDeprecatedClaudeModel,
   normalizeClaudeThinkingConfig,
 } from '../anthropic/util';
+import {
+  executeProviderFunctionCallback,
+  loadProviderCallbackFromFileUrl,
+} from '../functionCallbackUtils';
 import { MCPClient } from '../mcp/client';
 import { getMcpErrorMessage, isMcpErrorResult } from '../mcp/util';
 import { providerRegistry } from '../providerRegistry';
@@ -826,14 +824,7 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
    * @returns The loaded function
    */
   private async loadExternalFunction(fileRef: string): Promise<Function> {
-    try {
-      return await loadCallbackFromFileUrl(fileRef, { logPrefix: '[Bedrock Converse]' });
-    } catch (error) {
-      if (error instanceof CallbackPathTraversalError) {
-        throw error;
-      }
-      throw wrapError(`Error loading function from ${fileRef}: ${(error as Error).message}`, error);
-    }
+    return loadProviderCallbackFromFileUrl(fileRef, '[Bedrock Converse]');
   }
 
   /**
@@ -844,59 +835,14 @@ export class AwsBedrockConverseProvider extends AwsBedrockGenericProvider implem
     args: string,
     callId?: string,
   ): Promise<string> {
-    try {
-      // Check if we've already loaded this function
-      let callback = this.loadedFunctionCallbacks[functionName];
-
-      // If not loaded yet, try to load it now
-      if (!callback) {
-        const callbackRef = this.config.functionToolCallbacks?.[functionName];
-
-        if (callbackRef && typeof callbackRef === 'string') {
-          const callbackStr: string = callbackRef;
-          if (callbackStr.startsWith('file://')) {
-            callback = await this.loadExternalFunction(callbackStr);
-          } else {
-            callback = new Function('return ' + callbackStr)();
-          }
-
-          // Cache for future use
-          this.loadedFunctionCallbacks[functionName] = callback;
-        } else if (typeof callbackRef === 'function') {
-          callback = callbackRef;
-          this.loadedFunctionCallbacks[functionName] = callback;
-        }
-      }
-
-      if (!callback) {
-        throw new Error(`No callback found for function '${functionName}'`);
-      }
-
-      // Execute the callback
-      logger.debug(`[Bedrock Converse] Executing function '${functionName}' with args: ${args}`);
-      const result = await withGenAIToolSpan({ name: functionName, arguments: args, callId }, () =>
-        callback(args),
-      );
-
-      // Format the result
-      if (result === undefined || result === null) {
-        return '';
-      } else if (typeof result === 'object') {
-        try {
-          return JSON.stringify(result);
-        } catch (error) {
-          logger.warn(`Error stringifying result from function '${functionName}': ${error}`);
-          return String(result);
-        }
-      } else {
-        return String(result);
-      }
-    } catch (error: any) {
-      logger.error(
-        `[Bedrock Converse] Error executing function '${functionName}': ${error.message || String(error)}`,
-      );
-      throw error;
-    }
+    return executeProviderFunctionCallback({
+      functionName,
+      args,
+      callId,
+      callbacks: this.config.functionToolCallbacks,
+      cache: this.loadedFunctionCallbacks,
+      logPrefix: '[Bedrock Converse]',
+    });
   }
 
   /**

--- a/src/providers/functionCallbackUtils.ts
+++ b/src/providers/functionCallbackUtils.ts
@@ -17,6 +17,103 @@ import type {
 import type { MCPClient } from './mcp/client';
 
 /**
+ * Resolve a `file://` callback reference through the shared path-traversal guard,
+ * preserving the underlying error on `cause` so callers can classify it.
+ */
+export async function loadProviderCallbackFromFileUrl(
+  fileRef: string,
+  logPrefix?: string,
+): Promise<Function> {
+  try {
+    return await loadCallbackFromFileUrl(fileRef, logPrefix ? { logPrefix } : undefined);
+  } catch (error) {
+    if (error instanceof CallbackPathTraversalError) {
+      throw error;
+    }
+    throw wrapError(`Error loading function from ${fileRef}: ${(error as Error).message}`, error);
+  }
+}
+
+/**
+ * Load, cache, and invoke one `functionToolCallbacks` entry, returning the string a
+ * tool-result message expects.
+ *
+ * Shared by the two providers that implement function-tool callbacks directly on the
+ * provider class — Bedrock Converse and OpenAI Chat — whose copies were identical apart
+ * from log prefixes. Keeping one implementation is what stops them drifting: the
+ * path-traversal guard is a worked example of a fix that reached one copy of this logic
+ * and not the others.
+ *
+ * The remaining providers with a `loadedFunctionCallbacks` cache (Azure Foundry, Google
+ * base and live) have genuinely different loading and caching behaviour — Azure preloads,
+ * Google Live gates on a shared-cache flag — so they deliberately keep their own.
+ */
+export async function executeProviderFunctionCallback({
+  functionName,
+  args,
+  callId,
+  callbacks,
+  cache,
+  logPrefix,
+}: {
+  functionName: string;
+  args: string;
+  callId?: string;
+  callbacks: Record<string, any> | undefined;
+  /** Per-provider-instance memo of resolved callbacks. Mutated in place. */
+  cache: Record<string, Function>;
+  /** This provider's log prefix, e.g. `[Bedrock Converse]`. */
+  logPrefix?: string;
+}): Promise<string> {
+  const prefix = logPrefix ? `${logPrefix} ` : '';
+  try {
+    let callback = cache[functionName];
+
+    if (!callback) {
+      const callbackRef = callbacks?.[functionName];
+
+      if (callbackRef && typeof callbackRef === 'string') {
+        callback = callbackRef.startsWith('file://')
+          ? await loadProviderCallbackFromFileUrl(callbackRef, logPrefix)
+          : new Function('return ' + callbackRef)();
+        cache[functionName] = callback;
+      } else if (typeof callbackRef === 'function') {
+        callback = callbackRef;
+        cache[functionName] = callback;
+      }
+    }
+
+    if (!callback) {
+      throw new Error(`No callback found for function '${functionName}'`);
+    }
+
+    logger.debug(`${prefix}Executing function '${functionName}' with args: ${args}`);
+    const result = await withGenAIToolSpan({ name: functionName, arguments: args, callId }, () =>
+      callback(args),
+    );
+
+    if (result === undefined || result === null) {
+      return '';
+    }
+    if (typeof result === 'object') {
+      try {
+        return JSON.stringify(result);
+      } catch (error) {
+        logger.warn(`Error stringifying result from function '${functionName}': ${error}`);
+        return String(result);
+      }
+    }
+    return String(result);
+  } catch (error: any) {
+    logger.error(
+      `${prefix}Error executing function '${functionName}': ${error.message || String(error)}`,
+    );
+    // Re-thrown so the caller can apply its own fallback behavior.
+    throw error;
+  }
+}
+
+/**
  * Handles function callback execution for AI providers.
  * Provides a unified way to execute function callbacks across different provider formats.
  */

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -4,16 +4,15 @@ import logger from '../../logger';
 import { formatRateLimitErrorMessage, HttpRateLimitError } from '../../util/fetch/errors';
 import { FINISH_REASON_MAP, normalizeFinishReason } from '../../util/finishReason';
 import {
-  CallbackPathTraversalError,
-  loadCallbackFromFileUrl,
-  wrapError,
-} from '../../util/functions/loadFunction';
-import {
   maybeLoadFromExternalFileWithVars,
   maybeLoadResponseFormatFromExternalFile,
   maybeLoadToolsFromExternalFile,
   renderVarsInObject,
 } from '../../util/index';
+import {
+  executeProviderFunctionCallback,
+  loadProviderCallbackFromFileUrl,
+} from '../functionCallbackUtils';
 import { MCPClient } from '../mcp/client';
 import { transformMCPToolsToOpenAi } from '../mcp/transform';
 import { getMcpErrorMessage, isMcpErrorResult } from '../mcp/util';
@@ -27,7 +26,6 @@ import {
   extractProviderResponseAttributes,
   type GenAISpanContext,
   withGenAISpan,
-  withGenAIToolSpan,
 } from '../tracing';
 import { OpenAiGenericProvider } from './';
 import { calculateOpenAIUsageCost } from './billing';
@@ -139,16 +137,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
    * @returns The loaded function
    */
   private async loadExternalFunction(fileRef: string): Promise<Function> {
-    try {
-      return await loadCallbackFromFileUrl(fileRef);
-    } catch (error) {
-      // Preserve the underlying error (path-traversal, missing module, bad
-      // export, etc.) on `cause` so upstream code can downcast/classify it.
-      if (error instanceof CallbackPathTraversalError) {
-        throw error;
-      }
-      throw wrapError(`Error loading function from ${fileRef}: ${(error as Error).message}`, error);
-    }
+    return loadProviderCallbackFromFileUrl(fileRef);
   }
 
   /**
@@ -160,57 +149,13 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
     config: OpenAiCompletionOptions,
     callId?: string,
   ): Promise<string> {
-    try {
-      // Check if we've already loaded this function
-      let callback = this.loadedFunctionCallbacks[functionName];
-
-      // If not loaded yet, try to load it now
-      if (!callback) {
-        const callbackRef = config.functionToolCallbacks?.[functionName];
-
-        if (callbackRef && typeof callbackRef === 'string') {
-          const callbackStr: string = callbackRef;
-          if (callbackStr.startsWith('file://')) {
-            callback = await this.loadExternalFunction(callbackStr);
-          } else {
-            callback = new Function('return ' + callbackStr)();
-          }
-
-          // Cache for future use
-          this.loadedFunctionCallbacks[functionName] = callback;
-        } else if (typeof callbackRef === 'function') {
-          callback = callbackRef;
-          this.loadedFunctionCallbacks[functionName] = callback;
-        }
-      }
-
-      if (!callback) {
-        throw new Error(`No callback found for function '${functionName}'`);
-      }
-
-      // Execute the callback
-      logger.debug(`Executing function '${functionName}' with args: ${args}`);
-      const result = await withGenAIToolSpan({ name: functionName, arguments: args, callId }, () =>
-        callback(args),
-      );
-
-      // Format the result
-      if (result === undefined || result === null) {
-        return '';
-      } else if (typeof result === 'object') {
-        try {
-          return JSON.stringify(result);
-        } catch (error) {
-          logger.warn(`Error stringifying result from function '${functionName}': ${error}`);
-          return String(result);
-        }
-      } else {
-        return String(result);
-      }
-    } catch (error: any) {
-      logger.error(`Error executing function '${functionName}': ${error.message || String(error)}`);
-      throw error; // Re-throw so caller can handle fallback behavior
-    }
+    return executeProviderFunctionCallback({
+      functionName,
+      args,
+      callId,
+      callbacks: config.functionToolCallbacks,
+      cache: this.loadedFunctionCallbacks,
+    });
   }
 
   async getOpenAiBody(


### PR DESCRIPTION
## Summary

`executeFunctionCallback` was duplicated between the Bedrock Converse and OpenAI Chat providers. Measured similarity of the normalized method bodies:

| Provider | Lines | Similarity to Bedrock Converse |
| --- | ---: | ---: |
| `bedrock/converse.ts` | 59 | 100% |
| `openai/chat.ts` | 58 | **90.6%** |
| `google/live.ts` | 50 | 67.9% |
| `google/base.ts` | 63 | 63.9% |
| `azure/foundry-agent.ts` | 50 | 53.2% |

The Bedrock/OpenAI pair differed only in where it read the callbacks map and in two log prefixes. Their `loadExternalFunction` wrappers were likewise identical apart from the prefix passed to `loadCallbackFromFileUrl`.

Both now call `executeProviderFunctionCallback` / `loadProviderCallbackFromFileUrl` in `functionCallbackUtils.ts`, which already imported everything they needed (`logger`, `withGenAIToolSpan`, `loadCallbackFromFileUrl`, `wrapError`, `CallbackPathTraversalError`) — no new imports, no new module.

## Why this is worth doing

The duplication is not theoretical. #9472 had to add the same path-traversal guard to seven separate loaders because the original guard reached only the Google one. This is the same class of drift, one level up.

## Scope

Deliberately limited to the 90.6% pair. Azure Foundry preloads callbacks, and Google Live gates its cache on a `shouldUseSharedCache` flag — those are different implementations rather than copies, and folding them in would change behaviour rather than remove duplication. They keep their own, and the helper's docstring says so.

Behaviour is preserved exactly, including the falsy-string guard (`callbackRef && typeof callbackRef === 'string'`), the `cache[functionName] = callback` memo semantics, the object-stringify fallback, and the re-throw so callers keep their own fallback handling.

## Validation

- `npx vitest run` — **23,323 passed**, 10 skipped (full backend suite)
- Targeted: `openai/chat`, `bedrock/converse`, `functionCallbackUtils`, `util/functions` — 393 passed
- Path-traversal guard re-probed through the new shared loader after the refactor: still rejects an absolute path outside `basePath`
- `npx tsc --noEmit`, `npx @biomejs/biome ci .` (0 errors), `npm run architecture:check`, `npx knip` — all clean

Net 134 deletions against 122 insertions, with one implementation instead of two.