### PR TITLE
fix(providers): count cached and thinking tokens for Claude on Bedrock

### DIFF
--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -714,13 +714,24 @@ export function getRefusalDetails(data: Anthropic.Messages.Message): string | un
   return parts.join(' — ');
 }
 
+/**
+ * Coerce a token count that may arrive as a numeric string.
+ *
+ * Bedrock's InvokeModel responses have been observed serializing counts as strings, and
+ * plain `?? 0` would make the sums below concatenate rather than add ("15" + 0 -> "150").
+ */
+function toTokenCount(value: unknown): number {
+  const parsed = typeof value === 'string' ? Number(value) : value;
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : 0;
+}
+
 export function getTokenUsage(data: any, cached: boolean): Partial<TokenUsage> {
   if (data.usage) {
     // Anthropic: total input = input_tokens + cache_read_input_tokens + cache_creation_input_tokens
-    const cacheRead = data.usage.cache_read_input_tokens ?? 0;
-    const cacheCreation = data.usage.cache_creation_input_tokens ?? 0;
-    const allInputTokens = (data.usage.input_tokens ?? 0) + cacheRead + cacheCreation;
-    const total_tokens = allInputTokens + (data.usage.output_tokens ?? 0);
+    const cacheRead = toTokenCount(data.usage.cache_read_input_tokens);
+    const cacheCreation = toTokenCount(data.usage.cache_creation_input_tokens);
+    const allInputTokens = toTokenCount(data.usage.input_tokens) + cacheRead + cacheCreation;
+    const total_tokens = allInputTokens + toTokenCount(data.usage.output_tokens);
 
     if (cached) {
       return { cached: total_tokens, total: total_tokens };
@@ -728,7 +739,7 @@ export function getTokenUsage(data: any, cached: boolean): Partial<TokenUsage> {
       const usage: Partial<TokenUsage> = {
         total: total_tokens,
         prompt: allInputTokens,
-        completion: data.usage.output_tokens ?? 0,
+        completion: toTokenCount(data.usage.output_tokens),
       };
 
       const thinkingTokens = data.usage.output_tokens_details?.thinking_tokens;
@@ -738,7 +749,7 @@ export function getTokenUsage(data: any, cached: boolean): Partial<TokenUsage> {
 
       if (thinkingTokens != null || hasCacheDetails) {
         usage.completionDetails = {
-          ...(thinkingTokens != null && { reasoning: thinkingTokens }),
+          ...(thinkingTokens != null && { reasoning: toTokenCount(thinkingTokens) }),
           // Cache *input* token counts go under completionDetails because Promptfoo's
           // TokenUsage contract has no input-details field.
           ...(hasCacheDetails && {

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -6,6 +6,7 @@ import logger from '../../logger';
 import { maybeLoadToolsFromExternalFile } from '../../util/index';
 import { createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import {
+  getTokenUsage,
   isAlwaysOnAdaptiveThinkingClaudeModel,
   isSamplingParamsDeprecatedClaudeModel,
   isThinkingOnByDefaultClaudeModel,
@@ -1675,30 +1676,24 @@ export const BEDROCK_MODEL = {
         };
       }
 
+      // Bedrock relays the Anthropic Messages `usage` object, so read it with the shared
+      // reader instead of maintaining a second interpretation. The hand-rolled version
+      // counted only `input_tokens`, so a cached prompt was under-reported — 100 rather
+      // than 1200 for a prompt with 900 cache-read and 200 cache-creation tokens — and it
+      // dropped the cache and thinking breakdowns entirely, even though
+      // calculateBedrockInvokeModelCost in this same file bills from those very fields.
+      //
+      // The alternate field names this handler has long accepted are normalized first.
+      // `??` rather than `||` so a genuine zero count is not treated as missing.
       const usage = responseJson.usage;
-
-      // Get input tokens
-      const inputTokens = usage.input_tokens || usage.prompt_tokens;
-      const inputTokensNum = coerceStrToNum(inputTokens);
-
-      // Get output tokens
-      const outputTokens = usage.output_tokens || usage.completion_tokens;
-      const outputTokensNum = coerceStrToNum(outputTokens);
-
-      // Get or calculate total tokens
-      let totalTokens = usage.totalTokens || usage.total_tokens;
-      if (
-        (totalTokens === null || totalTokens === undefined) &&
-        inputTokensNum !== undefined &&
-        outputTokensNum !== undefined
-      ) {
-        totalTokens = inputTokensNum + outputTokensNum;
-      }
+      const normalizedUsage = {
+        ...usage,
+        input_tokens: usage.input_tokens ?? usage.prompt_tokens,
+        output_tokens: usage.output_tokens ?? usage.completion_tokens,
+      };
 
       return {
-        prompt: inputTokensNum,
-        completion: outputTokensNum,
-        total: coerceStrToNum(totalTokens),
+        ...getTokenUsage({ usage: normalizedUsage }, false),
         numRequests: 1,
       };
     },

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -3262,6 +3262,61 @@ describe('BEDROCK_MODEL token counting functionality', () => {
       });
     });
 
+    it('counts cached prompt tokens and reports the cache breakdown', async () => {
+      // The hand-rolled reader counted only input_tokens, so a cached prompt reported 100
+      // instead of 1200 — while calculateBedrockInvokeModelCost billed from the very same
+      // cache fields, leaving cost and usage disagreeing about one response.
+      const result = BEDROCK_MODEL.CLAUDE_MESSAGES.tokenUsage!(
+        {
+          usage: {
+            input_tokens: 100,
+            cache_read_input_tokens: 900,
+            cache_creation_input_tokens: 200,
+            output_tokens: 50,
+          },
+        },
+        'Test prompt',
+      );
+      expect(result).toEqual({
+        prompt: 1200,
+        completion: 50,
+        total: 1250,
+        numRequests: 1,
+        completionDetails: { cacheReadInputTokens: 900, cacheCreationInputTokens: 200 },
+      });
+    });
+
+    it('reports Claude thinking tokens as reasoning', async () => {
+      const result = BEDROCK_MODEL.CLAUDE_MESSAGES.tokenUsage!(
+        {
+          usage: {
+            input_tokens: 10,
+            output_tokens: 50,
+            output_tokens_details: { thinking_tokens: 30 },
+          },
+        },
+        'Test prompt',
+      );
+      expect(result.completionDetails).toEqual({ reasoning: 30 });
+    });
+
+    it('still accepts the alternate prompt_tokens/completion_tokens names', async () => {
+      const result = BEDROCK_MODEL.CLAUDE_MESSAGES.tokenUsage!(
+        { usage: { prompt_tokens: 15, completion_tokens: 25 } },
+        'Test prompt',
+      );
+      expect(result).toEqual({ prompt: 15, completion: 25, total: 40, numRequests: 1 });
+    });
+
+    it('treats a zero input_tokens count as zero rather than missing', async () => {
+      const result = BEDROCK_MODEL.CLAUDE_MESSAGES.tokenUsage!(
+        { usage: { input_tokens: 0, output_tokens: 7 } },
+        'Test prompt',
+      );
+      expect(result.prompt).toBe(0);
+      expect(result.total).toBe(7);
+    });
+
     it('should handle string token counts in Claude Messages', async () => {
       const mockResponse = {
         usage: {


### PR DESCRIPTION
## Problem

`BEDROCK_MODEL.CLAUDE_MESSAGES` read the Anthropic `usage` object by hand and counted only `input_tokens`. For a cached prompt that is a large under-report, and the cache and thinking breakdowns were dropped entirely.

Same response, two readers:

```
usage: input 100, cache_read 900, cache_creation 200, output 50, thinking 30

shared reader   prompt 1200  total 1250  completionDetails{reasoning:30,
                                          cacheReadInputTokens:900,
                                          cacheCreationInputTokens:200}
bedrock claude  prompt  100  total  150
```

**Cost was already correct.** `calculateBedrockInvokeModelCost`, in this same file, bills from `usage.cache_read_input_tokens` and `usage.cache_creation_input_tokens` (lines 2910–2912). So cost and usage disagreed about the same response — and only on this route: the Anthropic Messages and Vertex Claude paths both use the shared `getTokenUsage`.

## Fix

Delegate to `getTokenUsage` instead of maintaining a second interpretation of the same wire format. Verified the two now agree exactly:

```js
expect({ ...getTokenUsage(response, false), numRequests: 1 })
  .toEqual(BEDROCK_MODEL.CLAUDE_MESSAGES.tokenUsage(response, ''));  // passes
```

## Behaviours deliberately preserved

Delegating naively would have lost two things this handler did, so both are kept:

- **Alternate field names.** It has long accepted `prompt_tokens` / `completion_tokens` alongside the canonical Anthropic names; those are normalized before delegating, and there is a test.
- **Numeric strings.** An existing test feeds `input_tokens: '15'`, which `getTokenUsage`'s `?? 0` would have *concatenated* into `"150"`. `getTokenUsage` now coerces numeric strings, which is strictly more robust for every caller.

## One small correction

Field selection moves from `||` to `??`, so a genuine `input_tokens: 0` is reported as `0` rather than falling through and being dropped as missing. Covered by a test.

## Validation

- `npx vitest run` — **23,332 passed**, 10 skipped (full backend suite)
- New test verified to fail without the fix: `expected { prompt: 100 … } to deeply equal { prompt: 1200 … }`
- The pre-existing string-token and alternate-name tests still pass
- `tsc --noEmit`, `biome ci .` (0 errors), `architecture:check` — clean

Found while auditing what still differs between the four ways promptfoo calls Claude; companion to #10491.