### PR TITLE
fix(go-provider): support importable packages

### DIFF
--- a/examples/provider-golang/evaluation/main.go
+++ b/examples/provider-golang/evaluation/main.go
@@ -1,7 +1,7 @@
-// Package main implements a promptfoo provider that uses OpenAI's API with reasoning effort control.
+// Package evaluation implements a promptfoo provider that uses OpenAI's API with reasoning effort control.
 // It provides a CallApi function that can be used by promptfoo to generate responses
 // with configurable reasoning levels.
-package main
+package evaluation
 
 import (
 	"fmt"

--- a/examples/provider-golang/main.go
+++ b/examples/provider-golang/main.go
@@ -1,7 +1,7 @@
-// Package main implements a promptfoo provider that uses OpenAI's API.
+// Package provider implements a promptfoo provider that uses OpenAI's API.
 // It demonstrates a simple implementation of the provider interface using
 // shared code from the core and pkg1 packages.
-package main
+package provider
 
 import (
 	"fmt"

--- a/site/docs/providers/go.md
+++ b/site/docs/providers/go.md
@@ -50,8 +50,8 @@ providers:
 Here's a complete example using the OpenAI API:
 
 ```go
-// Package main implements a promptfoo provider that uses OpenAI's API.
-package main
+// Package provider implements a promptfoo provider that uses OpenAI's API.
+package provider
 
 import (
     "fmt"
@@ -94,6 +94,12 @@ func CallApi(prompt string, options map[string]interface{}, ctx map[string]inter
     }, nil
 }
 ```
+
+Use a named, importable package as shown above when the provider lives in a regular Go module.
+Promptfoo builds its generated entry point separately and imports the package through the module
+path from `go.mod`, so repository-wide commands such as `go build ./...` continue to work. The
+`CallApi` symbol must be exported. Existing `package main` providers remain supported, but a provider
+without its own `main` function cannot also be built as a standalone command.
 
 ## Using the Provider
 

--- a/src/providers/golangCompletion.ts
+++ b/src/providers/golangCompletion.ts
@@ -129,22 +129,39 @@ export class GolangProvider implements ApiProvider {
 
         const relativeScriptPath = path.relative(moduleRoot, absPath);
         const scriptDir = path.dirname(path.join(tempDir, relativeScriptPath));
-
-        // Copy wrapper.go to the same directory as the script
-        const tempWrapperPath = path.join(scriptDir, 'wrapper.go');
         await fs.mkdir(scriptDir, { recursive: true });
-        await fs.copyFile(path.join(getWrapperDir('golang'), 'wrapper.go'), tempWrapperPath);
 
         const executablePath = path.join(tempDir, 'golang_wrapper');
         const tempScriptPath = path.join(tempDir, relativeScriptPath);
-
-        // Build from the script directory using execFile (no shell injection)
         const goExecutable = this.config.goExecutable || 'go';
-        await execFileAsync(
-          goExecutable,
-          ['build', '-o', executablePath, 'wrapper.go', path.basename(relativeScriptPath)],
-          { cwd: scriptDir },
+        const { stdout: packageJson } = await execFileAsync(goExecutable, ['list', '-json', '.'], {
+          cwd: scriptDir,
+        });
+        const packageInfo = JSON.parse(packageJson) as { ImportPath?: string; Name?: string };
+        let buildDir = scriptDir;
+        let buildFiles = ['wrapper.go', path.basename(relativeScriptPath)];
+
+        if (packageInfo.Name && packageInfo.Name !== 'main') {
+          if (!packageInfo.ImportPath) {
+            throw new Error('Could not determine Go provider import path');
+          }
+
+          buildDir = await fs.mkdtemp(path.join(tempDir, '.promptfoo-wrapper-'));
+          await fs.writeFile(
+            path.join(buildDir, 'provider.go'),
+            `package main\n\nimport provider ${JSON.stringify(packageInfo.ImportPath)}\n\nvar CallApi = provider.CallApi\n`,
+          );
+          buildFiles = ['wrapper.go', 'provider.go'];
+        }
+
+        await fs.copyFile(
+          path.join(getWrapperDir('golang'), 'wrapper.go'),
+          path.join(buildDir, 'wrapper.go'),
         );
+
+        await execFileAsync(goExecutable, ['build', '-o', executablePath, ...buildFiles], {
+          cwd: buildDir,
+        });
 
         const jsonArgs = safeJsonStringify(args) || '[]';
         logger.debug(`Running Go executable: ${executablePath}`);

--- a/test/providers/golangCompletion.test.ts
+++ b/test/providers/golangCompletion.test.ts
@@ -45,6 +45,18 @@ vi.mock('../../src/logger', () => ({
   },
 }));
 
+vi.mock('../../src/esm', () => ({
+  getWrapperDir: vi.fn(() => '/absolute/path/to'),
+}));
+
+vi.mock('../../src/util/file', () => ({
+  pathExists: vi.fn(async (filePath: string) => fsMocks.existsSync(filePath)),
+}));
+
+vi.mock('../../src/util/json', () => ({
+  safeJsonStringify: vi.fn((value: unknown) => JSON.stringify(value)),
+}));
+
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
   return {
@@ -72,24 +84,21 @@ vi.mock('fs/promises', () => {
   const mkdtemp = vi.fn(async (...args: any[]) => fsMocks.mkdtempSync(...args));
   const mkdir = vi.fn(async (...args: any[]) => fsMocks.mkdirSync(...args));
   const copyFile = vi.fn(async (...args: any[]) => fsMocks.copyFileSync(...args));
+  const writeFile = vi.fn(async (...args: any[]) => fsMocks.writeFileSync(...args));
   const rm = vi.fn(async (...args: any[]) => fsMocks.rmSync(...args));
-  const promiseApi = { readFile, readdir, mkdtemp, mkdir, copyFile, rm, access };
+  const promiseApi = { readFile, readdir, mkdtemp, mkdir, copyFile, writeFile, rm, access };
   return { default: promiseApi, ...promiseApi };
 });
 vi.mock('path');
 
-vi.mock('../../src/util', async () => {
-  const actual = await vi.importActual('../../src/util');
-  return {
-    ...actual,
-    parsePathOrGlob: vi.fn(() => ({
-      extension: 'go',
-      functionName: undefined,
-      isPathPattern: false,
-      filePath: '/absolute/path/to/script.go',
-    })),
-  };
-});
+vi.mock('../../src/util', () => ({
+  parsePathOrGlob: vi.fn(() => ({
+    extension: 'go',
+    functionName: undefined,
+    isPathPattern: false,
+    filePath: '/absolute/path/to/script.go',
+  })),
+}));
 
 describe('GolangProvider', () => {
   const mockReadFileSync = vi.mocked(fs.readFileSync);
@@ -100,6 +109,7 @@ describe('GolangProvider', () => {
   const mockReaddirSync = vi.mocked(fs.readdirSync);
   const mockCopyFileSync = vi.mocked(fs.copyFileSync);
   const mockMkdirSync = vi.mocked(fs.mkdirSync);
+  const mockWriteFileSync = vi.mocked(fs.writeFileSync);
   const mockDirname = vi.mocked(path.dirname);
   const mockJoin = vi.mocked(path.join);
   const mockRelative = vi.mocked(path.relative);
@@ -251,7 +261,13 @@ describe('GolangProvider', () => {
       // Use setImmediate to ensure proper async behavior
       setImmediate(() => {
         try {
-          if (file === 'go' && args[0] === 'build') {
+          if (file === 'go' && args[0] === 'list') {
+            callback(
+              null,
+              { stdout: '{"Name":"main","ImportPath":"example.com/provider"}', stderr: '' },
+              '',
+            );
+          } else if (file === 'go' && args[0] === 'build') {
             callback(null, { stdout: '', stderr: '' }, '');
           } else if (file.includes('golang_wrapper')) {
             callback(null, { stdout: '{"output":"test output"}', stderr: '' }, '');
@@ -388,7 +404,7 @@ describe('GolangProvider', () => {
 
       mockExecFile.mockImplementation(((
         file: string,
-        _args: any[],
+        args: any[],
         optionsOrCallback: any,
         maybeCallback?: any,
       ) => {
@@ -398,7 +414,9 @@ describe('GolangProvider', () => {
           return {} as any;
         }
         setImmediate(() => {
-          if (file.includes('golang_wrapper')) {
+          if (args[0] === 'list') {
+            callback(null, { stdout: '{"Name":"main"}', stderr: '' }, '');
+          } else if (file.includes('golang_wrapper')) {
             callback(null, { stdout: '{"error":"test error in result"}', stderr: '' }, '');
           } else {
             callback(null, { stdout: '', stderr: '' }, '');
@@ -522,7 +540,7 @@ describe('GolangProvider', () => {
       });
       mockExecFile.mockImplementation(((
         file: string,
-        _args: any[],
+        args: any[],
         optionsOrCallback: any,
         maybeCallback?: any,
       ) => {
@@ -535,7 +553,12 @@ describe('GolangProvider', () => {
           callback(
             null,
             {
-              stdout: file.includes('golang_wrapper') ? '{"embedding":[0.1,0.2,0.3]}' : '',
+              stdout:
+                args[0] === 'list'
+                  ? '{"Name":"main"}'
+                  : file.includes('golang_wrapper')
+                    ? '{"embedding":[0.1,0.2,0.3]}'
+                    : '',
               stderr: '',
             },
             '',
@@ -554,7 +577,7 @@ describe('GolangProvider', () => {
       });
       mockExecFile.mockImplementation(((
         file: string,
-        _args: any[],
+        args: any[],
         optionsOrCallback: any,
         maybeCallback?: any,
       ) => {
@@ -567,7 +590,12 @@ describe('GolangProvider', () => {
           callback(
             null,
             {
-              stdout: file.includes('golang_wrapper') ? '{"classification":"test_class"}' : '',
+              stdout:
+                args[0] === 'list'
+                  ? '{"Name":"main"}'
+                  : file.includes('golang_wrapper')
+                    ? '{"classification":"test_class"}'
+                    : '',
               stderr: '',
             },
             '',
@@ -586,7 +614,7 @@ describe('GolangProvider', () => {
       });
       mockExecFile.mockImplementation(((
         file: string,
-        _args: any[],
+        args: any[],
         optionsOrCallback: any,
         maybeCallback?: any,
       ) => {
@@ -599,7 +627,12 @@ describe('GolangProvider', () => {
           callback(
             null,
             {
-              stdout: file.includes('golang_wrapper') ? '{"output":"test"}' : '',
+              stdout:
+                args[0] === 'list'
+                  ? '{"Name":"main"}'
+                  : file.includes('golang_wrapper')
+                    ? '{"output":"test"}'
+                    : '',
               stderr: 'warning: some go warning',
             },
             '',
@@ -679,6 +712,59 @@ describe('GolangProvider', () => {
   });
 
   describe('script execution', () => {
+    it('should import named provider packages from a separate wrapper directory', async () => {
+      mockMkdtempSync
+        .mockReturnValueOnce('/tmp/golang-provider-xyz')
+        .mockReturnValueOnce('/tmp/golang-provider-xyz/.promptfoo-wrapper-abc');
+      mockExecFile.mockImplementation(((
+        file: string,
+        args: any[],
+        optionsOrCallback: any,
+        maybeCallback?: any,
+      ) => {
+        const callback =
+          typeof optionsOrCallback === 'function' ? optionsOrCallback : maybeCallback;
+        if (!callback) {
+          return {} as any;
+        }
+        setImmediate(() => {
+          if (file === 'go' && args[0] === 'list') {
+            callback(
+              null,
+              {
+                stdout: '{"Name":"provider","ImportPath":"example.com/project/provider"}',
+                stderr: '',
+              },
+              '',
+            );
+          } else if (file.includes('golang_wrapper')) {
+            callback(null, { stdout: '{"output":"test"}', stderr: '' }, '');
+          } else {
+            callback(null, { stdout: '', stderr: '' }, '');
+          }
+        });
+        return {} as any;
+      }) as any);
+
+      const provider = new GolangProvider('script.go', {
+        config: { basePath: '/absolute/path/to' },
+      });
+
+      await expect(provider.callApi('test prompt')).resolves.toEqual({ output: 'test' });
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('provider.go'),
+        expect.stringContaining('import provider "example.com/project/provider"'),
+      );
+      expect(mockExecFile).toHaveBeenCalledWith(
+        'go',
+        expect.arrayContaining(['build', 'wrapper.go', 'provider.go']),
+        expect.objectContaining({
+          cwd: '/tmp/golang-provider-xyz/.promptfoo-wrapper-abc',
+        }),
+        expect.any(Function),
+      );
+    });
+
     it('should handle JSON parsing errors', async () => {
       const provider = new GolangProvider('script.go', {
         config: { basePath: '/absolute/path/to' },


### PR DESCRIPTION
## Summary

- detect the provider package with `go list -json`
- build named packages through a generated adapter in a separate temporary wrapper directory
- preserve existing `package main` providers and update the official example/docs to use buildable named packages

Fixes #10538.

## Validation

- `npm exec --yes --package=vitest@4.1.11 -- vitest run test/providers/golangCompletion.test.ts --sequence.shuffle=false` (29 passed)
- `go build ./...` in `examples/provider-golang`
- compiled the real `src/golang/wrapper.go` with an adapter importing the named example package
- Biome 2.5.8 check on the touched TypeScript files
- Prettier check on `site/docs/providers/go.md`
- `gofmt -d` on the touched Go files

## Risk boundary

Named providers must expose `CallApi` from an importable package in the module containing `go.mod`. Legacy `package main` behavior is unchanged. The focused provider suite and both Go build paths were verified locally; the full repository suite and TypeScript project check were left to CI.