### PR TITLE
docs(site): document Portkey model catalog provider slugs

### DIFF
--- a/examples/provider-portkey/README.md
+++ b/examples/provider-portkey/README.md
@@ -7,10 +7,11 @@ npx promptfoo@latest init --example provider-portkey
 cd provider-portkey
 ```
 
-There are two examples:
+There are three examples:
 
 - prompt_example.yaml shows how to pull from portkey's prompt management platform. It requires you to set PORTKEY_API_KEY and OPENAI_API_KEY environment variables. Replace the portkey prompt with your own portkey prompt id.
 - provider_example.yaml shows how to use portkey's gateway. It requires the PORTKEY_API_KEY environment variable.
+- model_catalog_example.yaml shows how to address a model from Portkey's model catalog with an `@<ai-provider-slug>/<model-name>` reference. Replace the slug and model with your own. It requires the PORTKEY_API_KEY environment variable.
 
 Then run:
 

--- a/examples/provider-portkey/README.md
+++ b/examples/provider-portkey/README.md
@@ -11,12 +11,14 @@ There are three examples:
 
 - prompt_example.yaml shows how to pull from portkey's prompt management platform. It requires you to set PORTKEY_API_KEY and OPENAI_API_KEY environment variables. Replace the portkey prompt with your own portkey prompt id.
 - provider_example.yaml shows how to use portkey's gateway. It requires the PORTKEY_API_KEY environment variable.
-- model_catalog_example.yaml shows how to address a model from Portkey's model catalog with an `@<ai-provider-slug>/<model-name>` reference. Replace the slug and model with your own. It requires the PORTKEY_API_KEY environment variable.
+- model_catalog_example.yaml shows how to reference a model from Portkey's model catalog. Replace the provider slug and model with your own. It requires the PORTKEY_API_KEY environment variable.
 
-Then run:
+Then run whichever example you want, selecting its config explicitly:
 
 ```bash
-promptfoo eval
+promptfoo eval -c prompt_example.yaml
+promptfoo eval -c provider_example.yaml
+promptfoo eval -c model_catalog_example.yaml
 ```
 
 Afterwards, you can view the results by running `promptfoo view`

--- a/examples/provider-portkey/model_catalog_example.yaml
+++ b/examples/provider-portkey/model_catalog_example.yaml
@@ -5,13 +5,9 @@ prompts:
   - 'Write a short tweet about {{topic}}'
 
 providers:
-  # Model catalog reference: @<ai-provider-slug>/<model-name>
+  # Catalog reference: @<ai-provider-slug>/<model-name>.
+  # The slug can go in config.portkeyProvider instead of the id.
   - id: 'portkey:@bedrock-eu/eu.anthropic.claude-sonnet-4-5-20250929-v1:0'
-
-  # Equivalent, with the AI provider slug sent as a header
-  - id: 'portkey:eu.anthropic.claude-sonnet-4-5-20250929-v1:0'
-    config:
-      portkeyProvider: '@bedrock-eu'
 
 tests:
   - vars:

--- a/examples/provider-portkey/model_catalog_example.yaml
+++ b/examples/provider-portkey/model_catalog_example.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'Portkey.ai model catalog integration'
+
+prompts:
+  - 'Write a short tweet about {{topic}}'
+
+providers:
+  # Model catalog reference: @<ai-provider-slug>/<model-name>
+  - id: 'portkey:@bedrock-eu/eu.anthropic.claude-sonnet-4-5-20250929-v1:0'
+
+  # Equivalent, with the AI provider slug sent as a header
+  - id: 'portkey:eu.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    config:
+      portkeyProvider: '@bedrock-eu'
+
+tests:
+  - vars:
+      topic: bananas

--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -46,6 +46,32 @@ providers:
     portkeyProvider: openai
 ```
 
