### PR TITLE
fix(assertions): handle circular provider references when cloning grading test

### DIFF
--- a/src/assertions/utils.ts
+++ b/src/assertions/utils.ts
@@ -7,7 +7,15 @@ import { importModule } from '../esm';
 import { type Assertion, type TestCase } from '../types/index';
 import { loadYaml } from '../util/yamlLoad';
 
-const clone = Clone();
+// `circles: true` is required because `test.assert` can carry an already-resolved,
+// live `ApiProvider` instance (see resolveRuntimeGradingProviderReferences in
+// evaluator.ts, which substitutes a configured provider's live instance in place
+// of an id string whenever an assertion's judge `provider:` matches one of the
+// eval's target provider ids). That instance's lazily-constructed SDK client
+// (e.g. Anthropic's) can contain genuine internal circular references. rfdc's
+// default (non-circular) clone recurses forever on such a structure instead of
+// throwing, crashing the eval with "Maximum call stack size exceeded".
+const clone = Clone({ circles: true });
 
 export function getFinalTest(test: TestCase, assertion: Assertion) {
   // Deep copy

--- a/test/assertions/utils.test.ts
+++ b/test/assertions/utils.test.ts
@@ -219,6 +219,43 @@ describe('getFinalTest', () => {
     expect(result.provider).toBe(directProvider);
     expect(result.options?.provider).toBe(assertionProvider);
   });
+
+  it('does not throw when test.assert carries a provider with circular internal references', () => {
+    // Regression test for https://github.com/promptfoo/promptfoo/issues/10501.
+    //
+    // evaluator.ts's resolveRuntimeGradingProviderReferences substitutes an
+    // already-instantiated, live ApiProvider into testCase.assert[i].provider
+    // whenever an assertion's judge `provider:` id matches one of the eval's
+    // target provider ids. A live SDK client (e.g. Anthropic's) can contain
+    // genuine internal circular references (e.g. client.messages._client ===
+    // client). getFinalTest deep-clones `test` (including `test.assert`), so
+    // without circular-reference support the clone recurses forever.
+    const circularProvider = createMockProvider('circularProvider') as ApiProvider & {
+      client?: Record<string, unknown>;
+    };
+    const client: Record<string, unknown> = {};
+    client.self = client;
+    circularProvider.client = client;
+
+    const testCase: TestCase = {
+      vars: { var1: 'value1' },
+      assert: [
+        {
+          type: 'llm-rubric',
+          value: 'some rubric',
+          provider: circularProvider,
+        },
+      ],
+    };
+
+    const assertion: Assertion = {
+      type: 'llm-rubric',
+      value: 'some rubric',
+      provider: circularProvider,
+    };
+
+    expect(() => getFinalTest(testCase, assertion)).not.toThrow();
+  });
 });
 
 describe('loadFromJavaScriptFile', () => {


### PR DESCRIPTION
## Summary

Fixes #10501 — `RangeError: Maximum call stack size exceeded` when an `llm-rubric` assertion's judge `provider:` id matches one of the eval's configured target provider ids.

## Root cause

`resolveRuntimeGradingProviderReferences` (`src/evaluator.ts:2312-2336`, called at `src/evaluator.ts:2490`, added in #9460) substitutes an already-instantiated, live `ApiProvider` into `testCase.assert[i].provider` whenever an assertion's judge `provider:` id matches a configured target provider's id — reusing the live instance instead of creating a fresh one.

`getFinalTest` (`src/assertions/utils.ts`) then deep-clones that same test case via `rfdc`, including its (now-mutated) `assert` array. `getFinalTest` already explicitly strips `test.provider` and `test.options.provider` before cloning (and reattaches them by reference afterward, since — per the existing comment — "Clone does not copy functions"), but `test.assert` isn't stripped. Once the target provider's SDK client is instantiated (e.g. Anthropic's `this.anthropic = new Anthropic(...)`, which carries genuine internal circular back-references such as `client.messages._client === client`), that live client flows through `test.assert[i].provider` straight into `clone()`.

`rfdc`'s default export does not handle circular references — that's opt-in via `Clone({ circles: true })`. Without it, cloning an object graph containing the live client's circular internals recurses forever instead of throwing a clear "converting circular structure" error, crashing the eval mid-run.

This is the same underlying class of bug as #8687 (fixed by #8688 on 2026-04-14) — a live provider instance's circular SDK client ending up in a generic serialize/clone call — but through a different code path: #8687 was `JSON.stringify` in the web UI's `EvalResult` persistence; this is `rfdc.clone()` in the CLI-side `getFinalTest`, introduced later by #9460 and not covered by #8688's fix.

## Fix

Enable `rfdc`'s `circles` option in `src/assertions/utils.ts` so the clone terminates on repeated references instead of recursing infinitely.

Confirmed nothing downstream reads `test.assert` off the object `getFinalTest` returns (grep across `src/assertions/`) — the resolved judge provider actually used for grading is reattached by reference via `ret.options.provider = assertion.provider || test?.options?.provider` (line untouched by this change), exactly as it already was before this fix. So this only affects the otherwise-unused cloned copy of `test.assert`, with no behavior change to grading itself.

I considered the more surgical alternative (strip resolved `ApiProvider` instances out of `test.assert[*].provider` before cloning, mirroring the existing `test.provider`/`test.options.provider` handling) but `circles: true` is safer here: `test.assert` entries can be `assert-set` items with their own nested `assert` arrays, `ProviderTypeMap` values (`{ text: ..., embedding: ... }`), or other shapes a surgical strip would need to enumerate correctly. Enabling circular-reference support closes the whole class of "live object accidentally ends up somewhere inside `test`" bugs, not just this one call site's current trigger.

## Testing

- Added a regression test in `test/assertions/utils.test.ts` (`getFinalTest > does not throw when test.assert carries a provider with circular internal references`) that constructs a mock provider with a genuine circular reference (mirroring `client.self = client`) and asserts `getFinalTest` doesn't throw.
  - Verified this test fails with `RangeError: Maximum call stack size exceeded` against the pre-fix code (reverted `Clone({ circles: true })` back to `Clone()` locally to confirm), and passes with the fix.
- `npx vitest run test/assertions/utils.test.ts` — 21/21 passed
- `npx vitest run test/evaluator.test.ts test/evaluate.test.ts test/assertions/` — 1370/1370 passed (60 files)
- `npx tsc --noEmit` — clean
- Pre-commit Biome lint hook passed

## Test plan for reviewers

```yaml
# repro.yaml
description: "repro"
prompts:
  - "respond to: {{x}}"
providers:
  - id: anthropic:messages:claude-haiku-4-5-20251001
defaultTest:
  assert:
    - type: llm-rubric
      value: "is this a reasonable response?"
      provider: anthropic:messages:claude-haiku-4-5-20251001   # same id as the target provider above
tests:
  - vars: { x: "hello" }
```
```
npx promptfoo eval -c repro.yaml --no-cache
```
Crashes with `RangeError: Maximum call stack size exceeded` on `main`; runs normally on this branch.
