### PR TITLE
fix(providers): retain failed security scan costs

### DIFF
--- a/src/providers/openai/codex-security.ts
+++ b/src/providers/openai/codex-security.ts
@@ -217,10 +217,10 @@ function resolveConfigPath(value: string | undefined, configBasePath?: string): 
   return resolveAgenticWorkingDir(value, configBasePath ?? cliState.basePath);
 }
 
-function getTokenUsage(result: ScanResult, observedCost?: ScanCost): TokenUsage | undefined {
-  const usage = result.turnResult.usage;
+function getTokenUsage(result?: ScanResult, observedCost?: ScanCost): TokenUsage | undefined {
+  const usage = result?.turnResult.usage;
   const values = usage && typeof usage === 'object' ? (usage as Record<string, unknown>) : {};
-  const cost = result.cost ?? observedCost;
+  const cost = result?.cost ?? observedCost;
   const inputTokens =
     cost?.inputTokens ??
     (typeof values.input_tokens === 'number' ? values.input_tokens : undefined);
@@ -311,6 +311,8 @@ export class OpenAICodexSecurityProvider implements ApiProvider {
     context?: CallApiContextParams,
     callOptions?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
+    const observers: ScanObservers = { warnings: [] };
+
     try {
       const mergedConfig = { ...this.config, ...context?.prompt?.config };
       delete mergedConfig.provider;
@@ -368,6 +370,7 @@ export class OpenAICodexSecurityProvider implements ApiProvider {
           repository,
           operation,
           config,
+          observers,
           callOptions,
         );
       } finally {
@@ -379,8 +382,13 @@ export class OpenAICodexSecurityProvider implements ApiProvider {
         }
       }
     } catch (error) {
+      const observedCost = observers.cost;
+      const tokenUsage = observedCost ? getTokenUsage(undefined, observedCost) : undefined;
+
       return {
         error: `Codex Security operation failed: ${error instanceof Error ? error.message : String(error)}`,
+        ...(observedCost ? { cost: observedCost.estimatedUsd } : {}),
+        ...(tokenUsage ? { tokenUsage } : {}),
       };
     }
   }
@@ -392,6 +400,7 @@ export class OpenAICodexSecurityProvider implements ApiProvider {
     repository: string,
     operation: 'security-scan' | 'deep-security-scan' | 'security-diff-scan',
     config: OpenAICodexSecurityConfig,
+    observers: ScanObservers,
     callOptions?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
     const mode = operation === 'deep-security-scan' ? 'deep' : 'standard';
@@ -400,7 +409,6 @@ export class OpenAICodexSecurityProvider implements ApiProvider {
       return targetResult;
     }
 
-    const observers: ScanObservers = { warnings: [] };
     const options = this.buildScanOptions(
       prompt,
       mode,

--- a/test/providers/openai-codex-security.test.ts
+++ b/test/providers/openai-codex-security.test.ts
@@ -693,6 +693,98 @@ describe('OpenAICodexSecurityProvider', () => {
       expect(mockClose).toHaveBeenCalledTimes(1);
     });
 
+    it('retains observed scan cost and token usage when a paid scan fails', async () => {
+      mockRun.mockImplementation(async (_repository, options) => {
+        options.onCost({
+          model: 'gpt-5.6-sol',
+          inputTokens: 500,
+          cachedInputTokens: 100,
+          cacheWriteInputTokens: 25,
+          outputTokens: 200,
+          estimatedUsd: 0.08,
+        });
+        throw new Error('Scan completed without required artifacts');
+      });
+      const provider = new OpenAICodexSecurityProvider();
+
+      expect(await provider.callApi('Scan')).toEqual({
+        error: 'Codex Security operation failed: Scan completed without required artifacts',
+        cost: 0.08,
+        tokenUsage: {
+          prompt: 500,
+          completion: 200,
+          cached: 100,
+          total: 700,
+          completionDetails: {
+            cacheReadInputTokens: 100,
+            cacheCreationInputTokens: 25,
+          },
+        },
+      });
+      expect(mockClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('retains the latest cumulative worker cost when a deep scan fails', async () => {
+      mockRun.mockImplementation(async (_repository, options) => {
+        options.onCost({
+          model: 'gpt-5.6-terra',
+          inputTokens: 100,
+          cachedInputTokens: 20,
+          cacheWriteInputTokens: 5,
+          outputTokens: 40,
+          estimatedUsd: 0.01,
+        });
+        options.onCost({
+          model: 'gpt-5.6-terra',
+          inputTokens: 900,
+          cachedInputTokens: 200,
+          cacheWriteInputTokens: 40,
+          outputTokens: 300,
+          estimatedUsd: 0.12,
+        });
+        throw new Error('Deep scan worker was interrupted');
+      });
+      const provider = new OpenAICodexSecurityProvider({
+        config: { operation: 'deep-security-scan' },
+      });
+
+      expect(await provider.callApi('Scan')).toMatchObject({
+        error: 'Codex Security operation failed: Deep scan worker was interrupted',
+        cost: 0.12,
+        tokenUsage: {
+          prompt: 900,
+          completion: 300,
+          cached: 200,
+          total: 1200,
+        },
+      });
+    });
+
+    it('retains work already incurred when an active scan is canceled', async () => {
+      const controller = new AbortController();
+      mockRun.mockImplementation(async (_repository, options) => {
+        options.onCost({
+          model: 'gpt-5.6-sol',
+          inputTokens: 120,
+          cachedInputTokens: 0,
+          cacheWriteInputTokens: 0,
+          outputTokens: 30,
+          estimatedUsd: 0.02,
+        });
+        controller.abort();
+        throw new Error('The scan was interrupted');
+      });
+      const provider = new OpenAICodexSecurityProvider();
+
+      expect(
+        await provider.callApi('Scan', undefined, { abortSignal: controller.signal }),
+      ).toMatchObject({
+        error: 'Codex Security operation failed: The scan was interrupted',
+        cost: 0.02,
+        tokenUsage: { prompt: 120, completion: 30, total: 150 },
+      });
+    });
+
     it('preserves successful scan results when closing the SDK client fails', async () => {
       mockClose.mockRejectedValue(new Error('cleanup failed'));
       const provider = new OpenAICodexSecurityProvider();


### PR DESCRIPTION
## Summary

- Preserve the latest SDK-reported scan cost and token usage when a security scan fails after model work has already run.
- Keep cumulative deep-worker accounting and cancellation costs visible without fabricating usage for preflight failures.
- Add failing-first regressions for artifact failures, deep-scan interruptions, and canceled scans.

## Verification

- `npx vitest run test/providers/openai-codex-security.test.ts test/providers/registry.test.ts test/providers/agentic-utils.test.ts test/matchers/agent-rubric.test.ts test/util/tokenUsageUtils.test.ts --configLoader runner --no-cache --sequence.shuffle --sequence.seed=8272026` — 255 tests passed.
- `npm run tsc`
- `npm run l && npm run f`
- Ran an uncached CLI eval against a deterministic SDK fixture that reports 500 prompt tokens, 200 completion tokens, and $0.08 before failing. The exported failed evaluation preserves all 700 tokens, cached-token details, and the $0.08 incurred cost; exit code 100 is expected for the intentionally failed scan.
