### PR TITLE
fix(webui): stop the media bulk download when the page unmounts

### DIFF
--- a/src/app/src/pages/media/Media.test.tsx
+++ b/src/app/src/pages/media/Media.test.tsx
@@ -18,11 +18,16 @@ vi.mock('@app/hooks/useTelemetry', () => ({
 }));
 
 // Mock thumbnail cache cleanup
+vi.mock('@app/utils/media', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@app/utils/media')>()),
+  downloadFile: vi.fn(),
+}));
 vi.mock('./hooks/useThumbnailCache', () => ({
   clearExpiredThumbnails: () => Promise.resolve(),
 }));
 
 import { callApi } from '@app/utils/api';
+import { downloadFile } from '@app/utils/media';
 import Media from './Media';
 
 // Helper to capture current location for assertions
@@ -174,6 +179,34 @@ describe('Media page URL state machine', () => {
 
     const cancelDownloadButton = await screen.findByRole('button', { name: 'Cancel download' });
     expect(cancelDownloadButton.parentElement?.parentElement).toHaveClass('flex-wrap');
+  });
+
+  it('stops the bulk download loop when the page unmounts mid-download', async () => {
+    // The loop awaits a timer between files, so before the unmount abort it kept
+    // running after teardown and called setState on an unmounted component —
+    // surfacing in CI as "ReferenceError: window is not defined".
+    const user = userEvent.setup();
+    mockApiResponses();
+    const { unmount } = renderMedia();
+
+    await waitFor(() => {
+      expect(screen.getByText('First item')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('button', { name: /^Download$/ })[0]);
+    await user.click(screen.getByRole('menuitem', { name: /Select Items/i }));
+    await user.click(screen.getByRole('button', { name: 'Select All' }));
+    await user.click(screen.getByRole('button', { name: 'Download (2)' }));
+
+    await screen.findByRole('button', { name: 'Cancel download' });
+    const callsBeforeUnmount = vi.mocked(downloadFile).mock.calls.length;
+
+    expect(() => unmount()).not.toThrow();
+
+    // Well past the 200ms inter-file delay: an un-aborted loop would have started
+    // the next download by now.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(vi.mocked(downloadFile).mock.calls.length).toBe(callsBeforeUnmount);
   });
 
   it('clicking a card adds hash to URL', async () => {

--- a/src/app/src/pages/media/Media.tsx
+++ b/src/app/src/pages/media/Media.tsx
@@ -78,6 +78,18 @@ export default function Media() {
   const [isDeepLinkLoading, setIsDeepLinkLoading] = useState(false);
   const [showBulkDownloadConfirm, setShowBulkDownloadConfirm] = useState(false);
   const downloadAbortRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
+
+  // The bulk-download loop awaits a timer between files, so it can outlive the
+  // component. Abort it on unmount and record that we are gone, so the loop stops
+  // promptly and its finally block does not set state on an unmounted component.
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      downloadAbortRef.current?.abort();
+    };
+  }, []);
 
   // Eval search state — lifted here so the server-side search can be debounced
   const [evalSearchQuery, setEvalSearchQuery] = useState('');
@@ -432,16 +444,34 @@ export default function Media() {
 
         setDownloadProgress({ current: i + 1, total: itemsToDownload.length, currentFile: '' });
 
-        // Delay between downloads to avoid overwhelming the browser
-        await new Promise((r) => setTimeout(r, 200));
+        // Delay between downloads to avoid overwhelming the browser. Resolve early on
+        // abort so a cancel or an unmount does not leave this timer pending.
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, 200);
+          signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            { once: true },
+          );
+        });
       }
     } finally {
-      setIsDownloading(false);
-      setDownloadProgress({ current: 0, total: 0, currentFile: '' });
-      // Exit selection mode after download
-      if (isSelectionMode) {
-        setIsSelectionMode(false);
-        setSelectedHashes(new Set());
+      // Only the loop that still owns downloadAbortRef resets the UI, and only while
+      // mounted. A user cancel keeps the same controller, so it still resets here; a
+      // newer download replaces the controller and owns the state from then on; an
+      // unmount clears isMountedRef and nothing is set at all.
+      const supersededByNewerDownload = downloadAbortRef.current?.signal !== signal;
+      if (isMountedRef.current && !supersededByNewerDownload) {
+        setIsDownloading(false);
+        setDownloadProgress({ current: 0, total: 0, currentFile: '' });
+        // Exit selection mode after download
+        if (isSelectionMode) {
+          setIsSelectionMode(false);
+          setSelectedHashes(new Set());
+        }
       }
     }
   }, [items, isSelectionMode, selectedHashes, recordEvent]);


### PR DESCRIPTION
## Problem

This is the bug behind the `webui tests` failure that reddened `main` earlier today — the one where **all 5,392 tests passed** but the job still failed:

```
Test Files  285 passed (285)
Tests       5392 passed (5392)
Errors      1 error

Unhandled Rejection
ReferenceError: window is not defined
 ❯ resolveUpdatePriority  react-dom-client.development.js:1308:7
 ❯ setIsDownloading       react-dom-client.development.js:9126:14
 ❯ src/pages/media/Media.tsx:439:7
```

`handleBulkDownload` awaits a 200 ms timer between files. Nothing aborted that loop on unmount, so it kept running after the component was gone and its `finally` called `setIsDownloading` / `setDownloadProgress` on an unmounted component. Once jsdom had been torn down, React's scheduler reached for `window` and threw.

The existing test `allows the header actions to wrap while a bulk download is running` starts a bulk download and then ends — leaving the loop running straight into teardown. Whether it lands before or after teardown is a race, which is why this flaked rather than failing every run.

## Fix

- **Abort on unmount.** An effect aborts `downloadAbortRef` and clears `isMountedRef` on teardown.
- **Make the delay abort-aware.** The inter-file `setTimeout` now resolves early on abort, so a cancel or an unmount stops promptly instead of leaving a pending timer.
- **Guard the `finally`.** Only the loop that still owns `downloadAbortRef` resets the UI, and only while mounted.

The three abort causes need different handling, which is why the guard isn't a blanket skip:

| Cause | Controller | Behaviour |
| --- | --- | --- |
| User clicks Cancel | unchanged | still resets the UI |
| Newer download starts | replaced | old loop skips; the new one owns the state |
| Unmount | — | `isMountedRef` false, nothing is set |

## Also fixes a pre-existing race

The "newer download" condition fixes a real bug independent of the flake: starting a second bulk download aborted the first, and the first's `finally` then set `isDownloading` back to `false` while the second was still running — leaving the UI showing no download in progress.

## Test

The regression test unmounts mid-download and asserts no further downloads start. Verified it fails without the fix:

```
× stops the bulk download loop when the page unmounts mid-download
AssertionError: expected 2 to be 1
```

Two downloads instead of one — the loop had already started the next file after teardown, which is exactly the mechanism that produced the crash.

## Validation

- `src/pages/media` — 184 passed (11 files)
- `tsc -b` in `src/app` — clean
- `biome ci .` — 0 errors