### PR TITLE
fix(providers): raise max_tokens above a manual thinking budget on every Claude route

### DIFF
--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -32,6 +32,7 @@ import { AnthropicGenericProvider, hashAnthropicCacheValue } from './generic';
 import {
   ANTHROPIC_MODELS,
   calculateAnthropicCost,
+  clampMaxTokensForThinkingBudget,
   claudeThinkingConsumesTokens,
   getClaudeModelWarningName,
   getRefusalDetails,
@@ -873,9 +874,13 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
     const params: Anthropic.MessageCreateParams = {
       model: this.modelName,
       ...(resolvedSystem && resolvedSystem.length > 0 ? { system: resolvedSystem } : {}),
-      max_tokens:
+      // resolvedThinking, not the raw config: a sampling-deprecated model has already had
+      // its manual budget converted to adaptive, and there is nothing left to clamp against.
+      max_tokens: clampMaxTokensForThinkingBudget(
         config.max_tokens ??
-        getEnvInt('ANTHROPIC_MAX_TOKENS', thinkingConsumesTokens ? 2048 : 1024),
+          getEnvInt('ANTHROPIC_MAX_TOKENS', thinkingConsumesTokens ? 2048 : 1024),
+        resolvedThinking,
+      ),
       messages: extractedMessages,
       stream: shouldStream,
       ...(omitTemperature

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -392,6 +392,30 @@ export function looksLikeClaudeModelId(modelId: string): boolean {
   return /^claude-[a-z0-9]/i.test(modelId);
 }
 
+/**
+ * Raise `max_tokens` above a manual thinking budget.
+ *
+ * Anthropic rejects any request where `max_tokens <= thinking.budget_tokens` with
+ * "`max_tokens` must be greater than `thinking.budget_tokens`" — thinking draws from the
+ * same output budget as the answer, so a budget at or above the cap leaves no room to reply.
+ * The rule is the API's, not a platform's, so every Claude route needs it: a user who sets
+ * `thinking: { type: 'enabled', budget_tokens: 8000 }` and leaves `max_tokens` at the
+ * provider default otherwise gets a 400 rather than a longer think.
+ *
+ * Headroom of 1024 above the budget matches what the Vertex path has always used. Callers
+ * keep their own `max_tokens` defaults, which legitimately differ per platform; this only
+ * enforces the floor.
+ */
+export function clampMaxTokensForThinkingBudget(
+  maxTokens: number,
+  thinking: { type?: string; budget_tokens?: number } | undefined,
+): number {
+  if (thinking?.type !== 'enabled' || !thinking.budget_tokens) {
+    return maxTokens;
+  }
+  return maxTokens < thinking.budget_tokens ? thinking.budget_tokens + 1024 : maxTokens;
+}
+
 export function normalizeAnthropicModelName(modelName: string): string {
   return modelName.replace(/^(?:(?:global|us|eu|jp|au)\.)?anthropic\./, '');
 }

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -6,6 +6,7 @@ import logger from '../../logger';
 import { maybeLoadToolsFromExternalFile } from '../../util/index';
 import { createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import {
+  clampMaxTokensForThinkingBudget,
   isAlwaysOnAdaptiveThinkingClaudeModel,
   isSamplingParamsDeprecatedClaudeModel,
   isThinkingOnByDefaultClaudeModel,
@@ -1656,6 +1657,11 @@ export const BEDROCK_MODEL = {
           normalizeClaudeThinkingConfig(modelName, config?.thinking, undefined)
         : config?.thinking;
       addConfigParam(params, 'thinking', thinking, undefined, undefined);
+      // max_tokens was resolved above, before the thinking config was known. Anthropic
+      // rejects a budget at or above the cap, so raise the floor now that both are settled.
+      if (typeof params.max_tokens === 'number') {
+        params.max_tokens = clampMaxTokensForThinkingBudget(params.max_tokens, thinking);
+      }
       if (systemPrompt) {
         addConfigParam(params, 'system', systemPrompt, undefined, undefined);
       }

--- a/src/providers/google/vertex.ts
+++ b/src/providers/google/vertex.ts
@@ -17,6 +17,7 @@ import { loadYaml } from '../../util/yamlLoad';
 import {
   applyClaudeRegionalPremium,
   calculateAnthropicCost,
+  clampMaxTokensForThinkingBudget,
   claudeThinkingConsumesTokens,
   getTokenUsage,
   isSamplingParamsDeprecatedClaudeModel,
@@ -363,14 +364,7 @@ export class VertexChatProvider extends GoogleGenericProvider {
     if (!maxTokens) {
       maxTokens = thinkingConsumesTokens ? 2048 : 512;
     }
-    // Claude requires max_tokens >= budget_tokens when thinking is enabled
-    if (
-      thinkingConfig?.type === 'enabled' &&
-      thinkingConfig.budget_tokens &&
-      maxTokens < thinkingConfig.budget_tokens
-    ) {
-      maxTokens = thinkingConfig.budget_tokens + 1024;
-    }
+    maxTokens = clampMaxTokensForThinkingBudget(maxTokens, thinkingConfig);
 
     // Newer Claude models deprecate manual sampling controls at the model
     // level — the underlying Anthropic API returns 400 for any request that

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -3166,6 +3166,63 @@ describe('AnthropicMessagesProvider', () => {
     });
   });
 
+  describe('thinking budget vs max_tokens', () => {
+    const mockResp = {
+      content: [{ type: 'text', text: 'ok' }],
+      model: 'claude-sonnet-4-5',
+      id: 'test-id',
+      role: 'assistant',
+      stop_reason: 'end_turn',
+      stop_details: null,
+      stop_sequence: null,
+      type: 'message',
+      usage: { input_tokens: 10, output_tokens: 5 },
+    } as Anthropic.Messages.Message;
+
+    it('raises the default max_tokens above a manual thinking budget', async () => {
+      // Anthropic 400s on max_tokens <= budget_tokens. The default here is 2048 once
+      // thinking consumes tokens, so an 8000-token budget used to fail the request.
+      const provider = createProvider('claude-sonnet-4-5', {
+        config: { thinking: { type: 'enabled', budget_tokens: 8000 } },
+      });
+      const createSpy = vi.spyOn(provider.anthropic.messages, 'create').mockResolvedValue(mockResp);
+
+      await provider.callApi('Hello');
+
+      const params = createSpy.mock.calls[0][0] as any;
+      expect(params.max_tokens).toBe(9024);
+      expect(params.max_tokens).toBeGreaterThan(params.thinking.budget_tokens);
+    });
+
+    it('leaves an explicit max_tokens that already clears the budget', async () => {
+      const provider = createProvider('claude-sonnet-4-5', {
+        config: { max_tokens: 20000, thinking: { type: 'enabled', budget_tokens: 8000 } },
+      });
+      const createSpy = vi.spyOn(provider.anthropic.messages, 'create').mockResolvedValue(mockResp);
+
+      await provider.callApi('Hello');
+
+      expect((createSpy.mock.calls[0][0] as any).max_tokens).toBe(20000);
+    });
+
+    it('does not inflate max_tokens when the budget was converted to adaptive', async () => {
+      // Opus 5 is sampling-deprecated: the manual budget is normalized away, so there is
+      // nothing to clamp against and the default must stand.
+      const provider = createProvider('claude-opus-5', {
+        config: { thinking: { type: 'enabled', budget_tokens: 8000 } },
+      });
+      const createSpy = vi
+        .spyOn(provider.anthropic.messages, 'create')
+        .mockResolvedValue({ ...mockResp, model: 'claude-opus-5' });
+
+      await provider.callApi('Hello');
+
+      const params = createSpy.mock.calls[0][0] as any;
+      expect(params.thinking).toEqual({ type: 'adaptive' });
+      expect(params.max_tokens).toBe(2048);
+    });
+  });
+
   describe('Opus 4.7 temperature handling', () => {
     const mockResp = {
       content: [{ type: 'text', text: 'ok' }],

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -2,6 +2,7 @@ import dedent from 'dedent';
 import { describe, expect, it } from 'vitest';
 import {
   calculateAnthropicCost,
+  clampMaxTokensForThinkingBudget,
   claudeThinkingConsumesTokens,
   getClaudeModelWarningName,
   getRefusalDetails,
@@ -2030,6 +2031,31 @@ describe('Anthropic utilities', () => {
         'claude-opus-4-5-20251101',
       ]) {
         expect(isSamplingParamsDeprecatedClaudeModel(id)).toBe(false);
+      }
+    });
+
+    it('raises max_tokens above a manual thinking budget', () => {
+      // Anthropic rejects max_tokens <= thinking.budget_tokens with a 400. Only the Vertex
+      // path used to enforce this, so the same config errored on the direct API.
+      expect(clampMaxTokensForThinkingBudget(2048, { type: 'enabled', budget_tokens: 8000 })).toBe(
+        9024,
+      );
+    });
+
+    it('leaves max_tokens alone when it already clears the budget', () => {
+      expect(clampMaxTokensForThinkingBudget(9000, { type: 'enabled', budget_tokens: 8000 })).toBe(
+        9000,
+      );
+    });
+
+    it('leaves max_tokens alone when there is no manual budget to clear', () => {
+      for (const thinking of [
+        undefined,
+        { type: 'adaptive' },
+        { type: 'disabled' },
+        { type: 'enabled' },
+      ]) {
+        expect(clampMaxTokensForThinkingBudget(1024, thinking as any)).toBe(1024);
       }
     });
 


### PR DESCRIPTION
## Problem

Anthropic rejects any request where `max_tokens <= thinking.budget_tokens`:

> `` `max_tokens` must be greater than `thinking.budget_tokens` ``

Thinking draws from the same output budget as the answer, so a budget at or above the cap leaves no room to reply. **Only the Vertex path enforced this.** Comparing the four Claude routes:

| Route | `max_tokens` default (thinking / not) | Budget clamp |
| --- | --- | :---: |
| Anthropic Messages | 2048 / 1024 (`ANTHROPIC_MAX_TOKENS`) | ✗ |
| Bedrock InvokeModel | 2048 / 1024 (`AWS_BEDROCK_MAX_TOKENS`) | ✗ |
| Bedrock Converse | none | ✗ |
| Vertex | 2048 / 512 | ✓ |

Since the default is 2048 once thinking consumes tokens, **any manual budget of 2048 or more failed** on the direct API. Reproduced end-to-end:

```yaml
providers:
  - id: anthropic:messages:claude-sonnet-4-5
    config:
      thinking: { type: enabled, budget_tokens: 8000 }
```

```
before:  1 error (100%)
         API call error: `max_tokens` must be greater than `thinking.budget_tokens`
after:   0 errors, 88 tokens (38 prompt, 50 completion, 35 reasoning)
```

The identical config worked on Vertex, which is what makes this a drift bug rather than a missing feature.

## Fix

The constraint belongs to the API, not to any one platform, so it is extracted as `clampMaxTokensForThinkingBudget` in `anthropic/util.ts` alongside the other shared Claude rules (`normalizeClaudeThinkingConfig`, `isSamplingParamsDeprecatedClaudeModel`, …) and applied on the Anthropic Messages and Bedrock InvokeModel paths. Vertex now calls the helper instead of its own inline copy — the 1024 headroom above the budget is the value it has always used.

## What is deliberately *not* unified

**Per-platform `max_tokens` defaults.** They differ for real reasons — different env vars, and Converse sets no default at all, deferring to Bedrock. Homogenising them would be a behaviour change wearing a refactor's clothes. This only enforces the floor.

**Bedrock Converse** is untouched: it sets no numeric `max_tokens`, so clamping would mean inventing a request field it does not currently send.

## One subtlety worth reviewing

The Anthropic path clamps against the **resolved** thinking config, not the raw one. A sampling-deprecated model (Opus 5, Sonnet 5, Opus 4.7/4.8) has already had its manual budget converted to adaptive by `normalizeClaudeThinkingConfig`, so there is nothing to clamp against and the default must stand. There is a test for exactly that:

```
does not inflate max_tokens when the budget was converted to adaptive
  → thinking = { type: 'adaptive' }, max_tokens = 2048
```

Using the raw config instead would silently inflate `max_tokens` on every Claude 5 request that carried a budget.

## Validation

- `npx vitest run` — **23,334 passed**, 10 skipped (full backend suite)
- The provider test verified to fail without the fix: `expected 2048 to be 9024`
- Live re-run of the failing eval config: now succeeds with 35 reasoning tokens
- `tsc --noEmit`, `biome ci .` (0 errors), `architecture:check` — clean

Found while auditing what still differs between the four ways promptfoo calls Claude.