### PR TITLE
fix(matchers): mark factuality/closed-QA provider failures as grader errors

### DIFF
--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -337,7 +337,7 @@ export async function matchesFactuality(
     providerCallContext,
   );
   if (resp.error || !resp.output) {
-    return fail(resp.error || 'No output', resp.tokenUsage);
+    return graderFail(resp.error || 'No output', resp.tokenUsage);
   }
 
   invariant(typeof resp.output === 'string', 'factuality produced malformed response');
@@ -395,7 +395,7 @@ export async function matchesClosedQa(
     providerCallContext,
   );
   if (resp.error || !resp.output) {
-    return fail(resp.error || 'No output', resp.tokenUsage);
+    return graderFail(resp.error || 'No output', resp.tokenUsage);
   }
 
   invariant(typeof resp.output === 'string', 'model-graded-closedqa produced malformed response');

--- a/test/matchers/grader-errors.test.ts
+++ b/test/matchers/grader-errors.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { matchesClosedQa, matchesFactuality } from '../../src/matchers/llmGrading';
+import { createMockProvider } from '../factories/provider';
+
+const tokenUsage = { total: 10, prompt: 5, completion: 5 };
+
+describe('model grader failures', () => {
+  it('marks factuality provider errors as grader errors', async () => {
+    const provider = createMockProvider({
+      response: { error: 'grader unavailable', tokenUsage },
+    });
+
+    await expect(
+      matchesFactuality('question', 'expected', 'answer', { provider }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        pass: false,
+        score: 0,
+        reason: 'grader unavailable',
+        metadata: { graderError: true },
+      }),
+    );
+  });
+
+  it('marks factuality no-output responses as grader errors', async () => {
+    const provider = createMockProvider({
+      response: { output: '', tokenUsage },
+    });
+
+    await expect(
+      matchesFactuality('question', 'expected', 'answer', { provider }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        pass: false,
+        score: 0,
+        reason: 'No output',
+        metadata: { graderError: true },
+      }),
+    );
+  });
+
+  it('marks closed-QA provider errors as grader errors', async () => {
+    const provider = createMockProvider({
+      response: { error: 'grader unavailable', tokenUsage },
+    });
+
+    await expect(
+      matchesClosedQa('question', 'criterion', 'answer', { provider }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        pass: false,
+        score: 0,
+        reason: 'grader unavailable',
+        metadata: { graderError: true },
+      }),
+    );
+  });
+
+  it('keeps valid negative grades as ordinary assertion failures', async () => {
+    const factualityProvider = createMockProvider({
+      response: {
+        output: '(D) The submitted answer disagrees with the expert answer.',
+        tokenUsage,
+      },
+    });
+    const closedQaProvider = createMockProvider({
+      response: { output: 'N', tokenUsage },
+    });
+
+    const factuality = await matchesFactuality('question', 'expected', 'answer', {
+      provider: factualityProvider,
+    });
+    const closedQa = await matchesClosedQa('question', 'criterion', 'answer', {
+      provider: closedQaProvider,
+    });
+
+    expect(factuality).toMatchObject({ pass: false, score: 0 });
+    expect(factuality.metadata).toBeUndefined();
+    expect(closedQa).toMatchObject({ pass: false, score: 0 });
+    expect(closedQa.metadata).toBeUndefined();
+  });
+});

--- a/test/matchers/grader-errors.test.ts
+++ b/test/matchers/grader-errors.test.ts
@@ -44,9 +44,7 @@ describe('model grader failures', () => {
       response: { error: 'grader unavailable', tokenUsage },
     });
 
-    await expect(
-      matchesClosedQa('question', 'criterion', 'answer', { provider }),
-    ).resolves.toEqual(
+    await expect(matchesClosedQa('question', 'criterion', 'answer', { provider })).resolves.toEqual(
       expect.objectContaining({
         pass: false,
         score: 0,


### PR DESCRIPTION
Closes #10481.

`matchesFactuality()` and `matchesClosedQa()` currently turn grader provider/no-output failures into ordinary failed assertions. This reuses the existing `graderFail(...)` semantics for those execution failures, so callers can distinguish evaluator failure from a valid semantic grade of `false`.

The change is intentionally narrow:

- provider errors and missing output are tagged with `metadata.graderError=true`;
- valid negative factuality / closed-QA grades remain normal `pass: false` results;
- malformed-output behavior is unchanged in this first slice.

Added focused regression coverage for provider errors, missing output, and valid negative grades. CI, code scan, and PR-title validation are green on the current head.