### PR TITLE
fix(assertions): interpolate variables in file reference values

### DIFF
--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -478,9 +478,10 @@ async function runAssertionInternal({
   let renderedValue = assertion.value;
   let valueFromScript: ValueFromScriptType;
   if (typeof renderedValue === 'string') {
-    if (renderedValue.startsWith('file://')) {
+    const interpolatedValue = nunjucks.renderString(renderedValue, resolvedVars);
+    if (interpolatedValue.startsWith('file://')) {
       const basePath = cliState.basePath || '';
-      const fileRef = renderedValue.slice('file://'.length);
+      const fileRef = interpolatedValue.slice('file://'.length);
       let filePath = fileRef;
       let functionName: string | undefined;
 
@@ -531,7 +532,10 @@ async function runAssertionInternal({
           };
         }
       } else {
-        renderedValue = processFileReference(renderedValue);
+        renderedValue = processFileReference(interpolatedValue);
+        if (typeof renderedValue === 'string') {
+          renderedValue = nunjucks.renderString(renderedValue, resolvedVars);
+        }
       }
     } else if (isPackagePath(renderedValue)) {
       const basePath = cliState.basePath || '';
@@ -545,16 +549,21 @@ async function runAssertionInternal({
       valueFromScript = await Promise.resolve(requiredModule(output, context));
     } else {
       // It's a normal string value
-      renderedValue = nunjucks.renderString(renderedValue, resolvedVars);
+      renderedValue = interpolatedValue;
     }
   } else if (renderedValue && Array.isArray(renderedValue)) {
     // Process each element in the array
     renderedValue = renderedValue.map((v) => {
       if (typeof v === 'string') {
-        if (v.startsWith('file://')) {
-          return processFileReference(v);
+        const interpolated = nunjucks.renderString(v, resolvedVars);
+        if (interpolated.startsWith('file://')) {
+          const processed = processFileReference(interpolated);
+          if (typeof processed === 'string') {
+            return nunjucks.renderString(processed, resolvedVars);
+          }
+          return processed;
         }
-        return nunjucks.renderString(v, resolvedVars);
+        return interpolated;
       }
       return v;
     });

--- a/test/assertions/runAssertion.test.ts
+++ b/test/assertions/runAssertion.test.ts
@@ -3773,6 +3773,122 @@ describe('runAssertion', () => {
       );
     });
 
+    it('should interpolate variables in file reference content', async () => {
+      const assertion: Assertion = {
+        type: 'equals',
+        value: 'file://expected_output.txt',
+      };
+
+      const fileTemplateContent = 'Expected output for {{ topic }}';
+      vi.mocked(fs.readFileSync).mockReturnValue(fileTemplateContent);
+      vi.mocked(path.resolve).mockReturnValue('/base/path/expected_output.txt');
+      vi.mocked(path.extname).mockReturnValue('.txt');
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Some prompt',
+        provider: new OpenAiChatCompletionProvider('gpt-4o-mini'),
+        assertion,
+        test: {
+          vars: { topic: 'capybaras' },
+        } as unknown as AtomicTestCase,
+        providerResponse: { output: 'Expected output for capybaras' },
+      });
+
+      expect(fs.readFileSync).toHaveBeenCalledWith('/base/path/expected_output.txt', 'utf8');
+      expect(result.pass).toBe(true);
+    });
+
+    it('should interpolate variables in file reference path and content', async () => {
+      const assertion: Assertion = {
+        type: 'equals',
+        value: 'file://{{ filename }}.txt',
+      };
+
+      const fileTemplateContent = 'Result is {{ value }}';
+      vi.mocked(fs.readFileSync).mockReturnValue(fileTemplateContent);
+      vi.mocked(path.resolve).mockReturnValue('/base/path/my_file.txt');
+      vi.mocked(path.extname).mockReturnValue('.txt');
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Some prompt',
+        provider: new OpenAiChatCompletionProvider('gpt-4o-mini'),
+        assertion,
+        test: {
+          vars: { filename: 'my_file', value: '42' },
+        } as unknown as AtomicTestCase,
+        providerResponse: { output: 'Result is 42' },
+      });
+
+      expect(fs.readFileSync).toHaveBeenCalledWith('/base/path/my_file.txt', 'utf8');
+      expect(result.pass).toBe(true);
+    });
+
+    it('should interpolate variables in file references within array values', async () => {
+      const assertion: Assertion = {
+        type: 'contains-any',
+        value: ['Static {{ topic }}', 'file://templated_output.txt'],
+      };
+
+      const fileContent = 'Loaded {{ topic }}';
+      vi.mocked(fs.readFileSync).mockReturnValue(fileContent);
+      vi.mocked(path.resolve).mockReturnValue('/base/path/templated_output.txt');
+      vi.mocked(path.extname).mockReturnValue('.txt');
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Some prompt',
+        provider: new OpenAiChatCompletionProvider('gpt-4o-mini'),
+        assertion,
+        test: {
+          vars: { topic: 'capybaras' },
+        } as unknown as AtomicTestCase,
+        providerResponse: { output: 'Here is Loaded capybaras today' },
+      });
+
+      expect(fs.readFileSync).toHaveBeenCalledWith('/base/path/templated_output.txt', 'utf8');
+      expect(result.pass).toBe(true);
+    });
+
+    it('should interpolate variables in llm-rubric file reference value', async () => {
+      const Grader = createMockProvider({
+        id: 'Grader',
+        callApi: vi.fn<ApiProvider['callApi']>().mockResolvedValue({
+          output: JSON.stringify({ pass: true, reason: 'Mentions capybaras', score: 1 }),
+        }),
+      });
+
+      const assertion: Assertion = {
+        type: 'llm-rubric',
+        value: 'file://rubric.txt',
+        provider: Grader,
+      };
+
+      const rubricContent = 'Fail unless the output mentions "{{ topic }}".';
+      vi.mocked(fs.readFileSync).mockReturnValue(rubricContent);
+      vi.mocked(path.resolve).mockReturnValue('/base/path/rubric.txt');
+      vi.mocked(path.extname).mockReturnValue('.txt');
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Write about capybaras',
+        assertion,
+        test: {
+          vars: { topic: 'capybaras' },
+        } as unknown as AtomicTestCase,
+        providerResponse: { output: 'I love capybaras' },
+        provider: new OpenAiChatCompletionProvider('gpt-4o-mini'),
+      });
+
+      expect(fs.readFileSync).toHaveBeenCalledWith('/base/path/rubric.txt', 'utf8');
+      expect(Grader.callApi).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          vars: expect.objectContaining({
+            rubric: 'Fail unless the output mentions "capybaras".',
+          }),
+        }),
+      );
+      expect(result.pass).toBe(true);
+    });
+
     it('should handle file reference in object value', async () => {
       const assertion: Assertion = {
         type: 'is-json',


### PR DESCRIPTION
Fixes #10447

### Summary
When an assertion value uses a `file://` reference (such as `type: llm-rubric` with `value: file://rubric.txt`), the loaded file content was previously not rendered through Nunjucks template interpolation, causing variables like `{{ topic }}` to remain as literal strings in the grader.

This change:
1. Renders variables in file reference paths (e.g. `file://{{ filename }}.txt`).
2. Renders variables in loaded string content from `file://` references (both single string values and within array values).
3. Adds comprehensive unit test coverage verifying variable interpolation for `llm-rubric` and other file reference assertions.

### Test Plan
- Unit tests added in `test/assertions/runAssertion.test.ts`
- Ran `npx vitest run test/assertions` (all 60 test suites and 1,374 tests passing)