### PR TITLE
feat(eval): distinguish scan footprint from incurred token usage

### DIFF
--- a/src/app/src/pages/eval/components/ResultsTable.tsx
+++ b/src/app/src/pages/eval/components/ResultsTable.tsx
@@ -19,7 +19,11 @@ import { callApi } from '@app/utils/api';
 import { formatDuration } from '@app/utils/date';
 import { normalizeMediaText, resolveAudioSource, resolveImageSource } from '@app/utils/media';
 import { getActualPrompt } from '@app/utils/providerResponse';
-import { getPrimaryTokenUsageLabel, getTokenUsageTotal } from '@app/utils/tokenUsage';
+import {
+  getIncurredTokenAccounting,
+  getPrimaryTokenUsageLabel,
+  getTokenUsageTotal,
+} from '@app/utils/tokenUsage';
 import { FILE_METADATA_KEY, HUMAN_ASSERTION_TYPE } from '@promptfoo/providers/constants';
 import {
   type EvalResultsFilterMode,
@@ -713,6 +717,7 @@ function renderTokenMetrics({
   const primaryTokens = getTokenUsageTotal(metrics?.tokenUsage);
   const attackerTokens = getTokenUsageTotal(metrics?.tokenUsage?.attacker);
   const gradingTokens = getTokenUsageTotal(metrics?.tokenUsage?.assertions);
+  const incurredAccounting = getIncurredTokenAccounting(metrics?.tokenUsage);
 
   if (primaryTokens === 0 && attackerTokens === 0 && gradingTokens === 0) {
     return null;
@@ -768,6 +773,20 @@ function renderTokenMetrics({
             ? null
             : renderFilteredSuffix(formatMetricValue(filteredGradingTokens))}
         </div>
+      ) : null}
+      {incurredAccounting ? (
+        <>
+          <div>
+            <strong>Incurred Tokens:</strong> {formatMetricValue(incurredAccounting.incurredTokens)}
+          </div>
+          <div>
+            <strong>Cached Savings:</strong> {formatMetricValue(incurredAccounting.cachedSavings)}
+          </div>
+          <div>
+            <strong>Actual Target Requests:</strong>{' '}
+            {formatMetricValue(incurredAccounting.actualRequests)}
+          </div>
+        </>
       ) : null}
       <div>
         <strong>Avg Tokens:</strong> {formatMetricValue(totalAverage)}

--- a/src/app/src/pages/redteam/report/components/Report.tsx
+++ b/src/app/src/pages/redteam/report/components/Report.tsx
@@ -29,7 +29,12 @@ import { useTelemetry } from '@app/hooks/useTelemetry';
 import { cn } from '@app/lib/utils';
 import { callApi } from '@app/utils/api';
 import { formatDataGridDate } from '@app/utils/date';
-import { getPrimaryTokenUsageLabel, getTokenUsageTotal } from '@app/utils/tokenUsage';
+import {
+  getCombinedTokenUsageTotal,
+  getIncurredTokenAccounting,
+  getPrimaryTokenUsageLabel,
+  getTokenUsageTotal,
+} from '@app/utils/tokenUsage';
 import {
   type EvaluateResult,
   type EvaluateSummaryV2,
@@ -682,19 +687,12 @@ const App = ({ evalId: evalIdProp, embedded, onActionsReady }: ReportProps = {})
   const generationTokens = getTokenUsageTotal(scanTokenUsage?.generation);
   const generationRequests = scanTokenUsage?.generation?.numRequests ?? 0;
   const evaluationTokens = scanTokenUsage
-    ? getTokenUsageTotal(scanTokenUsage) +
-      getTokenUsageTotal(scanTokenUsage.attacker) +
-      getTokenUsageTotal(scanTokenUsage.assertions)
+    ? getCombinedTokenUsageTotal(scanTokenUsage) - generationTokens
     : prompts.reduce((total, prompt) => {
-        const tokenUsage = prompt.metrics?.tokenUsage;
-        return (
-          total +
-          getTokenUsageTotal(tokenUsage) +
-          getTokenUsageTotal(tokenUsage?.attacker) +
-          getTokenUsageTotal(tokenUsage?.assertions)
-        );
+        return total + getCombinedTokenUsageTotal(prompt.metrics?.tokenUsage);
       }, 0);
   const totalTokens = evaluationTokens + generationTokens;
+  const incurredAccounting = getIncurredTokenAccounting(scanTokenUsage ?? selectedTokenUsage);
   const tableData =
     (evalData.version >= 4
       ? convertResultsToTable(evalData).body
@@ -821,6 +819,22 @@ const App = ({ evalId: evalIdProp, embedded, onActionsReady }: ReportProps = {})
                           <span>
                             <strong>Grading Tokens:</strong> {gradingTokens.toLocaleString()}
                           </span>
+                          {incurredAccounting ? (
+                            <>
+                              <span>
+                                <strong>Incurred Tokens:</strong>{' '}
+                                {incurredAccounting.incurredTokens.toLocaleString()}
+                              </span>
+                              <span>
+                                <strong>Cached Savings:</strong>{' '}
+                                {incurredAccounting.cachedSavings.toLocaleString()}
+                              </span>
+                              <span>
+                                <strong>Actual Target Requests:</strong>{' '}
+                                {incurredAccounting.actualRequests.toLocaleString()}
+                              </span>
+                            </>
+                          ) : null}
                           {prompts.length > 1 || generationTokens > 0 || generationRequests > 0 ? (
                             <>
                               <span>

--- a/src/app/src/utils/tokenUsage.test.ts
+++ b/src/app/src/utils/tokenUsage.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getCombinedTokenUsageTotal,
+  getIncurredTokenAccounting,
+  getPrimaryTokenUsageLabel,
+} from './tokenUsage';
+
+describe('token usage helpers', () => {
+  it('includes each independent token category exactly once', () => {
+    expect(
+      getCombinedTokenUsageTotal({
+        total: 100,
+        attacker: { total: 50 },
+        assertions: { total: 25 },
+        generation: { total: 40 },
+      }),
+    ).toBe(215);
+  });
+
+  it('separates cached scan footprint from fresh grading work', () => {
+    expect(
+      getIncurredTokenAccounting({
+        total: 295,
+        numRequests: 1,
+        assertions: { total: 37 },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          assertions: { total: 37 },
+        },
+      }),
+    ).toEqual({ incurredTokens: 37, cachedSavings: 295, actualRequests: 0 });
+  });
+
+  it('omits redundant details when every provider request was fresh', () => {
+    expect(
+      getIncurredTokenAccounting({
+        total: 100,
+        numRequests: 1,
+        incurredTokenUsage: { total: 100, numRequests: 1 },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('uses target terminology only for red team scans', () => {
+    expect(getPrimaryTokenUsageLabel(true)).toBe('Target');
+    expect(getPrimaryTokenUsageLabel(false)).toBe('Provider');
+  });
+});

--- a/src/app/src/utils/tokenUsage.ts
+++ b/src/app/src/utils/tokenUsage.ts
@@ -4,8 +4,49 @@ interface TokenUsageBreakdown {
   total?: number;
 }
 
+interface CategorizedTokenUsage extends TokenUsageBreakdown {
+  numRequests?: number;
+  attacker?: TokenUsageBreakdown;
+  assertions?: TokenUsageBreakdown;
+  generation?: TokenUsageBreakdown;
+  incurredTokenUsage?: Omit<CategorizedTokenUsage, 'incurredTokenUsage'>;
+}
+
 export function getTokenUsageTotal(usage: TokenUsageBreakdown | undefined): number {
   return usage?.total ?? (usage?.prompt ?? 0) + (usage?.completion ?? 0);
+}
+
+/** Sum independent categories without counting target tokens twice. */
+export function getCombinedTokenUsageTotal(usage: CategorizedTokenUsage | undefined): number {
+  if (!usage) {
+    return 0;
+  }
+
+  return (
+    getTokenUsageTotal(usage) +
+    getTokenUsageTotal(usage.attacker) +
+    getTokenUsageTotal(usage.assertions) +
+    getTokenUsageTotal(usage.generation)
+  );
+}
+
+/** Return avoided response-cache work when logical and incurred usage differ. */
+export function getIncurredTokenAccounting(
+  usage: CategorizedTokenUsage | undefined,
+): { incurredTokens: number; cachedSavings: number; actualRequests: number } | undefined {
+  if (!usage?.incurredTokenUsage) {
+    return undefined;
+  }
+
+  const incurredTokens = getCombinedTokenUsageTotal(usage.incurredTokenUsage);
+  const cachedSavings = Math.max(getCombinedTokenUsageTotal(usage) - incurredTokens, 0);
+  return cachedSavings > 0
+    ? {
+        incurredTokens,
+        cachedSavings,
+        actualRequests: usage.incurredTokenUsage.numRequests ?? 0,
+      }
+    : undefined;
 }
 
 export function getPrimaryTokenUsageLabel(isRedteam: boolean): 'Provider' | 'Target' {

--- a/src/assertions/assertionsResult.ts
+++ b/src/assertions/assertionsResult.ts
@@ -2,7 +2,6 @@ import { isDeepStrictEqual } from 'node:util';
 
 import { getEnvBool } from '../envars';
 import { isGradingResult } from '../types/index';
-import { accumulateTokenUsage, cloneTokenUsageBreakdown } from '../util/tokenUsageUtils';
 
 import type { AssertionSet, GradingResult, ScoringFunction } from '../types/index';
 
@@ -78,10 +77,53 @@ function normalizeAssertionTokenUsage(result: GradingResult) {
 }
 
 function accumulateNormalizedAssertionTokenUsage(
-  target: AssertionTokenUsage,
+  target: NonNullable<GradingResult['tokensUsed']>,
   update: NonNullable<GradingResult['tokensUsed']>,
 ): void {
-  accumulateTokenUsage(target, update);
+  const trackIncurredUsage = Boolean(target.incurredTokenUsage || update.incurredTokenUsage);
+  if (trackIncurredUsage && !target.incurredTokenUsage) {
+    target.incurredTokenUsage = cloneAssertionTokenUsage(target);
+  }
+
+  for (const field of ['total', 'prompt', 'completion', 'cached', 'numRequests'] as const) {
+    target[field] = (target[field] ?? 0) + (update[field] ?? 0);
+  }
+
+  if (update.completionDetails) {
+    const currentDetails = target.completionDetails;
+    const incomingDetails = update.completionDetails;
+    target.completionDetails = {
+      reasoning: (currentDetails?.reasoning ?? 0) + (incomingDetails.reasoning ?? 0),
+      acceptedPrediction:
+        (currentDetails?.acceptedPrediction ?? 0) + (incomingDetails.acceptedPrediction ?? 0),
+      rejectedPrediction:
+        (currentDetails?.rejectedPrediction ?? 0) + (incomingDetails.rejectedPrediction ?? 0),
+      cacheReadInputTokens:
+        (currentDetails?.cacheReadInputTokens ?? 0) + (incomingDetails.cacheReadInputTokens ?? 0),
+      cacheCreationInputTokens:
+        (currentDetails?.cacheCreationInputTokens ?? 0) +
+        (incomingDetails.cacheCreationInputTokens ?? 0),
+    };
+  }
+
+  if (trackIncurredUsage && target.incurredTokenUsage) {
+    accumulateNormalizedAssertionTokenUsage(
+      target.incurredTokenUsage,
+      update.incurredTokenUsage ?? cloneAssertionTokenUsage(update),
+    );
+  }
+}
+
+function cloneAssertionTokenUsage(
+  tokenUsage: NonNullable<GradingResult['tokensUsed']>,
+): NonNullable<NonNullable<GradingResult['tokensUsed']>['incurredTokenUsage']> {
+  const { incurredTokenUsage: _incurredTokenUsage, ...assertionUsage } = tokenUsage;
+  return {
+    ...assertionUsage,
+    ...(assertionUsage.completionDetails && {
+      completionDetails: { ...assertionUsage.completionDetails },
+    }),
+  };
 }
 
 function mergeScoringMetadata(
@@ -151,7 +193,7 @@ function mergeScoringTokenUsage(
       completionDetails: { ...baseTokensUsed.completionDetails },
     }),
     ...(baseTokensUsed?.incurredTokenUsage && {
-      incurredTokenUsage: cloneTokenUsageBreakdown(baseTokensUsed.incurredTokenUsage),
+      incurredTokenUsage: cloneAssertionTokenUsage(baseTokensUsed.incurredTokenUsage),
     }),
   };
   const scorerUsedTokens =

--- a/src/assertions/assertionsResult.ts
+++ b/src/assertions/assertionsResult.ts
@@ -2,6 +2,7 @@ import { isDeepStrictEqual } from 'node:util';
 
 import { getEnvBool } from '../envars';
 import { isGradingResult } from '../types/index';
+import { accumulateTokenUsage, cloneTokenUsageBreakdown } from '../util/tokenUsageUtils';
 
 import type { AssertionSet, GradingResult, ScoringFunction } from '../types/index';
 
@@ -16,7 +17,7 @@ export const DEFAULT_TOKENS_USED = {
 };
 
 type AssertionTokenUsage = typeof DEFAULT_TOKENS_USED &
-  Pick<NonNullable<GradingResult['tokensUsed']>, 'completionDetails'>;
+  Pick<NonNullable<GradingResult['tokensUsed']>, 'completionDetails' | 'incurredTokenUsage'>;
 
 interface ParentAssertionSet {
   index: number;
@@ -57,14 +58,15 @@ function normalizeAssertionTokenUsage(result: GradingResult) {
   if (result.metadata?.cachedResponse === true) {
     const reportedTotal =
       tokensUsed.total ?? (tokensUsed.prompt ?? 0) + (tokensUsed.completion ?? 0);
-    const { completionDetails: _cachedCompletionDetails, ...cachedTokensUsed } = tokensUsed;
+    const logicalTotal = reportedTotal || (tokensUsed.cached ?? 0);
     return {
-      ...cachedTokensUsed,
-      total: 0,
-      prompt: 0,
-      completion: 0,
-      cached: Math.max(tokensUsed.cached ?? 0, reportedTotal),
-      numRequests: 0,
+      ...tokensUsed,
+      total: logicalTotal,
+      prompt: tokensUsed.prompt ?? 0,
+      completion: tokensUsed.completion ?? 0,
+      cached: Math.max(tokensUsed.cached ?? 0, logicalTotal),
+      numRequests: Math.max(tokensUsed.numRequests ?? 0, 1),
+      incurredTokenUsage: { ...DEFAULT_TOKENS_USED },
     };
   }
 
@@ -79,28 +81,7 @@ function accumulateNormalizedAssertionTokenUsage(
   target: AssertionTokenUsage,
   update: NonNullable<GradingResult['tokensUsed']>,
 ): void {
-  for (const field of ['total', 'prompt', 'completion', 'cached', 'numRequests'] as const) {
-    target[field] += update[field] ?? 0;
-  }
-
-  if (!update.completionDetails) {
-    return;
-  }
-
-  const currentDetails = target.completionDetails;
-  const incomingDetails = update.completionDetails;
-  target.completionDetails = {
-    reasoning: (currentDetails?.reasoning ?? 0) + (incomingDetails.reasoning ?? 0),
-    acceptedPrediction:
-      (currentDetails?.acceptedPrediction ?? 0) + (incomingDetails.acceptedPrediction ?? 0),
-    rejectedPrediction:
-      (currentDetails?.rejectedPrediction ?? 0) + (incomingDetails.rejectedPrediction ?? 0),
-    cacheReadInputTokens:
-      (currentDetails?.cacheReadInputTokens ?? 0) + (incomingDetails.cacheReadInputTokens ?? 0),
-    cacheCreationInputTokens:
-      (currentDetails?.cacheCreationInputTokens ?? 0) +
-      (incomingDetails.cacheCreationInputTokens ?? 0),
-  };
+  accumulateTokenUsage(target, update);
 }
 
 function mergeScoringMetadata(
@@ -168,6 +149,9 @@ function mergeScoringTokenUsage(
     numRequests: baseTokensUsed?.numRequests ?? 0,
     ...(baseTokensUsed?.completionDetails && {
       completionDetails: { ...baseTokensUsed.completionDetails },
+    }),
+    ...(baseTokensUsed?.incurredTokenUsage && {
+      incurredTokenUsage: cloneTokenUsageBreakdown(baseTokensUsed.incurredTokenUsage),
     }),
   };
   const scorerUsedTokens =

--- a/src/contracts/providers.ts
+++ b/src/contracts/providers.ts
@@ -38,6 +38,8 @@ export interface ImageOutput {
 export interface ProviderResponse {
   cached?: boolean;
   cost?: number;
+  /** Actual target-provider cost incurred during this run, excluding response-cache replays. */
+  incurredCost?: number;
   error?: string;
   /**
    * Indicates that a remote Promptfoo server already materialized multi-input vars

--- a/src/contracts/shared.ts
+++ b/src/contracts/shared.ts
@@ -21,15 +21,25 @@ const TokenUsageCoreSchema = z.object({
 });
 
 /** Target usage with independent generation, attacker, and assertion breakdowns. */
-export const BaseTokenUsageSchema = TokenUsageCoreSchema.extend({
+const TokenUsageBreakdownSchema = TokenUsageCoreSchema.extend({
   attacker: TokenUsageCoreSchema.optional(),
   assertions: TokenUsageCoreSchema.optional(),
   generation: TokenUsageCoreSchema.optional(),
 });
 
+/**
+ * The root describes the full evaluation footprint, including replayed responses.
+ * The optional incurred view contains only requests executed during this run.
+ */
+export const BaseTokenUsageSchema = TokenUsageBreakdownSchema.extend({
+  incurredTokenUsage: TokenUsageBreakdownSchema.optional(),
+});
+
 export type TokenUsage = z.infer<typeof BaseTokenUsageSchema>;
-export type NormalizedTokenUsage = Required<Omit<TokenUsage, 'attacker' | 'generation'>> &
-  Pick<TokenUsage, 'attacker' | 'generation'>;
+export type NormalizedTokenUsage = Required<
+  Omit<TokenUsage, 'attacker' | 'generation' | 'incurredTokenUsage'>
+> &
+  Pick<TokenUsage, 'attacker' | 'generation' | 'incurredTokenUsage'>;
 
 export type NunjucksFilterMap = Record<string, (...args: any[]) => string>;
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -105,6 +105,7 @@ import {
   accumulateGradingRequest,
   accumulateGradingTokenUsage,
   accumulateResponseTokenUsage,
+  cloneTokenUsageBreakdown,
   createEmptyAssertions,
   createEmptyTokenUsage,
 } from './util/tokenUsageUtils';
@@ -382,6 +383,20 @@ function updateAssertionMetrics(
   options?: { cached?: boolean },
 ): void {
   if (metrics.tokenUsage && assertionTokens) {
+    const reportedTotal =
+      assertionTokens.total ?? (assertionTokens.prompt ?? 0) + (assertionTokens.completion ?? 0);
+    const cachedTokens = assertionTokens.cached ?? 0;
+    const cachedResponse =
+      options?.cached === true ||
+      (options?.cached === undefined &&
+        assertionTokens.numRequests === 0 &&
+        cachedTokens > 0 &&
+        reportedTotal <= cachedTokens);
+
+    if (cachedResponse && !metrics.tokenUsage.incurredTokenUsage) {
+      metrics.tokenUsage.incurredTokenUsage = cloneTokenUsageBreakdown(metrics.tokenUsage);
+    }
+
     if (!metrics.tokenUsage.assertions) {
       metrics.tokenUsage.assertions = createEmptyAssertions();
     }
@@ -389,23 +404,12 @@ function updateAssertionMetrics(
     // Accumulate assertion tokens using the specialized assertion function
     accumulateAssertionTokenUsage(metrics.tokenUsage.assertions, assertionTokens);
 
-    if (metrics.tokenUsage.incurredTokenUsage) {
-      const reportedTotal =
-        assertionTokens.total ?? (assertionTokens.prompt ?? 0) + (assertionTokens.completion ?? 0);
-      const cachedTokens = assertionTokens.cached ?? 0;
-      const cachedResponse =
-        options?.cached === true ||
-        (options?.cached === undefined &&
-          assertionTokens.numRequests === 0 &&
-          cachedTokens > 0 &&
-          reportedTotal <= cachedTokens);
-      if (!cachedResponse) {
-        metrics.tokenUsage.incurredTokenUsage.assertions ??= createEmptyAssertions();
-        accumulateAssertionTokenUsage(
-          metrics.tokenUsage.incurredTokenUsage.assertions,
-          assertionTokens.incurredTokenUsage ?? assertionTokens,
-        );
-      }
+    if (metrics.tokenUsage.incurredTokenUsage && !cachedResponse) {
+      metrics.tokenUsage.incurredTokenUsage.assertions ??= createEmptyAssertions();
+      accumulateAssertionTokenUsage(
+        metrics.tokenUsage.incurredTokenUsage.assertions,
+        assertionTokens.incurredTokenUsage ?? assertionTokens,
+      );
     }
   }
 }
@@ -2087,11 +2091,21 @@ function mergeComparisonTokenUsage(
     prompt: 0,
     completion: 0,
   };
-  updateAssertionMetrics(
-    { tokenUsage: { assertions: result.gradingResult.tokensUsed } },
-    gradingResult.tokensUsed,
-    { cached: gradingResult.metadata?.cachedResponse },
-  );
+  const rowTokensUsed = result.gradingResult.tokensUsed;
+  const rowMetrics = {
+    tokenUsage: {
+      assertions: rowTokensUsed,
+      ...(rowTokensUsed.incurredTokenUsage && {
+        incurredTokenUsage: { assertions: rowTokensUsed.incurredTokenUsage },
+      }),
+    },
+  };
+  updateAssertionMetrics(rowMetrics, gradingResult.tokensUsed, {
+    cached: gradingResult.metadata?.cachedResponse,
+  });
+  if (rowMetrics.tokenUsage.incurredTokenUsage?.assertions) {
+    rowTokensUsed.incurredTokenUsage = rowMetrics.tokenUsage.incurredTokenUsage.assertions;
+  }
 
   if (resultHasModelGradedAssertion(result)) {
     updateAssertionMetrics({ tokenUsage: evalTokenUsage }, gradingResult.tokensUsed, {

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -4440,6 +4440,31 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
       wasScore,
       metrics,
     );
+    if (
+      result.response?.cached &&
+      result.response.tokenUsage &&
+      (result.response.tokenUsage.numRequests ?? 0) === 0 &&
+      gradingResult.tokensUsed
+    ) {
+      const comparisonUsage = createEmptyAssertions();
+      accumulateGradingRequest(comparisonUsage, gradingResult.tokensUsed, {
+        cached: gradingResult.metadata?.cachedResponse,
+      });
+      if ((comparisonUsage.numRequests ?? 0) > 0) {
+        result.response.tokenUsage.numRequests = 1;
+        const evaluatedResult = this.store.toEvaluateResult(result);
+        if (evaluatedResult.tokenUsage) {
+          evaluatedResult.tokenUsage.numRequests = Math.max(
+            evaluatedResult.tokenUsage.numRequests ?? 0,
+            1,
+          );
+        }
+        this.stats.tokenUsage.numRequests = (this.stats.tokenUsage.numRequests ?? 0) + 1;
+        if (metrics) {
+          metrics.tokenUsage.numRequests = (metrics.tokenUsage.numRequests ?? 0) + 1;
+        }
+      }
+    }
     this.trackFinalJsonlResult(result);
     if (this.store.persisted && !this.store.hasResultPersistenceFailure(result)) {
       await this.store.saveResult(result);

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -598,6 +598,12 @@ function applyGradingResult(row: EvaluateResult, checkResult: GradingResult) {
   accumulateGradingRequest(row.tokenUsage.assertions, checkResult.tokensUsed, {
     cached: checkResult.metadata?.cachedResponse,
   });
+  if (row.response?.cached && (row.tokenUsage.assertions.numRequests ?? 0) > 0) {
+    row.tokenUsage.numRequests = Math.max(row.tokenUsage.numRequests ?? 0, 1);
+    if (row.response.tokenUsage) {
+      row.response.tokenUsage.numRequests = row.tokenUsage.numRequests;
+    }
+  }
   row.gradingResult = checkResult;
 }
 
@@ -1248,6 +1254,17 @@ function createEvaluateResult({
   return ret;
 }
 
+/** Persist only avoided usage for cached targets so later metric refreshes remain accurate. */
+function normalizeCachedTargetResponse(response: ProviderResponse): ProviderResponse {
+  if (!response.cached) {
+    return response;
+  }
+
+  const tokenUsage = createEmptyTokenUsage();
+  accumulateResponseTokenUsage(tokenUsage, response);
+  return { ...response, tokenUsage };
+}
+
 function trackProviderUsage(provider: ApiProvider, response: ProviderResponse) {
   if (!response.tokenUsage) {
     return;
@@ -1256,7 +1273,7 @@ function trackProviderUsage(provider: ApiProvider, response: ProviderResponse) {
   const trackingId = provider.constructor?.name
     ? `${providerId} (${provider.constructor.name})`
     : providerId;
-  TokenUsageTracker.getInstance().trackUsage(trackingId, response.tokenUsage);
+  TokenUsageTracker.getInstance().trackResponseUsage(trackingId, response);
 }
 
 async function applyRunEvalResponseOutcome({
@@ -1662,7 +1679,7 @@ async function runEvalInternal({
             traceContext: executionTraceContext,
             vars: state.vars,
           });
-          const { response } = providerCall;
+          const response = normalizeCachedTargetResponse(providerCall.response);
           latencyMs = providerCall.latencyMs;
 
           updateConversationHistory({
@@ -3459,7 +3476,9 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
     metrics.assertFailCount +=
       row.gradingResult?.componentResults?.filter((r) => !r.pass).length || 0;
     metrics.totalLatencyMs += row.latencyMs || 0;
-    accumulateResponseTokenUsage(metrics.tokenUsage, row.response);
+    accumulateResponseTokenUsage(metrics.tokenUsage, row.response, {
+      countCachedAsRequest: (row.tokenUsage?.numRequests ?? 0) > 0,
+    });
 
     if (row.gradingResult?.tokensUsed) {
       updateAssertionMetrics(metrics, row.gradingResult.tokensUsed);

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -103,6 +103,7 @@ import { TokenUsageTracker } from './util/tokenUsage';
 import {
   accumulateAssertionTokenUsage,
   accumulateGradingRequest,
+  accumulateGradingTokenUsage,
   accumulateResponseTokenUsage,
   createEmptyAssertions,
   createEmptyTokenUsage,
@@ -378,6 +379,7 @@ export class ProgressBarManager {
 function updateAssertionMetrics(
   metrics: { tokenUsage: Partial<TokenUsage> },
   assertionTokens: Partial<TokenUsage>,
+  options?: { cached?: boolean },
 ): void {
   if (metrics.tokenUsage && assertionTokens) {
     if (!metrics.tokenUsage.assertions) {
@@ -386,6 +388,25 @@ function updateAssertionMetrics(
 
     // Accumulate assertion tokens using the specialized assertion function
     accumulateAssertionTokenUsage(metrics.tokenUsage.assertions, assertionTokens);
+
+    if (metrics.tokenUsage.incurredTokenUsage) {
+      const reportedTotal =
+        assertionTokens.total ?? (assertionTokens.prompt ?? 0) + (assertionTokens.completion ?? 0);
+      const cachedTokens = assertionTokens.cached ?? 0;
+      const cachedResponse =
+        options?.cached === true ||
+        (options?.cached === undefined &&
+          assertionTokens.numRequests === 0 &&
+          cachedTokens > 0 &&
+          reportedTotal <= cachedTokens);
+      if (!cachedResponse) {
+        metrics.tokenUsage.incurredTokenUsage.assertions ??= createEmptyAssertions();
+        accumulateAssertionTokenUsage(
+          metrics.tokenUsage.incurredTokenUsage.assertions,
+          assertionTokens.incurredTokenUsage ?? assertionTokens,
+        );
+      }
+    }
   }
 }
 
@@ -592,18 +613,9 @@ function applyGradingResult(row: EvaluateResult, checkResult: GradingResult) {
   if (!row.tokenUsage) {
     row.tokenUsage = createEmptyTokenUsage();
   }
-  if (!row.tokenUsage.assertions) {
-    row.tokenUsage.assertions = createEmptyAssertions();
-  }
-  accumulateGradingRequest(row.tokenUsage.assertions, checkResult.tokensUsed, {
+  accumulateGradingTokenUsage(row.tokenUsage, checkResult.tokensUsed, {
     cached: checkResult.metadata?.cachedResponse,
   });
-  if (row.response?.cached && (row.tokenUsage.assertions.numRequests ?? 0) > 0) {
-    row.tokenUsage.numRequests = Math.max(row.tokenUsage.numRequests ?? 0, 1);
-    if (row.response.tokenUsage) {
-      row.response.tokenUsage.numRequests = row.tokenUsage.numRequests;
-    }
-  }
   row.gradingResult = checkResult;
 }
 
@@ -1233,6 +1245,7 @@ function createEvaluateResult({
     namedScores: {},
     latencyMs: response.latencyMs ?? latencyMs,
     cost: response.cost,
+    ...(response.incurredCost !== undefined && { incurredCost: response.incurredCost }),
     metadata: {
       ...test.metadata,
       ...response.metadata,
@@ -1254,15 +1267,22 @@ function createEvaluateResult({
   return ret;
 }
 
-/** Persist only avoided usage for cached targets so later metric refreshes remain accurate. */
+/** Persist both the logical evaluation footprint and the work actually incurred. */
 function normalizeCachedTargetResponse(response: ProviderResponse): ProviderResponse {
-  if (!response.cached) {
+  if (!response.cached && !response.tokenUsage) {
     return response;
   }
 
   const tokenUsage = createEmptyTokenUsage();
   accumulateResponseTokenUsage(tokenUsage, response);
-  return { ...response, tokenUsage };
+  return {
+    ...response,
+    tokenUsage,
+    ...(response.cost !== undefined &&
+      (response.cached || response.incurredCost !== undefined) && {
+        incurredCost: response.incurredCost ?? (response.cached ? 0 : response.cost),
+      }),
+  };
 }
 
 function trackProviderUsage(provider: ApiProvider, response: ProviderResponse) {
@@ -2070,10 +2090,13 @@ function mergeComparisonTokenUsage(
   updateAssertionMetrics(
     { tokenUsage: { assertions: result.gradingResult.tokensUsed } },
     gradingResult.tokensUsed,
+    { cached: gradingResult.metadata?.cachedResponse },
   );
 
   if (resultHasModelGradedAssertion(result)) {
-    updateAssertionMetrics({ tokenUsage: evalTokenUsage }, gradingResult.tokensUsed);
+    updateAssertionMetrics({ tokenUsage: evalTokenUsage }, gradingResult.tokensUsed, {
+      cached: gradingResult.metadata?.cachedResponse,
+    });
   }
 }
 
@@ -3378,12 +3401,13 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
     wasSuccess: boolean,
     wasScore: number,
     metrics: CompletedPrompt['metrics'] | undefined,
+    gradingCached?: boolean,
   ): void {
     if (metrics) {
       metrics.assertPassCount += passed ? 1 : 0;
       metrics.assertFailCount += passed ? 0 : 1;
       if (tokensUsed) {
-        updateAssertionMetrics(metrics, tokensUsed);
+        updateAssertionMetrics(metrics, tokensUsed, { cached: gradingCached });
       }
       if (!passed && result.score !== wasScore) {
         metrics.score += result.score - wasScore;
@@ -3481,9 +3505,15 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
     });
 
     if (row.gradingResult?.tokensUsed) {
-      updateAssertionMetrics(metrics, row.gradingResult.tokensUsed);
+      accumulateGradingTokenUsage(metrics.tokenUsage, row.gradingResult.tokensUsed, {
+        cached: row.gradingResult.metadata?.cachedResponse,
+      });
     }
 
+    if (row.incurredCost !== undefined || metrics.incurredCost !== undefined) {
+      metrics.incurredCost =
+        (metrics.incurredCost ?? metrics.cost) + (row.incurredCost ?? row.cost ?? 0);
+    }
     metrics.cost += row.cost || 0;
   }
 
@@ -4439,6 +4469,7 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
       wasSuccess,
       wasScore,
       metrics,
+      gradingResult.metadata?.cachedResponse,
     );
     if (
       result.response?.cached &&

--- a/src/matchers/comparison.ts
+++ b/src/matchers/comparison.ts
@@ -46,10 +46,24 @@ export async function matchesSelectBest(
     templateVars,
     providerCallContext,
   );
+  const tokensUsed = normalizeMatcherTokenUsage(
+    resp.cached
+      ? {
+          ...resp.tokenUsage,
+          cached: Math.max(
+            resp.tokenUsage?.cached ?? 0,
+            resp.tokenUsage?.total ??
+              (resp.tokenUsage?.prompt ?? 0) + (resp.tokenUsage?.completion ?? 0),
+          ),
+        }
+      : resp.tokenUsage,
+  );
+  const cacheMetadata = resp.cached ? { metadata: { cachedResponse: true } } : {};
   if (resp.error || !resp.output) {
-    return Array.from({ length: outputs.length }, () =>
-      fail(resp.error || 'No output', resp.tokenUsage),
-    );
+    return Array.from({ length: outputs.length }, () => ({
+      ...fail(resp.error || 'No output', tokensUsed),
+      ...cacheMetadata,
+    }));
   }
 
   invariant(typeof resp.output === 'string', 'select-best produced malformed response');
@@ -58,12 +72,12 @@ export async function matchesSelectBest(
   const verdict = firstIntegerMatch ? Number.parseInt(firstIntegerMatch[0], 10) : Number.NaN;
 
   if (Number.isNaN(verdict) || verdict < 0 || verdict >= outputs.length) {
-    return Array.from({ length: outputs.length }, () =>
-      fail(`Invalid select-best verdict: ${verdict}`, resp.tokenUsage),
-    );
+    return Array.from({ length: outputs.length }, () => ({
+      ...fail(`Invalid select-best verdict: ${verdict}`, tokensUsed),
+      ...cacheMetadata,
+    }));
   }
 
-  const tokensUsed = normalizeMatcherTokenUsage(resp.tokenUsage);
   return outputs.map((_output, index) => {
     if (index === verdict) {
       return {
@@ -71,6 +85,7 @@ export async function matchesSelectBest(
         score: 1,
         reason: `Output selected as the best: ${criteria}`,
         tokensUsed,
+        ...cacheMetadata,
       };
     } else {
       return {
@@ -78,6 +93,7 @@ export async function matchesSelectBest(
         score: 0,
         reason: `Output not selected: ${criteria}`,
         tokensUsed,
+        ...cacheMetadata,
       };
     }
   });

--- a/src/matchers/shared.ts
+++ b/src/matchers/shared.ts
@@ -3,8 +3,8 @@ import type { GradingResult, TokenUsage } from '../types/index';
 /**
  * Normalize token usage for matcher results. Unlike the evaluator-level
  * normalizeTokenUsage, this excludes the `assertions` field and preserves
- * the existing completionDetails shape (passing through whatever the
- * provider returned, or undefined if not present).
+ * the existing completionDetails shape and any incurred usage reported by
+ * the provider.
  */
 export function normalizeMatcherTokenUsage(
   tokenUsage: Partial<TokenUsage> | undefined,
@@ -26,6 +26,9 @@ export function normalizeMatcherTokenUsage(
       acceptedPrediction: 0,
       rejectedPrediction: 0,
     },
+    ...(tokenUsage?.incurredTokenUsage && {
+      incurredTokenUsage: tokenUsage.incurredTokenUsage,
+    }),
   };
 }
 

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -24,7 +24,7 @@ import { safeJsonStringify } from '../util/json';
 import { isSecretField, REDACTED, sanitizeObject } from '../util/sanitizer';
 import { getCurrentTimestamp } from '../util/time';
 import {
-  accumulateGradingRequest,
+  accumulateGradingTokenUsage,
   accumulateResponseTokenUsage,
   createEmptyTokenUsage,
 } from '../util/tokenUsageUtils';
@@ -991,16 +991,16 @@ export default class EvalResult {
       accumulateResponseTokenUsage(tokenUsage, this.response);
     }
     if (this.gradingResult) {
-      accumulateGradingRequest(tokenUsage.assertions, this.gradingResult.tokensUsed, {
+      accumulateGradingTokenUsage(tokenUsage, this.gradingResult.tokensUsed, {
         cached: this.gradingResult.metadata?.cachedResponse,
       });
-      if (this.response?.cached && (tokenUsage.assertions.numRequests ?? 0) > 0) {
-        tokenUsage.numRequests = Math.max(tokenUsage.numRequests ?? 0, 1);
-      }
     }
 
     return {
       cost: this.cost,
+      ...(this.response?.incurredCost !== undefined && {
+        incurredCost: this.response.incurredCost,
+      }),
       description: this.description || undefined,
       error: this.error || undefined,
       gradingResult: shouldStripGradingResult ? null : this.gradingResult,

--- a/src/models/evalResult.ts
+++ b/src/models/evalResult.ts
@@ -994,6 +994,9 @@ export default class EvalResult {
       accumulateGradingRequest(tokenUsage.assertions, this.gradingResult.tokensUsed, {
         cached: this.gradingResult.metadata?.cachedResponse,
       });
+      if (this.response?.cached && (tokenUsage.assertions.numRequests ?? 0) > 0) {
+        tokenUsage.numRequests = Math.max(tokenUsage.numRequests ?? 0, 1);
+      }
     }
 
     return {

--- a/src/node/retry.ts
+++ b/src/node/retry.ts
@@ -20,9 +20,8 @@ import { writeMultipleOutputs } from '../util/output';
 import { getOutputFileFormat } from '../util/outputFormats';
 import { shouldShareResults } from '../util/sharing';
 import {
-  accumulateAssertionTokenUsage,
+  accumulateGradingTokenUsage,
   accumulateResponseTokenUsage,
-  createEmptyAssertions,
   createEmptyTokenUsage,
 } from '../util/tokenUsageUtils';
 
@@ -271,20 +270,14 @@ export async function recalculatePromptMetrics(evalRecord: Eval): Promise<void> 
 
         // Update token usage
         if (result.response?.tokenUsage) {
-          accumulateResponseTokenUsage(metrics.tokenUsage, {
-            tokenUsage: result.response.tokenUsage,
-          });
+          accumulateResponseTokenUsage(metrics.tokenUsage, result.response);
         }
 
         // Update assertion token usage
         if (result.gradingResult?.tokensUsed) {
-          if (!metrics.tokenUsage.assertions) {
-            metrics.tokenUsage.assertions = createEmptyAssertions();
-          }
-          accumulateAssertionTokenUsage(
-            metrics.tokenUsage.assertions,
-            result.gradingResult.tokensUsed,
-          );
+          accumulateGradingTokenUsage(metrics.tokenUsage, result.gradingResult.tokensUsed, {
+            cached: result.gradingResult.metadata?.cachedResponse,
+          });
         }
       }
 

--- a/src/providers/simulatedUser.ts
+++ b/src/providers/simulatedUser.ts
@@ -234,16 +234,12 @@ export class SimulatedUser implements ApiProvider {
     tokenUsage: TokenUsage,
     response: ProviderResponse,
   ): void {
-    if (!response.cached) {
-      accumulateResponseTokenUsage(tokenUsage, response);
-    }
+    accumulateResponseTokenUsage(tokenUsage, response);
   }
 
-  /** Accumulate fresh target usage without charging Promptfoo response-cache hits. */
+  /** Preserve logical target usage while separately recording cache-missed requests. */
   private accumulateTargetTokenUsage(tokenUsage: TokenUsage, response: ProviderResponse): void {
-    if (!response.cached) {
-      accumulateResponseTokenUsage(tokenUsage, response);
-    }
+    accumulateResponseTokenUsage(tokenUsage, response);
   }
 
   private async sendMessageToAgent(

--- a/src/redteam/providers/bestOfN.ts
+++ b/src/redteam/providers/bestOfN.ts
@@ -200,13 +200,21 @@ export default class BestOfNProvider implements ApiProvider {
       );
 
       if (successfulResponse) {
-        (successfulResponse as ProviderResponse).tokenUsage = targetTokenUsage;
-        return successfulResponse;
+        const aggregatedResponse = successfulResponse as ProviderResponse;
+        aggregatedResponse.tokenUsage = targetTokenUsage;
+        if (aggregatedResponse.cached && (targetTokenUsage.numRequests ?? 0) > 0) {
+          aggregatedResponse.cached = false;
+        }
+        return aggregatedResponse;
       }
       if (lastResponse) {
-        (lastResponse as ProviderResponse).tokenUsage = targetTokenUsage;
-        (lastResponse as ProviderResponse).metadata = {
-          ...((lastResponse as ProviderResponse).metadata ?? {}),
+        const aggregatedResponse = lastResponse as ProviderResponse;
+        aggregatedResponse.tokenUsage = targetTokenUsage;
+        if (aggregatedResponse.cached && (targetTokenUsage.numRequests ?? 0) > 0) {
+          aggregatedResponse.cached = false;
+        }
+        aggregatedResponse.metadata = {
+          ...(aggregatedResponse.metadata ?? {}),
           sessionIds,
         };
       }

--- a/src/redteam/providers/bestOfN.ts
+++ b/src/redteam/providers/bestOfN.ts
@@ -202,7 +202,10 @@ export default class BestOfNProvider implements ApiProvider {
       if (successfulResponse) {
         const aggregatedResponse = successfulResponse as ProviderResponse;
         aggregatedResponse.tokenUsage = targetTokenUsage;
-        if (aggregatedResponse.cached && (targetTokenUsage.numRequests ?? 0) > 0) {
+        if (
+          aggregatedResponse.cached &&
+          (targetTokenUsage.incurredTokenUsage?.numRequests ?? 0) > 0
+        ) {
           aggregatedResponse.cached = false;
         }
         return aggregatedResponse;
@@ -210,7 +213,10 @@ export default class BestOfNProvider implements ApiProvider {
       if (lastResponse) {
         const aggregatedResponse = lastResponse as ProviderResponse;
         aggregatedResponse.tokenUsage = targetTokenUsage;
-        if (aggregatedResponse.cached && (targetTokenUsage.numRequests ?? 0) > 0) {
+        if (
+          aggregatedResponse.cached &&
+          (targetTokenUsage.incurredTokenUsage?.numRequests ?? 0) > 0
+        ) {
           aggregatedResponse.cached = false;
         }
         aggregatedResponse.metadata = {

--- a/src/redteam/providers/bestOfN.ts
+++ b/src/redteam/providers/bestOfN.ts
@@ -80,6 +80,8 @@ export default class BestOfNProvider implements ApiProvider {
 
     const targetProvider: ApiProvider = context.originalProvider;
     const targetTokenUsage = createEmptyTokenUsage();
+    let targetCost: number | undefined;
+    let incurredTargetCost: number | undefined;
     const sessionIds: string[] = [];
     try {
       // Get candidate prompts from the server
@@ -180,6 +182,12 @@ export default class BestOfNProvider implements ApiProvider {
             }
             lastResponse = response;
             accumulateResponseTokenUsage(targetTokenUsage, response);
+            if (response.cost !== undefined) {
+              targetCost = (targetCost ?? 0) + response.cost;
+              incurredTargetCost =
+                (incurredTargetCost ?? 0) +
+                (response.incurredCost ?? (response.cached ? 0 : response.cost));
+            }
             currentStep++;
             if (!response.error) {
               successfulResponse = response;
@@ -199,8 +207,8 @@ export default class BestOfNProvider implements ApiProvider {
         },
       );
 
-      if (successfulResponse) {
-        const aggregatedResponse = successfulResponse as ProviderResponse;
+      const aggregatedResponse = (successfulResponse ?? lastResponse) as ProviderResponse | null;
+      if (aggregatedResponse) {
         aggregatedResponse.tokenUsage = targetTokenUsage;
         if (
           aggregatedResponse.cached &&
@@ -208,30 +216,30 @@ export default class BestOfNProvider implements ApiProvider {
         ) {
           aggregatedResponse.cached = false;
         }
+
+        if (targetCost !== undefined) {
+          aggregatedResponse.cost = targetCost;
+          if (incurredTargetCost !== targetCost || aggregatedResponse.incurredCost !== undefined) {
+            aggregatedResponse.incurredCost = incurredTargetCost;
+          }
+        }
+
+        if (!successfulResponse) {
+          aggregatedResponse.metadata = {
+            ...(aggregatedResponse.metadata ?? {}),
+            sessionIds,
+          };
+        }
+
         return aggregatedResponse;
       }
-      if (lastResponse) {
-        const aggregatedResponse = lastResponse as ProviderResponse;
-        aggregatedResponse.tokenUsage = targetTokenUsage;
-        if (
-          aggregatedResponse.cached &&
-          (targetTokenUsage.incurredTokenUsage?.numRequests ?? 0) > 0
-        ) {
-          aggregatedResponse.cached = false;
-        }
-        aggregatedResponse.metadata = {
-          ...(aggregatedResponse.metadata ?? {}),
+
+      return {
+        error: 'All candidates failed',
+        metadata: {
           sessionIds,
-        };
-      }
-      return (
-        lastResponse || {
-          error: 'All candidates failed',
-          metadata: {
-            sessionIds,
-          },
-        }
-      );
+        },
+      };
     } catch (err) {
       // Re-throw abort errors to properly cancel the operation
       if (err instanceof Error && err.name === 'AbortError') {

--- a/src/redteam/providers/crescendo/index.ts
+++ b/src/redteam/providers/crescendo/index.ts
@@ -895,7 +895,7 @@ export class CrescendoProvider implements ApiProvider {
     );
 
     accumulateAttackerTokenUsage(totalTokenUsage, response);
-    TokenUsageTracker.getInstance().trackUsage(redTeamingChat.id(), response.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(redTeamingChat.id(), response);
 
     if (redTeamingChat.delay) {
       logger.debug(`[Crescendo] Sleeping for ${redTeamingChat.delay}ms`);
@@ -1310,7 +1310,7 @@ export class CrescendoProvider implements ApiProvider {
       },
       options,
     );
-    TokenUsageTracker.getInstance().trackUsage(scoringProvider.id(), refusalResponse.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(scoringProvider.id(), refusalResponse);
     accumulateGradingResponseTokenUsage(tokenUsage, refusalResponse);
     if (scoringProvider.delay) {
       logger.debug(`[Crescendo] Sleeping for ${scoringProvider.delay}ms`);
@@ -1376,7 +1376,7 @@ export class CrescendoProvider implements ApiProvider {
       },
       options,
     );
-    TokenUsageTracker.getInstance().trackUsage(scoringProvider.id(), evalResponse.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(scoringProvider.id(), evalResponse);
     accumulateGradingResponseTokenUsage(tokenUsage, evalResponse);
     if (scoringProvider.delay) {
       logger.debug(`[Crescendo] Sleeping for ${scoringProvider.delay}ms`);

--- a/src/redteam/providers/custom/index.ts
+++ b/src/redteam/providers/custom/index.ts
@@ -756,7 +756,7 @@ export class CustomProvider implements ApiProvider {
       options,
     );
     accumulateAttackerTokenUsage(totalTokenUsage, response);
-    TokenUsageTracker.getInstance().trackUsage(redTeamingChat.id(), response.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(redTeamingChat.id(), response);
     if (redTeamingChat.delay) {
       logger.debug(`[Custom] Sleeping for ${redTeamingChat.delay}ms`);
       await sleep(redTeamingChat.delay);
@@ -1002,7 +1002,7 @@ export class CustomProvider implements ApiProvider {
       },
       options,
     );
-    TokenUsageTracker.getInstance().trackUsage(scoringProvider.id(), refusalResponse.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(scoringProvider.id(), refusalResponse);
     accumulateGradingResponseTokenUsage(tokenUsage, refusalResponse);
     if (scoringProvider.delay) {
       logger.debug(`[Custom] Sleeping for ${scoringProvider.delay}ms`);
@@ -1066,7 +1066,7 @@ export class CustomProvider implements ApiProvider {
       },
       options,
     );
-    TokenUsageTracker.getInstance().trackUsage(scoringProvider.id(), evalResponse.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(scoringProvider.id(), evalResponse);
     accumulateGradingResponseTokenUsage(tokenUsage, evalResponse);
     if (scoringProvider.delay) {
       logger.debug(`[Custom] Sleeping for ${scoringProvider.delay}ms`);

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -284,7 +284,7 @@ export async function runRedteamConversation({
       },
       options,
     );
-    TokenUsageTracker.getInstance().trackUsage(redteamProvider.id(), redteamResp.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(redteamProvider.id(), redteamResp);
     accumulateAttackerTokenUsage(totalTokenUsage, redteamResp);
     if (redteamProvider.delay) {
       logger.debug(`[Iterative] Sleeping for ${redteamProvider.delay}ms`);
@@ -669,7 +669,7 @@ export async function runRedteamConversation({
       options,
     );
 
-    TokenUsageTracker.getInstance().trackUsage(gradingProvider.id(), judgeResp.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(gradingProvider.id(), judgeResp);
     accumulateGradingResponseTokenUsage(totalTokenUsage, judgeResp);
     if (gradingProvider.delay) {
       logger.debug(`[Iterative] Sleeping for ${gradingProvider.delay}ms`);

--- a/src/redteam/providers/iterativeImage.ts
+++ b/src/redteam/providers/iterativeImage.ts
@@ -314,7 +314,7 @@ async function runRedteamConversation({
         await sleep(redteamProvider.delay);
       }
 
-      TokenUsageTracker.getInstance().trackUsage(redteamProvider.id(), redteamResp.tokenUsage);
+      TokenUsageTracker.getInstance().trackResponseUsage(redteamProvider.id(), redteamResp);
       accumulateAttackerTokenUsage(totalTokenUsage, redteamResp);
 
       if (redteamResp.error) {
@@ -507,7 +507,7 @@ async function runRedteamConversation({
         await sleep(redteamProvider.delay);
       }
 
-      TokenUsageTracker.getInstance().trackUsage(redteamProvider.id(), judgeResp.tokenUsage);
+      TokenUsageTracker.getInstance().trackResponseUsage(redteamProvider.id(), judgeResp);
 
       let score: number;
       let scoreComponents: JudgeResponse['currentResponse']['components'];

--- a/src/redteam/providers/iterativeTree.ts
+++ b/src/redteam/providers/iterativeTree.ts
@@ -216,7 +216,7 @@ export async function evaluateResponse(
     },
     vars: {},
   });
-  TokenUsageTracker.getInstance().trackUsage(provider.id(), judgeResp.tokenUsage);
+  TokenUsageTracker.getInstance().trackResponseUsage(provider.id(), judgeResp);
   if (tokenUsage) {
     accumulateGradingResponseTokenUsage(tokenUsage, judgeResp);
   }
@@ -306,7 +306,7 @@ export async function getNewPrompt(
   if (totalTokenUsage) {
     accumulateAttackerTokenUsage(totalTokenUsage, redteamResp);
   }
-  TokenUsageTracker.getInstance().trackUsage(redteamProvider.id(), redteamResp.tokenUsage);
+  TokenUsageTracker.getInstance().trackResponseUsage(redteamProvider.id(), redteamResp);
   if (redteamProvider.delay) {
     logger.debug(`[IterativeTree] Sleeping for ${redteamProvider.delay}ms`);
     await sleep(redteamProvider.delay);

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -987,7 +987,7 @@ export async function tryUnblocking({
       vars: {},
     });
 
-    TokenUsageTracker.getInstance().trackUsage(unblockingProvider.id(), response.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(unblockingProvider.id(), response);
 
     if (response.error) {
       logger.error(`[Unblocking] Unblocking provider error: ${response.error}`);

--- a/src/redteam/providers/voiceCrescendo/index.ts
+++ b/src/redteam/providers/voiceCrescendo/index.ts
@@ -336,7 +336,7 @@ export class VoiceCrescendoProvider implements ApiProvider {
     );
 
     accumulateAttackerTokenUsage(totalTokenUsage, response);
-    TokenUsageTracker.getInstance().trackUsage(redTeamProvider.id(), response.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(redTeamProvider.id(), response);
 
     if (response.error) {
       throw new Error(`Failed to generate voice prompt: ${response.error}`);
@@ -434,7 +434,7 @@ export class VoiceCrescendoProvider implements ApiProvider {
       ]),
     );
 
-    TokenUsageTracker.getInstance().trackUsage(scoringProvider.id(), evalResponse.tokenUsage);
+    TokenUsageTracker.getInstance().trackResponseUsage(scoringProvider.id(), evalResponse);
 
     if (evalResponse.error) {
       logger.warn(`[VoiceCrescendo] Evaluation error: ${evalResponse.error}`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -342,6 +342,7 @@ const PromptMetricsSchema = z.object({
     })
     .optional(),
   cost: z.number(),
+  incurredCost: z.number().optional(),
 });
 export type PromptMetrics = z.infer<typeof PromptMetricsSchema>;
 
@@ -407,6 +408,7 @@ export interface EvaluateResult {
   gradingResult?: GradingResult | null;
   namedScores: Record<string, number>;
   cost?: number;
+  incurredCost?: number;
   metadata?: Record<string, any>;
   tokenUsage?: NormalizedTokenUsage;
   /**

--- a/src/util/calculateFilteredMetrics.ts
+++ b/src/util/calculateFilteredMetrics.ts
@@ -57,7 +57,12 @@ function jsonUsageTotal(column: SQL, usagePath: string, cachedResponsePath?: str
     : sql`0`;
 
   return sql`CASE
-    WHEN ${explicitlyCached} THEN 0
+    WHEN ${explicitlyCached} THEN
+      CASE
+        WHEN COALESCE(${explicitTotal}, 0) > 0 THEN ${explicitTotal}
+        WHEN ${cached} > 0 THEN ${cached}
+        ELSE ${prompt} + ${completion}
+      END
     WHEN ${explicitTotal} IS NOT NULL THEN ${explicitTotal}
     WHEN ${requests} = 0 AND ${cached} > 0 AND (${prompt} + ${completion}) <= ${cached} THEN 0
     ELSE ${prompt} + ${completion}
@@ -69,8 +74,9 @@ function jsonUsageRequests(column: SQL, usagePath: string, cachedResponsePath?: 
     ? sql`COALESCE(json_extract(${column}, ${cachedResponsePath}), 0) = 1`
     : sql`0`;
   return sql`CASE
-    WHEN ${explicitlyCached} THEN 0
     WHEN json_extract(${column}, ${usagePath}) IS NULL THEN 0
+    WHEN ${explicitlyCached} THEN
+      MAX(COALESCE(CAST(json_extract(${column}, ${`${usagePath}.numRequests`}) AS INTEGER), 1), 1)
     ELSE COALESCE(CAST(json_extract(${column}, ${`${usagePath}.numRequests`}) AS INTEGER), 1)
   END`;
 }
@@ -90,6 +96,144 @@ function jsonUsageCached(column: SQL, usagePath: string, cachedResponsePath?: st
       CASE WHEN ${cached} > 0 THEN ${cached} ELSE ${reportedTotal} END
     ELSE ${cached}
   END`;
+}
+
+type TokenUsageField = 'total' | 'prompt' | 'completion' | 'cached' | 'numRequests';
+
+interface FilteredBasicMetricsRow {
+  prompt_idx: number;
+  total_count: number;
+  pass_count: number;
+  fail_count: number;
+  error_count: number;
+  total_score: number;
+  total_latency: number;
+  total_cost: number;
+  total_tokens: number | null;
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+  cached_tokens: number | null;
+  num_requests_with_tokens: number;
+  attacker_total_tokens: number | null;
+  attacker_prompt_tokens: number | null;
+  attacker_completion_tokens: number | null;
+  attacker_cached_tokens: number | null;
+  attacker_num_requests: number | null;
+  grading_total_tokens: number | null;
+  grading_prompt_tokens: number | null;
+  grading_completion_tokens: number | null;
+  grading_cached_tokens: number | null;
+  grading_num_requests: number | null;
+  has_incurred_usage: number;
+  incurred_total_tokens: number | null;
+  incurred_prompt_tokens: number | null;
+  incurred_completion_tokens: number | null;
+  incurred_cached_tokens: number | null;
+  incurred_num_requests: number | null;
+  incurred_attacker_total_tokens: number | null;
+  incurred_attacker_prompt_tokens: number | null;
+  incurred_attacker_completion_tokens: number | null;
+  incurred_attacker_cached_tokens: number | null;
+  incurred_attacker_num_requests: number | null;
+  incurred_grading_total_tokens: number | null;
+  incurred_grading_prompt_tokens: number | null;
+  incurred_grading_completion_tokens: number | null;
+  incurred_grading_cached_tokens: number | null;
+  incurred_grading_num_requests: number | null;
+}
+
+function jsonUsageField(
+  column: SQL,
+  usagePath: string,
+  field: TokenUsageField,
+  cachedResponsePath?: string,
+): SQL {
+  switch (field) {
+    case 'total':
+      return jsonUsageTotal(column, usagePath, cachedResponsePath);
+    case 'numRequests':
+      return jsonUsageRequests(column, usagePath, cachedResponsePath);
+    case 'cached':
+      return jsonUsageCached(column, usagePath, cachedResponsePath);
+    default:
+      return jsonUsageNumber(column, usagePath, field);
+  }
+}
+
+function jsonIncurredUsageField(
+  column: SQL,
+  logicalPath: string,
+  incurredPath: string,
+  field: TokenUsageField,
+  options?: { cachedResponsePath?: string; parentIncurredPath?: string },
+): SQL {
+  const logicalUsage = jsonUsageField(column, logicalPath, field, options?.cachedResponsePath);
+  const incurredUsage = jsonUsageField(column, incurredPath, field);
+  const parentHasIncurredUsage = options?.parentIncurredPath
+    ? sql`json_extract(${column}, ${options.parentIncurredPath}) IS NOT NULL`
+    : sql`0`;
+  const explicitlyCached = options?.cachedResponsePath
+    ? sql`COALESCE(json_extract(${column}, ${options.cachedResponsePath}), 0) = 1`
+    : sql`0`;
+
+  return sql`CASE
+    WHEN json_extract(${column}, ${incurredPath}) IS NOT NULL THEN ${incurredUsage}
+    WHEN ${parentHasIncurredUsage} OR ${explicitlyCached} THEN 0
+    ELSE ${logicalUsage}
+  END`;
+}
+
+function getIncurredTokenUsage(
+  row: FilteredBasicMetricsRow,
+): NonNullable<PromptMetrics['tokenUsage']['incurredTokenUsage']> {
+  return {
+    total: row.incurred_total_tokens || 0,
+    prompt: row.incurred_prompt_tokens || 0,
+    completion: row.incurred_completion_tokens || 0,
+    cached: row.incurred_cached_tokens || 0,
+    numRequests: row.incurred_num_requests || 0,
+    attacker: {
+      total: row.incurred_attacker_total_tokens || 0,
+      prompt: row.incurred_attacker_prompt_tokens || 0,
+      completion: row.incurred_attacker_completion_tokens || 0,
+      cached: row.incurred_attacker_cached_tokens || 0,
+      numRequests: row.incurred_attacker_num_requests || 0,
+    },
+    assertions: {
+      total: row.incurred_grading_total_tokens || 0,
+      prompt: row.incurred_grading_prompt_tokens || 0,
+      completion: row.incurred_grading_completion_tokens || 0,
+      cached: row.incurred_grading_cached_tokens || 0,
+      numRequests: row.incurred_grading_num_requests || 0,
+    },
+  };
+}
+
+function getFilteredTokenUsage(row: FilteredBasicMetricsRow): PromptMetrics['tokenUsage'] {
+  return {
+    total: row.total_tokens || 0,
+    prompt: row.prompt_tokens || 0,
+    completion: row.completion_tokens || 0,
+    cached: row.cached_tokens || 0,
+    numRequests: row.num_requests_with_tokens || 0,
+    attacker: {
+      total: row.attacker_total_tokens || 0,
+      prompt: row.attacker_prompt_tokens || 0,
+      completion: row.attacker_completion_tokens || 0,
+      cached: row.attacker_cached_tokens || 0,
+      numRequests: row.attacker_num_requests || 0,
+    },
+    assertions: {
+      total: row.grading_total_tokens || 0,
+      prompt: row.grading_prompt_tokens || 0,
+      completion: row.grading_completion_tokens || 0,
+      cached: row.grading_cached_tokens || 0,
+      numRequests: row.grading_num_requests || 0,
+    },
+    ...(row.has_incurred_usage > 0 && {
+      incurredTokenUsage: getIncurredTokenUsage(row),
+    }),
+  };
 }
 
 /**
@@ -167,10 +311,33 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
   const response = sql`response`;
   const gradingResult = sql`grading_result`;
   const targetPath = '$.tokenUsage';
+  const incurredTargetPath = '$.tokenUsage.incurredTokenUsage';
   const attackerPath = '$.tokenUsage.attacker';
+  const incurredAttackerPath = '$.tokenUsage.incurredTokenUsage.attacker';
   const internalGradingPath = '$.tokenUsage.assertions';
+  const incurredInternalGradingPath = '$.tokenUsage.incurredTokenUsage.assertions';
   const gradingPath = '$.tokensUsed';
+  const incurredGradingPath = '$.tokensUsed.incurredTokenUsage';
   const gradingCachePath = '$.metadata.cachedResponse';
+  const responseCachePath = '$.cached';
+  const incurredTargetUsage = (field: TokenUsageField) =>
+    jsonIncurredUsageField(response, targetPath, incurredTargetPath, field, {
+      cachedResponsePath: responseCachePath,
+    });
+  const incurredAttackerUsage = (field: TokenUsageField) =>
+    jsonIncurredUsageField(response, attackerPath, incurredAttackerPath, field, {
+      cachedResponsePath: responseCachePath,
+      parentIncurredPath: incurredTargetPath,
+    });
+  const incurredInternalGradingUsage = (field: TokenUsageField) =>
+    jsonIncurredUsageField(response, internalGradingPath, incurredInternalGradingPath, field, {
+      cachedResponsePath: responseCachePath,
+      parentIncurredPath: incurredTargetPath,
+    });
+  const incurredGradingUsage = (field: TokenUsageField) =>
+    jsonIncurredUsageField(gradingResult, gradingPath, incurredGradingPath, field, {
+      cachedResponsePath: gradingCachePath,
+    });
 
   // ===== QUERY 1: Basic metrics + token usage (ALL PROMPTS) =====
   const basicMetricsQuery = sql`
@@ -200,15 +367,11 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
       ) as grading_total_tokens,
       SUM(
         ${jsonUsageNumber(response, internalGradingPath, 'prompt')} +
-        CASE WHEN COALESCE(json_extract(grading_result, ${gradingCachePath}), 0) = 1 THEN 0
-          ELSE ${jsonUsageNumber(gradingResult, gradingPath, 'prompt')}
-        END
+        ${jsonUsageNumber(gradingResult, gradingPath, 'prompt')}
       ) as grading_prompt_tokens,
       SUM(
         ${jsonUsageNumber(response, internalGradingPath, 'completion')} +
-        CASE WHEN COALESCE(json_extract(grading_result, ${gradingCachePath}), 0) = 1 THEN 0
-          ELSE ${jsonUsageNumber(gradingResult, gradingPath, 'completion')}
-        END
+        ${jsonUsageNumber(gradingResult, gradingPath, 'completion')}
       ) as grading_completion_tokens,
       SUM(
         ${jsonUsageCached(response, internalGradingPath)} +
@@ -217,38 +380,49 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
       SUM(
         ${jsonUsageRequests(response, internalGradingPath)} +
         ${jsonUsageRequests(gradingResult, gradingPath, gradingCachePath)}
-      ) as grading_num_requests
+      ) as grading_num_requests,
+      SUM(
+        CASE
+          WHEN json_extract(response, ${incurredTargetPath}) IS NOT NULL
+            OR json_extract(grading_result, ${incurredGradingPath}) IS NOT NULL
+            OR COALESCE(json_extract(response, ${responseCachePath}), 0) = 1
+            OR COALESCE(json_extract(grading_result, ${gradingCachePath}), 0) = 1
+          THEN 1
+          ELSE 0
+        END
+      ) as has_incurred_usage,
+      SUM(${incurredTargetUsage('total')}) as incurred_total_tokens,
+      SUM(${incurredTargetUsage('prompt')}) as incurred_prompt_tokens,
+      SUM(${incurredTargetUsage('completion')}) as incurred_completion_tokens,
+      SUM(${incurredTargetUsage('cached')}) as incurred_cached_tokens,
+      SUM(${incurredTargetUsage('numRequests')}) as incurred_num_requests,
+      SUM(${incurredAttackerUsage('total')}) as incurred_attacker_total_tokens,
+      SUM(${incurredAttackerUsage('prompt')}) as incurred_attacker_prompt_tokens,
+      SUM(${incurredAttackerUsage('completion')}) as incurred_attacker_completion_tokens,
+      SUM(${incurredAttackerUsage('cached')}) as incurred_attacker_cached_tokens,
+      SUM(${incurredAttackerUsage('numRequests')}) as incurred_attacker_num_requests,
+      SUM(
+        ${incurredInternalGradingUsage('total')} + ${incurredGradingUsage('total')}
+      ) as incurred_grading_total_tokens,
+      SUM(
+        ${incurredInternalGradingUsage('prompt')} + ${incurredGradingUsage('prompt')}
+      ) as incurred_grading_prompt_tokens,
+      SUM(
+        ${incurredInternalGradingUsage('completion')} + ${incurredGradingUsage('completion')}
+      ) as incurred_grading_completion_tokens,
+      SUM(
+        ${incurredInternalGradingUsage('cached')} + ${incurredGradingUsage('cached')}
+      ) as incurred_grading_cached_tokens,
+      SUM(
+        ${incurredInternalGradingUsage('numRequests')} + ${incurredGradingUsage('numRequests')}
+      ) as incurred_grading_num_requests
     FROM eval_results
     WHERE ${whereSql}
     GROUP BY prompt_idx
     ORDER BY prompt_idx
   `;
 
-  const basicResults = (await db.all(basicMetricsQuery)) as Array<{
-    prompt_idx: number;
-    total_count: number;
-    pass_count: number;
-    fail_count: number;
-    error_count: number;
-    total_score: number;
-    total_latency: number;
-    total_cost: number;
-    total_tokens: number | null;
-    prompt_tokens: number | null;
-    completion_tokens: number | null;
-    cached_tokens: number | null;
-    num_requests_with_tokens: number;
-    attacker_total_tokens: number | null;
-    attacker_prompt_tokens: number | null;
-    attacker_completion_tokens: number | null;
-    attacker_cached_tokens: number | null;
-    attacker_num_requests: number | null;
-    grading_total_tokens: number | null;
-    grading_prompt_tokens: number | null;
-    grading_completion_tokens: number | null;
-    grading_cached_tokens: number | null;
-    grading_num_requests: number | null;
-  }>;
+  const basicResults = (await db.all(basicMetricsQuery)) as FilteredBasicMetricsRow[];
 
   // Populate basic metrics
   for (const row of basicResults) {
@@ -265,27 +439,7 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
       testErrorCount: row.error_count || 0,
       totalLatencyMs: row.total_latency || 0,
       cost: row.total_cost || 0,
-      tokenUsage: {
-        total: row.total_tokens || 0,
-        prompt: row.prompt_tokens || 0,
-        completion: row.completion_tokens || 0,
-        cached: row.cached_tokens || 0,
-        numRequests: row.num_requests_with_tokens || 0,
-        attacker: {
-          total: row.attacker_total_tokens || 0,
-          prompt: row.attacker_prompt_tokens || 0,
-          completion: row.attacker_completion_tokens || 0,
-          cached: row.attacker_cached_tokens || 0,
-          numRequests: row.attacker_num_requests || 0,
-        },
-        assertions: {
-          total: row.grading_total_tokens || 0,
-          prompt: row.grading_prompt_tokens || 0,
-          completion: row.grading_completion_tokens || 0,
-          cached: row.grading_cached_tokens || 0,
-          numRequests: row.grading_num_requests || 0,
-        },
-      },
+      tokenUsage: getFilteredTokenUsage(row),
       namedScores: {},
       namedScoresCount: {},
       namedScoreWeights: {},

--- a/src/util/eval/summary.ts
+++ b/src/util/eval/summary.ts
@@ -262,6 +262,29 @@ function getTokenUsageLines(
     lines.push(gradingUsageLine);
   }
 
+  const incurredUsage = tokenUsage.incurredTokenUsage;
+  if (incurredUsage) {
+    const incurredTokens =
+      getTokenUsageTotal(incurredUsage) +
+      getTokenUsageTotal(incurredUsage.attacker) +
+      getTokenUsageTotal(incurredUsage.assertions) +
+      getTokenUsageTotal(incurredUsage.generation);
+    const evaluationTokens =
+      evalTokens.total +
+      attackerTokens +
+      getTokenUsageTotal(tokenUsage.assertions) +
+      generationTokens;
+    const cachedSavings = Math.max(evaluationTokens - incurredTokens, 0);
+
+    if (cachedSavings > 0) {
+      lines.push(
+        `${chalk.bold('Incurred Tokens:')} ${chalk.white.bold(incurredTokens.toLocaleString())}`,
+        `  ${chalk.gray('Cached Savings:')} ${chalk.white(cachedSavings.toLocaleString())}`,
+        `  ${chalk.gray('Actual Target Requests:')} ${chalk.white((incurredUsage.numRequests ?? 0).toLocaleString())}`,
+      );
+    }
+  }
+
   lines.push(...getProviderUsageLines(tracker));
   return lines;
 }

--- a/src/util/tokenUsage.ts
+++ b/src/util/tokenUsage.ts
@@ -60,7 +60,7 @@ export class TokenUsageTracker {
    */
   public trackResponseUsage(
     providerId: string,
-    response: { tokenUsage?: TokenUsage } | undefined,
+    response: { cached?: boolean; tokenUsage?: TokenUsage } | undefined,
   ): void {
     const current = this.providersMap.get(providerId) ?? createEmptyTokenUsage();
     const updated = { ...current };

--- a/src/util/tokenUsage.ts
+++ b/src/util/tokenUsage.ts
@@ -64,7 +64,9 @@ export class TokenUsageTracker {
   ): void {
     const current = this.providersMap.get(providerId) ?? createEmptyTokenUsage();
     const updated = { ...current };
-    accumulateResponseTokenUsage(updated, response);
+    const accounting = createEmptyTokenUsage();
+    accumulateResponseTokenUsage(accounting, response);
+    accumulateTokenUsage(updated, accounting.incurredTokenUsage ?? accounting);
     this.providersMap.set(providerId, updated);
     logger.debug(
       `Tracked response usage for ${sanitizeProviderIdForLog(providerId)}: total=${response?.tokenUsage?.total ?? 0}, cached=${response?.tokenUsage?.cached ?? 0}`,

--- a/src/util/tokenUsage.ts
+++ b/src/util/tokenUsage.ts
@@ -66,7 +66,10 @@ export class TokenUsageTracker {
     const updated = { ...current };
     const accounting = createEmptyTokenUsage();
     accumulateResponseTokenUsage(accounting, response);
-    accumulateTokenUsage(updated, accounting.incurredTokenUsage ?? accounting);
+    accumulateTokenUsage(updated, {
+      ...(accounting.incurredTokenUsage ?? accounting),
+      cached: accounting.cached,
+    });
     this.providersMap.set(providerId, updated);
     logger.debug(
       `Tracked response usage for ${sanitizeProviderIdForLog(providerId)}: total=${response?.tokenUsage?.total ?? 0}, cached=${response?.tokenUsage?.cached ?? 0}`,

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -327,10 +327,22 @@ export function accumulateGradingRequest(
  */
 export function accumulateResponseTokenUsage(
   target: TokenUsage,
-  response: { tokenUsage?: Partial<TokenUsage> } | undefined,
-  options?: { countAsRequest?: boolean },
+  response: { cached?: boolean; tokenUsage?: Partial<TokenUsage> } | undefined,
+  options?: { countAsRequest?: boolean; countCachedAsRequest?: boolean },
 ): void {
   const countAsRequest = options?.countAsRequest ?? true;
+
+  if (response?.cached) {
+    const reportedTotal =
+      response.tokenUsage?.total ??
+      (response.tokenUsage?.prompt ?? 0) + (response.tokenUsage?.completion ?? 0);
+
+    accumulateTokenUsage(target, {
+      cached: Math.max(response.tokenUsage?.cached ?? 0, reportedTotal),
+      numRequests: countAsRequest && options?.countCachedAsRequest ? 1 : 0,
+    });
+    return;
+  }
 
   if (response?.tokenUsage) {
     if (countAsRequest) {

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -67,7 +67,7 @@ function addNumbers(a: number | undefined, b: number | undefined): number {
 }
 
 /** Copy a usage breakdown without allowing the incurred view to recurse. */
-function cloneTokenUsageBreakdown(
+export function cloneTokenUsageBreakdown(
   usage: Partial<TokenUsage>,
 ): NonNullable<TokenUsage['incurredTokenUsage']> {
   const { incurredTokenUsage: _incurredTokenUsage, ...breakdown } = usage;

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -340,6 +340,7 @@ export function accumulateResponseTokenUsage(
     accumulateTokenUsage(target, {
       cached: Math.max(response.tokenUsage?.cached ?? 0, reportedTotal),
       numRequests: countAsRequest && options?.countCachedAsRequest ? 1 : 0,
+      ...(response.tokenUsage?.attacker && { attacker: response.tokenUsage.attacker }),
     });
     return;
   }

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -66,6 +66,43 @@ function addNumbers(a: number | undefined, b: number | undefined): number {
   return (a ?? 0) + (b ?? 0);
 }
 
+/** Copy a usage breakdown without allowing the incurred view to recurse. */
+function cloneTokenUsageBreakdown(
+  usage: Partial<TokenUsage>,
+): NonNullable<TokenUsage['incurredTokenUsage']> {
+  const { incurredTokenUsage: _incurredTokenUsage, ...breakdown } = usage;
+  return {
+    ...breakdown,
+    ...(breakdown.completionDetails && {
+      completionDetails: { ...breakdown.completionDetails },
+    }),
+    ...(breakdown.attacker && {
+      attacker: {
+        ...breakdown.attacker,
+        ...(breakdown.attacker.completionDetails && {
+          completionDetails: { ...breakdown.attacker.completionDetails },
+        }),
+      },
+    }),
+    ...(breakdown.assertions && {
+      assertions: {
+        ...breakdown.assertions,
+        ...(breakdown.assertions.completionDetails && {
+          completionDetails: { ...breakdown.assertions.completionDetails },
+        }),
+      },
+    }),
+    ...(breakdown.generation && {
+      generation: {
+        ...breakdown.generation,
+        ...(breakdown.generation.completionDetails && {
+          completionDetails: { ...breakdown.generation.completionDetails },
+        }),
+      },
+    }),
+  };
+}
+
 /** Derive omitted totals without turning a response-cache replay into fresh usage. */
 function getAccumulatedTokenTotal(usage: Partial<TokenUsage>): number {
   if (usage.total !== undefined) {
@@ -117,6 +154,13 @@ export function accumulateTokenUsage(
 ): void {
   if (!update) {
     return;
+  }
+
+  // Existing legacy usage predates dual accounting. When the first response with
+  // provenance arrives, retain that earlier work as incurred rather than losing it.
+  const trackIncurredUsage = Boolean(target.incurredTokenUsage || update.incurredTokenUsage);
+  if (trackIncurredUsage && !target.incurredTokenUsage) {
+    target.incurredTokenUsage = cloneTokenUsageBreakdown(target);
   }
 
   // Accumulate basic fields
@@ -184,6 +228,14 @@ export function accumulateTokenUsage(
     target.generation ??= createEmptyAssertions();
     accumulateTokenUsage(target.generation, update.generation);
   }
+
+  if (trackIncurredUsage && target.incurredTokenUsage) {
+    accumulateTokenUsage(
+      target.incurredTokenUsage,
+      update.incurredTokenUsage ?? cloneTokenUsageBreakdown(update),
+      incrementRequests,
+    );
+  }
 }
 
 /** Record attacker-model usage separately without inflating target tokens or probes. */
@@ -191,21 +243,48 @@ export function accumulateAttackerTokenUsage(
   target: TokenUsage,
   response: { cached?: boolean; tokenUsage?: Partial<TokenUsage> } | undefined,
 ): void {
-  if (!response || response.cached) {
-    return;
-  }
-  target.attacker ??= createEmptyAssertions();
-  if (!response.tokenUsage) {
-    accumulateResponseTokenUsage(target.attacker, response);
+  if (!response) {
     return;
   }
 
-  const { assertions, ...attackerUsage } = response.tokenUsage;
-  accumulateResponseTokenUsage(target.attacker, { tokenUsage: attackerUsage });
-  if (assertions) {
-    target.assertions ??= createEmptyAssertions();
-    accumulateAssertionTokenUsage(target.assertions, assertions);
-  }
+  const { assertions, incurredTokenUsage, ...attackerUsage } = response.tokenUsage ?? {};
+  const attackerAccounting = createEmptyTokenUsage();
+  accumulateResponseTokenUsage(attackerAccounting, {
+    cached: response.cached,
+    tokenUsage: {
+      ...attackerUsage,
+      ...(incurredTokenUsage && {
+        incurredTokenUsage: {
+          ...incurredTokenUsage,
+          assertions: undefined,
+        },
+      }),
+    },
+  });
+
+  const {
+    assertions: _unusedAssertions,
+    incurredTokenUsage: incurredAttacker,
+    ...logicalAttacker
+  } = attackerAccounting;
+  const actualAttacker = cloneTokenUsageBreakdown(incurredAttacker ?? logicalAttacker);
+  delete actualAttacker.assertions;
+  const actualAssertions =
+    incurredTokenUsage?.assertions ?? (response.cached ? undefined : assertions);
+  const trackIncurredUsage = Boolean(
+    target.incurredTokenUsage || incurredTokenUsage || response.cached,
+  );
+
+  accumulateTokenUsage(target, {
+    attacker: logicalAttacker,
+    ...(assertions && { assertions }),
+    ...(trackIncurredUsage && {
+      incurredTokenUsage: {
+        attacker: actualAttacker,
+        ...(actualAssertions && { assertions: actualAssertions }),
+      },
+    }),
+  });
 }
 
 /** Record one strategy grading task while retaining all model usage reported for that task. */
@@ -225,21 +304,70 @@ export function accumulateGradingResponseTokenUsage(
     response.cached === true ||
     (response.tokenUsage?.numRequests === 0 && reportedTotal <= cachedTokens);
 
-  target.assertions ??= createEmptyAssertions();
-  if (cachedResponse) {
-    accumulateAssertionTokenUsage(target.assertions, {
-      total: 0,
-      prompt: 0,
-      completion: 0,
-      cached: cachedTokens || reportedTotal,
-      numRequests: 0,
-    });
-    return;
+  const logicalUsage = {
+    ...response.tokenUsage,
+    ...(cachedResponse && reportedTotal === 0 && cachedTokens > 0 && { total: cachedTokens }),
+    ...(cachedResponse && { cached: Math.max(cachedTokens, reportedTotal) }),
+    numRequests: 1,
+  };
+  const incurredUsage = cachedResponse
+    ? createEmptyAssertions()
+    : {
+        ...(response.tokenUsage?.incurredTokenUsage ?? response.tokenUsage),
+        numRequests: 1,
+      };
+
+  accumulateTokenUsage(target, {
+    assertions: logicalUsage,
+    ...((target.incurredTokenUsage ||
+      response.tokenUsage?.incurredTokenUsage ||
+      cachedResponse) && {
+      incurredTokenUsage: { assertions: incurredUsage },
+    }),
+  });
+}
+
+/** Record logical grading alongside the subset of grading work executed during this run. */
+export function accumulateGradingTokenUsage(
+  target: TokenUsage,
+  tokensUsed: Partial<TokenUsage> | undefined,
+  options?: { cached?: boolean; fresh?: boolean },
+): void {
+  const reportedTotal =
+    tokensUsed?.total ?? (tokensUsed?.prompt ?? 0) + (tokensUsed?.completion ?? 0);
+  const cachedTokens = tokensUsed?.cached ?? 0;
+  const cachedResponse =
+    options?.cached === true ||
+    (options?.cached === undefined &&
+      tokensUsed?.numRequests === 0 &&
+      cachedTokens > 0 &&
+      reportedTotal <= cachedTokens);
+
+  const logicalAssertions = createEmptyAssertions();
+  const logicalTokensUsed =
+    cachedResponse && reportedTotal === 0 && cachedTokens > 0
+      ? { ...tokensUsed, total: cachedTokens }
+      : tokensUsed;
+  accumulateGradingRequest(logicalAssertions, logicalTokensUsed, {
+    ...options,
+    cached: cachedResponse ? false : options?.cached,
+    fresh: cachedResponse || options?.fresh,
+  });
+
+  const incurredAssertions = createEmptyAssertions();
+  if (!cachedResponse) {
+    accumulateGradingRequest(
+      incurredAssertions,
+      tokensUsed?.incurredTokenUsage ?? tokensUsed,
+      options,
+    );
   }
 
-  accumulateAssertionTokenUsage(target.assertions, {
-    ...response.tokenUsage,
-    numRequests: 1,
+  accumulateTokenUsage(target, {
+    assertions: logicalAssertions,
+    ...((target.incurredTokenUsage || tokensUsed?.incurredTokenUsage || cachedResponse) && {
+      incurredTokenUsage: { assertions: incurredAssertions },
+    }),
   });
 }
 
@@ -330,40 +458,52 @@ export function accumulateResponseTokenUsage(
   response: { cached?: boolean; tokenUsage?: Partial<TokenUsage> } | undefined,
   options?: { countAsRequest?: boolean; countCachedAsRequest?: boolean },
 ): void {
-  const countAsRequest = options?.countAsRequest ?? true;
-
-  if (response?.cached) {
-    const reportedTotal =
-      response.tokenUsage?.total ??
-      (response.tokenUsage?.prompt ?? 0) + (response.tokenUsage?.completion ?? 0);
-
-    accumulateTokenUsage(target, {
-      cached: Math.max(response.tokenUsage?.cached ?? 0, reportedTotal),
-      numRequests: countAsRequest && options?.countCachedAsRequest ? 1 : 0,
-      ...(response.tokenUsage?.attacker && { attacker: response.tokenUsage.attacker }),
-    });
+  if (!response) {
     return;
   }
 
-  if (response?.tokenUsage) {
-    if (countAsRequest) {
-      accumulateTokenUsage(target, response.tokenUsage);
-      // Increment numRequests if not already present in tokenUsage
-      if (response.tokenUsage.numRequests === undefined) {
-        target.numRequests = (target.numRequests ?? 0) + 1;
-      }
-    } else {
-      // Preserve token totals while explicitly excluding request counting.
-      const tokenUsageWithoutRequests: Partial<TokenUsage> = {
-        ...response.tokenUsage,
-        numRequests: undefined,
-      };
-      accumulateTokenUsage(target, tokenUsageWithoutRequests);
-    }
-  } else if (response && countAsRequest) {
-    // Only increment numRequests if we got a response but no token usage
-    target.numRequests = (target.numRequests ?? 0) + 1;
+  const countAsRequest = options?.countAsRequest ?? true;
+  const reportedUsage = response.tokenUsage ?? {};
+  const reportedTotal =
+    reportedUsage.total ?? (reportedUsage.prompt ?? 0) + (reportedUsage.completion ?? 0);
+  const logicalRequests = countAsRequest
+    ? response.cached
+      ? Math.max(reportedUsage.numRequests ?? 0, 1)
+      : (reportedUsage.numRequests ?? 1)
+    : 0;
+
+  const logicalUsage: Partial<TokenUsage> = {
+    ...reportedUsage,
+    ...(response.cached &&
+      reportedTotal === 0 &&
+      (reportedUsage.cached ?? 0) > 0 && {
+        total: reportedUsage.cached,
+      }),
+    ...(response.cached && { cached: Math.max(reportedUsage.cached ?? 0, reportedTotal) }),
+    numRequests: logicalRequests,
+  };
+
+  const incurredUsage = reportedUsage.incurredTokenUsage
+    ? cloneTokenUsageBreakdown(reportedUsage.incurredTokenUsage)
+    : response.cached
+      ? {
+          ...(reportedUsage.attacker && { attacker: reportedUsage.attacker }),
+          ...(reportedUsage.assertions && { assertions: reportedUsage.assertions }),
+          ...(reportedUsage.generation && { generation: reportedUsage.generation }),
+          numRequests: 0,
+        }
+      : cloneTokenUsageBreakdown(logicalUsage);
+
+  if (!countAsRequest) {
+    incurredUsage.numRequests = 0;
   }
+
+  accumulateTokenUsage(target, {
+    ...logicalUsage,
+    ...((target.incurredTokenUsage || reportedUsage.incurredTokenUsage || response.cached) && {
+      incurredTokenUsage: incurredUsage,
+    }),
+  });
 }
 
 /**
@@ -380,6 +520,7 @@ export function accumulateGenerationTokenUsage(target: TokenUsage, update: unkno
     attacker: _attacker,
     assertions: _assertions,
     generation: _generation,
+    incurredTokenUsage,
     ...generationUsage
   } = parsed.data;
   const hasUsage =
@@ -388,8 +529,12 @@ export function accumulateGenerationTokenUsage(target: TokenUsage, update: unkno
   if (!hasUsage) {
     return false;
   }
-  target.generation ??= createEmptyAssertions();
-  accumulateTokenUsage(target.generation, generationUsage);
+  accumulateTokenUsage(target, {
+    generation: generationUsage,
+    ...((target.incurredTokenUsage || incurredTokenUsage) && {
+      incurredTokenUsage: { generation: incurredTokenUsage ?? generationUsage },
+    }),
+  });
   return true;
 }
 
@@ -412,5 +557,8 @@ export function normalizeTokenUsage(
     assertions: tokenUsage?.assertions || createEmptyAssertions(),
     ...(tokenUsage?.attacker ? { attacker: tokenUsage.attacker } : {}),
     ...(tokenUsage?.generation ? { generation: tokenUsage.generation } : {}),
+    ...(tokenUsage?.incurredTokenUsage
+      ? { incurredTokenUsage: tokenUsage.incurredTokenUsage }
+      : {}),
   };
 }

--- a/test/assertions/assertionsResult.test.ts
+++ b/test/assertions/assertionsResult.test.ts
@@ -5,7 +5,12 @@ import {
   GUARDRAIL_BLOCKED_REASON,
 } from '../../src/assertions/assertionsResult';
 import { getEnvBool } from '../../src/envars';
-import { accumulateGradingRequest, createEmptyAssertions } from '../../src/util/tokenUsageUtils';
+import {
+  accumulateGradingRequest,
+  accumulateGradingTokenUsage,
+  createEmptyAssertions,
+  createEmptyTokenUsage,
+} from '../../src/util/tokenUsageUtils';
 
 import type { AssertionSet, GradingResult, ScoringFunction } from '../../src/types/index';
 
@@ -167,7 +172,12 @@ describe('AssertionsResult', () => {
         cached: result.metadata?.cachedResponse === true,
       });
 
-      expect(result.tokensUsed).toMatchObject({ total: 0, cached: 0, numRequests: 0 });
+      expect(result.tokensUsed).toMatchObject({
+        total: 0,
+        cached: 0,
+        numRequests: 1,
+        incurredTokenUsage: { total: 0, numRequests: 0 },
+      });
       expect(result.metadata).toEqual({ cachedResponse: true });
       expect(usage.numRequests).toBe(0);
     });
@@ -202,7 +212,8 @@ describe('AssertionsResult', () => {
       });
 
       expect(result.metadata?.cachedResponse).toBeUndefined();
-      expect(usage.numRequests).toBe(1);
+      expect(usage.numRequests).toBe(2);
+      expect(result.tokensUsed?.incurredTokenUsage?.numRequests).toBe(1);
     });
 
     it('counts fresh matcher calls when avoided cached tokens exceed fresh token usage', async () => {
@@ -234,8 +245,74 @@ describe('AssertionsResult', () => {
         cached: result.metadata?.cachedResponse === true,
       });
 
-      expect(usage).toMatchObject({ total: 50, cached: 97, numRequests: 1 });
+      expect(usage).toMatchObject({ total: 147, cached: 97, numRequests: 2 });
+      expect(result.tokensUsed?.incurredTokenUsage).toMatchObject({
+        total: 50,
+        numRequests: 1,
+      });
       expect(result.metadata?.cachedResponse).toBeUndefined();
+    });
+
+    it('preserves logical and incurred usage when cached and fresh graders are combined', async () => {
+      const assertionsResult = new AssertionsResult({});
+      assertionsResult.addResult({
+        index: 0,
+        result: {
+          pass: true,
+          score: 1,
+          reason: 'Cached grading result',
+          metadata: { cachedResponse: true },
+          tokensUsed: {
+            total: 37,
+            prompt: 23,
+            completion: 14,
+            numRequests: 1,
+            completionDetails: { reasoning: 9 },
+          },
+        },
+      });
+      assertionsResult.addResult({
+        index: 1,
+        result: {
+          pass: true,
+          score: 1,
+          reason: 'Fresh grading result',
+          tokensUsed: {
+            total: 23,
+            prompt: 15,
+            completion: 8,
+            numRequests: 1,
+            completionDetails: { reasoning: 4 },
+          },
+        },
+      });
+
+      const result = await assertionsResult.testResult();
+      const accounting = createEmptyTokenUsage();
+      accumulateGradingTokenUsage(accounting, result.tokensUsed, {
+        cached: result.metadata?.cachedResponse,
+      });
+
+      expect(result.metadata?.cachedResponse).toBeUndefined();
+      expect(result.tokensUsed).toMatchObject({
+        total: 60,
+        prompt: 38,
+        completion: 22,
+        cached: 37,
+        numRequests: 2,
+        completionDetails: { reasoning: 13 },
+        incurredTokenUsage: {
+          total: 23,
+          prompt: 15,
+          completion: 8,
+          numRequests: 1,
+          completionDetails: { reasoning: 4 },
+        },
+      });
+      expect(accounting).toMatchObject({
+        assertions: { total: 60, cached: 37, numRequests: 2 },
+        incurredTokenUsage: { assertions: { total: 23, numRequests: 1 } },
+      });
     });
 
     it('should calculate final result with threshold', async () => {
@@ -469,10 +546,16 @@ describe('AssertionsResult', () => {
 
       expect(result.metadata?.cachedResponse).toBeUndefined();
       expect(usage).toMatchObject({
-        total: 23,
+        total: 120,
         prompt: 15,
         completion: 8,
         cached: 97,
+        numRequests: 2,
+      });
+      expect(result.tokensUsed?.incurredTokenUsage).toMatchObject({
+        total: 23,
+        prompt: 15,
+        completion: 8,
         numRequests: 1,
       });
     });
@@ -482,25 +565,28 @@ describe('AssertionsResult', () => {
         label: 'fresh components and fresh scoring',
         componentCached: false,
         scorerCached: false,
-        expected: { total: 73, prompt: 45, completion: 28, cached: 0, numRequests: 2 },
+        expectedLogical: { total: 73, prompt: 45, completion: 28, cached: 0, numRequests: 2 },
       },
       {
         label: 'fresh components and cached scoring',
         componentCached: false,
         scorerCached: true,
-        expected: { total: 50, prompt: 30, completion: 20, cached: 37, numRequests: 1 },
+        expectedLogical: { total: 87, prompt: 52, completion: 35, cached: 37, numRequests: 2 },
+        expectedIncurred: { total: 50, prompt: 30, completion: 20, numRequests: 1 },
       },
       {
         label: 'cached components and fresh scoring',
         componentCached: true,
         scorerCached: false,
-        expected: { total: 23, prompt: 15, completion: 8, cached: 97, numRequests: 1 },
+        expectedLogical: { total: 120, prompt: 76, completion: 44, cached: 97, numRequests: 2 },
+        expectedIncurred: { total: 23, prompt: 15, completion: 8, numRequests: 1 },
       },
       {
         label: 'cached components and cached scoring',
         componentCached: true,
         scorerCached: true,
-        expected: { total: 0, prompt: 0, completion: 0, cached: 134, numRequests: 0 },
+        expectedLogical: { total: 134, prompt: 83, completion: 51, cached: 134, numRequests: 2 },
+        expectedIncurred: { total: 0, prompt: 0, completion: 0, numRequests: 0 },
       },
     ])('accounts for $label without losing or double-counting usage', async (scenario) => {
       const assertionsResult = new AssertionsResult({});
@@ -527,12 +613,17 @@ describe('AssertionsResult', () => {
       });
 
       const result = await assertionsResult.testResult(scoringFunction);
-      const usage = createEmptyAssertions();
-      accumulateGradingRequest(usage, result.tokensUsed, {
+      const accounting = createEmptyTokenUsage();
+      accumulateGradingTokenUsage(accounting, result.tokensUsed, {
         cached: result.metadata?.cachedResponse,
       });
 
-      expect(usage).toMatchObject(scenario.expected);
+      expect(accounting.assertions).toMatchObject(scenario.expectedLogical);
+      if (scenario.expectedIncurred) {
+        expect(accounting.incurredTokenUsage?.assertions).toMatchObject(scenario.expectedIncurred);
+      } else {
+        expect(accounting.incurredTokenUsage).toBeUndefined();
+      }
       expect(result.metadata?.cachedResponse).toBe(
         scenario.componentCached && scenario.scorerCached ? true : undefined,
       );

--- a/test/evaluator/metrics.test.ts
+++ b/test/evaluator/metrics.test.ts
@@ -508,8 +508,12 @@ describeEvaluator('evaluator metrics and scoring', () => {
       for (const result of summary.results) {
         expect(result.gradingResult?.metadata?.cachedResponse).toBeUndefined();
         expect(result.tokenUsage?.assertions).toMatchObject({
-          total: 13,
+          total: 110,
           cached: 97,
+          numRequests: 2,
+        });
+        expect(result.tokenUsage?.incurredTokenUsage?.assertions).toMatchObject({
+          total: 13,
           numRequests: 1,
         });
       }

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -346,6 +346,133 @@ describeEvaluator('evaluator token usage', () => {
     }
   });
 
+  it('preserves fresh grading when a cached comparison creates the first incurred-usage split', async () => {
+    const freshTargetProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('fresh-target-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Fresh target response',
+        tokenUsage: {
+          total: 100,
+          prompt: 60,
+          completion: 40,
+          numRequests: 1,
+          completionDetails: { reasoning: 2 },
+        },
+      }),
+    };
+    const freshGradingProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('fresh-grading-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'Fresh grading result' }),
+        tokenUsage: {
+          total: 20,
+          prompt: 12,
+          completion: 8,
+          numRequests: 1,
+          completionDetails: { reasoning: 3 },
+        },
+      }),
+    };
+    const cachedComparisonProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('cached-comparison-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: '0',
+        cached: true,
+        tokenUsage: {
+          total: 30,
+          prompt: 18,
+          completion: 12,
+          numRequests: 1,
+          completionDetails: { reasoning: 4 },
+        },
+      }),
+    };
+    const matchers = await import('../../src/matchers/comparison');
+    const matchComparison = matchers.matchesSelectBest;
+    const matchesSelectBestSpy = vi
+      .spyOn(matchers, 'matchesSelectBest')
+      .mockImplementation((criteria, outputs, _grading, vars, context) =>
+        matchComparison(criteria, outputs, { provider: cachedComparisonProvider }, vars, context),
+      );
+    const testSuite: TestSuite = {
+      providers: [freshTargetProvider],
+      prompts: [toPrompt('Prompt A'), toPrompt('Prompt B')],
+      tests: [
+        {
+          assert: [
+            {
+              type: 'llm-rubric',
+              value: 'The response should be useful',
+              provider: freshGradingProvider,
+            },
+            { type: 'select-best', value: 'choose the best response' },
+          ],
+        },
+      ],
+    };
+    try {
+      const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+      await evaluate(testSuite, evalRecord, {});
+      const summary = await evalRecord.toEvaluateSummary();
+
+      expect(cachedComparisonProvider.callApi).toHaveBeenCalledTimes(1);
+      expect(summary.stats.tokenUsage).toMatchObject({
+        total: 200,
+        numRequests: 2,
+        assertions: { total: 100, cached: 60, numRequests: 4 },
+        incurredTokenUsage: {
+          total: 200,
+          numRequests: 2,
+          assertions: { total: 40, numRequests: 2 },
+        },
+      });
+
+      for (const prompt of evalRecord.prompts) {
+        expect(prompt.metrics?.tokenUsage).toMatchObject({
+          total: 100,
+          numRequests: 1,
+          assertions: {
+            total: 50,
+            cached: 30,
+            numRequests: 2,
+            completionDetails: { reasoning: 7 },
+          },
+          incurredTokenUsage: {
+            total: 100,
+            numRequests: 1,
+            assertions: {
+              total: 20,
+              numRequests: 1,
+              completionDetails: { reasoning: 3 },
+            },
+          },
+        });
+      }
+
+      for (const result of summary.results) {
+        expect(result.tokenUsage).toMatchObject({
+          total: 100,
+          numRequests: 1,
+          assertions: { total: 50, cached: 30, numRequests: 2 },
+          incurredTokenUsage: {
+            total: 100,
+            numRequests: 1,
+            assertions: { total: 20, numRequests: 1 },
+          },
+        });
+        expect(result.gradingResult?.tokensUsed).toMatchObject({
+          total: 50,
+          cached: 30,
+          numRequests: 2,
+          incurredTokenUsage: { total: 20, numRequests: 1 },
+        });
+      }
+    } finally {
+      matchesSelectBestSpy.mockRestore();
+    }
+  });
+
   it('does not treat untrusted provider metadata as a cached grading response', async () => {
     const gradingProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('fresh-grading-provider'),

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -208,6 +208,125 @@ describeEvaluator('evaluator token usage', () => {
     });
   });
 
+  it.each(['cached-first', 'fresh-first'] as const)(
+    'preserves mixed cached and fresh grading in summaries and filtered metrics (%s)',
+    async (ordering) => {
+      const targetProvider: ApiProvider = {
+        id: vi.fn().mockReturnValue('fresh-target-provider'),
+        callApi: vi.fn().mockResolvedValue({
+          output: 'Fresh target response',
+          tokenUsage: { total: 100, prompt: 60, completion: 40, numRequests: 1 },
+        }),
+      };
+      const cachedGradingProvider: ApiProvider = {
+        id: vi.fn().mockReturnValue('cached-grading-provider'),
+        callApi: vi.fn().mockResolvedValue({
+          output: JSON.stringify({ pass: true, score: 1, reason: 'Cached grading result' }),
+          cached: true,
+          tokenUsage: {
+            total: 37,
+            prompt: 23,
+            completion: 14,
+            numRequests: 1,
+            completionDetails: { reasoning: 9 },
+          },
+        }),
+      };
+      const freshGradingProvider: ApiProvider = {
+        id: vi.fn().mockReturnValue('fresh-grading-provider'),
+        callApi: vi.fn().mockResolvedValue({
+          output: JSON.stringify({ pass: true, score: 1, reason: 'Fresh grading result' }),
+          tokenUsage: {
+            total: 23,
+            prompt: 15,
+            completion: 8,
+            numRequests: 1,
+            completionDetails: { reasoning: 4 },
+          },
+        }),
+      };
+      const gradingProviders =
+        ordering === 'cached-first'
+          ? [cachedGradingProvider, freshGradingProvider]
+          : [freshGradingProvider, cachedGradingProvider];
+      const testSuite: TestSuite = {
+        providers: [targetProvider],
+        prompts: [toPrompt('Test prompt')],
+        tests: [
+          {
+            assert: gradingProviders.map((provider, index) => ({
+              type: 'llm-rubric' as const,
+              value: `Grading criterion ${index}`,
+              provider,
+            })),
+          },
+        ],
+      };
+      const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+      await evaluate(testSuite, evalRecord, {});
+      const summary = await evalRecord.toEvaluateSummary();
+      const [filteredMetrics] = await evalRecord.getFilteredMetrics({});
+
+      for (const tokenUsage of [
+        summary.stats.tokenUsage,
+        summary.results[0].tokenUsage,
+        evalRecord.prompts[0].metrics?.tokenUsage,
+      ]) {
+        expect(tokenUsage).toMatchObject({
+          total: 100,
+          numRequests: 1,
+          assertions: {
+            total: 60,
+            prompt: 38,
+            completion: 22,
+            cached: 37,
+            numRequests: 2,
+            completionDetails: { reasoning: 13 },
+          },
+          incurredTokenUsage: {
+            total: 100,
+            numRequests: 1,
+            assertions: {
+              total: 23,
+              prompt: 15,
+              completion: 8,
+              numRequests: 1,
+              completionDetails: { reasoning: 4 },
+            },
+          },
+        });
+      }
+      expect(summary.results[0].gradingResult?.tokensUsed).toMatchObject({
+        total: 60,
+        cached: 37,
+        numRequests: 2,
+        completionDetails: { reasoning: 13 },
+        incurredTokenUsage: {
+          total: 23,
+          numRequests: 1,
+          completionDetails: { reasoning: 4 },
+        },
+      });
+      expect(filteredMetrics.tokenUsage).toMatchObject({
+        total: 100,
+        numRequests: 1,
+        assertions: {
+          total: 60,
+          prompt: 38,
+          completion: 22,
+          cached: 37,
+          numRequests: 2,
+        },
+        incurredTokenUsage: {
+          total: 100,
+          numRequests: 1,
+          assertions: { total: 23, prompt: 15, completion: 8, numRequests: 1 },
+        },
+      });
+    },
+  );
+
   it('retains fresh attacker usage when a strategy reuses a cached target response', async () => {
     const strategyProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('cached-target-strategy-provider'),

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -110,6 +110,46 @@ describeEvaluator('evaluator token usage', () => {
     },
   );
 
+  it('preserves logical and incurred costs from mixed-cache composite target responses', async () => {
+    const mixedTargetProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('mixed-cache-target-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Cached winning response after a fresh candidate',
+        cost: 0.16,
+        incurredCost: 0.06,
+        tokenUsage: {
+          total: 160,
+          prompt: 105,
+          completion: 55,
+          cached: 100,
+          numRequests: 2,
+          incurredTokenUsage: { total: 60, prompt: 40, completion: 20, numRequests: 1 },
+        },
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [mixedTargetProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{ assert: [{ type: 'contains', value: 'winning response' }] }],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    expect(summary.results[0]).toMatchObject({
+      cost: 0.16,
+      incurredCost: 0.06,
+      response: { cost: 0.16, incurredCost: 0.06 },
+      tokenUsage: {
+        total: 160,
+        numRequests: 2,
+        incurredTokenUsage: { total: 60, numRequests: 1 },
+      },
+    });
+    expect(evalRecord.prompts[0].metrics).toMatchObject({ cost: 0.16, incurredCost: 0.06 });
+  });
+
   it('preserves logical target and grading calls when both responses are cached', async () => {
     const cachedTargetProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('cached-target-provider'),

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -150,6 +150,102 @@ describeEvaluator('evaluator token usage', () => {
     });
   });
 
+  it('retains fresh attacker usage when a strategy reuses a cached target response', async () => {
+    const strategyProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('cached-target-strategy-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Cached target response',
+        cached: true,
+        tokenUsage: {
+          total: 0,
+          cached: 295,
+          numRequests: 0,
+          attacker: {
+            total: 28,
+            prompt: 20,
+            completion: 8,
+            numRequests: 1,
+            completionDetails: { reasoning: 3 },
+          },
+        },
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [strategyProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{ assert: [{ type: 'contains', value: 'Cached' }] }],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
+      expect(tokenUsage).toMatchObject({
+        total: 0,
+        cached: 295,
+        numRequests: 0,
+        attacker: { total: 28, prompt: 20, completion: 8, numRequests: 1 },
+      });
+    }
+    expect(summary.results[0].response?.tokenUsage).toMatchObject({
+      total: 0,
+      cached: 295,
+      attacker: { total: 28, numRequests: 1 },
+    });
+  });
+
+  it('counts a fresh model grader without reported token usage as one probe', async () => {
+    const cachedTargetProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('cached-target-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Cached target response',
+        cached: true,
+        tokenUsage: { total: 295, prompt: 201, completion: 94, numRequests: 1 },
+      }),
+    };
+    const gradingProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('fresh-grading-provider-without-usage'),
+      callApi: vi.fn().mockResolvedValue({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'Fresh grading result' }),
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [cachedTargetProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          assert: [
+            {
+              type: 'llm-rubric',
+              value: 'The response should be useful',
+              provider: gradingProvider,
+            },
+          ],
+        },
+      ],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    expect(gradingProvider.callApi).toHaveBeenCalledTimes(1);
+    for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
+      expect(tokenUsage).toMatchObject({
+        total: 0,
+        cached: 295,
+        numRequests: 1,
+        assertions: { total: 0, numRequests: 1 },
+      });
+    }
+    expect(summary.results[0].response?.tokenUsage).toMatchObject({
+      total: 0,
+      cached: 295,
+      numRequests: 1,
+    });
+  });
+
   it('counts cached target turns as probes when comparison grading runs afterward', async () => {
     const matchers = await import('../../src/matchers/comparison');
     const freshComparison = {

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -28,74 +28,75 @@ describeEvaluator('evaluator token usage', () => {
     });
   });
 
-  it.each([
-    1, 2,
-  ])('counts fresh grading as one probe without recharging a cached target at concurrency %i', async (maxConcurrency) => {
-    const cachedTargetProvider: ApiProvider = {
-      id: vi.fn().mockReturnValue('cached-target-provider'),
-      callApi: vi.fn().mockResolvedValue({
-        output: 'Cached target response',
+  it.each([1, 2])(
+    'counts fresh grading as one probe without recharging a cached target at concurrency %i',
+    async (maxConcurrency) => {
+      const cachedTargetProvider: ApiProvider = {
+        id: vi.fn().mockReturnValue('cached-target-provider'),
+        callApi: vi.fn().mockResolvedValue({
+          output: 'Cached target response',
+          cached: true,
+          tokenUsage: {
+            total: 295,
+            prompt: 201,
+            completion: 94,
+            cached: 12,
+            numRequests: 1,
+            completionDetails: { reasoning: 8 },
+          },
+        }),
+      };
+      const gradingProvider: ApiProvider = {
+        id: vi.fn().mockReturnValue('fresh-grading-provider'),
+        callApi: vi.fn().mockResolvedValue({
+          output: JSON.stringify({ pass: true, score: 1, reason: 'Fresh grading result' }),
+          tokenUsage: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+        }),
+      };
+      const testSuite: TestSuite = {
+        providers: [cachedTargetProvider],
+        prompts: [toPrompt('Test prompt')],
+        tests: [
+          {
+            assert: [
+              {
+                type: 'llm-rubric',
+                value: 'The response should be useful',
+                provider: gradingProvider,
+              },
+            ],
+          },
+        ],
+      };
+      const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+      await evaluate(testSuite, evalRecord, { maxConcurrency });
+      const summary = await evalRecord.toEvaluateSummary();
+
+      for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
+        expect(tokenUsage).toMatchObject({
+          total: 0,
+          prompt: 0,
+          completion: 0,
+          cached: 295,
+          numRequests: 1,
+          completionDetails: { reasoning: 0 },
+          assertions: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+        });
+      }
+      expect(summary.results[0].response).toMatchObject({
         cached: true,
         tokenUsage: {
-          total: 295,
-          prompt: 201,
-          completion: 94,
-          cached: 12,
+          total: 0,
+          prompt: 0,
+          completion: 0,
+          cached: 295,
           numRequests: 1,
-          completionDetails: { reasoning: 8 },
+          completionDetails: { reasoning: 0 },
         },
-      }),
-    };
-    const gradingProvider: ApiProvider = {
-      id: vi.fn().mockReturnValue('fresh-grading-provider'),
-      callApi: vi.fn().mockResolvedValue({
-        output: JSON.stringify({ pass: true, score: 1, reason: 'Fresh grading result' }),
-        tokenUsage: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
-      }),
-    };
-    const testSuite: TestSuite = {
-      providers: [cachedTargetProvider],
-      prompts: [toPrompt('Test prompt')],
-      tests: [
-        {
-          assert: [
-            {
-              type: 'llm-rubric',
-              value: 'The response should be useful',
-              provider: gradingProvider,
-            },
-          ],
-        },
-      ],
-    };
-    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
-
-    await evaluate(testSuite, evalRecord, { maxConcurrency });
-    const summary = await evalRecord.toEvaluateSummary();
-
-    for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
-      expect(tokenUsage).toMatchObject({
-        total: 0,
-        prompt: 0,
-        completion: 0,
-        cached: 295,
-        numRequests: 1,
-        completionDetails: { reasoning: 0 },
-        assertions: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
       });
-    }
-    expect(summary.results[0].response).toMatchObject({
-      cached: true,
-      tokenUsage: {
-        total: 0,
-        prompt: 0,
-        completion: 0,
-        cached: 295,
-        numRequests: 1,
-        completionDetails: { reasoning: 0 },
-      },
-    });
-  });
+    },
+  );
 
   it('does not count a probe when both target and grading responses are cached', async () => {
     const cachedTargetProvider: ApiProvider = {
@@ -147,6 +148,68 @@ describeEvaluator('evaluator token usage', () => {
       cached: 295,
       numRequests: 0,
     });
+  });
+
+  it('counts cached target turns as probes when comparison grading runs afterward', async () => {
+    const matchers = await import('../../src/matchers/comparison');
+    const freshComparison = {
+      pass: true,
+      score: 1,
+      reason: 'Fresh comparison grade',
+      tokensUsed: { total: 13, prompt: 8, completion: 5, numRequests: 1 },
+    };
+    const matchesSelectBestSpy = vi
+      .spyOn(matchers, 'matchesSelectBest')
+      .mockResolvedValue([freshComparison, { ...freshComparison }]);
+    const cachedTargetProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('cached-target-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Cached target response',
+        cached: true,
+        tokenUsage: { total: 295, prompt: 201, completion: 94, numRequests: 1 },
+      }),
+    };
+
+    try {
+      const testSuite: TestSuite = {
+        providers: [cachedTargetProvider],
+        prompts: [toPrompt('Prompt A'), toPrompt('Prompt B')],
+        tests: [
+          {
+            assert: [
+              { type: 'contains', value: 'Cached' },
+              { type: 'select-best', value: 'choose the best response' },
+            ],
+          },
+        ],
+      };
+      const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+      await evaluate(testSuite, evalRecord, {});
+      const summary = await evalRecord.toEvaluateSummary();
+
+      expect(summary.stats.tokenUsage).toMatchObject({
+        total: 0,
+        cached: 590,
+        numRequests: 2,
+        assertions: { total: 26, numRequests: 2 },
+      });
+      for (const result of summary.results) {
+        expect(result.tokenUsage).toMatchObject({
+          total: 0,
+          cached: 295,
+          numRequests: 1,
+          assertions: { total: 13, numRequests: 1 },
+        });
+        expect(result.response?.tokenUsage).toMatchObject({
+          total: 0,
+          cached: 295,
+          numRequests: 1,
+        });
+      }
+    } finally {
+      matchesSelectBestSpy.mockRestore();
+    }
   });
 
   it('does not treat untrusted provider metadata as a cached grading response', async () => {

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -327,6 +327,91 @@ describeEvaluator('evaluator token usage', () => {
     },
   );
 
+  it('preserves mixed-cache grading provider usage through evaluation summaries', async () => {
+    const targetProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('fresh-target-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Fresh target response',
+        tokenUsage: { total: 50, prompt: 30, completion: 20, numRequests: 1 },
+      }),
+    };
+    const mixedCacheGradingProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('mixed-cache-grading-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'Mixed grading result' }),
+        tokenUsage: {
+          total: 100,
+          prompt: 70,
+          completion: 30,
+          cached: 70,
+          numRequests: 2,
+          completionDetails: { reasoning: 9 },
+          incurredTokenUsage: {
+            total: 30,
+            prompt: 20,
+            completion: 10,
+            numRequests: 1,
+            completionDetails: { reasoning: 4 },
+          },
+        },
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [targetProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          assert: [
+            {
+              type: 'llm-rubric',
+              value: 'The response should be useful',
+              provider: mixedCacheGradingProvider,
+            },
+          ],
+        },
+      ],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    for (const tokenUsage of [
+      summary.stats.tokenUsage,
+      summary.results[0].tokenUsage,
+      evalRecord.prompts[0].metrics?.tokenUsage,
+    ]) {
+      expect(tokenUsage).toMatchObject({
+        total: 50,
+        numRequests: 1,
+        assertions: {
+          total: 100,
+          prompt: 70,
+          completion: 30,
+          cached: 70,
+          numRequests: 2,
+          completionDetails: { reasoning: 9 },
+        },
+        incurredTokenUsage: {
+          total: 50,
+          numRequests: 1,
+          assertions: {
+            total: 30,
+            prompt: 20,
+            completion: 10,
+            numRequests: 1,
+            completionDetails: { reasoning: 4 },
+          },
+        },
+      });
+    }
+    expect(summary.results[0].gradingResult?.tokensUsed).toMatchObject({
+      total: 100,
+      numRequests: 2,
+      incurredTokenUsage: { total: 30, numRequests: 1 },
+    });
+  });
+
   it('retains fresh attacker usage when a strategy reuses a cached target response', async () => {
     const strategyProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('cached-target-strategy-provider'),

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -29,13 +29,14 @@ describeEvaluator('evaluator token usage', () => {
   });
 
   it.each([1, 2])(
-    'counts fresh grading as one probe without recharging a cached target at concurrency %i',
+    'separates cached target footprint from fresh grading at concurrency %i',
     async (maxConcurrency) => {
       const cachedTargetProvider: ApiProvider = {
         id: vi.fn().mockReturnValue('cached-target-provider'),
         callApi: vi.fn().mockResolvedValue({
           output: 'Cached target response',
           cached: true,
+          cost: 0.29,
           tokenUsage: {
             total: 295,
             prompt: 201,
@@ -75,30 +76,41 @@ describeEvaluator('evaluator token usage', () => {
 
       for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
         expect(tokenUsage).toMatchObject({
-          total: 0,
-          prompt: 0,
-          completion: 0,
+          total: 295,
+          prompt: 201,
+          completion: 94,
           cached: 295,
           numRequests: 1,
-          completionDetails: { reasoning: 0 },
+          completionDetails: { reasoning: 8 },
           assertions: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+          incurredTokenUsage: {
+            total: 0,
+            prompt: 0,
+            completion: 0,
+            numRequests: 0,
+            assertions: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+          },
         });
       }
       expect(summary.results[0].response).toMatchObject({
         cached: true,
+        cost: 0.29,
+        incurredCost: 0,
         tokenUsage: {
-          total: 0,
-          prompt: 0,
-          completion: 0,
+          total: 295,
+          prompt: 201,
+          completion: 94,
           cached: 295,
           numRequests: 1,
-          completionDetails: { reasoning: 0 },
+          completionDetails: { reasoning: 8 },
+          incurredTokenUsage: { total: 0, numRequests: 0 },
         },
       });
+      expect(summary.results[0]).toMatchObject({ cost: 0.29, incurredCost: 0 });
     },
   );
 
-  it('does not count a probe when both target and grading responses are cached', async () => {
+  it('preserves logical target and grading calls when both responses are cached', async () => {
     const cachedTargetProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('cached-target-provider'),
       callApi: vi.fn().mockResolvedValue({
@@ -137,16 +149,22 @@ describeEvaluator('evaluator token usage', () => {
 
     for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
       expect(tokenUsage).toMatchObject({
-        total: 0,
+        total: 295,
         cached: 295,
-        numRequests: 0,
-        assertions: { total: 0, cached: 37, numRequests: 0 },
+        numRequests: 1,
+        assertions: { total: 37, cached: 37, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          assertions: { total: 0, numRequests: 0 },
+        },
       });
     }
     expect(summary.results[0].response?.tokenUsage).toMatchObject({
-      total: 0,
+      total: 295,
       cached: 295,
-      numRequests: 0,
+      numRequests: 1,
+      incurredTokenUsage: { total: 0, numRequests: 0 },
     });
   });
 
@@ -182,14 +200,19 @@ describeEvaluator('evaluator token usage', () => {
 
     for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
       expect(tokenUsage).toMatchObject({
-        total: 0,
+        total: 295,
         cached: 295,
-        numRequests: 0,
+        numRequests: 1,
         attacker: { total: 28, prompt: 20, completion: 8, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          attacker: { total: 28, numRequests: 1 },
+        },
       });
     }
     expect(summary.results[0].response?.tokenUsage).toMatchObject({
-      total: 0,
+      total: 295,
       cached: 295,
       attacker: { total: 28, numRequests: 1 },
     });
@@ -233,14 +256,19 @@ describeEvaluator('evaluator token usage', () => {
     expect(gradingProvider.callApi).toHaveBeenCalledTimes(1);
     for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
       expect(tokenUsage).toMatchObject({
-        total: 0,
+        total: 295,
         cached: 295,
         numRequests: 1,
         assertions: { total: 0, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          assertions: { total: 0, numRequests: 1 },
+        },
       });
     }
     expect(summary.results[0].response?.tokenUsage).toMatchObject({
-      total: 0,
+      total: 295,
       cached: 295,
       numRequests: 1,
     });
@@ -285,20 +313,30 @@ describeEvaluator('evaluator token usage', () => {
       const summary = await evalRecord.toEvaluateSummary();
 
       expect(summary.stats.tokenUsage).toMatchObject({
-        total: 0,
+        total: 590,
         cached: 590,
         numRequests: 2,
         assertions: { total: 26, numRequests: 2 },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          assertions: { total: 26, numRequests: 2 },
+        },
       });
       for (const result of summary.results) {
         expect(result.tokenUsage).toMatchObject({
-          total: 0,
+          total: 295,
           cached: 295,
           numRequests: 1,
           assertions: { total: 13, numRequests: 1 },
+          incurredTokenUsage: {
+            total: 0,
+            numRequests: 0,
+            assertions: { total: 13, numRequests: 1 },
+          },
         });
         expect(result.response?.tokenUsage).toMatchObject({
-          total: 0,
+          total: 295,
           cached: 295,
           numRequests: 1,
         });
@@ -373,16 +411,12 @@ describeEvaluator('evaluator token usage', () => {
     await evaluate(testSuite, evalRecord, {});
     const summary = await evalRecord.toEvaluateSummary();
 
-    expect(summary.stats.tokenUsage.assertions).toMatchObject({
-      total: 0,
-      cached: 37,
-      numRequests: 0,
-    });
-    expect(summary.results[0].tokenUsage?.assertions).toMatchObject({
-      total: 0,
-      cached: 37,
-      numRequests: 0,
-    });
+    for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
+      expect(tokenUsage).toMatchObject({
+        assertions: { total: 37, cached: 37, numRequests: 1 },
+        incurredTokenUsage: { assertions: { total: 0, numRequests: 0 } },
+      });
+    }
     expect(summary.results[0].gradingResult?.componentResults?.[0]?.metadata).toMatchObject({
       graderError: true,
       cachedResponse: true,
@@ -415,7 +449,7 @@ describeEvaluator('evaluator token usage', () => {
       registers: {},
     });
 
-    expect(results[0].tokenUsage).toEqual({
+    expect(results[0].tokenUsage).toMatchObject({
       total: 10, // Only provider tokens, NOT assertion tokens
       prompt: 5, // Only provider tokens
       completion: 5, // Only provider tokens
@@ -501,7 +535,7 @@ describeEvaluator('evaluator token usage', () => {
     const summary = await evalRecord.toEvaluateSummary();
 
     // Verify main totals only include provider tokens, NOT assertion tokens
-    expect(summary.stats.tokenUsage).toEqual({
+    expect(summary.stats.tokenUsage).toMatchObject({
       total: 100, // Only provider tokens
       prompt: 60,
       completion: 40,

--- a/test/evaluator/tokenUsage.test.ts
+++ b/test/evaluator/tokenUsage.test.ts
@@ -28,6 +28,127 @@ describeEvaluator('evaluator token usage', () => {
     });
   });
 
+  it.each([
+    1, 2,
+  ])('counts fresh grading as one probe without recharging a cached target at concurrency %i', async (maxConcurrency) => {
+    const cachedTargetProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('cached-target-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Cached target response',
+        cached: true,
+        tokenUsage: {
+          total: 295,
+          prompt: 201,
+          completion: 94,
+          cached: 12,
+          numRequests: 1,
+          completionDetails: { reasoning: 8 },
+        },
+      }),
+    };
+    const gradingProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('fresh-grading-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'Fresh grading result' }),
+        tokenUsage: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [cachedTargetProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          assert: [
+            {
+              type: 'llm-rubric',
+              value: 'The response should be useful',
+              provider: gradingProvider,
+            },
+          ],
+        },
+      ],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, { maxConcurrency });
+    const summary = await evalRecord.toEvaluateSummary();
+
+    for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
+      expect(tokenUsage).toMatchObject({
+        total: 0,
+        prompt: 0,
+        completion: 0,
+        cached: 295,
+        numRequests: 1,
+        completionDetails: { reasoning: 0 },
+        assertions: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+      });
+    }
+    expect(summary.results[0].response).toMatchObject({
+      cached: true,
+      tokenUsage: {
+        total: 0,
+        prompt: 0,
+        completion: 0,
+        cached: 295,
+        numRequests: 1,
+        completionDetails: { reasoning: 0 },
+      },
+    });
+  });
+
+  it('does not count a probe when both target and grading responses are cached', async () => {
+    const cachedTargetProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('cached-target-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: 'Cached target response',
+        cached: true,
+        tokenUsage: { total: 295, prompt: 201, completion: 94, numRequests: 1 },
+      }),
+    };
+    const cachedGradingProvider: ApiProvider = {
+      id: vi.fn().mockReturnValue('cached-grading-provider'),
+      callApi: vi.fn().mockResolvedValue({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'Cached grading result' }),
+        cached: true,
+        tokenUsage: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [cachedTargetProvider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [
+        {
+          assert: [
+            {
+              type: 'llm-rubric',
+              value: 'The response should be useful',
+              provider: cachedGradingProvider,
+            },
+          ],
+        },
+      ],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+
+    await evaluate(testSuite, evalRecord, {});
+    const summary = await evalRecord.toEvaluateSummary();
+
+    for (const tokenUsage of [summary.stats.tokenUsage, summary.results[0].tokenUsage]) {
+      expect(tokenUsage).toMatchObject({
+        total: 0,
+        cached: 295,
+        numRequests: 0,
+        assertions: { total: 0, cached: 37, numRequests: 0 },
+      });
+    }
+    expect(summary.results[0].response?.tokenUsage).toMatchObject({
+      total: 0,
+      cached: 295,
+      numRequests: 0,
+    });
+  });
+
   it('does not treat untrusted provider metadata as a cached grading response', async () => {
     const gradingProvider: ApiProvider = {
       id: vi.fn().mockReturnValue('fresh-grading-provider'),

--- a/test/matchers/comparison.test.ts
+++ b/test/matchers/comparison.test.ts
@@ -49,6 +49,47 @@ describe('matchesSelectBest', () => {
     });
   });
 
+  it('preserves cache provenance and logical token usage for cached comparison responses', async () => {
+    const provider = createMockProvider({
+      id: 'cached-select-best-provider',
+      response: {
+        output: '0',
+        cached: true,
+        tokenUsage: { total: 30, prompt: 18, completion: 12, numRequests: 1 },
+      },
+    });
+
+    const result = await matchesSelectBest('choose the best output', ['A', 'B'], { provider });
+
+    for (const gradingResult of result) {
+      expect(gradingResult).toMatchObject({
+        metadata: { cachedResponse: true },
+        tokensUsed: { total: 30, prompt: 18, completion: 12, cached: 30, numRequests: 1 },
+      });
+    }
+  });
+
+  it('preserves cache provenance when a cached comparison response is malformed', async () => {
+    const provider = createMockProvider({
+      id: 'cached-invalid-select-best-provider',
+      response: {
+        output: 'not a verdict',
+        cached: true,
+        tokenUsage: { total: 30, prompt: 18, completion: 12, numRequests: 1 },
+      },
+    });
+
+    const result = await matchesSelectBest('choose the best output', ['A', 'B'], { provider });
+
+    for (const gradingResult of result) {
+      expect(gradingResult).toMatchObject({
+        pass: false,
+        metadata: { cachedResponse: true },
+        tokensUsed: { total: 30, cached: 30 },
+      });
+    }
+  });
+
   it('should keep reserved criteria and outputs vars ahead of user vars', async () => {
     const provider = createSelectBestProvider('0');
     const grading: GradingConfig = {

--- a/test/matchers/comparison.test.ts
+++ b/test/matchers/comparison.test.ts
@@ -90,6 +90,54 @@ describe('matchesSelectBest', () => {
     }
   });
 
+  it.each([
+    { label: 'valid verdict', response: { output: '0' } },
+    { label: 'invalid verdict', response: { output: 'not a verdict' } },
+    { label: 'provider error', response: { error: 'comparison provider failed', output: '' } },
+  ])('preserves mixed cached and incurred comparison usage for a $label', async ({ response }) => {
+    const provider = createMockProvider({
+      id: 'mixed-cache-select-best-provider',
+      response: {
+        ...response,
+        tokenUsage: {
+          total: 100,
+          prompt: 70,
+          completion: 30,
+          cached: 70,
+          numRequests: 2,
+          completionDetails: { reasoning: 9 },
+          incurredTokenUsage: {
+            total: 30,
+            prompt: 20,
+            completion: 10,
+            numRequests: 1,
+            completionDetails: { reasoning: 4 },
+          },
+        },
+      },
+    });
+
+    const result = await matchesSelectBest('choose the best output', ['A', 'B'], { provider });
+
+    for (const gradingResult of result) {
+      expect(gradingResult.tokensUsed).toMatchObject({
+        total: 100,
+        prompt: 70,
+        completion: 30,
+        cached: 70,
+        numRequests: 2,
+        completionDetails: { reasoning: 9 },
+        incurredTokenUsage: {
+          total: 30,
+          prompt: 20,
+          completion: 10,
+          numRequests: 1,
+          completionDetails: { reasoning: 4 },
+        },
+      });
+    }
+  });
+
   it('should keep reserved criteria and outputs vars ahead of user vars', async () => {
     const provider = createSelectBestProvider('0');
     const grading: GradingConfig = {

--- a/test/matchers/shared.test.ts
+++ b/test/matchers/shared.test.ts
@@ -35,6 +35,46 @@ describe('normalizeMatcherTokenUsage', () => {
       cached: 10,
     });
   });
+
+  it('preserves incurred usage and completion details for mixed cached and fresh grading', () => {
+    expect(
+      normalizeMatcherTokenUsage({
+        total: 100,
+        prompt: 70,
+        completion: 30,
+        cached: 70,
+        numRequests: 2,
+        completionDetails: { reasoning: 9 },
+        incurredTokenUsage: {
+          total: 30,
+          prompt: 20,
+          completion: 10,
+          numRequests: 1,
+          completionDetails: { reasoning: 4 },
+        },
+      }),
+    ).toMatchObject({
+      total: 100,
+      prompt: 70,
+      completion: 30,
+      cached: 70,
+      numRequests: 2,
+      completionDetails: { reasoning: 9 },
+      incurredTokenUsage: {
+        total: 30,
+        prompt: 20,
+        completion: 10,
+        numRequests: 1,
+        completionDetails: { reasoning: 4 },
+      },
+    });
+  });
+
+  it('does not add incurred accounting when the provider did not report it', () => {
+    expect(normalizeMatcherTokenUsage({ total: 30, numRequests: 1 })).not.toHaveProperty(
+      'incurredTokenUsage',
+    );
+  });
 });
 
 describe('splitIntoSentences', () => {

--- a/test/models/evalResult.test.ts
+++ b/test/models/evalResult.test.ts
@@ -1305,7 +1305,7 @@ describe('EvalResult', () => {
       });
     });
 
-    it('preserves cached request counts when legacy grading results omit cache provenance', () => {
+    it('separates logical and incurred requests when legacy grading results imply a cache hit', () => {
       const result = new EvalResult({
         id: 'test-id',
         evalId: 'test-eval-id',
@@ -1327,10 +1327,9 @@ describe('EvalResult', () => {
         namedScores: {},
       });
 
-      expect(result.toEvaluateResult().tokenUsage?.assertions).toMatchObject({
-        total: 97,
-        cached: 97,
-        numRequests: 0,
+      expect(result.toEvaluateResult().tokenUsage).toMatchObject({
+        assertions: { total: 97, cached: 97, numRequests: 1 },
+        incurredTokenUsage: { assertions: { total: 0, numRequests: 0 } },
       });
     });
 

--- a/test/node/retry.integration.test.ts
+++ b/test/node/retry.integration.test.ts
@@ -1435,6 +1435,129 @@ describe('retry command', () => {
       expect(evalRecord.prompts[0].metrics?.tokenUsage?.assertions?.completion).toBe(50); // 20 + 30
     });
 
+    it('preserves cached and incurred grading usage when recalculating persisted results', async () => {
+      const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
+      const db = await getDb();
+      const mockProvider = { id: 'test-provider' };
+      const mockPrompt = { raw: 'test', display: 'test', label: 'test', provider: 'test-provider' };
+
+      await evalRecord.addPrompts([mockPrompt]);
+      await db.insert(evalResultsTable).values([
+        {
+          id: `${evalRecord.id}-cached-target`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 0,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          response: {
+            output: 'cached target response',
+            cached: true,
+            tokenUsage: { total: 295, prompt: 201, completion: 94, numRequests: 1 },
+          },
+          gradingResult: {
+            pass: true,
+            score: 1,
+            reason: 'fresh grading result',
+            tokensUsed: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+          },
+        },
+        {
+          id: `${evalRecord.id}-cached-grader`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 1,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          response: {
+            output: 'fresh target response',
+            tokenUsage: { total: 100, prompt: 60, completion: 40, numRequests: 1 },
+          },
+          gradingResult: {
+            pass: true,
+            score: 1,
+            reason: 'cached grading result',
+            metadata: { cachedResponse: true },
+            tokensUsed: { total: 23, prompt: 15, completion: 8, cached: 23, numRequests: 1 },
+          },
+        },
+        {
+          id: `${evalRecord.id}-mixed-graders`,
+          evalId: evalRecord.id,
+          promptIdx: 0,
+          testIdx: 2,
+          prompt: mockPrompt,
+          testCase: { vars: {} },
+          provider: mockProvider,
+          success: true,
+          score: 1,
+          failureReason: ResultFailureReason.NONE,
+          namedScores: {},
+          response: {
+            output: 'another fresh target response',
+            tokenUsage: { total: 50, prompt: 30, completion: 20, numRequests: 1 },
+          },
+          gradingResult: {
+            pass: true,
+            score: 1,
+            reason: 'mixed grading result',
+            tokensUsed: {
+              total: 60,
+              prompt: 38,
+              completion: 22,
+              cached: 37,
+              numRequests: 2,
+              completionDetails: { reasoning: 13 },
+              incurredTokenUsage: {
+                total: 23,
+                prompt: 15,
+                completion: 8,
+                numRequests: 1,
+                completionDetails: { reasoning: 4 },
+              },
+            },
+          },
+        },
+      ]);
+
+      await recalculatePromptMetrics(evalRecord);
+
+      expect(evalRecord.prompts[0].metrics?.tokenUsage).toMatchObject({
+        total: 445,
+        cached: 295,
+        numRequests: 3,
+        assertions: {
+          total: 120,
+          prompt: 76,
+          completion: 44,
+          cached: 60,
+          numRequests: 4,
+          completionDetails: { reasoning: 13 },
+        },
+        incurredTokenUsage: {
+          total: 150,
+          numRequests: 2,
+          assertions: {
+            total: 60,
+            prompt: 38,
+            completion: 22,
+            numRequests: 2,
+            completionDetails: { reasoning: 4 },
+          },
+        },
+      });
+    });
+
     it('should skip results with invalid promptIdx', async () => {
       const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = await getDb();

--- a/test/node/retry.test.ts
+++ b/test/node/retry.test.ts
@@ -266,6 +266,119 @@ describe('retryCommand', () => {
     );
   });
 
+  it.each([
+    {
+      label: 'cached target and fresh grader',
+      response: {
+        cached: true,
+        tokenUsage: { total: 100, prompt: 60, completion: 40, numRequests: 1 },
+      },
+      gradingResult: {
+        tokensUsed: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+      },
+      expected: {
+        total: 100,
+        cached: 100,
+        numRequests: 1,
+        assertions: { total: 37, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          assertions: { total: 37, numRequests: 1 },
+        },
+      },
+    },
+    {
+      label: 'fresh target and cached grader',
+      response: {
+        tokenUsage: { total: 100, prompt: 60, completion: 40, numRequests: 1 },
+      },
+      gradingResult: {
+        metadata: { cachedResponse: true },
+        tokensUsed: { total: 37, prompt: 23, completion: 14, cached: 37, numRequests: 1 },
+      },
+      expected: {
+        total: 100,
+        numRequests: 1,
+        assertions: { total: 37, cached: 37, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 100,
+          numRequests: 1,
+          assertions: { total: 0, numRequests: 0 },
+        },
+      },
+    },
+    {
+      label: 'mixed cached and fresh graders',
+      response: {
+        tokenUsage: { total: 100, prompt: 60, completion: 40, numRequests: 1 },
+      },
+      gradingResult: {
+        tokensUsed: {
+          total: 60,
+          prompt: 38,
+          completion: 22,
+          cached: 37,
+          numRequests: 2,
+          completionDetails: { reasoning: 13 },
+          incurredTokenUsage: {
+            total: 23,
+            prompt: 15,
+            completion: 8,
+            numRequests: 1,
+            completionDetails: { reasoning: 4 },
+          },
+        },
+      },
+      expected: {
+        total: 100,
+        numRequests: 1,
+        assertions: {
+          total: 60,
+          cached: 37,
+          numRequests: 2,
+          completionDetails: { reasoning: 13 },
+        },
+        incurredTokenUsage: {
+          total: 100,
+          numRequests: 1,
+          assertions: {
+            total: 23,
+            numRequests: 1,
+            completionDetails: { reasoning: 4 },
+          },
+        },
+      },
+    },
+  ])('preserves logical and incurred accounting when retrying $label', async (scenario) => {
+    const prompts = [{}] as any[];
+    const evalRecord = createEval({
+      prompts,
+      fetchResultsBatched: vi.fn(async function* () {
+        yield [
+          {
+            id: 'retried-result',
+            promptIdx: 0,
+            success: true,
+            score: 1,
+            namedScores: {},
+            response: scenario.response,
+            gradingResult: {
+              pass: true,
+              score: 1,
+              reason: 'passed',
+              ...scenario.gradingResult,
+            },
+          },
+        ] as any[];
+      }),
+    });
+
+    await recalculatePromptMetrics(evalRecord);
+
+    expect(prompts[0].metrics.tokenUsage).toMatchObject(scenario.expected);
+  });
+
   it('logs and rethrows metric recalculation and persistence failures', async () => {
     const calculationError = new Error('batch unavailable');
     const calculationEval = createEval({

--- a/test/redteam/extraction/util.test.ts
+++ b/test/redteam/extraction/util.test.ts
@@ -170,7 +170,7 @@ describe('fetchRemoteGeneration', () => {
       'extraction timed out',
     );
 
-    expect(generationUsage).toEqual({ numRequests: 1 });
+    expect(generationUsage).toMatchObject({ total: 0, numRequests: 1 });
   });
 
   it('does not count an invalid remote extraction response twice', async () => {

--- a/test/redteam/generationTokenUsage.test.ts
+++ b/test/redteam/generationTokenUsage.test.ts
@@ -112,7 +112,7 @@ describe('generation token usage', () => {
 
     await expect(provider.callApi('generate a test')).rejects.toThrow('generation timed out');
 
-    expect(usage).toEqual({ numRequests: 1 });
+    expect(usage).toMatchObject({ total: 0, numRequests: 1 });
   });
 
   it('preserves token usage from failed provider requests exactly once', async () => {

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -266,7 +266,7 @@ describe('Plugins', () => {
         delayMs: 0,
       });
 
-      expect(generationUsage).toEqual({ numRequests: 1 });
+      expect(generationUsage).toMatchObject({ total: 0, numRequests: 1 });
     });
   });
 

--- a/test/redteam/providers/authoritativeMarkupInjection.test.ts
+++ b/test/redteam/providers/authoritativeMarkupInjection.test.ts
@@ -172,10 +172,15 @@ describe('AuthoritativeMarkupInjectionProvider', () => {
 
       expect(result.cached).toBe(true);
       expect(normalizedUsage).toMatchObject({
-        total: 0,
+        total: 75,
         cached: 75,
-        numRequests: 0,
+        numRequests: 1,
         attacker: { total: 28, prompt: 20, completion: 8, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          attacker: { total: 28, prompt: 20, completion: 8, numRequests: 1 },
+        },
       });
     });
 

--- a/test/redteam/providers/authoritativeMarkupInjection.test.ts
+++ b/test/redteam/providers/authoritativeMarkupInjection.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  accumulateResponseTokenUsage,
+  createEmptyTokenUsage,
+} from '../../../src/util/tokenUsageUtils';
+import {
   createMockProvider,
   createProviderResponse,
   type MockApiProvider,
@@ -145,6 +149,33 @@ describe('AuthoritativeMarkupInjectionProvider', () => {
           numRequests: 1,
           completionDetails: { reasoning: 3 },
         },
+      });
+    });
+
+    it('retains fresh attacker tokens when the target response is reused from cache', async () => {
+      mockFetchWithProxy.mockResolvedValueOnce({
+        json: async () => ({
+          message: { role: 'assistant', content: 'injected content' },
+          tokenUsage: { prompt: 20, completion: 8, total: 28, numRequests: 1 },
+        }),
+      });
+      mockTargetProvider.callApi.mockResolvedValueOnce({
+        output: 'cached target response',
+        cached: true,
+        tokenUsage: { prompt: 50, completion: 25, total: 75, numRequests: 1 },
+      });
+
+      const provider = new AuthoritativeMarkupInjectionProvider({ injectVar: 'input' });
+      const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
+      const normalizedUsage = createEmptyTokenUsage();
+      accumulateResponseTokenUsage(normalizedUsage, result);
+
+      expect(result.cached).toBe(true);
+      expect(normalizedUsage).toMatchObject({
+        total: 0,
+        cached: 75,
+        numRequests: 0,
+        attacker: { total: 28, prompt: 20, completion: 8, numRequests: 1 },
       });
     });
 

--- a/test/redteam/providers/bestOfN.test.ts
+++ b/test/redteam/providers/bestOfN.test.ts
@@ -150,11 +150,12 @@ describe('BestOfNProvider - Runtime Behavior', () => {
 
     expect(result.cached).toBe(false);
     expect(result.tokenUsage).toMatchObject({
-      total: 60,
-      prompt: 40,
-      completion: 20,
+      total: 160,
+      prompt: 105,
+      completion: 55,
       cached: 100,
-      numRequests: 1,
+      numRequests: 2,
+      incurredTokenUsage: { total: 60, prompt: 40, completion: 20, numRequests: 1 },
     });
   });
 
@@ -176,7 +177,12 @@ describe('BestOfNProvider - Runtime Behavior', () => {
     const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
 
     expect(result.cached).toBe(true);
-    expect(result.tokenUsage).toMatchObject({ total: 0, cached: 180, numRequests: 0 });
+    expect(result.tokenUsage).toMatchObject({
+      total: 180,
+      cached: 180,
+      numRequests: 2,
+      incurredTokenUsage: { total: 0, numRequests: 0 },
+    });
   });
 
   it('preserves fresh target usage when the final failed candidate was cached', async () => {
@@ -195,7 +201,12 @@ describe('BestOfNProvider - Runtime Behavior', () => {
     const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
 
     expect(result.cached).toBe(false);
-    expect(result.tokenUsage).toMatchObject({ total: 60, cached: 100, numRequests: 1 });
+    expect(result.tokenUsage).toMatchObject({
+      total: 160,
+      cached: 100,
+      numRequests: 2,
+      incurredTokenUsage: { total: 60, numRequests: 1 },
+    });
   });
 
   it('should re-throw AbortError and not swallow it', async () => {

--- a/test/redteam/providers/bestOfN.test.ts
+++ b/test/redteam/providers/bestOfN.test.ts
@@ -132,6 +132,72 @@ describe('BestOfNProvider - Runtime Behavior', () => {
     );
   });
 
+  it('preserves fresh target usage when a cached candidate finishes after a fresh candidate', async () => {
+    const provider = new BestOfNProvider({ injectVar: 'input', maxConcurrency: 1 });
+    mockTargetProvider.callApi
+      .mockResolvedValueOnce({
+        output: 'Fresh candidate failed',
+        error: 'Candidate was rejected',
+        tokenUsage: { total: 60, prompt: 40, completion: 20, numRequests: 1 },
+      })
+      .mockResolvedValueOnce({
+        output: 'Cached candidate succeeded',
+        cached: true,
+        tokenUsage: { total: 100, prompt: 65, completion: 35, numRequests: 1 },
+      });
+
+    const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
+
+    expect(result.cached).toBe(false);
+    expect(result.tokenUsage).toMatchObject({
+      total: 60,
+      prompt: 40,
+      completion: 20,
+      cached: 100,
+      numRequests: 1,
+    });
+  });
+
+  it('keeps an aggregate cached when every candidate response was cached', async () => {
+    const provider = new BestOfNProvider({ injectVar: 'input', maxConcurrency: 1 });
+    mockTargetProvider.callApi
+      .mockResolvedValueOnce({
+        output: 'First cached candidate failed',
+        error: 'Candidate was rejected',
+        cached: true,
+        tokenUsage: { total: 80, prompt: 50, completion: 30, numRequests: 1 },
+      })
+      .mockResolvedValueOnce({
+        output: 'Second cached candidate succeeded',
+        cached: true,
+        tokenUsage: { total: 100, prompt: 65, completion: 35, numRequests: 1 },
+      });
+
+    const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
+
+    expect(result.cached).toBe(true);
+    expect(result.tokenUsage).toMatchObject({ total: 0, cached: 180, numRequests: 0 });
+  });
+
+  it('preserves fresh target usage when the final failed candidate was cached', async () => {
+    const provider = new BestOfNProvider({ injectVar: 'input', maxConcurrency: 1 });
+    mockTargetProvider.callApi
+      .mockResolvedValueOnce({
+        error: 'Fresh candidate was rejected',
+        tokenUsage: { total: 60, prompt: 40, completion: 20, numRequests: 1 },
+      })
+      .mockResolvedValueOnce({
+        error: 'Cached candidate was rejected',
+        cached: true,
+        tokenUsage: { total: 100, prompt: 65, completion: 35, numRequests: 1 },
+      });
+
+    const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
+
+    expect(result.cached).toBe(false);
+    expect(result.tokenUsage).toMatchObject({ total: 60, cached: 100, numRequests: 1 });
+  });
+
   it('should re-throw AbortError and not swallow it', async () => {
     const provider = new BestOfNProvider({
       injectVar: 'input',

--- a/test/redteam/providers/bestOfN.test.ts
+++ b/test/redteam/providers/bestOfN.test.ts
@@ -138,17 +138,21 @@ describe('BestOfNProvider - Runtime Behavior', () => {
       .mockResolvedValueOnce({
         output: 'Fresh candidate failed',
         error: 'Candidate was rejected',
+        cost: 0.06,
         tokenUsage: { total: 60, prompt: 40, completion: 20, numRequests: 1 },
       })
       .mockResolvedValueOnce({
         output: 'Cached candidate succeeded',
         cached: true,
+        cost: 0.1,
         tokenUsage: { total: 100, prompt: 65, completion: 35, numRequests: 1 },
       });
 
     const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
 
     expect(result.cached).toBe(false);
+    expect(result.cost).toBeCloseTo(0.16);
+    expect(result.incurredCost).toBeCloseTo(0.06);
     expect(result.tokenUsage).toMatchObject({
       total: 160,
       prompt: 105,
@@ -166,17 +170,21 @@ describe('BestOfNProvider - Runtime Behavior', () => {
         output: 'First cached candidate failed',
         error: 'Candidate was rejected',
         cached: true,
+        cost: 0.08,
         tokenUsage: { total: 80, prompt: 50, completion: 30, numRequests: 1 },
       })
       .mockResolvedValueOnce({
         output: 'Second cached candidate succeeded',
         cached: true,
+        cost: 0.1,
         tokenUsage: { total: 100, prompt: 65, completion: 35, numRequests: 1 },
       });
 
     const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
 
     expect(result.cached).toBe(true);
+    expect(result.cost).toBeCloseTo(0.18);
+    expect(result.incurredCost).toBe(0);
     expect(result.tokenUsage).toMatchObject({
       total: 180,
       cached: 180,
@@ -190,22 +198,77 @@ describe('BestOfNProvider - Runtime Behavior', () => {
     mockTargetProvider.callApi
       .mockResolvedValueOnce({
         error: 'Fresh candidate was rejected',
+        cost: 0.06,
         tokenUsage: { total: 60, prompt: 40, completion: 20, numRequests: 1 },
       })
       .mockResolvedValueOnce({
         error: 'Cached candidate was rejected',
         cached: true,
+        cost: 0.1,
         tokenUsage: { total: 100, prompt: 65, completion: 35, numRequests: 1 },
       });
 
     const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
 
     expect(result.cached).toBe(false);
+    expect(result.cost).toBeCloseTo(0.16);
+    expect(result.incurredCost).toBeCloseTo(0.06);
     expect(result.tokenUsage).toMatchObject({
       total: 160,
       cached: 100,
       numRequests: 2,
       incurredTokenUsage: { total: 60, numRequests: 1 },
+    });
+  });
+
+  it('aggregates all fresh candidate costs without adding an unnecessary incurred-cost split', async () => {
+    const provider = new BestOfNProvider({ injectVar: 'input', maxConcurrency: 1 });
+    mockTargetProvider.callApi
+      .mockResolvedValueOnce({
+        error: 'Fresh candidate was rejected',
+        cost: 0.06,
+        tokenUsage: { total: 60, numRequests: 1 },
+      })
+      .mockResolvedValueOnce({
+        output: 'Fresh candidate succeeded',
+        cost: 0.1,
+        tokenUsage: { total: 100, numRequests: 1 },
+      });
+
+    const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
+
+    expect(result.cost).toBeCloseTo(0.16);
+    expect(result.incurredCost).toBeUndefined();
+    expect(result.tokenUsage).toMatchObject({ total: 160, numRequests: 2 });
+  });
+
+  it('preserves incurred costs already reported by composite candidate responses', async () => {
+    const provider = new BestOfNProvider({ injectVar: 'input', maxConcurrency: 1 });
+    mockTargetProvider.callApi
+      .mockResolvedValueOnce({
+        error: 'Composite candidate was rejected',
+        cost: 0.1,
+        incurredCost: 0.04,
+        tokenUsage: {
+          total: 100,
+          numRequests: 2,
+          incurredTokenUsage: { total: 40, numRequests: 1 },
+        },
+      })
+      .mockResolvedValueOnce({
+        output: 'Fresh candidate succeeded',
+        cost: 0.06,
+        tokenUsage: { total: 60, numRequests: 1 },
+      });
+
+    const result = await provider.callApi('test prompt', createMockContext(mockTargetProvider));
+
+    expect(result.cost).toBeCloseTo(0.16);
+    expect(result.incurredCost).toBeCloseTo(0.1);
+    expect(result.tokenUsage).toMatchObject({
+      total: 160,
+      numRequests: 3,
+      incurredTokenUsage: { total: 100, numRequests: 2 },
     });
   });
 

--- a/test/redteam/providers/crescendo/index.test.ts
+++ b/test/redteam/providers/crescendo/index.test.ts
@@ -1968,6 +1968,68 @@ describe('CrescendoProvider', () => {
       });
     });
 
+    it('preserves cached attacker and judge footprint without counting it as incurred provider usage', async () => {
+      const provider = new CrescendoProvider({
+        injectVar: 'objective',
+        maxTurns: 1,
+        redteamProvider: mockRedTeamProvider,
+      });
+      const { TokenUsageTracker } = await import('../../../../src/util/tokenUsage');
+      const tracker = TokenUsageTracker.getInstance();
+
+      mockRedTeamProvider.callApi.mockResolvedValue({
+        cached: true,
+        output: JSON.stringify({
+          generatedQuestion: 'test question',
+          rationaleBehindJailbreak: 'test rationale',
+          lastResponseSummary: 'test summary',
+        }),
+        tokenUsage: { total: 75, prompt: 35, completion: 40, numRequests: 1, cached: 0 },
+      });
+      mockTargetProvider.callApi.mockResolvedValue({
+        output: 'target response',
+        tokenUsage: { total: 100, prompt: 40, completion: 60, numRequests: 1, cached: 0 },
+      });
+      mockScoringProvider.callApi.mockResolvedValue({
+        cached: true,
+        output: JSON.stringify({
+          value: false,
+          metadata: 50,
+          rationale: 'Not successful',
+        }),
+        tokenUsage: { total: 40, prompt: 18, completion: 22, numRequests: 1, cached: 0 },
+      });
+
+      const result = await provider.callApi('test prompt', {
+        originalProvider: mockTargetProvider,
+        vars: { objective: 'test objective' },
+        prompt: { raw: 'test prompt', label: 'test' },
+      });
+
+      expect(result.tokenUsage).toMatchObject({
+        total: 100,
+        numRequests: 1,
+        attacker: { total: 75, numRequests: 1 },
+        assertions: { total: 80, numRequests: 2 },
+        incurredTokenUsage: {
+          total: 100,
+          numRequests: 1,
+          attacker: { total: 0, numRequests: 0 },
+          assertions: { total: 0, numRequests: 0 },
+        },
+      });
+      expect(tracker.getProviderUsage('mock-redteam')).toMatchObject({
+        total: 0,
+        cached: 75,
+        numRequests: 0,
+      });
+      expect(tracker.getProviderUsage('mock-scoring')).toMatchObject({
+        total: 0,
+        cached: 80,
+        numRequests: 0,
+      });
+    });
+
     it('should accumulate token usage with unblocking responses', async () => {
       const provider = new CrescendoProvider({
         injectVar: 'objective',

--- a/test/redteam/providers/iterativeTree.test.ts
+++ b/test/redteam/providers/iterativeTree.test.ts
@@ -128,6 +128,7 @@ describe('RedteamIterativeProvider', () => {
     beforeEach(() => {
       mockRedteamProvider = createMockProvider({ id: 'mock-provider' });
       mockRedteamProvider.callApi.mockReset();
+      TokenUsageTracker.getInstance().resetProviderUsage(mockRedteamProvider.id());
     });
 
     it('should evaluate response correctly without penalized phrase', async () => {
@@ -195,6 +196,35 @@ describe('RedteamIterativeProvider', () => {
           completionDetails: { reasoning: 4 },
         },
       });
+    });
+
+    it('keeps cached judge usage in the scan footprint but out of incurred provider totals', async () => {
+      mockRedteamProvider.callApi.mockResolvedValue({
+        cached: true,
+        output: JSON.stringify({
+          currentResponse: { rating: 8, explanation: 'Good response' },
+          previousBestResponse: { rating: 5, explanation: 'Previous response' },
+        }),
+        tokenUsage: { total: 19, prompt: 11, completion: 8, numRequests: 1 },
+      });
+      const tokenUsage = createEmptyTokenUsage();
+
+      await evaluateResponse(
+        mockRedteamProvider,
+        'Judge prompt',
+        'Target response',
+        'Previous response',
+        false,
+        tokenUsage,
+      );
+
+      expect(tokenUsage).toMatchObject({
+        assertions: { total: 19, numRequests: 1 },
+        incurredTokenUsage: { assertions: { total: 0, numRequests: 0 } },
+      });
+      expect(
+        TokenUsageTracker.getInstance().getProviderUsage(mockRedteamProvider.id()),
+      ).toMatchObject({ total: 0, cached: 19, numRequests: 0 });
     });
 
     it('should apply penalty for penalized phrases', async () => {
@@ -324,6 +354,25 @@ describe('RedteamIterativeProvider', () => {
       expect(
         TokenUsageTracker.getInstance().getProviderUsage(mockRedteamProvider.id()),
       ).toMatchObject({ total: 23, prompt: 15, completion: 8, numRequests: 1 });
+    });
+
+    it('keeps cached attacker usage in the scan footprint but out of incurred provider totals', async () => {
+      const usage = createEmptyTokenUsage();
+      mockRedteamProvider.callApi.mockResolvedValue({
+        cached: true,
+        output: JSON.stringify({ improvement: 'Improved aspect', prompt: 'New prompt' }),
+        tokenUsage: { total: 23, prompt: 15, completion: 8, numRequests: 1 },
+      });
+
+      await getNewPrompt(mockRedteamProvider, [], undefined, usage);
+
+      expect(usage).toMatchObject({
+        attacker: { total: 23, numRequests: 1 },
+        incurredTokenUsage: { attacker: { total: 0, numRequests: 0 } },
+      });
+      expect(
+        TokenUsageTracker.getInstance().getProviderUsage(mockRedteamProvider.id()),
+      ).toMatchObject({ total: 0, cached: 23, numRequests: 0 });
     });
 
     it('returns accumulated attacker usage when the tree provider fails', async () => {

--- a/test/redteam/providers/mischievousUser.test.ts
+++ b/test/redteam/providers/mischievousUser.test.ts
@@ -153,7 +153,7 @@ describe('RedteamMischievousUserProvider', () => {
     });
   });
 
-  it('does not charge Promptfoo response-cache hits', async () => {
+  it('retains cached logical usage without charging Promptfoo response-cache hits', async () => {
     mockUserProviderCallApi.mockResolvedValueOnce({
       cached: true,
       output: 'user response',
@@ -171,8 +171,25 @@ describe('RedteamMischievousUserProvider', () => {
 
     const result = await provider.callApi('test prompt', context);
 
-    expect(result.tokenUsage).toMatchObject({ total: 0, numRequests: 0 });
-    expect(result.tokenUsage?.attacker).toBeUndefined();
+    expect(result.tokenUsage).toMatchObject({
+      total: 200,
+      prompt: 120,
+      completion: 80,
+      cached: 200,
+      numRequests: 1,
+      attacker: {
+        total: 100,
+        prompt: 60,
+        completion: 40,
+        cached: 100,
+        numRequests: 1,
+      },
+      incurredTokenUsage: {
+        total: 0,
+        numRequests: 0,
+        attacker: { total: 0, numRequests: 0 },
+      },
+    });
   });
 
   it('retains provider-side cached tokens from a fresh attacker request', async () => {

--- a/test/redteam/providers/shared.test.ts
+++ b/test/redteam/providers/shared.test.ts
@@ -144,7 +144,7 @@ describe('shared redteam provider utilities', () => {
       expect(tokenUsage).not.toHaveProperty('numRequests');
     });
 
-    it('does not count disabled or cached unblocking tasks', () => {
+    it('omits disabled unblocking tasks and keeps cached tasks out of incurred usage', () => {
       const disabledUsage = {};
       accumulateUnblockingTokenUsage(disabledUsage, { attempted: false });
       expect(disabledUsage).toEqual({});
@@ -155,7 +155,10 @@ describe('shared redteam provider utilities', () => {
         cached: true,
         tokenUsage: { total: 15, cached: 15, numRequests: 0 },
       });
-      expect(cachedUsage).toMatchObject({ assertions: { total: 0, numRequests: 0 } });
+      expect(cachedUsage).toMatchObject({
+        assertions: { total: 15, cached: 15, numRequests: 1 },
+        incurredTokenUsage: { assertions: { total: 0, numRequests: 0 } },
+      });
     });
   });
 

--- a/test/redteam/providers/voiceCrescendo/index.test.ts
+++ b/test/redteam/providers/voiceCrescendo/index.test.ts
@@ -270,7 +270,13 @@ describe('VoiceCrescendoProvider', () => {
       total: 30,
       numRequests: 1,
       attacker: { total: 15, numRequests: 1 },
-      assertions: { total: 0, prompt: 0, completion: 0, cached: 19, numRequests: 0 },
+      assertions: { total: 19, prompt: 12, completion: 7, cached: 19, numRequests: 1 },
+      incurredTokenUsage: {
+        total: 30,
+        numRequests: 1,
+        attacker: { total: 15, numRequests: 1 },
+        assertions: { total: 0, numRequests: 0 },
+      },
     });
   });
 

--- a/test/redteam/util.test.ts
+++ b/test/redteam/util.test.ts
@@ -240,7 +240,7 @@ describe('extractGoalFromPrompt', () => {
     );
 
     expect(result).toBeNull();
-    expect(usage).toEqual({ numRequests: 1 });
+    expect(usage).toMatchObject({ total: 0, numRequests: 1 });
   });
 
   it('should return null on HTTP error', async () => {

--- a/test/util/calculateFilteredMetrics.test.ts
+++ b/test/util/calculateFilteredMetrics.test.ts
@@ -147,12 +147,14 @@ describe('calculateFilteredMetrics', () => {
         tokenUsage,
         gradingUsage,
         gradingCached = false,
+        responseCached = false,
       }: {
         testIdx: number;
         promptIdx?: number;
         tokenUsage: TokenUsage;
         gradingUsage?: TokenUsage;
         gradingCached?: boolean;
+        responseCached?: boolean;
       },
     ) {
       await eval_.addResult({
@@ -163,7 +165,7 @@ describe('calculateFilteredMetrics', () => {
         provider: { id: 'test-provider', label: 'test' },
         prompt: { raw: 'Test prompt', label: 'Test prompt' },
         vars: { test: 'value' },
-        response: { output: 'test output', tokenUsage },
+        response: { output: 'test output', ...(responseCached && { cached: true }), tokenUsage },
         error: null,
         failureReason: ResultFailureReason.NONE,
         success: true,
@@ -291,7 +293,7 @@ describe('calculateFilteredMetrics', () => {
       });
     });
 
-    it('preserves zero probes and excludes cached grading replays from fresh totals', async () => {
+    it('preserves cached grading footprint without counting it as incurred usage', async () => {
       const eval_ = await EvalFactory.create({ numResults: 0 });
       await addTokenResult(eval_, {
         testIdx: 0,
@@ -319,7 +321,101 @@ describe('calculateFilteredMetrics', () => {
         cached: 30,
         numRequests: 0,
         attacker: { total: 0, cached: 7, numRequests: 0 },
-        assertions: { total: 0, cached: 18, numRequests: 0 },
+        assertions: { total: 12, prompt: 12, completion: 6, cached: 18, numRequests: 1 },
+        incurredTokenUsage: { assertions: { total: 0, numRequests: 0 } },
+      });
+    });
+
+    it('preserves both logical and incurred buckets for filtered mixed-cache results', async () => {
+      const eval_ = await EvalFactory.create({ numResults: 0 });
+      await addTokenResult(eval_, {
+        testIdx: 0,
+        tokenUsage: {
+          total: 100,
+          prompt: 60,
+          completion: 40,
+          cached: 70,
+          numRequests: 2,
+          attacker: { total: 40, prompt: 25, completion: 15, cached: 30, numRequests: 2 },
+          assertions: { total: 18, prompt: 11, completion: 7, cached: 12, numRequests: 2 },
+          incurredTokenUsage: {
+            total: 30,
+            prompt: 20,
+            completion: 10,
+            numRequests: 1,
+            attacker: { total: 10, prompt: 7, completion: 3, numRequests: 1 },
+            assertions: { total: 6, prompt: 4, completion: 2, numRequests: 1 },
+          },
+        },
+        gradingUsage: {
+          total: 50,
+          prompt: 30,
+          completion: 20,
+          cached: 30,
+          numRequests: 2,
+          incurredTokenUsage: { total: 20, prompt: 12, completion: 8, numRequests: 1 },
+        },
+      });
+      await addTokenResult(eval_, {
+        testIdx: 1,
+        tokenUsage: { total: 999, numRequests: 7 },
+      });
+
+      const metrics = await calculateFilteredMetrics({
+        evalId: eval_.id,
+        numPrompts: 1,
+        whereSql: sql`eval_id = ${eval_.id} AND test_idx = 0`,
+      });
+
+      expect(metrics[0].tokenUsage).toMatchObject({
+        total: 100,
+        prompt: 60,
+        completion: 40,
+        numRequests: 2,
+        attacker: { total: 40, prompt: 25, completion: 15, numRequests: 2 },
+        assertions: { total: 68, prompt: 41, completion: 27, numRequests: 4 },
+        incurredTokenUsage: {
+          total: 30,
+          prompt: 20,
+          completion: 10,
+          numRequests: 1,
+          attacker: { total: 10, prompt: 7, completion: 3, numRequests: 1 },
+          assertions: { total: 26, prompt: 16, completion: 10, numRequests: 2 },
+        },
+      });
+    });
+
+    it('retains fresh grading in incurred usage when a filtered target was cached', async () => {
+      const eval_ = await EvalFactory.create({ numResults: 0 });
+      await addTokenResult(eval_, {
+        testIdx: 0,
+        responseCached: true,
+        tokenUsage: {
+          total: 100,
+          prompt: 60,
+          completion: 40,
+          cached: 100,
+          numRequests: 1,
+          incurredTokenUsage: { total: 0, numRequests: 0 },
+        },
+        gradingUsage: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+      });
+
+      const metrics = await calculateFilteredMetrics({
+        evalId: eval_.id,
+        numPrompts: 1,
+        whereSql: sql`eval_id = ${eval_.id}`,
+      });
+
+      expect(metrics[0].tokenUsage).toMatchObject({
+        total: 100,
+        numRequests: 1,
+        assertions: { total: 37, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          assertions: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+        },
       });
     });
 

--- a/test/util/eval/summary.test.ts
+++ b/test/util/eval/summary.test.ts
@@ -367,6 +367,73 @@ describe('generateEvalSummary', () => {
       expect(output).toContain('Probes: 2');
     });
 
+    it('reports cached scan footprint separately from tokens actually incurred', () => {
+      const lines = generateEvalSummary({
+        evalId: 'eval-logical-and-incurred-usage',
+        isRedteam: true,
+        writeToDatabase: false,
+        shareableUrl: null,
+        wantsToShare: false,
+        hasExplicitDisable: false,
+        cloudEnabled: false,
+        tokenUsage: {
+          total: 295,
+          prompt: 201,
+          completion: 94,
+          cached: 295,
+          numRequests: 1,
+          assertions: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+          incurredTokenUsage: {
+            total: 0,
+            numRequests: 0,
+            assertions: { total: 37, prompt: 23, completion: 14, numRequests: 1 },
+          },
+        },
+        successes: 1,
+        failures: 0,
+        errors: 0,
+        duration: 1000,
+        maxConcurrency: 1,
+        tracker: mockTracker,
+      });
+      const output = stripAnsi(lines.join('\n'));
+
+      expect(output).toContain('Total Tokens: 332');
+      expect(output).toContain('Target: 295');
+      expect(output).toContain('Grading: 37');
+      expect(output).toContain('Incurred Tokens: 37');
+      expect(output).toContain('Cached Savings: 295');
+      expect(output).toContain('Actual Target Requests: 0');
+      expect(output).toContain('Probes: 1');
+    });
+
+    it('omits redundant incurred accounting when all provider responses were fresh', () => {
+      const lines = generateEvalSummary({
+        evalId: 'eval-fresh-usage-only',
+        isRedteam: true,
+        writeToDatabase: false,
+        shareableUrl: null,
+        wantsToShare: false,
+        hasExplicitDisable: false,
+        cloudEnabled: false,
+        tokenUsage: {
+          total: 100,
+          numRequests: 1,
+          incurredTokenUsage: { total: 100, numRequests: 1 },
+        },
+        successes: 1,
+        failures: 0,
+        errors: 0,
+        duration: 1000,
+        maxConcurrency: 1,
+        tracker: mockTracker,
+      });
+      const output = stripAnsi(lines.join('\n'));
+
+      expect(output).toContain('Total Tokens: 100');
+      expect(output).not.toContain('Incurred Tokens:');
+    });
+
     it('derives category totals from prompt and completion usage when total is absent', () => {
       const aggregatedUsage = createEmptyTokenUsage();
       accumulateTokenUsage(aggregatedUsage, {

--- a/test/util/tokenUsage.test.ts
+++ b/test/util/tokenUsage.test.ts
@@ -124,6 +124,27 @@ describe('TokenUsageTracker', () => {
     });
   });
 
+  it('tracks a cached provider response without repeating its historical usage', () => {
+    tracker.trackResponseUsage('cached-provider', {
+      cached: true,
+      tokenUsage: {
+        total: 100,
+        prompt: 60,
+        completion: 40,
+        cached: 10,
+        numRequests: 1,
+      },
+    });
+
+    expect(tracker.getProviderUsage('cached-provider')).toMatchObject({
+      total: 0,
+      prompt: 0,
+      completion: 0,
+      cached: 100,
+      numRequests: 0,
+    });
+  });
+
   it('should merge token usage for the same provider', () => {
     const usage1: TokenUsage = {
       total: 100,

--- a/test/util/tokenUsage.test.ts
+++ b/test/util/tokenUsage.test.ts
@@ -145,6 +145,24 @@ describe('TokenUsageTracker', () => {
     });
   });
 
+  it('combines fresh provider usage with cache-hit visibility without charging the replay', () => {
+    tracker.trackResponseUsage('mixed-provider', {
+      tokenUsage: { total: 25, prompt: 15, completion: 10, cached: 5, numRequests: 1 },
+    });
+    tracker.trackResponseUsage('mixed-provider', {
+      cached: true,
+      tokenUsage: { total: 40, prompt: 25, completion: 15, cached: 0, numRequests: 1 },
+    });
+
+    expect(tracker.getProviderUsage('mixed-provider')).toMatchObject({
+      total: 25,
+      prompt: 15,
+      completion: 10,
+      cached: 45,
+      numRequests: 1,
+    });
+  });
+
   it('should merge token usage for the same provider', () => {
     const usage1: TokenUsage = {
       total: 100,

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -295,6 +295,60 @@ describe('tokenUsageUtils', () => {
       expect(target.numRequests).toBe(1);
     });
 
+    it('records historical target usage as cached without charging tokens or a probe', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateResponseTokenUsage(target, {
+        cached: true,
+        tokenUsage: {
+          total: 100,
+          prompt: 60,
+          completion: 40,
+          cached: 10,
+          numRequests: 1,
+          completionDetails: { reasoning: 12 },
+        },
+      });
+
+      expect(target).toMatchObject({
+        total: 0,
+        prompt: 0,
+        completion: 0,
+        cached: 100,
+        numRequests: 0,
+        completionDetails: { reasoning: 0 },
+      });
+    });
+
+    it('counts a cached target turn as one probe when fresh grading still runs', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateResponseTokenUsage(
+        target,
+        {
+          cached: true,
+          tokenUsage: { prompt: 60, completion: 40, numRequests: 1 },
+        },
+        { countCachedAsRequest: true },
+      );
+
+      expect(target).toMatchObject({
+        total: 0,
+        prompt: 0,
+        completion: 0,
+        cached: 100,
+        numRequests: 1,
+      });
+    });
+
+    it('does not count a cached response without token usage as a request', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateResponseTokenUsage(target, { cached: true });
+
+      expect(target).toMatchObject({ total: 0, cached: 0, numRequests: 0 });
+    });
+
     it('should increment numRequests when response exists but has no tokenUsage', () => {
       const target = createEmptyTokenUsage();
       const response = {};

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -320,6 +320,42 @@ describe('tokenUsageUtils', () => {
       });
     });
 
+    it('preserves independently incurred attacker usage when the target response is cached', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateResponseTokenUsage(target, {
+        cached: true,
+        tokenUsage: {
+          total: 100,
+          prompt: 60,
+          completion: 40,
+          numRequests: 1,
+          attacker: {
+            total: 28,
+            prompt: 20,
+            completion: 8,
+            numRequests: 1,
+            completionDetails: { reasoning: 3 },
+          },
+        },
+      });
+
+      expect(target).toMatchObject({
+        total: 0,
+        prompt: 0,
+        completion: 0,
+        cached: 100,
+        numRequests: 0,
+        attacker: {
+          total: 28,
+          prompt: 20,
+          completion: 8,
+          numRequests: 1,
+          completionDetails: { reasoning: 3 },
+        },
+      });
+    });
+
     it('counts a cached target turn as one probe when fresh grading still runs', () => {
       const target = createEmptyTokenUsage();
 

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -295,7 +295,7 @@ describe('tokenUsageUtils', () => {
       expect(target.numRequests).toBe(1);
     });
 
-    it('records historical target usage as cached without charging tokens or a probe', () => {
+    it('retains the logical footprint of a cached target without incurring another request', () => {
       const target = createEmptyTokenUsage();
 
       accumulateResponseTokenUsage(target, {
@@ -311,12 +311,13 @@ describe('tokenUsageUtils', () => {
       });
 
       expect(target).toMatchObject({
-        total: 0,
-        prompt: 0,
-        completion: 0,
+        total: 100,
+        prompt: 60,
+        completion: 40,
         cached: 100,
-        numRequests: 0,
-        completionDetails: { reasoning: 0 },
+        numRequests: 1,
+        completionDetails: { reasoning: 12 },
+        incurredTokenUsage: { total: 0, prompt: 0, completion: 0, numRequests: 0 },
       });
     });
 
@@ -341,17 +342,22 @@ describe('tokenUsageUtils', () => {
       });
 
       expect(target).toMatchObject({
-        total: 0,
-        prompt: 0,
-        completion: 0,
+        total: 100,
+        prompt: 60,
+        completion: 40,
         cached: 100,
-        numRequests: 0,
+        numRequests: 1,
         attacker: {
           total: 28,
           prompt: 20,
           completion: 8,
           numRequests: 1,
           completionDetails: { reasoning: 3 },
+        },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          attacker: { total: 28, numRequests: 1 },
         },
       });
     });
@@ -369,20 +375,45 @@ describe('tokenUsageUtils', () => {
       );
 
       expect(target).toMatchObject({
-        total: 0,
-        prompt: 0,
-        completion: 0,
+        total: 100,
+        prompt: 60,
+        completion: 40,
         cached: 100,
         numRequests: 1,
+        incurredTokenUsage: { total: 0, numRequests: 0 },
       });
     });
 
-    it('does not count a cached response without token usage as a request', () => {
+    it('counts a cached response without usage as a logical turn but not an incurred request', () => {
       const target = createEmptyTokenUsage();
 
       accumulateResponseTokenUsage(target, { cached: true });
 
-      expect(target).toMatchObject({ total: 0, cached: 0, numRequests: 0 });
+      expect(target).toMatchObject({
+        total: 0,
+        cached: 0,
+        numRequests: 1,
+        incurredTokenUsage: { total: 0, numRequests: 0 },
+      });
+    });
+
+    it('keeps provider-side prompt cache hits in incurred usage because a model call still ran', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateResponseTokenUsage(target, {
+        tokenUsage: { total: 100, prompt: 60, completion: 40, cached: 45, numRequests: 1 },
+      });
+
+      expect(target).toMatchObject({
+        total: 100,
+        cached: 45,
+        numRequests: 1,
+      });
+      expect(target.incurredTokenUsage ?? target).toMatchObject({
+        total: 100,
+        cached: 45,
+        numRequests: 1,
+      });
     });
 
     it('should increment numRequests when response exists but has no tokenUsage', () => {
@@ -477,7 +508,7 @@ describe('tokenUsageUtils', () => {
       });
     });
 
-    it('does not add historical usage from fully cached attacker responses', () => {
+    it('keeps cached attacker usage in the logical footprint but excludes it from incurred usage', () => {
       const target = createEmptyTokenUsage();
 
       accumulateAttackerTokenUsage(target, {
@@ -485,8 +516,11 @@ describe('tokenUsageUtils', () => {
         tokenUsage: { total: 32, prompt: 20, completion: 12, numRequests: 1 },
       });
 
-      expect(target.attacker).toBeUndefined();
-      expect(target.numRequests).toBe(0);
+      expect(target).toMatchObject({
+        numRequests: 0,
+        attacker: { total: 32, prompt: 20, completion: 12, numRequests: 1 },
+        incurredTokenUsage: { attacker: { total: 0, numRequests: 0 } },
+      });
     });
 
     it('routes grading-model work nested in an attack task into the grading bucket', () => {
@@ -562,7 +596,10 @@ describe('tokenUsageUtils', () => {
         tokenUsage: { total: 40, cached: 40, numRequests: 0 },
       });
 
-      expect(target.assertions).toMatchObject({ total: 0, cached: 40, numRequests: 0 });
+      expect(target).toMatchObject({
+        assertions: { total: 40, cached: 40, numRequests: 1 },
+        incurredTokenUsage: { assertions: { total: 0, numRequests: 0 } },
+      });
     });
 
     it('does not count explicitly cached strategy responses with missing usage', () => {
@@ -570,7 +607,10 @@ describe('tokenUsageUtils', () => {
 
       accumulateGradingResponseTokenUsage(target, { cached: true });
 
-      expect(target.assertions).toMatchObject({ total: 0, numRequests: 0 });
+      expect(target).toMatchObject({
+        assertions: { total: 0, numRequests: 1 },
+        incurredTokenUsage: { assertions: { total: 0, numRequests: 0 } },
+      });
     });
 
     it('counts fresh strategy grading tasks normalized to zero requests', () => {


### PR DESCRIPTION
## Summary

- Keep existing token and cost totals as the full evaluation footprint, including cached target responses, and add optional incurred usage/cost only when actual execution differs.
- Preserve separate target, attacker, grading, and generation accounting through shared accumulators, composite providers, persisted results, deferred comparison grading, CLI summaries, and the OSS UI.
- Count logical target turns as probes while exposing actual target requests separately; provider-side prompt caching still counts as an executed request.

## Verification

- 920 upstream evaluator, model, utility, and red-team strategy tests passed.
- 115 OSS UI tests and the OSS app typecheck passed.
- Live Cloud-backed replay: 295 cached target tokens + 675 fresh grading tokens = 970 logical scan tokens, with 675 incurred tokens, one logical probe, and zero actual target requests. PostgreSQL metric refresh preserved every value, and the reused generation event was not charged again.
- Companion Cloud support: https://github.com/promptfoo/promptfoo-cloud/pull/4499
