### PR TITLE
fix(openai): handle empty or missing data array in image provider

### DIFF
--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -579,14 +579,14 @@ export function formatOutput(
   outputFormat?: string,
 ): string | { error: string } {
   if (responseFormat === 'b64_json') {
-    const b64Json = data.data[0].b64_json;
+    const b64Json = data?.data?.[0]?.b64_json;
     if (!b64Json) {
       return { error: `No base64 image data found in response: ${JSON.stringify(data)}` };
     }
 
     return `data:${getMimeTypeForOutputFormat(outputFormat)};base64,${b64Json}`;
   } else {
-    const url = data.data[0].url;
+    const url = data?.data?.[0]?.url;
     if (!url) {
       return { error: `No image URL found in response: ${JSON.stringify(data)}` };
     }
@@ -796,6 +796,7 @@ export async function processApiResponse(
   try {
     const formattedOutput = formatOutput(data, prompt, responseFormat, outputFormat);
     if (typeof formattedOutput === 'object') {
+      await data?.deleteFromCache?.();
       return formattedOutput;
     }
 

--- a/test/providers/openai/image.functions.test.ts
+++ b/test/providers/openai/image.functions.test.ts
@@ -129,14 +129,48 @@ describe('OpenAI Image Provider Functions', () => {
       const data = { data: [{}] };
       const result = formatOutput(data, 'prompt');
       expect(typeof result).toBe('object');
-      expect(result).toHaveProperty('error');
+      expect(result).toHaveProperty('error', 'No image URL found in response: {"data":[{}]}');
+    });
+
+    it('should return error when data array is empty for URL format', () => {
+      const data = { data: [] };
+      const result = formatOutput(data, 'prompt');
+      expect(typeof result).toBe('object');
+      expect(result).toHaveProperty('error', 'No image URL found in response: {"data":[]}');
+    });
+
+    it('should return error when data field is missing for URL format', () => {
+      const data = { created: 123 };
+      const result = formatOutput(data, 'prompt');
+      expect(typeof result).toBe('object');
+      expect(result).toHaveProperty('error', 'No image URL found in response: {"created":123}');
     });
 
     it('should return error when base64 data is missing', () => {
       const data = { data: [{}] };
       const result = formatOutput(data, 'prompt', 'b64_json');
       expect(typeof result).toBe('object');
-      expect(result).toHaveProperty('error');
+      expect(result).toHaveProperty(
+        'error',
+        'No base64 image data found in response: {"data":[{}]}',
+      );
+    });
+
+    it('should return error when data array is empty for base64 format', () => {
+      const data = { data: [] };
+      const result = formatOutput(data, 'prompt', 'b64_json');
+      expect(typeof result).toBe('object');
+      expect(result).toHaveProperty('error', 'No base64 image data found in response: {"data":[]}');
+    });
+
+    it('should return error when data field is missing for base64 format', () => {
+      const data = { created: 123 };
+      const result = formatOutput(data, 'prompt', 'b64_json');
+      expect(typeof result).toBe('object');
+      expect(result).toHaveProperty(
+        'error',
+        'No base64 image data found in response: {"created":123}',
+      );
     });
   });
 
@@ -570,11 +604,9 @@ describe('OpenAI Image Provider Functions', () => {
       expect(result.cost).toBeCloseTo((10 * 5 + 20 * 30) / 1e6, 12);
     });
 
-    it('should handle errors during output formatting', async () => {
-      const mockDeleteFromCache = vi.fn();
+    it('should return error when response has empty or missing data array', async () => {
       const data = {
-        data: undefined,
-        deleteFromCache: mockDeleteFromCache,
+        data: [],
       };
 
       const result = await processApiResponse(
@@ -587,9 +619,30 @@ describe('OpenAI Image Provider Functions', () => {
         undefined,
       );
 
+      expect(result).toEqual({
+        error: 'No image URL found in response: {"data":[]}',
+      });
+    });
+
+    it('should handle unexpected errors during output formatting', async () => {
+      const mockDeleteFromCache = vi.fn();
+      const data = {
+        data: [{ url: 'https://example.com/image.png' }],
+        deleteFromCache: mockDeleteFromCache,
+      };
+
+      const result = await processApiResponse(
+        data,
+        null as any,
+        'url',
+        false,
+        'dall-e-2',
+        '512x512',
+        undefined,
+      );
+
       expect(result).toHaveProperty('error');
       expect(result.error).toContain('API error: TypeError');
-      expect(result.error).toContain('Cannot read properties of undefined');
       expect(mockDeleteFromCache).toHaveBeenCalledWith();
     });
 
@@ -611,7 +664,7 @@ describe('OpenAI Image Provider Functions', () => {
       );
 
       expect(result).toHaveProperty('error');
-      expect(result.error).toContain('API error:');
+      expect(result.error).toContain('No image URL found in response');
       expect(mockDeleteFromCache).toHaveBeenCalledWith();
     });
   });

--- a/test/providers/openai/image.test.ts
+++ b/test/providers/openai/image.test.ts
@@ -333,6 +333,44 @@ describe('OpenAiImageProvider', () => {
       expect(result.error).toContain('No image URL found in response');
     });
 
+    it('should handle empty data array in response', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { data: [] },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result).toEqual({
+        error: 'No image URL found in response: {"data":[]}',
+      });
+    });
+
+    it('should handle missing data field in response', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { created: 123 },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result).toEqual({
+        error: 'No image URL found in response: {"created":123}',
+      });
+    });
+
     it('should handle error with minimal details', async () => {
       const provider = new OpenAiImageProvider('dall-e-3', {
         config: { apiKey: 'test-key' },
@@ -417,6 +455,44 @@ describe('OpenAiImageProvider', () => {
 
       expect(result).toHaveProperty('error');
       expect(result.error).toContain('No base64 image data found in response');
+    });
+
+    it('should handle empty data array for base64 response format', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key', response_format: 'b64_json' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { data: [] },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result).toEqual({
+        error: 'No base64 image data found in response: {"data":[]}',
+      });
+    });
+
+    it('should handle missing data field for base64 response format', async () => {
+      const provider = new OpenAiImageProvider('dall-e-3', {
+        config: { apiKey: 'test-key', response_format: 'b64_json' },
+      });
+
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: { created: 123 },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result).toEqual({
+        error: 'No base64 image data found in response: {"created":123}',
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Closes #10262.

When the OpenAI image API endpoint returns a 200 response with an empty `data: []` array or no `data` field (such as on soft moderation filters or transient upstream edge cases), accessing `data.data[0]` previously caused an uncaught `TypeError` (`Cannot read properties of undefined`), which was caught and wrapped as an opaque `API error: TypeError...` string instead of a clean, structured error.

This PR uses optional chaining (`data?.data?.[0]?.url` and `data?.data?.[0]?.b64_json`) in `formatOutput` and ensures bad responses are cleared from cache via `deleteFromCache`, matching the graceful error handling for present-but-empty entries and existing fixes in Azure (#10124, #9867).

## Changes
- Use optional chaining in `formatOutput` in `src/providers/openai/image.ts`.
- Call `await data?.deleteFromCache?.()` when `formattedOutput` returns an error object in `processApiResponse`.
- Added unit tests in `test/providers/openai/image.functions.test.ts` and `test/providers/openai/image.test.ts` covering empty `data: []` and missing `data` responses for both URL and `b64_json` output formats.

## Testing
- Unit tests: `npm test test/providers/openai/image.test.ts test/providers/openai/image.functions.test.ts` (139/139 passed)
- TypeScript typecheck: `npm run tsc` (passed)