### PR TITLE
fix(providers): address AI code quality findings

### DIFF
--- a/src/esm.ts
+++ b/src/esm.ts
@@ -299,14 +299,16 @@ export async function importModule(modulePath: string, functionName?: string) {
         logger.error(`CJS fallback also failed: ${cjsErrorMessage}`);
 
         // Create a combined error that includes both failure reasons
-        const combinedError = new Error(
-          `Failed to load module ${modulePath}:\n` +
-            `  ESM import error: ${errorMessage}\n` +
-            `  CJS fallback error: ${cjsErrorMessage}\n` +
-            `To fix this, either:\n` +
-            `  1. Rename the file to .cjs (recommended for CommonJS)\n` +
-            `  2. Convert to ESM syntax (import/export)\n` +
-            `  3. Ensure the file has valid JavaScript syntax`,
+        const combinedError = Object.assign(
+          new Error(
+            `Failed to load module ${modulePath}:\n` +
+              `  ESM import error: ${errorMessage}\n` +
+              `  CJS fallback error: ${cjsErrorMessage}\n` +
+              `To fix this, either:\n` +
+              `  1. Rename the file to .cjs (recommended for CommonJS)\n` +
+              `  2. Convert to ESM syntax (import/export)\n` +
+              `  3. Ensure the file has valid JavaScript syntax`,
+          ),
           { cause: { esmError: err, cjsError: cjsErr } },
         );
         throw combinedError;

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -273,6 +273,8 @@ export async function importModule(modulePath: string, functionName?: string) {
     // Note: createRequire() doesn't work for .js files in "type": "module" packages
     // because Node.js still treats them as ESM based on package.json.
     // We use Node's vm module to execute the code with proper CJS globals.
+    // Intentionally limited to ".js": ".cjs" is already handled by Node as CJS and ".mjs"
+    // is always ESM, so this fallback only applies to ambiguous ".js" in ESM packages.
     if (loadPath.endsWith('.js') && isCjsInEsmError(errorMessage)) {
       logger.debug(
         `ESM import failed for ${modulePath}, attempting vm-based CJS fallback: ${errorMessage}`,
@@ -305,33 +307,31 @@ export async function importModule(modulePath: string, functionName?: string) {
             `  1. Rename the file to .cjs (recommended for CommonJS)\n` +
             `  2. Convert to ESM syntax (import/export)\n` +
             `  3. Ensure the file has valid JavaScript syntax`,
+          { cause: { esmError: err, cjsError: cjsErr } },
         );
-
-        // biome-ignore lint/suspicious/noExplicitAny: FIXME: this is broken
-        (combinedError as any).cause = { esmError: err, cjsError: cjsErr };
         throw combinedError;
       }
     }
 
-    // Normalize ERR_MODULE_NOT_FOUND to ENOENT when the file itself doesn't exist
-    // (vs a dependency inside the file being missing).
-    // This provides clearer error messages for users when their files don't exist.
+    // Normalize ERR_MODULE_NOT_FOUND to ENOENT only when the missing target is the
+    // entry module itself (vs a dependency inside that module).
+    // This provides clearer error messages for users without masking nested import failures.
     const nodeError = err as NodeJS.ErrnoException;
     if (nodeError.code === 'ERR_MODULE_NOT_FOUND') {
       const resolvedModulePath = safeResolve(loadPath);
-      try {
-        await fsPromises.access(resolvedModulePath);
-      } catch (accessError) {
-        if ((accessError as NodeJS.ErrnoException).code === 'ENOENT') {
-          // Expected during config discovery: normalize before logging any error or stack.
-          const enoentError = new Error(
-            `ENOENT: no such file or directory, open '${resolvedModulePath}'`,
-          ) as NodeJS.ErrnoException;
-          enoentError.code = 'ENOENT';
-          enoentError.path = resolvedModulePath;
-          throw enoentError;
-        }
-        // Other access failures do not establish absence; preserve the import error below.
+      const resolvedModuleFileUrl = pathToFileURL(resolvedModulePath).href;
+      const missingTarget = nodeError.message.match(/Cannot find module ['"]([^'"]+)['"]/)?.[1];
+      const missingEntryModule =
+        missingTarget === resolvedModulePath || missingTarget === resolvedModuleFileUrl;
+
+      if (missingEntryModule) {
+        // Expected during config discovery: normalize before logging any error or stack.
+        const enoentError = new Error(
+          `ENOENT: no such file or directory, open '${resolvedModulePath}'`,
+        ) as NodeJS.ErrnoException;
+        enoentError.code = 'ENOENT';
+        enoentError.path = resolvedModulePath;
+        throw enoentError;
       }
     }
 

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -315,18 +315,24 @@ export async function importModule(modulePath: string, functionName?: string) {
       }
     }
 
-    // Normalize ERR_MODULE_NOT_FOUND to ENOENT only when the missing target is the
-    // entry module itself (vs a dependency inside that module).
-    // This provides clearer error messages for users without masking nested import failures.
+    // Normalize ERR_MODULE_NOT_FOUND to ENOENT only when the entry module itself is the
+    // unresolved target (vs a dependency imported by it), so nested import failures keep
+    // their original diagnostics. Comparing against the reported target rather than
+    // re-stat'ing the path also avoids mistaking EACCES for absence.
+    //
+    // Both spellings are required: Node names the missing entry by filesystem path
+    // ("Cannot find module '/abs/config.ts'"), while Vite's module runner names it by
+    // file URL ("Cannot find module 'file:///abs/config.ts'"). Nested failures report the
+    // dependency instead (its resolved path under Node, its raw specifier under Vite), so
+    // they match neither spelling and fall through.
     const nodeError = err as NodeJS.ErrnoException;
     if (nodeError.code === 'ERR_MODULE_NOT_FOUND') {
       const resolvedModulePath = safeResolve(loadPath);
-      const resolvedModuleFileUrl = pathToFileURL(resolvedModulePath).href;
       const missingTarget = nodeError.message.match(/Cannot find module ['"]([^'"]+)['"]/)?.[1];
-      const missingEntryModule =
-        missingTarget === resolvedModulePath || missingTarget === resolvedModuleFileUrl;
-
-      if (missingEntryModule) {
+      if (
+        missingTarget === resolvedModulePath ||
+        missingTarget === pathToFileURL(resolvedModulePath).href
+      ) {
         // Expected during config discovery: normalize before logging any error or stack.
         const enoentError = new Error(
           `ENOENT: no such file or directory, open '${resolvedModulePath}'`,

--- a/src/providers/golangCompletion.ts
+++ b/src/providers/golangCompletion.ts
@@ -39,10 +39,10 @@ export class GolangProvider implements ApiProvider {
     private options?: ProviderOptions,
   ) {
     const { filePath: providerPath, functionName } = parsePathOrGlob(
-      options?.config.basePath || '',
+      options?.config?.basePath || '',
       runPath,
     );
-    this.scriptPath = path.relative(options?.config.basePath || '', providerPath);
+    this.scriptPath = path.relative(options?.config?.basePath || '', providerPath);
     this.functionName = functionName || null;
     this.id = () => options?.id ?? `golang:${this.scriptPath}:${this.functionName || 'default'}`;
     this.label = options?.label;
@@ -69,7 +69,7 @@ export class GolangProvider implements ApiProvider {
     context: CallApiContextParams | undefined,
     apiType: 'call_api' | 'call_embedding_api' | 'call_classification_api',
   ): Promise<any> {
-    const absPath = path.resolve(path.join(this.options?.config.basePath || '', this.scriptPath));
+    const absPath = path.resolve(path.join(this.options?.config?.basePath || '', this.scriptPath));
     const moduleRoot = await this.findModuleRoot(path.dirname(absPath));
     logger.debug(`Found module root at ${moduleRoot}`);
     logger.debug(`Computing file hash for script ${absPath}`);
@@ -185,7 +185,7 @@ export class GolangProvider implements ApiProvider {
         return result;
       } catch (error) {
         logger.error(`Error running Golang script: ${(error as Error).message}`);
-        logger.error(`Full error object: ${JSON.stringify(error)}`);
+        logger.error('Full error object', { error });
         throw new Error(`Error running Golang script: ${(error as Error).message}`);
       } finally {
         // Clean up temporary directory

--- a/src/providers/openai/codex-security.ts
+++ b/src/providers/openai/codex-security.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import dedent from 'dedent';
 import semverSatisfies from 'semver/functions/satisfies.js';
+import semverValid from 'semver/functions/valid.js';
 import { z } from 'zod';
 import { resolveAgenticWorkingDir } from '../agentic-utils';
 import { providerRegistry } from '../providerRegistry';
@@ -163,7 +164,11 @@ async function loadCodexSecurity(): Promise<CodexSecurityModule> {
     try {
       const module = (await importModule(entryPoint)) as CodexSecurityModule;
       const version = typeof module.VERSION === 'string' ? module.VERSION : 'unknown';
-      if (!semverSatisfies(version, `>=${MINIMUM_CODEX_SECURITY_SDK_VERSION}`)) {
+      const validVersion = semverValid(version);
+      if (
+        !validVersion ||
+        !semverSatisfies(validVersion, `>=${MINIMUM_CODEX_SECURITY_SDK_VERSION}`)
+      ) {
         incompatibleVersions.add(version);
         logger.warn(
           `[CodexSecurity] Ignoring @openai/codex-security ${version}; version ${MINIMUM_CODEX_SECURITY_SDK_VERSION} or newer is required for complete security operations and deep-scan usage accounting.`,
@@ -538,11 +543,12 @@ export class OpenAICodexSecurityProvider implements ApiProvider {
     const tokenUsage = getTokenUsage(result, observers.cost);
     const findings = Array.isArray(result.findings?.findings) ? result.findings.findings : [];
     const model = result.turnResult.model ?? cost?.model ?? config.model;
+    const raw = result.toJSON();
 
     return {
-      output: JSON.stringify(result.toJSON()),
+      output: JSON.stringify(raw),
       format: 'json',
-      raw: result.toJSON(),
+      raw,
       cached: false,
       sessionId: result.threadId,
       ...(cost ? { cost: cost.estimatedUsd } : {}),

--- a/src/providers/openai/codex-security.ts
+++ b/src/providers/openai/codex-security.ts
@@ -3,7 +3,6 @@ import path from 'path';
 
 import dedent from 'dedent';
 import semverSatisfies from 'semver/functions/satisfies.js';
-import semverValid from 'semver/functions/valid.js';
 import { z } from 'zod';
 import { resolveAgenticWorkingDir } from '../agentic-utils';
 import { providerRegistry } from '../providerRegistry';
@@ -164,11 +163,7 @@ async function loadCodexSecurity(): Promise<CodexSecurityModule> {
     try {
       const module = (await importModule(entryPoint)) as CodexSecurityModule;
       const version = typeof module.VERSION === 'string' ? module.VERSION : 'unknown';
-      const validVersion = semverValid(version);
-      if (
-        !validVersion ||
-        !semverSatisfies(validVersion, `>=${MINIMUM_CODEX_SECURITY_SDK_VERSION}`)
-      ) {
+      if (!semverSatisfies(version, `>=${MINIMUM_CODEX_SECURITY_SDK_VERSION}`)) {
         incompatibleVersions.add(version);
         logger.warn(
           `[CodexSecurity] Ignoring @openai/codex-security ${version}; version ${MINIMUM_CODEX_SECURITY_SDK_VERSION} or newer is required for complete security operations and deep-scan usage accounting.`,

--- a/test/esm.test.ts
+++ b/test/esm.test.ts
@@ -263,6 +263,13 @@ describe('ESM utilities', () => {
         error: { code: 'ERR_MODULE_NOT_FOUND' },
       },
       {
+        // A missing bare specifier names the package, never the entry module's path,
+        // so the ENOENT normalization must not claim the config file itself is absent.
+        name: 'missing bare package dependency',
+        source: "import 'promptfoo-not-a-real-package';",
+        error: { code: 'ERR_MODULE_NOT_FOUND' },
+      },
+      {
         name: 'invalid syntax',
         source: 'export default {;',
         // Vite reports parse failures as Error rather than Node's SyntaxError.

--- a/test/esm.test.ts
+++ b/test/esm.test.ts
@@ -1,4 +1,3 @@
-import fsPromises from 'node:fs/promises';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -288,18 +287,6 @@ describe('ESM utilities', () => {
       } finally {
         fs.rmSync(tempDir, { recursive: true, force: true });
       }
-    });
-
-    it('does not treat a failed access check as proof that the module is absent', async () => {
-      const modulePath = path.resolve(__dirname, '__fixtures__/nonExistent.mjs');
-      vi.spyOn(fsPromises, 'access').mockRejectedValue(
-        Object.assign(new Error('Permission denied'), { code: 'EACCES' }),
-      );
-
-      const thrown = await importModule(modulePath).catch((err) => err);
-      expect(thrown).toMatchObject({ code: 'ERR_MODULE_NOT_FOUND' });
-      expect(logger.debug).toHaveBeenCalledWith(thrown.stack);
-      expect(logger.error).toHaveBeenCalledWith(`ESM import failed: ${thrown}`);
     });
 
     it('logs debug information during import process', async () => {

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -12,6 +12,10 @@ type PackageManifest = {
   peerDependencies?: Record<string, string>;
 };
 
+type PackageLockManifest<T = PackageManifest & { version?: string }> = {
+  packages: Record<string, T>;
+};
+
 function readPackageJson<T>(relativePath: string): T {
   const packageJsonPath = path.join(process.cwd(), relativePath);
   return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as T;
@@ -240,9 +244,8 @@ describe('package manifests', () => {
   });
 
   it('keeps private npm registry endpoints out of the published lockfile', () => {
-    const packageLock = readPackageJson<{
-      packages: Record<string, { resolved?: string }>;
-    }>('package-lock.json');
+    const packageLock =
+      readPackageJson<PackageLockManifest<{ resolved?: string }>>('package-lock.json');
     const privateRegistryPackages = Object.entries(packageLock.packages)
       .filter(([, packageInfo]) => {
         if (!packageInfo.resolved || !URL.canParse(packageInfo.resolved)) {
@@ -261,9 +264,8 @@ describe('package manifests', () => {
 
   it('holds Knip below the incompatible public re-export audit', () => {
     const packageJson = readPackageJson<PackageManifest>('package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<string, { version?: string }>;
-    }>('package-lock.json');
+    const packageLock =
+      readPackageJson<PackageLockManifest<{ version?: string }>>('package-lock.json');
     const renovateConfig = readPackageJson<{
       packageRules?: Array<{
         allowedVersions?: string;
@@ -286,9 +288,8 @@ describe('package manifests', () => {
 
   it('holds TanStack Table below v9 until the shared table migration is complete', () => {
     const appPackageJson = readPackageJson<PackageManifest>('src/app/package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<string, { version?: string }>;
-    }>('package-lock.json');
+    const packageLock =
+      readPackageJson<PackageLockManifest<{ version?: string }>>('package-lock.json');
     const renovateConfig = readPackageJson<{
       packageRules?: Array<{
         allowedVersions?: string;
@@ -325,9 +326,10 @@ describe('package manifests', () => {
         overrides?: Record<string, Record<string, string> | string>;
       }
     >('package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<string, { engines?: Record<string, string>; version?: string }>;
-    }>('package-lock.json');
+    const packageLock =
+      readPackageJson<PackageLockManifest<{ engines?: Record<string, string>; version?: string }>>(
+        'package-lock.json',
+      );
     const renovateConfig = readPackageJson<{
       packageRules?: Array<{
         allowedVersions?: string;
@@ -492,14 +494,7 @@ describe('package manifests', () => {
 
   it('keeps Anthropic SDK manifests, lock entries, and optional binaries aligned', () => {
     const packageJson = readPackageJson<PackageManifest>('package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<
-        string,
-        PackageManifest & {
-          version?: string;
-        }
-      >;
-    }>('package-lock.json');
+    const packageLock = readPackageJson<PackageLockManifest>('package-lock.json');
     const sdkName = '@anthropic-ai/sdk';
     const agentName = '@anthropic-ai/claude-agent-sdk';
     const sdkVersion = packageJson.dependencies?.[sdkName];
@@ -528,9 +523,7 @@ describe('package manifests', () => {
 
   it('keeps the Langfuse client optional and its SDK packages on the supported floor', () => {
     const packageJson = readPackageJson<PackageManifest>('package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<string, PackageManifest & { version?: string }>;
-    }>('package-lock.json');
+    const packageLock = readPackageJson<PackageLockManifest>('package-lock.json');
     const dependencyName = '@langfuse/client';
     const developmentRange = packageJson.devDependencies?.[dependencyName];
     const optionalRange = packageJson.optionalDependencies?.[dependencyName];
@@ -552,14 +545,7 @@ describe('package manifests', () => {
 
   it('keeps the WatsonX authentication SDK manifest and lockfile on the supported floor', () => {
     const packageJson = readPackageJson<PackageManifest>('package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<
-        string,
-        PackageManifest & {
-          version?: string;
-        }
-      >;
-    }>('package-lock.json');
+    const packageLock = readPackageJson<PackageLockManifest>('package-lock.json');
     const dependencyName = 'ibm-cloud-sdk-core';
     const developmentRange = packageJson.devDependencies?.[dependencyName];
     const optionalRange = packageJson.optionalDependencies?.[dependencyName];
@@ -577,9 +563,7 @@ describe('package manifests', () => {
 
   it('keeps the protobuf runtime aligned with OTLP numeric and UTF-8 fixes', () => {
     const packageJson = readPackageJson<PackageManifest>('package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<string, PackageManifest & { version?: string }>;
-    }>('package-lock.json');
+    const packageLock = readPackageJson<PackageLockManifest>('package-lock.json');
     const protobufRange = packageJson.dependencies?.protobufjs;
 
     expect(protobufRange).toBeDefined();
@@ -595,9 +579,7 @@ describe('package manifests', () => {
     const packageJson = readPackageJson<
       PackageManifest & { overrides?: { mongoose?: Record<string, string> } }
     >('package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<string, PackageManifest & { version?: string }>;
-    }>('package-lock.json');
+    const packageLock = readPackageJson<PackageLockManifest>('package-lock.json');
     const dependencyName = 'gcp-metadata';
     const dependencyRange = packageJson.dependencies?.[dependencyName];
 
@@ -933,9 +915,7 @@ describe('package manifests', () => {
 
   it('keeps Playwright Chromium optional and its locked browser versions aligned', () => {
     const packageJson = readPackageJson<PackageManifest>('package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<string, PackageManifest & { version?: string }>;
-    }>('package-lock.json');
+    const packageLock = readPackageJson<PackageLockManifest>('package-lock.json');
     const browserName = '@playwright/browser-chromium';
     const optionalRange = packageJson.optionalDependencies?.[browserName];
 
@@ -973,9 +953,8 @@ describe('package manifests', () => {
     const exampleManifest = readPackageJson<PackageManifest & { engines?: { node?: string } }>(
       'examples/config-websockets/streaming/server/package.json',
     );
-    const lockfile = readPackageJson<{
-      packages: Record<string, { engines?: { node?: string } }>;
-    }>('package-lock.json');
+    const lockfile =
+      readPackageJson<PackageLockManifest<{ engines?: { node?: string } }>>('package-lock.json');
     const readme = fs.readFileSync(
       path.join(process.cwd(), 'examples/config-websockets/streaming/server/README.md'),
       'utf8',
@@ -1017,9 +996,7 @@ describe('package manifests', () => {
   });
 
   it('keeps every direct and transitive js-yaml installation patched', () => {
-    const packageLock = readPackageJson<{
-      packages: Record<string, PackageManifest & { version?: string }>;
-    }>('package-lock.json');
+    const packageLock = readPackageJson<PackageLockManifest>('package-lock.json');
     const workspaceManifests = [
       { path: 'package.json', lockPath: '', field: 'dependencies' },
       { path: 'site/package.json', lockPath: 'site', field: 'dependencies' },
@@ -1069,9 +1046,10 @@ describe('package manifests', () => {
     const packageJson = readPackageJson<PackageManifest & { engines?: { node?: string } }>(
       'package.json',
     );
-    const packageLock = readPackageJson<{
-      packages: Record<string, PackageManifest & { engines?: { node?: string }; version?: string }>;
-    }>('package-lock.json');
+    const packageLock =
+      readPackageJson<
+        PackageLockManifest<PackageManifest & { engines?: { node?: string }; version?: string }>
+      >('package-lock.json');
     const parserRange = packageJson.dependencies?.['@apidevtools/json-schema-ref-parser'];
     const parser = packageLock.packages['node_modules/@apidevtools/json-schema-ref-parser'];
     const parserTransportRange = parser?.dependencies?.undici;
@@ -1117,7 +1095,7 @@ describe('package manifests', () => {
     // The root fix landed in #10269 but code-scan-action/ carries its own lockfile,
     // so it kept resolving 7.28.0 and stayed on five open Dependabot alerts. Both
     // projects override undici; assert the floors and the resolved copies together.
-    const PATCHED_UNDICI = '7.29.0';
+    const PATCHED_UNDICI_FLOOR = '7.29.0';
     const rootPackageJson = readPackageJson<{
       overrides?: Record<string, string | Record<string, string>>;
     }>('package.json');
@@ -1149,14 +1127,12 @@ describe('package manifests', () => {
 
       const minimum = minVersion(pinnedRange as string);
       expect(
-        minimum?.compare(PATCHED_UNDICI),
-        `${manifest} must not allow undici below ${PATCHED_UNDICI}`,
+        minimum?.compare(PATCHED_UNDICI_FLOOR),
+        `${manifest} must not allow undici below ${PATCHED_UNDICI_FLOOR}`,
       ).toBeGreaterThanOrEqual(0);
       minimumVersions.push(minimum?.version ?? '');
 
-      const packageLock = readPackageJson<{
-        packages: Record<string, { version?: string }>;
-      }>(lockfile);
+      const packageLock = readPackageJson<PackageLockManifest<{ version?: string }>>(lockfile);
       const installations = Object.entries(packageLock.packages).filter(
         ([packagePath]) =>
           packagePath === 'node_modules/undici' || packagePath.endsWith('/node_modules/undici'),
@@ -1201,9 +1177,8 @@ describe('package manifests', () => {
     const packageJson = readPackageJson<
       PackageManifest & { overrides?: Record<string, string | Record<string, string>> }
     >('package.json');
-    const packageLock = readPackageJson<{
-      packages: Record<string, { version?: string }>;
-    }>('package-lock.json');
+    const packageLock =
+      readPackageJson<PackageLockManifest<{ version?: string }>>('package-lock.json');
 
     // No installation anywhere in the tree — including nested copies — may sit on a
     // compromised version.

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -3616,21 +3616,30 @@ describe('ClaudeCodeSDKProvider', () => {
           });
         });
 
-        it.each([
-          { behavior: 'permit' },
-          { behavior: true },
-          {},
-          { behavior: 'unknown' },
-          true,
-          null,
-        ])('rejects malformed ask_user_question config %#', async (askUserQuestion) => {
+        it.each([{ behavior: 'permit' }, { behavior: true }, { behavior: 'unknown' }, true, null])(
+          'rejects malformed ask_user_question config %#',
+          async (askUserQuestion) => {
+            const provider = new ClaudeCodeSDKProvider({
+              config: { ask_user_question: askUserQuestion as any },
+              env: { ANTHROPIC_API_KEY: 'test-api-key' },
+            });
+
+            await expect(provider.callApi('Test prompt')).rejects.toThrow(/ask_user_question/);
+            expect(mockQuery).not.toHaveBeenCalled();
+          },
+        );
+
+        it('defaults empty ask_user_question config to first_option', async () => {
+          mockQuery.mockReturnValue(createMockResponse('Response'));
           const provider = new ClaudeCodeSDKProvider({
-            config: { ask_user_question: askUserQuestion as any },
+            config: { ask_user_question: {} },
             env: { ANTHROPIC_API_KEY: 'test-api-key' },
           });
 
-          await expect(provider.callApi('Test prompt')).rejects.toThrow(/ask_user_question/);
-          expect(mockQuery).not.toHaveBeenCalled();
+          await expect(provider.callApi('Test prompt')).resolves.toMatchObject({
+            output: 'Response',
+          });
+          expect(mockQuery.mock.calls[0][0].options.canUseTool).toEqual(expect.any(Function));
         });
 
         it('denies malformed AskUserQuestion tool input', async () => {

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -1635,6 +1635,8 @@ describe('ClaudeCodeSDKProvider', () => {
         mockQuery.mockReturnValue(createMockResponse('ok'));
         const { loadApiProvider } = await import('../../src/providers/index');
 
+        // Expected env precedence for this regression: suite-level env < options.env < options.config.env.
+        // We intentionally set a conflicting suite-level base URL and assert the provider-level pin wins.
         const provider = await loadApiProvider('anthropic:claude-agent-sdk', {
           options: {
             config: {
@@ -3614,18 +3616,22 @@ describe('ClaudeCodeSDKProvider', () => {
           });
         });
 
-        it.each([{ behavior: 'permit' }, { behavior: true }, true, null])(
-          'rejects malformed ask_user_question config %#',
-          async (askUserQuestion) => {
-            const provider = new ClaudeCodeSDKProvider({
-              config: { ask_user_question: askUserQuestion as any },
-              env: { ANTHROPIC_API_KEY: 'test-api-key' },
-            });
+        it.each([
+          { behavior: 'permit' },
+          { behavior: true },
+          {},
+          { behavior: 'unknown' },
+          true,
+          null,
+        ])('rejects malformed ask_user_question config %#', async (askUserQuestion) => {
+          const provider = new ClaudeCodeSDKProvider({
+            config: { ask_user_question: askUserQuestion as any },
+            env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          });
 
-            await expect(provider.callApi('Test prompt')).rejects.toThrow(/ask_user_question/);
-            expect(mockQuery).not.toHaveBeenCalled();
-          },
-        );
+          await expect(provider.callApi('Test prompt')).rejects.toThrow(/ask_user_question/);
+          expect(mockQuery).not.toHaveBeenCalled();
+        });
 
         it('denies malformed AskUserQuestion tool input', async () => {
           mockQuery.mockReturnValue(createMockResponse('Response'));

--- a/test/providers/golangCompletion.test.ts
+++ b/test/providers/golangCompletion.test.ts
@@ -321,6 +321,12 @@ describe('GolangProvider', () => {
       expect(provider.config).toEqual({});
     });
 
+    it('should handle options without config', () => {
+      const provider = new GolangProvider('script.go', { id: 'testId' } as never);
+      expect(provider.id()).toBe('testId');
+      expect(provider.config).toEqual({});
+    });
+
     it('should use class id() method when no id is provided in options', () => {
       const provider = new GolangProvider('script.go:custom_function');
       expect(provider.id()).toBe('golang:script.go:custom_function');

--- a/test/providers/golangCompletion.test.ts
+++ b/test/providers/golangCompletion.test.ts
@@ -322,7 +322,7 @@ describe('GolangProvider', () => {
     });
 
     it('should handle options without config', () => {
-      const provider = new GolangProvider('script.go', { id: 'testId' } as never);
+      const provider = new GolangProvider('script.go', { id: 'testId' });
       expect(provider.id()).toBe('testId');
       expect(provider.config).toEqual({});
     });

--- a/test/providers/openai-codex-security.test.ts
+++ b/test/providers/openai-codex-security.test.ts
@@ -313,10 +313,24 @@ describe('OpenAICodexSecurityProvider', () => {
       expect(response.error).toContain('npm install promptfoo @openai/codex-security@^0.1.18');
       expect(mockRun).not.toHaveBeenCalled();
     });
+
+    it('reports malformed SDK versions as incompatible instead of import failures', async () => {
+      vi.mocked(importModule).mockResolvedValue({ ...mockModule, VERSION: 'unknown' });
+      const provider = new OpenAICodexSecurityProvider();
+
+      const response = await provider.callApi('Scan');
+
+      expect(response.error).toContain('package is incompatible (unknown)');
+      expect(response.error).not.toContain('Failed to load @openai/codex-security');
+      expect(mockRun).not.toHaveBeenCalled();
+    });
   });
 
   describe('repository scanning', () => {
     it('normalizes findings, usage, reasoning tokens, estimated cost, and artifacts', async () => {
+      const result = createScanResult();
+      const toJSON = vi.fn(result.toJSON);
+      mockRun.mockResolvedValue({ ...result, toJSON });
       const provider = new OpenAICodexSecurityProvider({
         config: {
           operation: 'security-scan',
@@ -369,6 +383,7 @@ describe('OpenAICodexSecurityProvider', () => {
         },
       });
       expect(JSON.parse(response.output)).toHaveProperty('findings.findings');
+      expect(toJSON).toHaveBeenCalledOnce();
       expect(response.latencyMs).toBeUndefined();
       expect(mockClose).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
## Summary
- make ESM missing-module normalization target-aware and preserve combined loader causes
- harden Golang and Codex Security provider edge cases while avoiding duplicate serialization
- clarify and expand regression coverage, and reuse package-lock manifest typings

## Test Plan
- npm run f
- npm run l
- npx vitest run test/esm.test.ts test/providers/golangCompletion.test.ts test/providers/openai-codex-security.test.ts test/package-manifests.test.ts
- npm run tsc