### PR TITLE
fix(mcp): pass per-server `env` through to stdio MCP servers

### DIFF
--- a/src/providers/mcp/transform.ts
+++ b/src/providers/mcp/transform.ts
@@ -218,11 +218,21 @@ async function transformMCPServerConfigToClaudeCode(
       headers: { ...(config.headers ?? {}), ...getAuthHeaders(renderedConfig, oauthToken) },
     };
   } else if (config.command) {
-    out = { type: 'stdio', command: config.command, args: config.args ?? [] };
+    out = {
+      type: 'stdio',
+      command: config.command,
+      args: config.args ?? [],
+      ...(config.env ? { env: config.env } : {}),
+    };
   } else if (config.path) {
     const isPy = config.path.endsWith('.py');
     const command = isPy ? (process.platform === 'win32' ? 'python' : 'python3') : process.execPath;
-    out = { type: 'stdio', command, args: [config.path] };
+    out = {
+      type: 'stdio',
+      command,
+      args: [config.path],
+      ...(config.env ? { env: config.env } : {}),
+    };
   } else {
     throw new Error('MCP configuration cannot be converted to Claude Agent SDK MCP server config');
   }

--- a/src/providers/mcp/types.ts
+++ b/src/providers/mcp/types.ts
@@ -10,6 +10,7 @@ export interface MCPServerConfig {
   url?: string; // URL for remote server (not currently supported)
   auth?: MCPServerAuth; // Authentication configuration
   headers?: Record<string, string>; // Additional HTTP headers for URL-based servers
+  env?: Record<string, string>; // Environment variables for stdio servers (passed to the child process)
 }
 
 // Bearer token authentication


### PR DESCRIPTION
## Pass per-server `env` through to stdio MCP servers (fixes #10509)

**The bug:** `McpStdioServerConfig` (from `@anthropic-ai/claude-agent-sdk`) supports `env?: Record<string, string>`, but `transformMCPServerConfigToClaudeCode` built the stdio config as `{type:'stdio', command, args}` and never forwarded per-server `env` — silently dropping it for both the `command` and `path` branches. (The SDK's `McpStdioServerConfig` explicitly declares `env` — verified at sdk.d.ts:1208.)

**The fix (minimal, 2 files):**
1. `types.ts` — add `env?: Record<string, string>` to `MCPServerConfig` so the field is actually configurable (before this, the config type didn't even expose `env` for stdio servers).
2. `transform.ts` — forward `env` to the Claude Agent SDK stdio config in both branches, only emitting it when present so existing configs are unchanged.

Verified: structural diff is clean (13 insertions / 2 deletions). No `mcp/__tests__` dir exists yet; a regression test asserting env is forwarded to the stdio config should be added alongside.
