### PR TITLE
fix(redteam): preserve cached generation and retry accounting

### DIFF
--- a/src/node/retry.ts
+++ b/src/node/retry.ts
@@ -248,7 +248,8 @@ export async function recalculatePromptMetrics(evalRecord: Eval): Promise<void> 
         // Update scores and other metrics
         metrics.score += result.score ?? 0;
         metrics.totalLatencyMs += result.latencyMs || 0;
-        const incurredCost = result.response?.incurredCost;
+        const incurredCost =
+          result.response?.incurredCost ?? (result.response?.cached ? 0 : undefined);
         if (incurredCost !== undefined || metrics.incurredCost !== undefined) {
           metrics.incurredCost =
             (metrics.incurredCost ?? metrics.cost) + (incurredCost ?? result.cost ?? 0);

--- a/src/node/retry.ts
+++ b/src/node/retry.ts
@@ -196,6 +196,7 @@ export async function recalculatePromptMetrics(evalRecord: Eval): Promise<void> 
       namedScoresCount: Record<string, number>;
       namedScoreWeights?: Record<string, number>;
       cost: number;
+      incurredCost?: number;
     }
   >();
 
@@ -247,6 +248,11 @@ export async function recalculatePromptMetrics(evalRecord: Eval): Promise<void> 
         // Update scores and other metrics
         metrics.score += result.score ?? 0;
         metrics.totalLatencyMs += result.latencyMs || 0;
