### PR TITLE
fix(eval): preserve incurred costs in filtered results

### DIFF
--- a/src/util/calculateFilteredMetrics.ts
+++ b/src/util/calculateFilteredMetrics.ts
@@ -109,6 +109,8 @@ interface FilteredBasicMetricsRow {
   total_score: number;
   total_latency: number;
   total_cost: number;
+  has_incurred_cost: number;
+  total_incurred_cost: number | null;
   total_tokens: number | null;
   prompt_tokens: number | null;
   completion_tokens: number | null;
@@ -320,6 +322,7 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
   const incurredGradingPath = '$.tokensUsed.incurredTokenUsage';
   const gradingCachePath = '$.metadata.cachedResponse';
   const responseCachePath = '$.cached';
+  const incurredCostPath = '$.incurredCost';
   const incurredTargetUsage = (field: TokenUsageField) =>
     jsonIncurredUsageField(response, targetPath, incurredTargetPath, field, {
       cachedResponsePath: responseCachePath,
@@ -350,6 +353,22 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
       SUM(score) as total_score,
       SUM(latency_ms) as total_latency,
       SUM(cost) as total_cost,
+      SUM(
+        CASE
+          WHEN json_extract(response, ${incurredCostPath}) IS NOT NULL
+            OR COALESCE(json_extract(response, ${responseCachePath}), 0) = 1
+          THEN 1
+          ELSE 0
+        END
+      ) as has_incurred_cost,
+      SUM(
+        CASE
+          WHEN json_extract(response, ${incurredCostPath}) IS NOT NULL
+          THEN CAST(json_extract(response, ${incurredCostPath}) AS REAL)
+          WHEN COALESCE(json_extract(response, ${responseCachePath}), 0) = 1 THEN 0
+          ELSE COALESCE(cost, 0)
+        END
+      ) as total_incurred_cost,
       -- Token usage aggregation (token usage is inside response JSON)
       SUM(${jsonUsageTotal(response, targetPath)}) as total_tokens,
       SUM(${jsonUsageNumber(response, targetPath, 'prompt')}) as prompt_tokens,
@@ -439,6 +458,7 @@ async function calculateWithOptimizedQuery(opts: FilteredMetricsOptions): Promis
       testErrorCount: row.error_count || 0,
       totalLatencyMs: row.total_latency || 0,
       cost: row.total_cost || 0,
+      ...(row.has_incurred_cost > 0 && { incurredCost: row.total_incurred_cost || 0 }),
       tokenUsage: getFilteredTokenUsage(row),
       namedScores: {},
       namedScoresCount: {},

--- a/test/util/calculateFilteredMetrics.test.ts
+++ b/test/util/calculateFilteredMetrics.test.ts
@@ -148,6 +148,8 @@ describe('calculateFilteredMetrics', () => {
         gradingUsage,
         gradingCached = false,
         responseCached = false,
+        cost = 0,
+        incurredCost,
       }: {
         testIdx: number;
         promptIdx?: number;
@@ -155,6 +157,8 @@ describe('calculateFilteredMetrics', () => {
         gradingUsage?: TokenUsage;
         gradingCached?: boolean;
         responseCached?: boolean;
+        cost?: number;
+        incurredCost?: number;
       },
     ) {
       await eval_.addResult({
@@ -165,7 +169,12 @@ describe('calculateFilteredMetrics', () => {
         provider: { id: 'test-provider', label: 'test' },
         prompt: { raw: 'Test prompt', label: 'Test prompt' },
         vars: { test: 'value' },
-        response: { output: 'test output', ...(responseCached && { cached: true }), tokenUsage },
+        response: {
+          output: 'test output',
+          ...(responseCached && { cached: true }),
+          ...(incurredCost !== undefined && { incurredCost }),
+          tokenUsage,
+        },
         error: null,
         failureReason: ResultFailureReason.NONE,
         success: true,
@@ -179,10 +188,95 @@ describe('calculateFilteredMetrics', () => {
           ...(gradingCached && { metadata: { cachedResponse: true } }),
         },
         namedScores: {},
-        cost: 0,
+        cost,
         metadata: {},
       });
     }
+
+    it.each([
+      {
+        label: 'a cached result with zero incurred cost',
+        results: [{ cost: 0.5, incurredCost: 0, responseCached: true }],
+        expectedCost: 0.5,
+        expectedIncurredCost: 0,
+      },
+      {
+        label: 'a legacy cached result without incurred cost',
+        results: [{ cost: 0.5, responseCached: true }],
+        expectedCost: 0.5,
+        expectedIncurredCost: 0,
+      },
+      {
+        label: 'a fresh legacy result before a cached result',
+        results: [{ cost: 0.25 }, { cost: 0.5, incurredCost: 0, responseCached: true }],
+        expectedCost: 0.75,
+        expectedIncurredCost: 0.25,
+      },
+      {
+        label: 'a fresh legacy result after a cached result',
+        results: [{ cost: 0.5, responseCached: true }, { cost: 0.25 }],
+        expectedCost: 0.75,
+        expectedIncurredCost: 0.25,
+      },
+      {
+        label: 'a partially incurred composite result',
+        results: [{ cost: 0.5, incurredCost: 0.25, responseCached: true }],
+        expectedCost: 0.5,
+        expectedIncurredCost: 0.25,
+      },
+    ])(
+      'preserves logical and incurred costs for filtered rows containing $label',
+      async ({ results, expectedCost, expectedIncurredCost }) => {
+        const eval_ = await EvalFactory.create({ numResults: 0 });
+        for (const [testIdx, result] of results.entries()) {
+          await addTokenResult(eval_, {
+            testIdx,
+            tokenUsage: { total: 10, numRequests: 1 },
+            ...result,
+          });
+        }
+        await addTokenResult(eval_, {
+          testIdx: results.length,
+          cost: 99,
+          incurredCost: 99,
+          tokenUsage: { total: 10, numRequests: 1 },
+        });
+
+        const metrics = await calculateFilteredMetrics({
+          evalId: eval_.id,
+          numPrompts: 1,
+          whereSql: sql`eval_id = ${eval_.id} AND test_idx < ${results.length}`,
+        });
+
+        expect(metrics[0].cost).toBeCloseTo(expectedCost);
+        expect(metrics[0].incurredCost).toBeCloseTo(expectedIncurredCost);
+      },
+    );
+
+    it('does not add incurred cost when all filtered results use legacy fresh accounting', async () => {
+      const eval_ = await EvalFactory.create({ numResults: 0 });
+      await addTokenResult(eval_, {
+        testIdx: 0,
+        cost: 0.25,
+        tokenUsage: { total: 10, numRequests: 1 },
+      });
+      await addTokenResult(eval_, {
+        testIdx: 1,
+        cost: 0.5,
+        incurredCost: 0,
+        responseCached: true,
+        tokenUsage: { total: 10, numRequests: 1 },
+      });
+
+      const metrics = await calculateFilteredMetrics({
+        evalId: eval_.id,
+        numPrompts: 1,
+        whereSql: sql`eval_id = ${eval_.id} AND test_idx = 0`,
+      });
+
+      expect(metrics[0].cost).toBeCloseTo(0.25);
+      expect(metrics[0]).not.toHaveProperty('incurredCost');
+    });
 
     it('should aggregate token usage correctly', async () => {
       const eval_ = await EvalFactory.create({

--- a/test/util/calculateFilteredMetrics.test.ts
+++ b/test/util/calculateFilteredMetrics.test.ts
@@ -213,12 +213,6 @@ describe('calculateFilteredMetrics', () => {
         expectedIncurredCost: 0.25,
       },
       {
-        label: 'a fresh legacy result after a cached result',
-        results: [{ cost: 0.5, responseCached: true }, { cost: 0.25 }],
-        expectedCost: 0.75,
-        expectedIncurredCost: 0.25,
-      },
-      {
         label: 'a partially incurred composite result',
         results: [{ cost: 0.5, incurredCost: 0.25, responseCached: true }],
         expectedCost: 0.5,


### PR DESCRIPTION
## Summary

- Preserve incurred provider costs when filtered evaluation metrics are rebuilt from persisted results.
- Honor explicit incurred costs, treat legacy cached responses as zero-cost, and count legacy fresh responses at their logical cost without introducing the field for fresh-only evaluations.
- Add failing-first database regressions for cached, mixed, partially incurred, and excluded results.

## Verification

- `npm run tsc`
- `npm run l && npm run f`
- `npx vitest run --configLoader runner test/util/calculateFilteredMetrics.test.ts test/evaluator/tokenUsage.test.ts test/node/retry.test.ts test/models/eval.test.ts test/models/evalResult.test.ts test/util/tokenUsageUtils.test.ts test/assertions/assertionsResult.test.ts test/util/eval/summary.test.ts` — 412 passing tests
- `npx vitest run --configLoader runner --config vitest.integration.config.ts test/node/retry.integration.test.ts` — 36 passing tests
- Real uncached CLI evaluation passed 2/2; persisted filtered metrics reported `$0.75` logical / `$0.25` incurred overall, `$0.50` logical / `$0.00` incurred for the cached row, and `$0.25` for the fresh-only row.
