### PR TITLE
docs(site): add Parallel MCP eval example

### DIFF
--- a/examples/parallel-search-mcp/README.md
+++ b/examples/parallel-search-mcp/README.md
@@ -1,0 +1,25 @@
+# parallel-search-mcp (Remote MCP Search and Fetch)
+
+Test a hosted MCP server without running a local server or configuring an API key. This example calls [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) directly through Promptfoo's existing `mcp` provider. It does not use an LLM or a model-graded assertion.
+
+## Run
+
+```bash
+npx promptfoo@latest init --example parallel-search-mcp
+cd parallel-search-mcp
+npx promptfoo@latest eval --no-cache --max-concurrency 1 -o results.json
+```
+
+No environment variables, Parallel account, or API keys are required. The connection uses Streamable HTTP at `https://search.parallel.ai/mcp` without authentication headers.
+
+The two test cases call `web_search` to find Promptfoo's MCP documentation and `web_fetch` to extract `https://example.com`. The assertions check for URLs and nonempty excerpts, the expected source in search results, and no per-URL fetch errors. The response transform reads structured content, with a JSON text fallback, and reports MCP tool errors as eval errors.
+
+Expect two passing tests. Inspect `results.json` for outputs and errors. Search rankings and page content can change, so this is a live integration smoke test, not a search-quality benchmark. Requests use the MCP client's 60-second timeout. Free access is rate limited; if a run hits a limit, wait before retrying rather than increasing concurrency.
+
+## Data sent to Parallel
+
+Running the eval sends the configured search queries, requested URLs, and objectives to Parallel. Use public test data only. The returned excerpts and URLs are included in your eval results. See Parallel's [Customer Terms](https://parallel.ai/customer-terms) and [Privacy Policy](https://parallel.ai/privacy-policy).
+
+This config makes only the listed tool calls. It does not enable web search for other providers, change existing defaults, or add a paid fallback. To stop using the service, stop running this config or remove its MCP provider from any config you copy it into.
+
+To adapt the example, edit the JSON tool arguments under `tests` and their expected assertions. Keep both `objective` and `search_queries` for `web_search`; `web_fetch` takes public URLs and uses excerpts by default.

--- a/examples/parallel-search-mcp/promptfooconfig.yaml
+++ b/examples/parallel-search-mcp/promptfooconfig.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: Remote MCP search and fetch smoke tests
+
+prompts:
+  - '{{prompt}}'
+
+providers:
+  - id: mcp
+    label: Parallel Search MCP
+    config:
+      enabled: true
+      server:
+        url: https://search.parallel.ai/mcp
+      tools: [web_search, web_fetch]
+      timeout: 60000
+      transformResponse: |
+        result.isError
+          ? { error: content }
+          : { output: result.structuredContent ?? JSON.parse(result.content[0].text) }
+
+defaultTest:
+  assert:
+    - type: javascript
+      value: |
+        return Array.isArray(output.results) && output.results.length > 0 &&
+          output.results.every((result) =>
+            typeof result.url === 'string' && /^https?:\/\//.test(result.url) &&
+            Array.isArray(result.excerpts) &&
+            result.excerpts.some((excerpt) => typeof excerpt === 'string' && excerpt.trim().length > 0)
+          );
+
+tests:
+  - description: Search for Promptfoo MCP documentation
+    vars:
+      prompt: |
+        {
+          "tool": "web_search",
+          "args": {
+            "objective": "Find the official Promptfoo documentation for evaluating MCP servers.",
+            "search_queries": ["promptfoo MCP provider documentation"]
+          }
+        }
+    assert:
+      - type: javascript
+        value: |
+          return output.results.some((result) => {
+            const url = new URL(result.url);
+            return (url.hostname === 'promptfoo.dev' || url.hostname === 'www.promptfoo.dev') &&
+              url.pathname.startsWith('/docs/');
+          });
+
+  - description: Fetch a public example page
+    vars:
+      prompt: |
+        {
+          "tool": "web_fetch",
+          "args": {
+            "urls": ["https://example.com"],
+            "objective": "Describe what this example domain is for.",
+            "full_content": false
+          }
+        }
+    assert:
+      - type: javascript
+        value: |
+          return Array.isArray(output.errors) && output.errors.length === 0 &&
+            output.results.some((result) => new URL(result.url).hostname === 'example.com');

--- a/site/docs/providers/mcp.md
+++ b/site/docs/providers/mcp.md
@@ -523,6 +523,7 @@ For complete working examples, see:
 - [Basic MCP Red Team Testing](https://github.com/promptfoo/promptfoo/tree/main/examples/redteam-mcp)
 - [MCP Authentication](https://github.com/promptfoo/promptfoo/tree/main/examples/redteam-mcp-auth) - OAuth and other authentication methods
 - [Simple MCP Integration](https://github.com/promptfoo/promptfoo/tree/main/examples/simple-mcp)
+- [Remote Search and Fetch with Parallel](https://github.com/promptfoo/promptfoo/tree/main/examples/parallel-search-mcp) - Live tool evals without a local server or API key
 
 You can initialize these examples with:
 


### PR DESCRIPTION
Adds a runnable remote MCP example for users who want to test tool calls without starting a local server or configuring API keys. It uses the existing `mcp` provider to call Parallel's `web_search` and `web_fetch`, with assertions for source URLs, excerpts, and fetch errors.

The example lives in `examples/parallel-search-mcp` and is linked from the MCP provider docs. It adds no provider adapter, dependencies, or changes to existing defaults. The README explains that running the eval sends the configured queries, URLs, and objectives to Parallel, and that anonymous access is rate limited. There is no paid fallback.

I work at Parallel, which operates this service. [Public Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp).

## Validation

From the repository root on Node 24.20.0:

```bash
npm ci
npm run local -- eval -c examples/parallel-search-mcp/promptfooconfig.yaml --no-cache --max-concurrency 1 -o results.json
npx vitest run test/providers/mcp/provider.test.ts test/providers/mcp/client.test.ts test/providers/mcp/transforms.test.ts
npm run l
npm run f
```

The local CLI run used an environment without API keys. Both live cases passed: search returned the expected documentation source, and fetch returned excerpts with no per-URL errors. The exported JSON has two successes, zero failures, and zero errors. All 72 existing MCP tests passed; formatting and diff checks passed too.

This is a small live integration smoke test, not a search-quality benchmark. Search results can change and free access can hit rate limits. The full repository suite and documentation build were not run.