+        const incurredCost = result.response?.incurredCost;
+        if (incurredCost !== undefined || metrics.incurredCost !== undefined) {
+          metrics.incurredCost =
+            (metrics.incurredCost ?? metrics.cost) + (incurredCost ?? result.cost ?? 0);
+        }
         metrics.cost += result.cost || 0;
 
         for (const [key, value] of Object.entries(result.namedScores || {})) {

--- a/src/redteam/extraction/util.ts
+++ b/src/redteam/extraction/util.ts
@@ -110,7 +110,9 @@ export async function fetchRemoteGeneration(
 export async function materializeMcpToolCallRemote(
   options: PromptfooMcpMaterializationOptions,
   callApiOptions?: CallApiOptionsParams,
-): Promise<{ prompt: string; tokenUsage?: ProviderResponse['tokenUsage'] } | undefined> {
+): Promise<
+  { cached?: boolean; prompt: string; tokenUsage?: ProviderResponse['tokenUsage'] } | undefined
+> {
   if (!shouldGenerateRemote()) {
     return undefined;
   }
@@ -158,6 +160,7 @@ export async function materializeMcpToolCallRemote(
     }
 
     return {
+      cached: response.cached,
       prompt: stringifyMcpToolCall(toolCall),
       tokenUsage: response.data.tokenUsage,
     };

--- a/src/redteam/generationTokenUsage.ts
+++ b/src/redteam/generationTokenUsage.ts
@@ -46,9 +46,7 @@ export function trackGenerationTokenUsage<T extends ApiProvider>(
   tokenUsage: TokenUsage,
 ): T {
   return trackProvider(provider, (response) => {
-    if (!response.cached) {
-      accumulateResponseTokenUsage(tokenUsage, response);
-    }
+    accumulateResponseTokenUsage(tokenUsage, response);
   });
 }
 

--- a/src/redteam/generationTokenUsage.ts
+++ b/src/redteam/generationTokenUsage.ts
@@ -1,4 +1,8 @@
-import { accumulateResponseTokenUsage, getErrorTokenUsage } from '../util/tokenUsageUtils';
+import {
+  accumulateResponseTokenUsage,
+  createEmptyTokenUsage,
+  getErrorTokenUsage,
+} from '../util/tokenUsageUtils';
 
 import type { ApiProvider, TokenUsage } from '../types/index';
 
@@ -46,7 +50,18 @@ export function trackGenerationTokenUsage<T extends ApiProvider>(
   tokenUsage: TokenUsage,
 ): T {
   return trackProvider(provider, (response) => {
-    accumulateResponseTokenUsage(tokenUsage, response);
+    accumulateResponseTokenUsage(
+      tokenUsage,
+      response.cached
+        ? {
+            ...response,
+            tokenUsage: {
+              ...response.tokenUsage,
+              incurredTokenUsage: createEmptyTokenUsage(),
+            },
+          }
+        : response,
+    );
   });
 }
 

--- a/src/redteam/mcpTargetProvider.ts
+++ b/src/redteam/mcpTargetProvider.ts
@@ -17,6 +17,10 @@ import type {
 
 const WRAPPED_MCP_PROVIDER = Symbol('wrappedMcpProvider');
 type ProviderTokenUsage = NonNullable<ProviderResponse['tokenUsage']>;
+type MaterializationUsage = {
+  cached?: boolean;
+  tokenUsage?: Partial<ProviderTokenUsage>;
+};
 
 type McpProviderWithTools = ApiProvider & {
   getAvailableTools: () => Promise<MCPTool[]>;
@@ -25,14 +29,14 @@ type McpProviderWithTools = ApiProvider & {
 
 function mergeMaterializationTokenUsage(
   response: ProviderResponse,
-  materializationTokenUsage: Partial<ProviderTokenUsage> | undefined,
+  materializationUsage: MaterializationUsage | undefined,
 ): ProviderResponse {
-  if (!materializationTokenUsage) {
+  if (!materializationUsage?.tokenUsage) {
     return response;
   }
 
   const tokenUsage = { ...(response.tokenUsage ?? {}) };
-  accumulateAttackerTokenUsage(tokenUsage, { tokenUsage: materializationTokenUsage });
+  accumulateAttackerTokenUsage(tokenUsage, materializationUsage);
 
   return {
     ...response,
@@ -90,7 +94,7 @@ class RedteamMcpTargetProvider implements ApiProvider {
       return this.target.callApi(prompt, context, options);
     }
 
-    let materializationTokenUsage: Partial<ProviderTokenUsage> | undefined;
+    let materializationUsage: MaterializationUsage | undefined;
 
     try {
       const intentValue =
@@ -124,7 +128,10 @@ class RedteamMcpTargetProvider implements ApiProvider {
 
         if (remoteMaterializedPrompt) {
           materializedPrompt = remoteMaterializedPrompt.prompt;
-          materializationTokenUsage = remoteMaterializedPrompt.tokenUsage;
+          materializationUsage = {
+            cached: remoteMaterializedPrompt.cached,
+            tokenUsage: remoteMaterializedPrompt.tokenUsage,
+          };
         } else {
           const materializerProvider = await redteamProviderManager.getProvider({
             jsonOnly: true,
@@ -133,20 +140,13 @@ class RedteamMcpTargetProvider implements ApiProvider {
           trackedMaterializerProvider.callApi = async (...args) => {
             try {
               const response = await materializerProvider.callApi(...args);
-              if (response.cached && response.tokenUsage) {
-                materializationTokenUsage = {
-                  total: 0,
-                  prompt: 0,
-                  completion: 0,
-                  cached: response.tokenUsage.cached ?? response.tokenUsage.total ?? 0,
-                  numRequests: 0,
-                };
-              } else {
-                materializationTokenUsage = response.tokenUsage;
-              }
+              materializationUsage = {
+                cached: response.cached,
+                tokenUsage: response.tokenUsage,
+              };
               return response;
             } catch (error) {
-              materializationTokenUsage = getErrorTokenUsage(error);
+              materializationUsage = { tokenUsage: getErrorTokenUsage(error) };
               throw error;
             }
           };
@@ -171,14 +171,14 @@ class RedteamMcpTargetProvider implements ApiProvider {
         : undefined;
 
       const response = await this.target.callApi(materializedPrompt, materializedContext, options);
-      return mergeMaterializationTokenUsage(response, materializationTokenUsage);
+      return mergeMaterializationTokenUsage(response, materializationUsage);
     } catch (error) {
       const errorResponse: ProviderResponse = {
         error: `Failed to materialize MCP target prompt: ${
           error instanceof Error ? error.message : String(error)
         }`,
       };
-      return mergeMaterializationTokenUsage(errorResponse, materializationTokenUsage);
+      return mergeMaterializationTokenUsage(errorResponse, materializationUsage);
     }
   }
 

--- a/src/redteam/mcpTargetProvider.ts
+++ b/src/redteam/mcpTargetProvider.ts
@@ -1,6 +1,11 @@
 import logger from '../logger';
 import { MCPProvider } from '../providers/mcp';
-import { accumulateAttackerTokenUsage, getErrorTokenUsage } from '../util/tokenUsageUtils';
+import {
+  accumulateAttackerTokenUsage,
+  accumulateResponseTokenUsage,
+  createEmptyTokenUsage,
+  getErrorTokenUsage,
+} from '../util/tokenUsageUtils';
 import { materializeMcpToolCallRemote } from './extraction/util';
 import { materializeMcpValue } from './mcpMaterialization';
 import { redteamProviderManager } from './providers/shared';
@@ -30,12 +35,14 @@ type McpProviderWithTools = ApiProvider & {
 function mergeMaterializationTokenUsage(
   response: ProviderResponse,
   materializationUsage: MaterializationUsage | undefined,
+  targetWasCalled: boolean,
 ): ProviderResponse {
   if (!materializationUsage?.tokenUsage) {
     return response;
   }
 
-  const tokenUsage = { ...(response.tokenUsage ?? {}) };
+  const tokenUsage = createEmptyTokenUsage();
+  accumulateResponseTokenUsage(tokenUsage, response, { countAsRequest: targetWasCalled });
   accumulateAttackerTokenUsage(tokenUsage, materializationUsage);
 
   return {
@@ -95,6 +102,7 @@ class RedteamMcpTargetProvider implements ApiProvider {
     }
 
     let materializationUsage: MaterializationUsage | undefined;
+    let targetWasCalled = false;
 
     try {
       const intentValue =
@@ -170,15 +178,16 @@ class RedteamMcpTargetProvider implements ApiProvider {
           }
         : undefined;
 
+      targetWasCalled = true;
       const response = await this.target.callApi(materializedPrompt, materializedContext, options);
-      return mergeMaterializationTokenUsage(response, materializationUsage);
+      return mergeMaterializationTokenUsage(response, materializationUsage, targetWasCalled);
     } catch (error) {
       const errorResponse: ProviderResponse = {
         error: `Failed to materialize MCP target prompt: ${
           error instanceof Error ? error.message : String(error)
         }`,
       };
-      return mergeMaterializationTokenUsage(errorResponse, materializationUsage);
+      return mergeMaterializationTokenUsage(errorResponse, materializationUsage, targetWasCalled);
     }
   }
 

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -248,9 +248,18 @@ export function accumulateAttackerTokenUsage(
   }
 
   const { assertions, incurredTokenUsage, ...attackerUsage } = response.tokenUsage ?? {};
+  const reportedTotal =
+    attackerUsage.total ?? (attackerUsage.prompt ?? 0) + (attackerUsage.completion ?? 0);
+  const cachedTokens = attackerUsage.cached ?? 0;
+  const cachedResponse =
+    response.cached === true ||
+    (response.cached === undefined &&
+      attackerUsage.numRequests === 0 &&
+      cachedTokens > 0 &&
+      reportedTotal <= cachedTokens);
   const attackerAccounting = createEmptyTokenUsage();
   accumulateResponseTokenUsage(attackerAccounting, {
-    cached: response.cached,
+    cached: cachedResponse,
     tokenUsage: {
       ...attackerUsage,
       ...(incurredTokenUsage && {
@@ -270,9 +279,9 @@ export function accumulateAttackerTokenUsage(
   const actualAttacker = cloneTokenUsageBreakdown(incurredAttacker ?? logicalAttacker);
   delete actualAttacker.assertions;
   const actualAssertions =
-    incurredTokenUsage?.assertions ?? (response.cached ? undefined : assertions);
+    incurredTokenUsage?.assertions ?? (cachedResponse ? undefined : assertions);
   const trackIncurredUsage = Boolean(
-    target.incurredTokenUsage || incurredTokenUsage || response.cached,
+    target.incurredTokenUsage || incurredTokenUsage || cachedResponse,
   );
 
   accumulateTokenUsage(target, {

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -247,7 +247,12 @@ export function accumulateAttackerTokenUsage(
     return;
   }
 
-  const { assertions, incurredTokenUsage, ...attackerUsage } = response.tokenUsage ?? {};
+  const {
+    assertions,
+    incurredTokenUsage: reportedIncurredTokenUsage,
+    ...attackerUsage
+  } = response.tokenUsage ?? {};
+  const incurredTokenUsage = response.cached ? undefined : reportedIncurredTokenUsage;
   const attackerAccounting = createEmptyTokenUsage();
   accumulateResponseTokenUsage(attackerAccounting, {
     cached: response.cached,

--- a/src/util/tokenUsageUtils.ts
+++ b/src/util/tokenUsageUtils.ts
@@ -248,18 +248,9 @@ export function accumulateAttackerTokenUsage(
   }
 
   const { assertions, incurredTokenUsage, ...attackerUsage } = response.tokenUsage ?? {};
-  const reportedTotal =
-    attackerUsage.total ?? (attackerUsage.prompt ?? 0) + (attackerUsage.completion ?? 0);
-  const cachedTokens = attackerUsage.cached ?? 0;
-  const cachedResponse =
-    response.cached === true ||
-    (response.cached === undefined &&
-      attackerUsage.numRequests === 0 &&
-      cachedTokens > 0 &&
-      reportedTotal <= cachedTokens);
   const attackerAccounting = createEmptyTokenUsage();
   accumulateResponseTokenUsage(attackerAccounting, {
-    cached: cachedResponse,
+    cached: response.cached,
     tokenUsage: {
       ...attackerUsage,
       ...(incurredTokenUsage && {
@@ -279,9 +270,9 @@ export function accumulateAttackerTokenUsage(
   const actualAttacker = cloneTokenUsageBreakdown(incurredAttacker ?? logicalAttacker);
   delete actualAttacker.assertions;
   const actualAssertions =
-    incurredTokenUsage?.assertions ?? (cachedResponse ? undefined : assertions);
+    incurredTokenUsage?.assertions ?? (response.cached ? undefined : assertions);
   const trackIncurredUsage = Boolean(
-    target.incurredTokenUsage || incurredTokenUsage || cachedResponse,
+    target.incurredTokenUsage || incurredTokenUsage || response.cached,
   );
 
   accumulateTokenUsage(target, {

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -1148,6 +1148,36 @@ describe('evaluator', () => {
       expect(eval1.getStats().tokenUsage.generation).toBeUndefined();
     });
 
+    it('preserves cached generation separately from incurred target usage', () => {
+      const eval1 = new Eval({
+        metadata: {
+          generationAccounting: {
+            id: 'generation-1',
+            tokenUsage: {
+              total: 40,
+              prompt: 25,
+              completion: 15,
+              cached: 40,
+              numRequests: 1,
+              incurredTokenUsage: { total: 0, numRequests: 0 },
+            },
+          },
+        },
+      });
+      eval1.prompts = [{ metrics: { tokenUsage: { total: 10, numRequests: 1 } } }] as any;
+
+      expect(eval1.getStats().tokenUsage).toMatchObject({
+        total: 10,
+        numRequests: 1,
+        generation: { total: 40, cached: 40, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 10,
+          numRequests: 1,
+          generation: { total: 0, numRequests: 0 },
+        },
+      });
+    });
+
     it('should accumulate assertion token usage correctly', () => {
       const eval1 = new Eval({});
       eval1.prompts = [

--- a/test/node/retry.integration.test.ts
+++ b/test/node/retry.integration.test.ts
@@ -1459,7 +1459,6 @@ describe('retry command', () => {
           response: {
             output: 'cached target response',
             cached: true,
-            incurredCost: 0,
             tokenUsage: { total: 295, prompt: 201, completion: 94, numRequests: 1 },
           },
           gradingResult: {

--- a/test/node/retry.integration.test.ts
+++ b/test/node/retry.integration.test.ts
@@ -1435,7 +1435,7 @@ describe('retry command', () => {
       expect(evalRecord.prompts[0].metrics?.tokenUsage?.assertions?.completion).toBe(50); // 20 + 30
     });
 
-    it('preserves cached and incurred grading usage when recalculating persisted results', async () => {
+    it('preserves cached usage and incurred costs when recalculating persisted results', async () => {
       const evalRecord = await Eval.create({}, [], { id: uniqueEvalId() });
       const db = await getDb();
       const mockProvider = { id: 'test-provider' };
@@ -1453,11 +1453,13 @@ describe('retry command', () => {
           provider: mockProvider,
           success: true,
           score: 1,
+          cost: 0.5,
           failureReason: ResultFailureReason.NONE,
           namedScores: {},
           response: {
             output: 'cached target response',
             cached: true,
+            incurredCost: 0,
             tokenUsage: { total: 295, prompt: 201, completion: 94, numRequests: 1 },
           },
           gradingResult: {
@@ -1477,6 +1479,7 @@ describe('retry command', () => {
           provider: mockProvider,
           success: true,
           score: 1,
+          cost: 0.25,
           failureReason: ResultFailureReason.NONE,
           namedScores: {},
           response: {
@@ -1501,10 +1504,12 @@ describe('retry command', () => {
           provider: mockProvider,
           success: true,
           score: 1,
+          cost: 0.5,
           failureReason: ResultFailureReason.NONE,
           namedScores: {},
           response: {
             output: 'another fresh target response',
+            incurredCost: 0.25,
             tokenUsage: { total: 50, prompt: 30, completion: 20, numRequests: 1 },
           },
           gradingResult: {
@@ -1532,6 +1537,7 @@ describe('retry command', () => {
 
       await recalculatePromptMetrics(evalRecord);
 
+      expect(evalRecord.prompts[0].metrics).toMatchObject({ cost: 1.25, incurredCost: 0.5 });
       expect(evalRecord.prompts[0].metrics?.tokenUsage).toMatchObject({
         total: 445,
         cached: 295,
@@ -1556,6 +1562,9 @@ describe('retry command', () => {
           },
         },
       });
+
+      const persistedEval = await Eval.findById(evalRecord.id);
+      expect(persistedEval?.prompts[0].metrics).toMatchObject({ cost: 1.25, incurredCost: 0.5 });
     });
 
     it('should skip results with invalid promptIdx', async () => {

--- a/test/node/retry.test.ts
+++ b/test/node/retry.test.ts
@@ -270,25 +270,55 @@ describe('retryCommand', () => {
   it.each([
     {
       label: 'cached result without actual cost',
-      costs: [{ logical: 0.5, incurred: 0 }],
+      costs: [{ logical: 0.5, incurred: 0, cached: true }],
+      expectedLogicalCost: 0.5,
+      expectedIncurredCost: 0,
+    },
+    {
+      label: 'legacy cached result without incurred cost',
+      costs: [{ logical: 0.5, cached: true }],
       expectedLogicalCost: 0.5,
       expectedIncurredCost: 0,
     },
     {
       label: 'fresh legacy result before a cached result',
-      costs: [{ logical: 0.25 }, { logical: 0.5, incurred: 0 }],
+      costs: [
+        { logical: 0.25, cached: false },
+        { logical: 0.5, incurred: 0, cached: true },
+      ],
       expectedLogicalCost: 0.75,
       expectedIncurredCost: 0.25,
     },
     {
       label: 'fresh legacy result after a cached result',
-      costs: [{ logical: 0.5, incurred: 0 }, { logical: 0.25 }],
+      costs: [
+        { logical: 0.5, incurred: 0, cached: true },
+        { logical: 0.25, cached: false },
+      ],
       expectedLogicalCost: 0.75,
       expectedIncurredCost: 0.25,
     },
     {
+      label: 'legacy cached result before a newer cached result',
+      costs: [
+        { logical: 0.5, cached: true },
+        { logical: 0.25, incurred: 0, cached: true },
+      ],
+      expectedLogicalCost: 0.75,
+      expectedIncurredCost: 0,
+    },
+    {
+      label: 'legacy cached result after a newer cached result',
+      costs: [
+        { logical: 0.25, incurred: 0, cached: true },
+        { logical: 0.5, cached: true },
+      ],
+      expectedLogicalCost: 0.75,
+      expectedIncurredCost: 0,
+    },
+    {
       label: 'partially incurred composite result',
-      costs: [{ logical: 0.5, incurred: 0.25 }],
+      costs: [{ logical: 0.5, incurred: 0.25, cached: true }],
       expectedLogicalCost: 0.5,
       expectedIncurredCost: 0.25,
     },
@@ -300,7 +330,7 @@ describe('retryCommand', () => {
         persisted: true,
         prompts,
         fetchResultsBatched: vi.fn(async function* () {
-          yield costs.map(({ logical, incurred }, index) => ({
+          yield costs.map(({ logical, incurred, cached }, index) => ({
             id: `retried-result-${index}`,
             promptIdx: 0,
             success: true,
@@ -308,6 +338,7 @@ describe('retryCommand', () => {
             cost: logical,
             namedScores: {},
             response: {
+              cached,
               ...(incurred !== undefined && { incurredCost: incurred }),
             },
           })) as any[];

--- a/test/node/retry.test.ts
+++ b/test/node/retry.test.ts
@@ -264,7 +264,65 @@ describe('retryCommand', () => {
       'Skipping result with invalid promptIdx: 99',
       expect.objectContaining({ resultId: 'invalid-prompt-result' }),
     );
+    expect(prompts[0].metrics).not.toHaveProperty('incurredCost');
   });
+
+  it.each([
+    {
+      label: 'cached result without actual cost',
+      costs: [{ logical: 0.5, incurred: 0 }],
+      expectedLogicalCost: 0.5,
+      expectedIncurredCost: 0,
+    },
+    {
+      label: 'fresh legacy result before a cached result',
+      costs: [{ logical: 0.25 }, { logical: 0.5, incurred: 0 }],
+      expectedLogicalCost: 0.75,
+      expectedIncurredCost: 0.25,
+    },
+    {
+      label: 'fresh legacy result after a cached result',
+      costs: [{ logical: 0.5, incurred: 0 }, { logical: 0.25 }],
+      expectedLogicalCost: 0.75,
+      expectedIncurredCost: 0.25,
+    },
+    {
+      label: 'partially incurred composite result',
+      costs: [{ logical: 0.5, incurred: 0.25 }],
+      expectedLogicalCost: 0.5,
+      expectedIncurredCost: 0.25,
+    },
+  ])(
+    'preserves logical and incurred cost when retrying a $label',
+    async ({ costs, expectedLogicalCost, expectedIncurredCost }) => {
+      const prompts = [{}] as any[];
+      const evalRecord = createEval({
+        persisted: true,
+        prompts,
+        fetchResultsBatched: vi.fn(async function* () {
+          yield costs.map(({ logical, incurred }, index) => ({
+            id: `retried-result-${index}`,
+            promptIdx: 0,
+            success: true,
+            score: 1,
+            cost: logical,
+            namedScores: {},
+            response: {
+              ...(incurred !== undefined && { incurredCost: incurred }),
+            },
+          })) as any[];
+        }),
+      });
+
+      await recalculatePromptMetrics(evalRecord);
+
+      expect(prompts[0].metrics).toMatchObject({
+        cost: expectedLogicalCost,
+        incurredCost: expectedIncurredCost,
+      });
+      expect(evalRecord.addPrompts).toHaveBeenCalledWith(prompts);
+    },
+  );
 
   it.each([
     {

--- a/test/redteam/extraction/util.test.ts
+++ b/test/redteam/extraction/util.test.ts
@@ -142,7 +142,7 @@ describe('fetchRemoteGeneration', () => {
     expect(generationUsage).toMatchObject({ ...tokenUsage, numRequests: 1 });
   });
 
-  it('does not count cached remote extraction responses', async () => {
+  it('preserves cached remote extraction usage without incurring it again', async () => {
     vi.mocked(fetchWithCache).mockResolvedValue({
       data: {
         task: 'entities',
@@ -158,7 +158,12 @@ describe('fetchRemoteGeneration', () => {
 
     await fetchRemoteGeneration('entities', ['prompt'], undefined, provider);
 
-    expect(generationUsage).toEqual({});
+    expect(generationUsage).toMatchObject({
+      total: 18,
+      cached: 18,
+      numRequests: 1,
+      incurredTokenUsage: { total: 0, numRequests: 0 },
+    });
   });
 
   it('counts failed remote extraction requests without token usage', async () => {

--- a/test/redteam/generationTokenUsage.test.ts
+++ b/test/redteam/generationTokenUsage.test.ts
@@ -38,6 +38,74 @@ describe('generation token usage', () => {
     });
   });
 
+  it('does not replay historical incurred usage from cached composite generation', async () => {
+    const usage: TokenUsage = {};
+    const provider = trackGenerationTokenUsage(
+      createProvider(
+        vi.fn().mockResolvedValue({
+          output: 'cached composite generation',
+          cached: true,
+          tokenUsage: {
+            total: 30,
+            prompt: 20,
+            completion: 10,
+            numRequests: 1,
+            incurredTokenUsage: {
+              total: 30,
+              prompt: 20,
+              completion: 10,
+              numRequests: 1,
+              assertions: { total: 7, numRequests: 1 },
+            },
+          },
+        }),
+      ),
+      usage,
+    );
+
+    await provider.callApi('generate a test');
+
+    expect(usage).toMatchObject({
+      total: 30,
+      prompt: 20,
+      completion: 10,
+      cached: 30,
+      numRequests: 1,
+      incurredTokenUsage: {
+        total: 0,
+        prompt: 0,
+        completion: 0,
+        numRequests: 0,
+        assertions: { total: 0, numRequests: 0 },
+      },
+    });
+  });
+
+  it('retains explicit incurred accounting for fresh composite generation', async () => {
+    const usage: TokenUsage = {};
+    const provider = trackGenerationTokenUsage(
+      createProvider(
+        vi.fn().mockResolvedValue({
+          output: 'fresh composite generation',
+          tokenUsage: {
+            total: 30,
+            numRequests: 2,
+            incurredTokenUsage: { total: 12, numRequests: 1 },
+          },
+        }),
+      ),
+      usage,
+    );
+
+    await provider.callApi('generate a test');
+
+    expect(usage).toMatchObject({
+      total: 30,
+      numRequests: 2,
+      incurredTokenUsage: { total: 12, numRequests: 1 },
+    });
+  });
+
   it.each([false, undefined])(
     'counts reported zero-token generation requests when cached is %s',
     async (cached) => {
@@ -206,6 +274,30 @@ describe('generation token usage', () => {
     recordGenerationTokenUsage(provider, {
       cached: true,
       tokenUsage: { total: 40, numRequests: 2 },
+    });
+
+    expect(usage).toMatchObject({
+      total: 40,
+      cached: 40,
+      numRequests: 2,
+      incurredTokenUsage: { total: 0, numRequests: 0 },
+    });
+  });
+
+  it('discards historical incurred accounting from cached remote generation', () => {
+    const usage: TokenUsage = {};
+    const provider = trackGenerationTokenUsage(
+      createProvider(vi.fn().mockResolvedValue({ output: 'unused' })),
+      usage,
+    );
+
+    recordGenerationTokenUsage(provider, {
+      cached: true,
+      tokenUsage: {
+        total: 40,
+        numRequests: 2,
+        incurredTokenUsage: { total: 25, numRequests: 1 },
+      },
     });
 
     expect(usage).toMatchObject({

--- a/test/redteam/generationTokenUsage.test.ts
+++ b/test/redteam/generationTokenUsage.test.ts
@@ -13,7 +13,7 @@ function createProvider(callApi: ApiProvider['callApi']): ApiProvider {
 }
 
 describe('generation token usage', () => {
-  it('does not count cached provider responses or their historical token usage', async () => {
+  it('preserves cached generation in the logical footprint without incurring usage', async () => {
     const usage: TokenUsage = {};
     const provider = trackGenerationTokenUsage(
       createProvider(
@@ -28,7 +28,14 @@ describe('generation token usage', () => {
 
     await provider.callApi('generate a test');
 
-    expect(usage).toEqual({});
+    expect(usage).toMatchObject({
+      total: 30,
+      prompt: 20,
+      completion: 10,
+      cached: 30,
+      numRequests: 1,
+      incurredTokenUsage: { total: 0, numRequests: 0 },
+    });
   });
 
   it.each([false, undefined])(
@@ -103,6 +110,38 @@ describe('generation token usage', () => {
     });
   });
 
+  it('keeps fresh generation incurred when cached responses follow it', async () => {
+    const usage: TokenUsage = {};
+    const provider = trackGenerationTokenUsage(
+      createProvider(
+        vi
+          .fn()
+          .mockResolvedValueOnce({
+            output: 'fresh generation',
+            tokenUsage: { total: 20, prompt: 12, completion: 8, numRequests: 1 },
+          })
+          .mockResolvedValueOnce({
+            output: 'cached generation',
+            cached: true,
+            tokenUsage: { total: 30, prompt: 20, completion: 10, numRequests: 1 },
+          }),
+      ),
+      usage,
+    );
+
+    await provider.callApi('generate the first test');
+    await provider.callApi('generate the second test');
+
+    expect(usage).toMatchObject({
+      total: 50,
+      prompt: 32,
+      completion: 18,
+      cached: 30,
+      numRequests: 2,
+      incurredTokenUsage: { total: 20, prompt: 12, completion: 8, numRequests: 1 },
+    });
+  });
+
   it('counts failed provider requests even when token usage is unavailable', async () => {
     const usage: TokenUsage = {};
     const provider = trackGenerationTokenUsage(
@@ -130,7 +169,7 @@ describe('generation token usage', () => {
     expect(usage).toMatchObject({ total: 14, prompt: 9, completion: 5, numRequests: 1 });
   });
 
-  it('applies the same cache rules to specialized generation providers', async () => {
+  it('preserves cached specialized generation without incurring usage', async () => {
     const usage: TokenUsage = {};
     const parent = trackGenerationTokenUsage(
       createProvider(vi.fn().mockResolvedValue({ output: 'unused' })),
@@ -149,10 +188,15 @@ describe('generation token usage', () => {
 
     await specialized.callApi('generate a specialized test');
 
-    expect(usage).toEqual({});
+    expect(usage).toMatchObject({
+      total: 45,
+      cached: 45,
+      numRequests: 1,
+      incurredTokenUsage: { total: 0, numRequests: 0 },
+    });
   });
 
-  it('ignores cached direct remote generation responses', () => {
+  it('preserves cached direct remote generation without incurring usage', () => {
     const usage: TokenUsage = {};
     const provider = trackGenerationTokenUsage(
       createProvider(vi.fn().mockResolvedValue({ output: 'unused' })),
@@ -164,6 +208,11 @@ describe('generation token usage', () => {
       tokenUsage: { total: 40, numRequests: 2 },
     });
 
-    expect(usage).toEqual({});
+    expect(usage).toMatchObject({
+      total: 40,
+      cached: 40,
+      numRequests: 2,
+      incurredTokenUsage: { total: 0, numRequests: 0 },
+    });
   });
 });

--- a/test/redteam/mcpRemoteMaterialization.test.ts
+++ b/test/redteam/mcpRemoteMaterialization.test.ts
@@ -110,6 +110,34 @@ describe('materializeMcpToolCallRemote', () => {
     expect(fetchWithCache).not.toHaveBeenCalled();
   });
 
+  it('preserves cache provenance from remote MCP materialization responses', async () => {
+    vi.mocked(getEnvString).mockImplementation((key: string) =>
+      key === 'PROMPTFOO_REMOTE_GENERATION_URL' ? 'https://remote.example.test/task' : '',
+    );
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      cached: true,
+      data: {
+        result: {
+          tool: 'search_companies',
+          args: { query: 'clean energy' },
+        },
+        tokenUsage: { total: 16, prompt: 12, completion: 4, numRequests: 1 },
+      },
+      status: 200,
+      statusText: 'OK',
+    } as Awaited<ReturnType<typeof fetchWithCache>>);
+
+    await expect(
+      materializeMcpToolCallRemote({
+        tools: [searchCompaniesTool],
+        value: 'Find clean energy companies.',
+      }),
+    ).resolves.toMatchObject({
+      cached: true,
+      tokenUsage: { total: 16, prompt: 12, completion: 4, numRequests: 1 },
+    });
+  });
+
   it('returns undefined when remote generation is explicitly disabled', async () => {
     vi.mocked(getEnvBool).mockImplementation(
       (key: string) => key === 'PROMPTFOO_DISABLE_REMOTE_GENERATION',

--- a/test/redteam/mcpTargetProvider.test.ts
+++ b/test/redteam/mcpTargetProvider.test.ts
@@ -155,6 +155,24 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     });
   });
 
+  it('preserves cached remote materialization without incurring attacker usage', async () => {
+    promptfooProviderMocks.materializeMcpToolCallRemote.mockResolvedValueOnce({
+      ...remoteMaterializedCall({ completion: 3, numRequests: 1, prompt: 7, total: 10 }),
+      cached: true,
+    });
+
+    const target = new FakeMcpProvider([searchCompaniesTool]);
+    const wrapped = maybeWrapMcpProviderForRedteam(target, redteamMetadata('harmful:hate'));
+
+    await expect(wrapped.callApi(searchCompaniesPrompt, redteamContext())).resolves.toMatchObject({
+      output: 'ok',
+      tokenUsage: {
+        attacker: { total: 10, prompt: 7, completion: 3, cached: 10, numRequests: 1 },
+        incurredTokenUsage: { attacker: { total: 0, numRequests: 0 } },
+      },
+    });
+  });
+
   it('passes linked cloud target context to remote materialization', async () => {
     promptfooProviderMocks.materializeMcpToolCallRemote.mockResolvedValueOnce(
       remoteMaterializedCall(),
@@ -271,9 +289,33 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     const response = await wrapped.callApi(searchCompaniesPrompt, redteamContext());
 
     expect(response.tokenUsage).toMatchObject({
-      attacker: { total: 13, cached: 13, numRequests: 1 },
+      attacker: { total: 13, prompt: 9, completion: 4, cached: 13, numRequests: 1 },
       incurredTokenUsage: { attacker: { total: 0, numRequests: 0 } },
     });
+  });
+
+  it('does not confuse a fully prompt-cached local request with a cached response', async () => {
+    promptfooProviderMocks.materializeMcpToolCallRemote.mockResolvedValueOnce(undefined);
+    providerManagerMocks.getProvider.mockResolvedValueOnce({
+      id: () => 'openai:test',
+      callApi: async () => ({
+        output: JSON.stringify(searchCompaniesCall),
+        cached: false,
+        tokenUsage: { prompt: 13, completion: 0, total: 13, cached: 13, numRequests: 0 },
+      }),
+    });
+
+    const target = new FakeMcpProvider([searchCompaniesTool]);
+    const wrapped = maybeWrapMcpProviderForRedteam(target, redteamMetadata('harmful:hate'));
+    const response = await wrapped.callApi(searchCompaniesPrompt, redteamContext());
+
+    expect(response.tokenUsage?.attacker).toMatchObject({
+      total: 13,
+      prompt: 13,
+      cached: 13,
+      numRequests: 0,
+    });
+    expect(response.tokenUsage).not.toHaveProperty('incurredTokenUsage');
   });
 
   it('returns a materialization error when inference provider is unavailable', async () => {

--- a/test/redteam/mcpTargetProvider.test.ts
+++ b/test/redteam/mcpTargetProvider.test.ts
@@ -193,8 +193,22 @@ describe('maybeWrapMcpProviderForRedteam', () => {
 
   it('preserves fresh target tokens and requests when cached materialization is merged', async () => {
     promptfooProviderMocks.materializeMcpToolCallRemote.mockResolvedValueOnce({
-      ...remoteMaterializedCall({ completion: 3, numRequests: 1, prompt: 7, total: 10 }),
+      prompt: JSON.stringify(searchCompaniesCall),
       cached: true,
+      tokenUsage: {
+        total: 10,
+        prompt: 7,
+        completion: 3,
+        numRequests: 1,
+        assertions: { total: 5, prompt: 3, completion: 2, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 10,
+          prompt: 7,
+          completion: 3,
+          numRequests: 1,
+          assertions: { total: 5, prompt: 3, completion: 2, numRequests: 1 },
+        },
+      },
     });
 
     const target = new FakeMcpProvider([searchCompaniesTool]);
@@ -212,12 +226,14 @@ describe('maybeWrapMcpProviderForRedteam', () => {
         completion: 7,
         numRequests: 1,
         attacker: { total: 10, numRequests: 1 },
+        assertions: { total: 5, numRequests: 1 },
         incurredTokenUsage: {
           total: 21,
           prompt: 14,
           completion: 7,
           numRequests: 1,
           attacker: { total: 0, numRequests: 0 },
+          assertions: { total: 0, numRequests: 0 },
         },
       },
     });
@@ -360,7 +376,19 @@ describe('maybeWrapMcpProviderForRedteam', () => {
       callApi: async () => ({
         output: JSON.stringify(searchCompaniesCall),
         cached: true,
-        tokenUsage: { prompt: 9, completion: 4, total: 13 },
+        tokenUsage: {
+          prompt: 9,
+          completion: 4,
+          total: 13,
+          assertions: { total: 5, numRequests: 1 },
+          incurredTokenUsage: {
+            prompt: 9,
+            completion: 4,
+            total: 13,
+            numRequests: 1,
+            assertions: { total: 5, numRequests: 1 },
+          },
+        },
       }),
     });
 
@@ -371,7 +399,12 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     expect(response.tokenUsage).toMatchObject({
       numRequests: 1,
       attacker: { total: 13, prompt: 9, completion: 4, cached: 13, numRequests: 1 },
-      incurredTokenUsage: { numRequests: 1, attacker: { total: 0, numRequests: 0 } },
+      assertions: { total: 5, numRequests: 1 },
+      incurredTokenUsage: {
+        numRequests: 1,
+        attacker: { total: 0, numRequests: 0 },
+        assertions: { total: 0, numRequests: 0 },
+      },
     });
     expect(target.calls).toHaveLength(1);
   });
@@ -482,7 +515,17 @@ describe('maybeWrapMcpProviderForRedteam', () => {
       callApi: async () => ({
         output: 'invalid cached tool call',
         cached: true,
-        tokenUsage: { prompt: 9, completion: 4, total: 13 },
+        tokenUsage: {
+          prompt: 9,
+          completion: 4,
+          total: 13,
+          assertions: { total: 5, numRequests: 1 },
+          incurredTokenUsage: {
+            total: 13,
+            numRequests: 1,
+            assertions: { total: 5, numRequests: 1 },
+          },
+        },
       }),
     });
 
@@ -495,9 +538,11 @@ describe('maybeWrapMcpProviderForRedteam', () => {
       tokenUsage: {
         numRequests: 0,
         attacker: { total: 13, cached: 13, numRequests: 1 },
+        assertions: { total: 5, numRequests: 1 },
         incurredTokenUsage: {
           numRequests: 0,
           attacker: { total: 0, numRequests: 0 },
+          assertions: { total: 0, numRequests: 0 },
         },
       },
     });

--- a/test/redteam/mcpTargetProvider.test.ts
+++ b/test/redteam/mcpTargetProvider.test.ts
@@ -255,7 +255,7 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     expect(target.cleanupCalls).toBe(1);
   });
 
-  it('does not charge cached local materialization responses as new attacker calls', async () => {
+  it('preserves cached local materialization in logical but not incurred attacker usage', async () => {
     promptfooProviderMocks.materializeMcpToolCallRemote.mockResolvedValueOnce(undefined);
     providerManagerMocks.getProvider.mockResolvedValueOnce({
       id: () => 'openai:test',
@@ -270,10 +270,9 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     const wrapped = maybeWrapMcpProviderForRedteam(target, redteamMetadata('harmful:hate'));
     const response = await wrapped.callApi(searchCompaniesPrompt, redteamContext());
 
-    expect(response.tokenUsage?.attacker).toMatchObject({
-      total: 0,
-      cached: 13,
-      numRequests: 0,
+    expect(response.tokenUsage).toMatchObject({
+      attacker: { total: 13, cached: 13, numRequests: 1 },
+      incurredTokenUsage: { attacker: { total: 0, numRequests: 0 } },
     });
   });
 

--- a/test/redteam/mcpTargetProvider.test.ts
+++ b/test/redteam/mcpTargetProvider.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCPProvider } from '../../src/providers/mcp';
 import { maybeWrapMcpProviderForRedteam } from '../../src/redteam/mcpTargetProvider';
+import {
+  accumulateResponseTokenUsage,
+  createEmptyTokenUsage,
+} from '../../src/util/tokenUsageUtils';
 
 import type { MCPTool } from '../../src/providers/mcp/types';
 import type { CallApiContextParams, CallApiOptionsParams, ProviderResponse } from '../../src/types';
@@ -164,11 +168,87 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     const target = new FakeMcpProvider([searchCompaniesTool]);
     const wrapped = maybeWrapMcpProviderForRedteam(target, redteamMetadata('harmful:hate'));
 
-    await expect(wrapped.callApi(searchCompaniesPrompt, redteamContext())).resolves.toMatchObject({
+    const response = await wrapped.callApi(searchCompaniesPrompt, redteamContext());
+
+    expect(response).toMatchObject({
       output: 'ok',
       tokenUsage: {
+        numRequests: 1,
         attacker: { total: 10, prompt: 7, completion: 3, cached: 10, numRequests: 1 },
-        incurredTokenUsage: { attacker: { total: 0, numRequests: 0 } },
+        incurredTokenUsage: {
+          numRequests: 1,
+          attacker: { total: 0, numRequests: 0 },
+        },
+      },
+    });
+    expect(target.calls).toHaveLength(1);
+
+    const evaluationUsage = createEmptyTokenUsage();
+    accumulateResponseTokenUsage(evaluationUsage, response);
+    expect(evaluationUsage).toMatchObject({
+      numRequests: 1,
+      incurredTokenUsage: { numRequests: 1, attacker: { total: 0, numRequests: 0 } },
+    });
+  });
+
+  it('preserves fresh target tokens and requests when cached materialization is merged', async () => {
+    promptfooProviderMocks.materializeMcpToolCallRemote.mockResolvedValueOnce({
+      ...remoteMaterializedCall({ completion: 3, numRequests: 1, prompt: 7, total: 10 }),
+      cached: true,
+    });
+
+    const target = new FakeMcpProvider([searchCompaniesTool]);
+    vi.spyOn(target, 'callApi').mockResolvedValueOnce({
+      output: 'target response',
+      tokenUsage: { total: 21, prompt: 14, completion: 7 },
+    });
+    const wrapped = maybeWrapMcpProviderForRedteam(target, redteamMetadata('harmful:hate'));
+
+    await expect(wrapped.callApi(searchCompaniesPrompt, redteamContext())).resolves.toMatchObject({
+      output: 'target response',
+      tokenUsage: {
+        total: 21,
+        prompt: 14,
+        completion: 7,
+        numRequests: 1,
+        attacker: { total: 10, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 21,
+          prompt: 14,
+          completion: 7,
+          numRequests: 1,
+          attacker: { total: 0, numRequests: 0 },
+        },
+      },
+    });
+  });
+
+  it('does not incur a cached target request when materialization is also cached', async () => {
+    promptfooProviderMocks.materializeMcpToolCallRemote.mockResolvedValueOnce({
+      ...remoteMaterializedCall({ completion: 3, numRequests: 1, prompt: 7, total: 10 }),
+      cached: true,
+    });
+
+    const target = new FakeMcpProvider([searchCompaniesTool]);
+    vi.spyOn(target, 'callApi').mockResolvedValueOnce({
+      output: 'cached target response',
+      cached: true,
+      tokenUsage: { total: 21, prompt: 14, completion: 7 },
+    });
+    const wrapped = maybeWrapMcpProviderForRedteam(target, redteamMetadata('harmful:hate'));
+
+    await expect(wrapped.callApi(searchCompaniesPrompt, redteamContext())).resolves.toMatchObject({
+      output: 'cached target response',
+      tokenUsage: {
+        total: 21,
+        cached: 21,
+        numRequests: 1,
+        attacker: { total: 10, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 0,
+          numRequests: 0,
+          attacker: { total: 0, numRequests: 0 },
+        },
       },
     });
   });
@@ -289,9 +369,11 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     const response = await wrapped.callApi(searchCompaniesPrompt, redteamContext());
 
     expect(response.tokenUsage).toMatchObject({
+      numRequests: 1,
       attacker: { total: 13, prompt: 9, completion: 4, cached: 13, numRequests: 1 },
-      incurredTokenUsage: { attacker: { total: 0, numRequests: 0 } },
+      incurredTokenUsage: { numRequests: 1, attacker: { total: 0, numRequests: 0 } },
     });
+    expect(target.calls).toHaveLength(1);
   });
 
   it('does not confuse a fully prompt-cached local request with a cached response', async () => {
@@ -386,10 +468,73 @@ describe('maybeWrapMcpProviderForRedteam', () => {
     expect(response).toMatchObject({
       error: expect.stringContaining('Failed to materialize MCP target prompt'),
       tokenUsage: {
+        numRequests: 0,
         attacker: { total: 13, prompt: 9, completion: 4, numRequests: 1 },
       },
     });
     expect(target.calls).toHaveLength(0);
+  });
+
+  it('does not invent target probes when cached materialization returns invalid output', async () => {
+    promptfooProviderMocks.materializeMcpToolCallRemote.mockResolvedValueOnce(undefined);
+    providerManagerMocks.getProvider.mockResolvedValueOnce({
+      id: () => 'openai:test',
+      callApi: async () => ({
+        output: 'invalid cached tool call',
+        cached: true,
+        tokenUsage: { prompt: 9, completion: 4, total: 13 },
+      }),
+    });
+
+    const target = new FakeMcpProvider([searchCompaniesTool]);
+    const wrapped = maybeWrapMcpProviderForRedteam(target, redteamMetadata('harmful:hate'));
+    const response = await wrapped.callApi(searchCompaniesPrompt, redteamContext());
+
+    expect(response).toMatchObject({
+      error: expect.stringContaining('Failed to materialize MCP target prompt'),
+      tokenUsage: {
+        numRequests: 0,
+        attacker: { total: 13, cached: 13, numRequests: 1 },
+        incurredTokenUsage: {
+          numRequests: 0,
+          attacker: { total: 0, numRequests: 0 },
+        },
+      },
+    });
+    expect(target.calls).toHaveLength(0);
+
+    const evaluationUsage = createEmptyTokenUsage();
+    accumulateResponseTokenUsage(evaluationUsage, response);
+    expect(evaluationUsage).toMatchObject({
+      numRequests: 0,
+      incurredTokenUsage: { numRequests: 0 },
+    });
+  });
+
+  it('counts an attempted target probe when cached materialization precedes a target error', async () => {
+    promptfooProviderMocks.materializeMcpToolCallRemote.mockResolvedValueOnce({
+      ...remoteMaterializedCall({ completion: 3, numRequests: 1, prompt: 7, total: 10 }),
+      cached: true,
+    });
+
+    const target = new FakeMcpProvider([searchCompaniesTool]);
+    const targetCall = vi
+      .spyOn(target, 'callApi')
+      .mockRejectedValueOnce(new Error('Target provider failed'));
+    const wrapped = maybeWrapMcpProviderForRedteam(target, redteamMetadata('harmful:hate'));
+
+    await expect(wrapped.callApi(searchCompaniesPrompt, redteamContext())).resolves.toMatchObject({
+      error: expect.stringContaining('Target provider failed'),
+      tokenUsage: {
+        numRequests: 1,
+        attacker: { total: 10, numRequests: 1 },
+        incurredTokenUsage: {
+          numRequests: 1,
+          attacker: { total: 0, numRequests: 0 },
+        },
+      },
+    });
+    expect(targetCall).toHaveBeenCalledTimes(1);
   });
 
   it('returns a materialization error when the wrapped provider call fails', async () => {

--- a/test/redteam/plugins/index.test.ts
+++ b/test/redteam/plugins/index.test.ts
@@ -200,7 +200,7 @@ describe('Plugins', () => {
       expect(generationUsage).toMatchObject(tokenUsage);
     });
 
-    it('does not charge cached remote plugin responses again', async () => {
+    it('preserves cached remote plugin usage without incurring it again', async () => {
       vi.mocked(shouldGenerateRemote).mockReturnValue(true);
       vi.mocked(neverGenerateRemote).mockReturnValue(false);
       vi.mocked(fetchWithCache).mockResolvedValue({
@@ -225,7 +225,12 @@ describe('Plugins', () => {
         delayMs: 0,
       });
 
-      expect(generationUsage).toEqual({});
+      expect(generationUsage).toMatchObject({
+        total: 28,
+        cached: 28,
+        numRequests: 2,
+        incurredTokenUsage: { total: 0, numRequests: 0 },
+      });
     });
 
     it('preserves usage reported by failed remote generation requests', async () => {

--- a/test/redteam/remoteGenerationTask.test.ts
+++ b/test/redteam/remoteGenerationTask.test.ts
@@ -57,7 +57,7 @@ describe('postRemoteGenerationTask', () => {
     expect(usage).toMatchObject({ total: 30, prompt: 20, completion: 10, numRequests: 3 });
   });
 
-  it('does not count historical usage from a cached remote response', async () => {
+  it('preserves cached remote strategy usage without incurring it again', async () => {
     const usage: TokenUsage = {};
     vi.mocked(fetchWithCache).mockResolvedValue({
       cached: true,
@@ -68,7 +68,14 @@ describe('postRemoteGenerationTask', () => {
 
     await postRemoteGenerationTask({ task: 'citation' }, createTrackedContext(usage));
 
-    expect(usage).toEqual({});
+    expect(usage).toMatchObject({
+      total: 45,
+      prompt: 30,
+      completion: 15,
+      cached: 45,
+      numRequests: 2,
+      incurredTokenUsage: { total: 0, numRequests: 0 },
+    });
   });
 
   it('records coalesced concurrent generation usage only for the request owner', async () => {

--- a/test/redteam/util.test.ts
+++ b/test/redteam/util.test.ts
@@ -195,7 +195,7 @@ describe('extractGoalFromPrompt', () => {
     expect(usage).toMatchObject({ total: 17, prompt: 10, completion: 7, numRequests: 1 });
   });
 
-  it('does not count cached goal extraction responses', async () => {
+  it('preserves cached goal extraction usage without incurring it again', async () => {
     vi.mocked(fetchWithCache).mockResolvedValue({
       cached: true,
       status: 200,
@@ -219,7 +219,12 @@ describe('extractGoalFromPrompt', () => {
       provider,
     );
 
-    expect(usage).toEqual({});
+    expect(usage).toMatchObject({
+      total: 17,
+      cached: 17,
+      numRequests: 1,
+      incurredTokenUsage: { total: 0, numRequests: 0 },
+    });
   });
 
   it('counts failed goal extraction requests without reported token usage', async () => {

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -523,6 +523,74 @@ describe('tokenUsageUtils', () => {
       });
     });
 
+    it('discards historical incurred attacker and grading usage without losing fresh target work', () => {
+      const target = createEmptyTokenUsage();
+      accumulateResponseTokenUsage(target, {
+        tokenUsage: { total: 21, prompt: 14, completion: 7 },
+      });
+
+      accumulateAttackerTokenUsage(target, {
+        cached: true,
+        tokenUsage: {
+          total: 10,
+          prompt: 7,
+          completion: 3,
+          numRequests: 1,
+          assertions: { total: 5, prompt: 3, completion: 2, numRequests: 1 },
+          incurredTokenUsage: {
+            total: 10,
+            prompt: 7,
+            completion: 3,
+            numRequests: 1,
+            assertions: { total: 5, prompt: 3, completion: 2, numRequests: 1 },
+          },
+        },
+      });
+
+      expect(target).toMatchObject({
+        total: 21,
+        prompt: 14,
+        completion: 7,
+        numRequests: 1,
+        attacker: { total: 10, prompt: 7, completion: 3, numRequests: 1 },
+        assertions: { total: 5, prompt: 3, completion: 2, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 21,
+          prompt: 14,
+          completion: 7,
+          numRequests: 1,
+          attacker: { total: 0, numRequests: 0 },
+          assertions: { total: 0, numRequests: 0 },
+        },
+      });
+    });
+
+    it('preserves explicit incurred attacker and grading usage for fresh composite responses', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateAttackerTokenUsage(target, {
+        tokenUsage: {
+          total: 10,
+          numRequests: 2,
+          assertions: { total: 5, numRequests: 2 },
+          incurredTokenUsage: {
+            total: 6,
+            numRequests: 1,
+            assertions: { total: 2, numRequests: 1 },
+          },
+        },
+      });
+
+      expect(target).toMatchObject({
+        attacker: { total: 10, numRequests: 2 },
+        assertions: { total: 5, numRequests: 2 },
+        incurredTokenUsage: {
+          attacker: { total: 6, numRequests: 1 },
+          assertions: { total: 2, numRequests: 1 },
+        },
+      });
+    });
+
     it('requires explicit cache provenance for normalized attacker usage', () => {
       const target = createEmptyTokenUsage();
 

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -523,6 +523,45 @@ describe('tokenUsageUtils', () => {
       });
     });
 
+    it('recognizes normalized cached attacker usage without an outer cache flag', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateAttackerTokenUsage(target, {
+        tokenUsage: { total: 0, prompt: 0, completion: 0, cached: 32, numRequests: 0 },
+      });
+
+      expect(target).toMatchObject({
+        numRequests: 0,
+        attacker: { total: 32, cached: 32, numRequests: 1 },
+        incurredTokenUsage: { attacker: { total: 0, numRequests: 0 } },
+      });
+    });
+
+    it('does not mistake provider-side prompt caching for a cached attacker response', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateAttackerTokenUsage(target, {
+        tokenUsage: { total: 32, prompt: 20, completion: 12, cached: 15, numRequests: 1 },
+      });
+
+      expect(target).toMatchObject({
+        attacker: { total: 32, prompt: 20, completion: 12, cached: 15, numRequests: 1 },
+      });
+      expect(target).not.toHaveProperty('incurredTokenUsage');
+    });
+
+    it('does not infer an attacker cache replay when the response is explicitly fresh', () => {
+      const target = createEmptyTokenUsage();
+
+      accumulateAttackerTokenUsage(target, {
+        cached: false,
+        tokenUsage: { total: 0, cached: 32, numRequests: 0 },
+      });
+
+      expect(target).toMatchObject({ attacker: { total: 0, cached: 32, numRequests: 0 } });
+      expect(target).not.toHaveProperty('incurredTokenUsage');
+    });
+
     it('routes grading-model work nested in an attack task into the grading bucket', () => {
       const target = createEmptyTokenUsage();
 
@@ -663,6 +702,34 @@ describe('tokenUsageUtils', () => {
       expect(accumulateGenerationTokenUsage(target, { numRequests: 3 })).toBe(true);
       expect(target.generation).toMatchObject({ total: 0, numRequests: 3 });
       expect(target.numRequests).toBe(0);
+    });
+
+    it('preserves logical and incurred cached generation as separate scan buckets', () => {
+      const target = createEmptyTokenUsage();
+      target.total = 10;
+      target.numRequests = 1;
+
+      expect(
+        accumulateGenerationTokenUsage(target, {
+          total: 30,
+          prompt: 20,
+          completion: 10,
+          cached: 30,
+          numRequests: 1,
+          incurredTokenUsage: { total: 0, numRequests: 0 },
+        }),
+      ).toBe(true);
+
+      expect(target).toMatchObject({
+        total: 10,
+        numRequests: 1,
+        generation: { total: 30, cached: 30, numRequests: 1 },
+        incurredTokenUsage: {
+          total: 10,
+          numRequests: 1,
+          generation: { total: 0, numRequests: 0 },
+        },
+      });
     });
   });
 

--- a/test/util/tokenUsageUtils.test.ts
+++ b/test/util/tokenUsageUtils.test.ts
@@ -523,17 +523,31 @@ describe('tokenUsageUtils', () => {
       });
     });
 
-    it('recognizes normalized cached attacker usage without an outer cache flag', () => {
+    it('requires explicit cache provenance for normalized attacker usage', () => {
       const target = createEmptyTokenUsage();
 
       accumulateAttackerTokenUsage(target, {
-        tokenUsage: { total: 0, prompt: 0, completion: 0, cached: 32, numRequests: 0 },
+        tokenUsage: { total: 32, prompt: 32, completion: 0, cached: 32, numRequests: 0 },
       });
 
       expect(target).toMatchObject({
         numRequests: 0,
-        attacker: { total: 32, cached: 32, numRequests: 1 },
-        incurredTokenUsage: { attacker: { total: 0, numRequests: 0 } },
+        attacker: { total: 32, prompt: 32, cached: 32, numRequests: 0 },
+      });
+      expect(target).not.toHaveProperty('incurredTokenUsage');
+    });
+
+    it('keeps fully prompt-cached attacker usage incurred when tracking actual work', () => {
+      const target = createEmptyTokenUsage();
+      target.incurredTokenUsage = createEmptyTokenUsage();
+
+      accumulateAttackerTokenUsage(target, {
+        tokenUsage: { total: 32, prompt: 32, completion: 0, cached: 32, numRequests: 0 },
+      });
+
+      expect(target).toMatchObject({
+        attacker: { total: 32, prompt: 32, cached: 32 },
+        incurredTokenUsage: { attacker: { total: 32, prompt: 32, cached: 32 } },
       });
     });
 


### PR DESCRIPTION
## Summary

- Preserve cached MCP attacker and red-team generation usage in the logical scan footprint while excluding it from incurred usage.
- Restore incurred cost when retry rebuilds persisted evaluation metrics, including mixed legacy and cached results.
- Cover cached plugin, strategy, extraction, goal-generation, MCP materialization, generation-event ownership, and persisted retry paths.

## Verification

- 667 focused unit tests and 36 persisted retry integration tests pass.
- An isolated local CLI evaluation completes successfully and its exported result contains the expected request accounting.
- Pinned Biome checks pass. Full local typechecking remains blocked by pre-existing Langfuse, Slack, and Anthropic dependency mismatches in the shared worktree installation.