+### Model catalog
+
+Portkey's [model catalog](https://portkey.ai/docs/product/model-catalog) replaced virtual keys. Models are addressed as `@<ai-provider-slug>/<model-name>`, where the slug is the AI provider from your workspace's catalog and the model name is the one listed against it. Put the whole reference after `portkey:`:
+
+```yaml
+providers:
+  - id: 'portkey:@bedrock-eu/eu.anthropic.claude-sonnet-4-5-20250929-v1:0'
+```
+
+Colons in the model name are preserved, so Bedrock and Vertex identifiers work as-is.
+
+The slug can also be sent separately, which is useful when the same model name is served by more than one provider:
+
+```yaml
+providers:
+  - id: 'portkey:eu.anthropic.claude-sonnet-4-5-20250929-v1:0'
+    config:
+      portkeyProvider: '@bedrock-eu'
+```
+
+Both forms authenticate with `PORTKEY_API_KEY`, which must be a key from the workspace that owns the AI provider. The workspace slug itself is not part of the promptfoo config.
+
+`portkeyVirtualKey` continues to work for gateways that have not migrated to the model catalog.
+
+### Other options
+
 More complex portkey configurations are also supported.
 
 ```yaml

--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Portkey AI
-description: Integrate Portkey AI gateway with promptfoo for LLM testing, including prompt management, observability, and custom configurations with OpenAI models and APIs.
+description: Integrate the Portkey AI gateway with promptfoo, including model catalog provider slugs, prompt management, observability, and gateway configuration.
 ---
 
 # Portkey AI integration
@@ -41,9 +41,9 @@ Example:
 
 ```yaml
 providers:
-  id: portkey:gpt-5.6
-  config:
-    portkeyProvider: openai
+  - id: portkey:gpt-5.6
+    config:
+      portkeyProvider: openai
 ```
 
 ### Model catalog
@@ -70,24 +70,33 @@ Both forms authenticate with `PORTKEY_API_KEY`, which must be a key from the wor
 
 `portkeyVirtualKey` continues to work for gateways that have not migrated to the model catalog.
 
-### Other options
+### Gateway options
 
-More complex portkey configurations are also supported.
+Any `portkey`-prefixed config key is sent as the matching [Portkey header](https://portkey.ai/docs/api-reference/inference-api/headers), so `portkeyCacheNamespace` becomes `x-portkey-cache-namespace`. The commonly used ones:
+
+| Config key                 | Header                          | Purpose                                                                |
+| -------------------------- | ------------------------------- | ---------------------------------------------------------------------- |
+| `portkeyApiKey`            | `x-portkey-api-key`             | Portkey credential. Prefer the `PORTKEY_API_KEY` environment variable. |
+| `portkeyProvider`          | `x-portkey-provider`            | AI provider slug (`@my-provider`) or provider name.                    |
+| `portkeyVirtualKey`        | `x-portkey-virtual-key`         | Legacy credential reference, superseded by the provider slug.          |
+| `portkeyConfig`            | `x-portkey-config`              | Config ID or JSON object for routing, caching, and fallbacks.          |
+| `portkeyCustomHost`        | `x-portkey-custom-host`         | Base URL for privately hosted models.                                  |
+| `portkeyMetadata`          | `x-portkey-metadata`            | Metadata for filtering in Portkey analytics.                           |
+| `portkeyTraceId`           | `x-portkey-trace-id`            | Correlates related requests.                                           |
+| `portkeyCacheForceRefresh` | `x-portkey-cache-force-refresh` | Bypasses the Portkey cache for the request.                            |
+| `portkeyCacheNamespace`    | `x-portkey-cache-namespace`     | Partitions the cache store.                                            |
+| `portkeyRequestTimeout`    | `x-portkey-request-timeout`     | Timeout in milliseconds.                                               |
+
+`portkeyApiBaseUrl` is the exception: it sets the gateway URL promptfoo calls rather than a header, and defaults to `https://api.portkey.ai/v1`. The `PORTKEY_API_BASE_URL` environment variable takes precedence over it.
 
 ```yaml
 providers:
-  id: portkey:gpt-5.6
-  config:
-    # Can alternatively set environment variable, e.g. PORTKEY_API_KEY
-    portkeyApiKey: xxx
-
-    # Other configuration options
-    portkeyVirtualKey: xxx
-    portkeyMetadata:
-      team: xxx
-    portkeyConfig: xxx
-    portkeyProvider: xxx
-    portkeyApiBaseUrl: xxx
+  - id: portkey:gpt-5.6
+    config:
+      portkeyProvider: openai
+      portkeyMetadata:
+        team: platform
+      portkeyTraceId: nightly-eval
 ```
 
 ## Portkey MCP Gateway

--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -7,8 +7,6 @@ description: Integrate the Portkey AI gateway with promptfoo, including model ca
 
 Portkey is an AI observability suite that includes prompt management capabilities.
 
-The examples below use OpenAI's current `gpt-5.6` model identifier.
-
 To reference prompts in Portkey:
 
 1. Set the `PORTKEY_API_KEY` environment variable.
