### PR TITLE
fix(providers): honor manual cost overrides for models not in the pricing table

### DIFF
--- a/src/providers/shared.ts
+++ b/src/providers/shared.ts
@@ -73,8 +73,20 @@ export function calculateCost(
   }
 
   const model = models.find((m) => m.id === modelName);
+
+  // A model promptfoo doesn't recognize yet (a model released after this version shipped, for
+  // example) has no built-in pricing to fall back on. Previously that meant cost tracking was
+  // simply unavailable until a promptfoo update baked in the new model's pricing table entry.
+  // If the caller supplied both an input and output rate, honor them directly instead of
+  // requiring a matching built-in model - this is the only way to get cost tracking for a model
+  // this version of promptfoo hasn't shipped pricing for.
   if (!model || !model.cost) {
-    return undefined;
+    const manualInputCost = config.inputCost ?? config.cost;
+    const manualOutputCost = config.outputCost ?? config.cost;
+    if (manualInputCost == null || manualOutputCost == null) {
+      return undefined;
+    }
+    return manualInputCost * promptTokens + manualOutputCost * completionTokens;
   }
 
   const longContextCost =

--- a/test/providers/shared.test.ts
+++ b/test/providers/shared.test.ts
@@ -256,6 +256,41 @@ describe('Shared Provider Functions', () => {
       expect(cost).toBeUndefined();
     });
 
+    it('should honor a manual inputCost/outputCost override for a model not in the known list', () => {
+      // A model released after this promptfoo version shipped has no built-in pricing entry.
+      // Without an override there's simply no way to get cost tracking for it until an update
+      // bakes in the new pricing - see https://github.com/promptfoo/promptfoo/issues/10501.
+      const cost = calculateCost(
+        'brand-new-unreleased-model',
+        { inputCost: 0.000002, outputCost: 0.00001 },
+        1000,
+        500,
+        models,
+      );
+      expect(cost).toBeCloseTo(0.000002 * 1000 + 0.00001 * 500);
+    });
+
+    it('should honor a manual flat cost override for a model not in the known list', () => {
+      const cost = calculateCost(
+        'brand-new-unreleased-model',
+        { cost: 0.000005 },
+        1000,
+        500,
+        models,
+      );
+      expect(cost).toBeCloseTo(0.000005 * 1500);
+    });
+
+    it('should still return undefined for an unknown model with only a partial override', () => {
+      // inputCost alone (no outputCost, no flat cost) isn't enough to price the completion side.
+      expect(
+        calculateCost('brand-new-unreleased-model', { inputCost: 0.000002 }, 1000, 500, models),
+      ).toBeUndefined();
+      expect(
+        calculateCost('brand-new-unreleased-model', { outputCost: 0.00001 }, 1000, 500, models),
+      ).toBeUndefined();
+    });
+
     it('should return undefined if tokens are not finite', () => {
       expect(calculateCost('model1', {}, Number.NaN, 500, models)).toBeUndefined();
       expect(calculateCost('model1', {}, 1000, Infinity, models)).toBeUndefined();


### PR DESCRIPTION
## Summary

`calculateCost()` (`src/providers/shared.ts`) returns `undefined` whenever the given model isn't found in the provider's built-in pricing list — **even if the caller supplied `config.inputCost`/`config.outputCost` (or `config.cost`)**. This means cost tracking is simply unavailable for any model released after the installed promptfoo version shipped, with no way to work around it, even though `inputCost`/`outputCost`/`cost` already exist as override mechanisms (added in #8254) for *known* models.

In practice: a new model ships, promptfoo hasn't cut a release with its pricing table entry yet, and there is currently no way to get cost tracking for it in the meantime — not even by manually specifying the rate.

## Fix

When the model isn't recognized, fall back to the manual override instead of immediately returning `undefined` — but only when *both* an input and an output rate are available (via `inputCost`+`outputCost`, or the flat `cost` field). A partial override with no known model to fall back on still can't produce a complete answer, so that case is unchanged (still `undefined`).

Behavior for known models, and for unknown models with no override supplied at all, is unchanged.

```ts
if (!model || !model.cost) {
  const manualInputCost = config.inputCost ?? config.cost;
  const manualOutputCost = config.outputCost ?? config.cost;
  if (manualInputCost == null || manualOutputCost == null) {
    return undefined;
  }
  return manualInputCost * promptTokens + manualOutputCost * completionTokens;
}
```

This affects every provider that funnels through the shared `calculateCost()` (confirmed for Anthropic, OpenAI, and Google — all three fall back to it via `calculateCostBase`/`calculateCost` once model-specific tiered/cache pricing doesn't apply), so the fix is a single, shared change rather than something that needs repeating per-provider.

## Related (not duplicates)

- #8254 (merged) added `inputCost`/`outputCost` as override fields in the first place, fixing #8184 (flat `cost` applying identically to input and output). This PR doesn't touch that — it only removes the requirement that the model already be *known* before those override fields are honored at all.
- #940 (open) asks for the built-in pricing table to be exposed *to* custom providers — a different direction (this PR is about *overriding into* the built-in calculation for standard providers, not reading out of it).
- #6271 (open) proposes live AWS Pricing API integration for Bedrock specifically — a different, larger-scope approach to the same underlying problem (pricing tables going stale between releases). This PR is the minimal fix that unblocks users right now regardless of whether that lands.

## Testing

- Added 3 regression tests to `test/providers/shared.test.ts`:
  - manual `inputCost`/`outputCost` override is honored for an unrecognized model
  - manual flat `cost` override is honored for an unrecognized model
  - a *partial* override (only one of input/output, no flat `cost`) for an unrecognized model still correctly returns `undefined`
- Verified the new tests fail against the pre-fix code (reverted the fix locally, confirmed both positive-case tests fail with the expected `undefined`) and pass with the fix.
- `npx vitest run test/providers/shared.test.ts` — 77/77 passed
- `npx vitest run test/providers/shared.test.ts test/providers/anthropic/ test/providers/openai/ test/providers/google/` — 2608/2608 passed (57 files)
- `npx tsc --noEmit` — clean
- Pre-commit Biome lint hook passed
