### PR TITLE
perf(scheduler): replace array queue with O(1) indexed deque in SlotQ…

### DIFF
--- a/src/scheduler/index.ts
+++ b/src/scheduler/index.ts
@@ -37,7 +37,7 @@ export {
   shouldRetry,
 } from './retryPolicy';
 // Slot queue
-export { SlotQueue } from './slotQueue';
+export { IndexedDeque, SlotQueue } from './slotQueue';
 
 export type { ConcurrencyChangeResult } from './adaptiveConcurrency';
 export type { ProviderMetrics } from './providerRateLimitState';

--- a/src/scheduler/slotQueue.ts
+++ b/src/scheduler/slotQueue.ts
@@ -7,6 +7,110 @@ interface QueuedRequest {
   queuedAt: number;
 }
 
+export interface DequeNode<T> {
+  value: T;
+  prev: DequeNode<T> | null;
+  next: DequeNode<T> | null;
+}
+
+/**
+ * An O(1) Doubly Linked Deque with a Hash Map index by ID.
+ *
+ * Provides:
+ * - O(1) push (enqueue to tail)
+ * - O(1) shift (dequeue from head)
+ * - O(1) remove (remove arbitrary node by ID, e.g. for timeouts/cancellations)
+ * - O(1) length getter
+ * - O(N) drain (empty all nodes into an array)
+ */
+export class IndexedDeque<T extends { id: string }> {
+  private head: DequeNode<T> | null = null;
+  private tail: DequeNode<T> | null = null;
+  private nodeMap = new Map<string, DequeNode<T>>();
+  private _size = 0;
+
+  get length(): number {
+    return this._size;
+  }
+
+  /**
+   * Push an item to the back of the queue (O(1)).
+   */
+  push(value: T): void {
+    const node: DequeNode<T> = { value, prev: this.tail, next: null };
+    if (this.tail) {
+      this.tail.next = node;
+      this.tail = node;
+    } else {
+      this.head = this.tail = node;
+    }
+    this.nodeMap.set(value.id, node);
+    this._size++;
+  }
+
+  /**
+   * Pop an item from the front of the queue (O(1)).
+   */
+  shift(): T | undefined {
+    if (!this.head) {
+      return undefined;
+    }
+    const node = this.head;
+    this.head = node.next;
+    if (this.head) {
+      this.head.prev = null;
+    } else {
+      this.tail = null;
+    }
+    this.nodeMap.delete(node.value.id);
+    this._size--;
+    return node.value;
+  }
+
+  /**
+   * Remove an item by ID from anywhere in the queue (O(1)).
+   */
+  remove(id: string): T | undefined {
+    const node = this.nodeMap.get(id);
+    if (!node) {
+      return undefined;
+    }
+
+    if (node.prev) {
+      node.prev.next = node.next;
+    } else {
+      this.head = node.next;
+    }
+
+    if (node.next) {
+      node.next.prev = node.prev;
+    } else {
+      this.tail = node.prev;
+    }
+
+    this.nodeMap.delete(id);
+    this._size--;
+    return node.value;
+  }
+
+  /**
+   * Drain and clear all items from the queue (O(N)).
+   */
+  drain(): T[] {
+    const items: T[] = [];
+    let curr = this.head;
+    while (curr) {
+      items.push(curr.value);
+      curr = curr.next;
+    }
+    this.head = null;
+    this.tail = null;
+    this.nodeMap.clear();
+    this._size = 0;
+    return items;
+  }
+}
+
 export interface SlotQueueOptions {
   maxConcurrency: number;
   minConcurrency: number;
@@ -29,7 +133,7 @@ export class SlotQueue {
   private activeCount = 0;
   private maxConcurrency: number;
   private minConcurrency: number;
-  private waiting: QueuedRequest[] = [];
+  private waiting = new IndexedDeque<QueuedRequest>();
   private resetTimer: NodeJS.Timeout | null = null;
   private queueTimeoutMs: number;
 
@@ -63,10 +167,9 @@ export class SlotQueue {
       let timeoutId: NodeJS.Timeout | null = null;
       if (this.queueTimeoutMs > 0) {
         timeoutId = setTimeout(() => {
-          // Remove from queue
-          const idx = this.waiting.findIndex((r) => r.id === requestId);
-          if (idx !== -1) {
-            this.waiting.splice(idx, 1);
+          // Remove from queue in O(1)
+          const removed = this.waiting.remove(requestId);
+          if (removed) {
             reject(
               new Error(`Request ${requestId} timed out after ${this.queueTimeoutMs}ms in queue`),
             );
@@ -90,7 +193,7 @@ export class SlotQueue {
         reject(error);
       };
 
-      // Always queue the request
+      // Always queue the request (O(1))
       this.waiting.push({
         id: requestId,
         resolve: wrappedResolve,
@@ -295,8 +398,7 @@ export class SlotQueue {
       this.resetTimer = null;
     }
     // Reject any waiting requests
-    const waiting = this.waiting;
-    this.waiting = [];
+    const waiting = this.waiting.drain();
     for (const request of waiting) {
       request.reject(new Error('Queue disposed'));
     }

--- a/src/scheduler/slotQueue.ts
+++ b/src/scheduler/slotQueue.ts
@@ -26,7 +26,7 @@ export interface DequeNode<T> {
 export class IndexedDeque<T extends { id: string }> {
   private head: DequeNode<T> | null = null;
   private tail: DequeNode<T> | null = null;
-  private nodeMap = new Map<string, DequeNode<T>>();
+  private nodeMap = new Map<string, Set<DequeNode<T>>>();
   private _size = 0;
 
   get length(): number {
@@ -44,7 +44,13 @@ export class IndexedDeque<T extends { id: string }> {
     } else {
       this.head = this.tail = node;
     }
-    this.nodeMap.set(value.id, node);
+
+    let nodeSet = this.nodeMap.get(value.id);
+    if (!nodeSet) {
+      nodeSet = new Set();
+      this.nodeMap.set(value.id, nodeSet);
+    }
+    nodeSet.add(node);
     this._size++;
   }
 
@@ -62,18 +68,34 @@ export class IndexedDeque<T extends { id: string }> {
     } else {
       this.tail = null;
     }
-    this.nodeMap.delete(node.value.id);
+
+    const nodeSet = this.nodeMap.get(node.value.id);
+    if (nodeSet) {
+      nodeSet.delete(node);
+      if (nodeSet.size === 0) {
+        this.nodeMap.delete(node.value.id);
+      }
+    }
+
     this._size--;
     return node.value;
   }
 
   /**
    * Remove an item by ID from anywhere in the queue (O(1)).
+   * If multiple queued items share the same ID, removes the earliest queued item (FIFO).
    */
   remove(id: string): T | undefined {
-    const node = this.nodeMap.get(id);
-    if (!node) {
+    const nodeSet = this.nodeMap.get(id);
+    if (!nodeSet || nodeSet.size === 0) {
       return undefined;
+    }
+
+    // Get the earliest queued node with this ID
+    const node = nodeSet.values().next().value!;
+    nodeSet.delete(node);
+    if (nodeSet.size === 0) {
+      this.nodeMap.delete(id);
     }
 
     if (node.prev) {
@@ -88,7 +110,6 @@ export class IndexedDeque<T extends { id: string }> {
       this.tail = node.prev;
     }
 
-    this.nodeMap.delete(id);
     this._size--;
     return node.value;
   }

--- a/test/scheduler/indexedDeque.test.ts
+++ b/test/scheduler/indexedDeque.test.ts
@@ -97,6 +97,41 @@ describe('IndexedDeque', () => {
     expect(deque.shift()).toEqual({ id: 'b', val: 2 });
   });
 
+  it('should preserve queued entries when IDs repeat', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    // Push two requests sharing the same ID
+    deque.push({ id: 'repeat-id', val: 1 });
+    deque.push({ id: 'repeat-id', val: 2 });
+    deque.push({ id: 'other-id', val: 3 });
+
+    expect(deque.length).toBe(3);
+
+    // First timeout / removal removes the earliest queued node
+    const removedFirst = deque.remove('repeat-id');
+    expect(removedFirst).toEqual({ id: 'repeat-id', val: 1 });
+    expect(deque.length).toBe(2);
+
+    // The second request with the same ID remains queued and can be dequeued
+    expect(deque.shift()).toEqual({ id: 'repeat-id', val: 2 });
+    expect(deque.shift()).toEqual({ id: 'other-id', val: 3 });
+    expect(deque.length).toBe(0);
+  });
+
+  it('should handle shift before remove on repeated IDs correctly', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    deque.push({ id: 'repeat-id', val: 1 });
+    deque.push({ id: 'repeat-id', val: 2 });
+
+    // Shift removes the first one
+    expect(deque.shift()).toEqual({ id: 'repeat-id', val: 1 });
+    expect(deque.length).toBe(1);
+
+    // Timeout / remove then correctly targets the second one
+    expect(deque.remove('repeat-id')).toEqual({ id: 'repeat-id', val: 2 });
+    expect(deque.length).toBe(0);
+    expect(deque.remove('repeat-id')).toBeUndefined();
+  });
+
   it('should drain all elements and reset size', () => {
     const deque = new IndexedDeque<{ id: string; val: number }>();
     deque.push({ id: 'a', val: 1 });

--- a/test/scheduler/indexedDeque.test.ts
+++ b/test/scheduler/indexedDeque.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { IndexedDeque } from '../../src/scheduler/slotQueue';
+
+describe('IndexedDeque', () => {
+  it('should initialize with length 0 and return undefined on empty shift', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    expect(deque.length).toBe(0);
+    expect(deque.shift()).toBeUndefined();
+  });
+
+  it('should push and shift elements in strict FIFO order', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    deque.push({ id: 'a', val: 1 });
+    deque.push({ id: 'b', val: 2 });
+    deque.push({ id: 'c', val: 3 });
+
+    expect(deque.length).toBe(3);
+
+    expect(deque.shift()).toEqual({ id: 'a', val: 1 });
+    expect(deque.length).toBe(2);
+
+    expect(deque.shift()).toEqual({ id: 'b', val: 2 });
+    expect(deque.length).toBe(1);
+
+    expect(deque.shift()).toEqual({ id: 'c', val: 3 });
+    expect(deque.length).toBe(0);
+
+    expect(deque.shift()).toBeUndefined();
+    expect(deque.length).toBe(0);
+  });
+
+  it('should remove elements from the middle correctly', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    deque.push({ id: 'a', val: 1 });
+    deque.push({ id: 'b', val: 2 });
+    deque.push({ id: 'c', val: 3 });
+
+    const removed = deque.remove('b');
+    expect(removed).toEqual({ id: 'b', val: 2 });
+    expect(deque.length).toBe(2);
+
+    // Remaining items should preserve FIFO order
+    expect(deque.shift()).toEqual({ id: 'a', val: 1 });
+    expect(deque.shift()).toEqual({ id: 'c', val: 3 });
+    expect(deque.shift()).toBeUndefined();
+  });
+
+  it('should remove the head element correctly via remove(id)', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    deque.push({ id: 'a', val: 1 });
+    deque.push({ id: 'b', val: 2 });
+
+    const removed = deque.remove('a');
+    expect(removed).toEqual({ id: 'a', val: 1 });
+    expect(deque.length).toBe(1);
+
+    expect(deque.shift()).toEqual({ id: 'b', val: 2 });
+    expect(deque.length).toBe(0);
+  });
+
+  it('should remove the tail element correctly via remove(id)', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    deque.push({ id: 'a', val: 1 });
+    deque.push({ id: 'b', val: 2 });
+
+    const removed = deque.remove('b');
+    expect(removed).toEqual({ id: 'b', val: 2 });
+    expect(deque.length).toBe(1);
+
+    // Can still push to new tail
+    deque.push({ id: 'c', val: 3 });
+    expect(deque.length).toBe(2);
+
+    expect(deque.shift()).toEqual({ id: 'a', val: 1 });
+    expect(deque.shift()).toEqual({ id: 'c', val: 3 });
+  });
+
+  it('should return undefined when removing non-existent id', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    deque.push({ id: 'a', val: 1 });
+
+    expect(deque.remove('non-existent')).toBeUndefined();
+    expect(deque.length).toBe(1);
+  });
+
+  it('should handle removing the only element in the deque', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    deque.push({ id: 'a', val: 1 });
+
+    expect(deque.remove('a')).toEqual({ id: 'a', val: 1 });
+    expect(deque.length).toBe(0);
+    expect(deque.shift()).toBeUndefined();
+
+    // Verify it can still accept new pushes cleanly
+    deque.push({ id: 'b', val: 2 });
+    expect(deque.length).toBe(1);
+    expect(deque.shift()).toEqual({ id: 'b', val: 2 });
+  });
+
+  it('should drain all elements and reset size', () => {
+    const deque = new IndexedDeque<{ id: string; val: number }>();
+    deque.push({ id: 'a', val: 1 });
+    deque.push({ id: 'b', val: 2 });
+    deque.push({ id: 'c', val: 3 });
+
+    const drained = deque.drain();
+    expect(drained).toEqual([
+      { id: 'a', val: 1 },
+      { id: 'b', val: 2 },
+      { id: 'c', val: 3 },
+    ]);
+    expect(deque.length).toBe(0);
+    expect(deque.shift()).toBeUndefined();
+    expect(deque.remove('a')).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
-Description

This PR improves the performance of `SlotQueue` when handling a large number of queued requests.

The previous implementation used an array, where operations such as removing a timed-out request or taking the next item from the queue could require shifting or searching through elements, resulting in O(N) work. To avoid this overhead, the queue now uses a custom `IndexedDeque`, allowing these operations to be handled in O(1).

-Key Changes

* Added a new `IndexedDeque` implementation that combines a doubly-linked list with a `Map` for efficient lookups and removals.
* Updated timeout cancellation in `acquire()` to remove queued requests directly instead of using `findIndex` and `splice`.
* Updated `processQueue()` to remove items from the front of the queue without the overhead of `Array.shift()`.
* Updated `dispose()` to clean up queued items using the new `drain()` method.
* Added unit tests covering FIFO behavior, removing items from the middle and tail, and other edge cases.

- Files Modified

* `src/scheduler/slotQueue.ts`
* `src/scheduler/index.ts`
* `test/scheduler/indexedDeque.test.ts`