@@ -48,7 +46,7 @@ providers:
 
 ### Model catalog
 
-Portkey's [model catalog](https://portkey.ai/docs/product/model-catalog) replaced virtual keys. Models are addressed as `@<ai-provider-slug>/<model-name>`, where the slug is the AI provider from your workspace's catalog and the model name is the one listed against it. Put the whole reference after `portkey:`:
+Portkey's [model catalog](https://portkey.ai/docs/product/model-catalog) replaced virtual keys. Address models as `@<ai-provider-slug>/<model-name>` after the `portkey:` prefix:
 
 ```yaml
 providers:
@@ -57,7 +55,7 @@ providers:
 
 Colons in the model name are preserved, so Bedrock and Vertex identifiers work as-is.
 
-The slug can also be sent separately, which is useful when the same model name is served by more than one provider:
+Send the slug separately when the same model name is served by more than one provider:
 
 ```yaml
 providers:
@@ -66,28 +64,26 @@ providers:
       portkeyProvider: '@bedrock-eu'
 ```
 
-Both forms authenticate with `PORTKEY_API_KEY`, which must be a key from the workspace that owns the AI provider. The workspace slug itself is not part of the promptfoo config.
-
-`portkeyVirtualKey` continues to work for gateways that have not migrated to the model catalog.
+Use a `PORTKEY_API_KEY` from the workspace that owns the AI provider.
 
 ### Gateway options
 
-Any `portkey`-prefixed config key is sent as the matching [Portkey header](https://portkey.ai/docs/api-reference/inference-api/headers), so `portkeyCacheNamespace` becomes `x-portkey-cache-namespace`. The commonly used ones:
+Any `portkey`-prefixed config key is sent as the matching [Portkey header](https://portkey.ai/docs/api-reference/inference-api/headers), so `portkeyCacheNamespace` becomes `x-portkey-cache-namespace`. Common options:
 
-| Config key                 | Header                          | Purpose                                                                |
-| -------------------------- | ------------------------------- | ---------------------------------------------------------------------- |
-| `portkeyApiKey`            | `x-portkey-api-key`             | Portkey credential. Prefer the `PORTKEY_API_KEY` environment variable. |
-| `portkeyProvider`          | `x-portkey-provider`            | AI provider slug (`@my-provider`) or provider name.                    |
-| `portkeyVirtualKey`        | `x-portkey-virtual-key`         | Legacy credential reference, superseded by the provider slug.          |
-| `portkeyConfig`            | `x-portkey-config`              | Config ID or JSON object for routing, caching, and fallbacks.          |
-| `portkeyCustomHost`        | `x-portkey-custom-host`         | Base URL for privately hosted models.                                  |
-| `portkeyMetadata`          | `x-portkey-metadata`            | Metadata for filtering in Portkey analytics.                           |
-| `portkeyTraceId`           | `x-portkey-trace-id`            | Correlates related requests.                                           |
-| `portkeyCacheForceRefresh` | `x-portkey-cache-force-refresh` | Bypasses the Portkey cache for the request.                            |
-| `portkeyCacheNamespace`    | `x-portkey-cache-namespace`     | Partitions the cache store.                                            |
-| `portkeyRequestTimeout`    | `x-portkey-request-timeout`     | Timeout in milliseconds.                                               |
+| Parameter                  | Description                                                    |
+| -------------------------- | -------------------------------------------------------------- |
+| `portkeyApiKey`            | Portkey credential.                                            |
+| `portkeyProvider`          | AI provider slug (`@my-provider`) or provider name.            |
+| `portkeyVirtualKey`        | Legacy credential reference. Use a model catalog slug instead. |
+| `portkeyConfig`            | Config ID or JSON object for routing, caching, and fallbacks.  |
+| `portkeyCustomHost`        | Base URL for privately hosted models.                          |
+| `portkeyMetadata`          | Metadata for filtering in Portkey analytics.                   |
+| `portkeyTraceId`           | Correlates related requests.                                   |
+| `portkeyCacheForceRefresh` | Bypasses the Portkey cache for the request.                    |
+| `portkeyCacheNamespace`    | Partitions the cache store.                                    |
+| `portkeyRequestTimeout`    | Timeout in milliseconds.                                       |
 
-`portkeyApiBaseUrl` is the exception: it sets the gateway URL promptfoo calls rather than a header, and defaults to `https://api.portkey.ai/v1`. The `PORTKEY_API_BASE_URL` environment variable takes precedence over it.
+`portkeyApiBaseUrl` sets the gateway URL Promptfoo calls, defaulting to `https://api.portkey.ai/v1`; `PORTKEY_API_BASE_URL` overrides it.
 
 ```yaml
 providers:
@@ -103,7 +99,7 @@ providers:
 
 Promptfoo can connect to [Portkey's MCP Gateway](https://portkey.ai/docs/product/mcp-gateway/) in two ways. Use the [`mcp` provider](/docs/providers/mcp/) to test or red team the MCP server directly. To test an LLM application that uses the server, add the same server block to the model provider's [`mcp` config](/docs/integrations/mcp/).
 
-`PORTKEY_API_BASE_URL` does not configure the MCP connection. It sets the OpenAI-compatible chat-completions endpoint used by the `portkey:` provider and defaults to `https://api.portkey.ai/v1`. Put the MCP Gateway URL in `server.url` instead.
+`PORTKEY_API_BASE_URL` does not configure the MCP connection. Put the MCP Gateway URL in `server.url` instead.
 
 The gateway exposes each registered server at `https://mcp.portkey.ai/<server-slug>/mcp`, where `<server-slug>` is the slug from Portkey's MCP Registry. For non-interactive CLI and CI runs, send a workspace user API key with `mcp invoke` permission in the `x-portkey-api-key` header. Without an API key, Portkey starts an interactive OAuth flow intended for browser-based clients. See [Portkey's authentication guide](https://portkey.ai/docs/product/mcp-gateway/authentication).
 


### PR DESCRIPTION
## Summary

Portkey replaced virtual keys with the [model catalog](https://portkey.ai/docs/product/model-catalog), where a model is addressed as `@<ai-provider-slug>/<model-name>`. Our integration docs only covered `portkeyProvider` and `portkeyVirtualKey`, so there was no guidance for catalog slugs — and Portkey's own promptfoo page predates the change too.

This came out of a user who had every value from the Portkey console (workspace slug, AI provider slug, Bedrock model name) and could not find where any of them go.

## Changes

- **New "Model catalog" section** covering both supported forms, verified against the request Promptfoo actually emits:
  - `portkey:@bedrock-eu/eu.anthropic.claude-sonnet-4-5-20250929-v1:0` → `"model": "@bedrock-eu/eu.anthropic…-v1:0"`
  - `portkeyProvider: '@bedrock-eu'` → `x-portkey-provider: @bedrock-eu`
  - Colons survive `registry.ts` parsing (`splits.slice(1).join(':')`), which the docs now state explicitly.
- **Fixed two invalid examples.** Both gateway snippets used a mapping under `providers:` rather than a list. That fails validation outright — `✖ Invalid input → at providers` / `You must specify at least 1 provider`. Anyone copy-pasting them got an error.
- **Documented the gateway options**, including several that were supported but undocumented (custom host, trace ID, cache controls, request timeout), replacing the `xxx` placeholder snippet.
- **Made the examples runnable.** The directory has no `promptfooconfig.yaml`, so the README's bare `promptfoo eval` exits before reaching any config; each is now invoked with an explicit `-c`.
- Added `examples/provider-portkey/model_catalog_example.yaml`.

## Review feedback addressed

- **Invalid `providers:` mapping** (@copilot, both occurrences): fixed.
- **Example not runnable via the documented command** (@chatgpt-codex-connector, @jameshiester-oai): README now documents `promptfoo eval -c <file>` per example.
- A docs pass also cut restated facts (the virtual-key line, the workspace-slug aside, the base URL default repeated in the MCP section), switched the option table to the two-column `Parameter | Description` form used across `site/docs/providers/`, and removed the stale "examples below use `gpt-5.6`" note that the new Bedrock examples falsify.

Every header row in the table was verified against `toKebabCase` + the prefix strip, and the `PORTKEY_API_BASE_URL` precedence and colon-preservation claims were checked against the code.

## Scope

Deliberately limited to what is true on `main` today, so this can land independently of #10536. The credential-model documentation ships with #10536, which is what makes it true.

## Testing

`npx vitest run test/examples/readme.test.ts test/examples/yaml-aliases.test.ts` — 1759 passed. Both corrected config forms confirmed with `promptfoo validate`. Prettier clean.