### PR TITLE
fix(providers): expose latencyMs for OpenRouter

### DIFF
--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -147,9 +147,10 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
     let status: number;
     let statusText: string;
     let cached = false;
+    let latencyMs: number | undefined;
 
     try {
-      ({ data, cached, status, statusText } =
+      ({ data, cached, status, statusText, latencyMs } =
         await fetchWithCache<OpenRouterChatCompletionResponse>(
           appendOpenAiApiPath(this.getApiUrl(), 'chat/completions'),
           {
@@ -246,6 +247,7 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
         data.usage?.prompt_tokens,
         data.usage?.completion_tokens,
       ),
+      ...(latencyMs !== undefined && { latencyMs }),
       ...(finishReason && { finishReason }),
     };
   }

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -254,6 +254,48 @@ describe('OpenRouter', () => {
       }
     });
 
+    it('should preserve fields from the original response on cache hits', async () => {
+      const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
+
+      try {
+        const mockResponse = {
+          choices: [{ message: { content: 'The output' }, finish_reason: 'stop' }],
+          usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
+        };
+
+        const response = new Response(JSON.stringify(mockResponse), {
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers({ 'Content-Type': 'application/json' }),
+        });
+        mockedFetchWithRetries.mockResolvedValueOnce(response);
+
+        const cachedProvider = new OpenRouterProvider('google/gemini-2.5-pro', {});
+
+        const first = await cachedProvider.callApi('Repeatable prompt');
+        expect(first.cached).toBe(false);
+        expect(first.output).toBe('The output');
+        expect(first.latencyMs).toEqual(expect.any(Number));
+        expect(first.finishReason).toBe('stop');
+        expect(mockedFetchWithRetries).toHaveBeenCalledTimes(1);
+
+        const second = await cachedProvider.callApi('Repeatable prompt');
+        expect(mockedFetchWithRetries).toHaveBeenCalledTimes(1); // Still 1
+        expect(second).toEqual({
+          ...first,
+
+          // The difference when the response is cached
+          cached: true,
+          tokenUsage: {
+            total: 10,
+            cached: 10,
+          },
+        });
+      } finally {
+        restoreEnv();
+      }
+    });
+
     it('returns a clean error instead of crashing on an empty choices array', async () => {
       const restoreEnv = mockProcessEnv({ OPENROUTER_API_KEY: 'test-key' });
 


### PR DESCRIPTION
## Summary

OpenRouter binding dropped `latencyMs`.

This PR introduces a fix and a generalized test for `latencyMs` and its sibling fields.

## Verification

Vitest:

    npx vitest run test/providers/openrouter.test.ts \
      -t "should preserve fields from the original response on cache hits"

Manual test:

<img width="1988" height="1162" alt="Add a heading (4)" src="https://github.com/user-attachments/assets/f5e914a8-db9e-46c9-835a-b4eb0f615b9f" />

<details>
  <summary>Config used for the test</summary>
  
```yaml
# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
description: Repro OpenRouter missing latencyMs on cache miss and cache hit

# Mirrors test/providers/openrouter.test.ts:
#   "should preserve fields from the original response on cache hits"
#
# Run from repo root (pass 1 — populates cache):
#   PROMPTFOO_CONFIG_DIR=tmp/openrouter-cached-latency/.promptfoo \
#   npm run local -- eval \
#     -c tmp/openrouter-cached-latency/promptfooconfig.yaml \
#     --env-file tmp/openrouter-cached-latency/.env \
#     -o tmp/openrouter-cached-latency/output-pass1.json
#
# Run again without --no-cache (pass 2 — all cache hits):
#   PROMPTFOO_CONFIG_DIR=tmp/openrouter-cached-latency/.promptfoo \
#   npm run local -- eval \
#     -c tmp/openrouter-cached-latency/promptfooconfig.yaml \
#     --env-file tmp/openrouter-cached-latency/.env \
#     -o tmp/openrouter-cached-latency/output-pass2.json
#
# Expected bug: results[].response.latencyMs is undefined on both passes.
# Pass 1 test 1 fails the latency assertion; pass 1 test 2 fails the cache-hit check
# unless latencyMs was stored on the miss.

prompts:
  - 'Repeatable prompt: {{question}}'

providers:
  - id: openrouter:google/gemini-2.5-flash
    config:
      temperature: 0

evaluateOptions:
  maxConcurrency: 1

tests:
  - description: '1st call — cache miss (latencyMs should be set)'
    vars:
      question: What is 2+2? Reply with just the number.
    assert:
      - type: latency
        threshold: 120000
      - type: javascript
        value: |
          if (context.providerResponse?.latencyMs === undefined) {
            throw new Error('BUG: cache miss missing latencyMs');
          }
          return true;

  - description: '2nd call — cache hit (latencyMs should match pass-1 value)'
    vars:
      question: What is 2+2? Reply with just the number.
    assert:
      - type: javascript
        value: |
          const r = context.providerResponse;
          if (!r?.cached) {
            throw new Error('Expected cache hit on duplicate request');
          }
          if (r.latencyMs === undefined) {
            throw new Error('BUG: cache hit missing latencyMs from original response');
          }
          return true;
```  
</details>