### PR TITLE
feat(assertions): optional Unicode normalization for equals and contains

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -331,6 +331,52 @@ assert:
     value: 'file://path/to/expected.json'
 ```
 
+#### Unicode normalization
+
+`equals` and `contains` compare raw strings, so an answer that is correct but
+differs from the expected value only in Unicode form scores 0. The commonest case
+is an accented character written as one codepoint in one place and as a letter
+plus a combining mark in the other: `café` and `café` look identical
+and are not equal.
+
+Set `normalizeUnicode` to compare normalized forms:
+
+```yaml
+assert:
+  - type: equals
+    value: 'café'
+    normalizeUnicode: true
+```
+
+`true` means **NFC** — canonical normalization, which only composes or decomposes
+sequences that Unicode defines as the same character. It is meaning-preserving
+and safe to turn on.
+
+The compatibility forms must be named explicitly:
+
+```yaml
+assert:
+  - type: contains
+    value: 'file'
+    normalizeUnicode: NFKC # also folds ligatures, non-breaking spaces, full-width forms
+```
+
+**Use `NFKC` and `NFKD` deliberately.** They fold characters that merely look
+related, and some of those distinctions are the answer:
+
+| Value | Under NFKC | What is lost                |
+| ----- | ---------- | --------------------------- |
+| `x²`  | `x2`       | the exponent                |
+| `½`   | `1⁄2`      | one character becomes three |
+| `Ⅳ`   | `IV`       | a Roman numeral             |
+| `Ａ`  | `A`        | full-width form             |
+
+With `normalizeUnicode: NFKC`, an `equals` assertion expecting `x²` passes on
+output of `x2`. That is occasionally what you want and is never the default.
+
+Accepted values are `true`, `false`, `NFC`, `NFD`, `NFKC` and `NFKD`. Omitted, no
+normalization is applied and comparison is byte-for-byte as before.
+
 ### Is-JSON
 
 The `is-json` assertion checks if the LLM output is a valid JSON string.

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -68,7 +68,9 @@
           "$ref": "#/definitions/__schema48"
         }
       },
-      "required": ["prompts"],
+      "required": [
+        "prompts"
+      ],
       "additionalProperties": false
     },
     "__schema0": {
@@ -618,7 +620,9 @@
                 "$ref": "#/definitions/__schema12"
               }
             },
-            "required": ["description"],
+            "required": [
+              "description"
+            ],
             "additionalProperties": false
           }
         ]
@@ -654,7 +658,12 @@
     },
     "__schema12": {
       "type": "string",
-      "enum": ["text", "pdf", "docx", "image"]
+      "enum": [
+        "text",
+        "pdf",
+        "docx",
+        "image"
+      ]
     },
     "__schema13": {
       "anyOf": [
@@ -681,7 +690,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "additionalProperties": false
               },
               {
@@ -705,7 +716,10 @@
                   "function": {},
                   "config": {}
                 },
-                "required": ["raw", "label"],
+                "required": [
+                  "raw",
+                  "label"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -822,7 +836,10 @@
               ]
             }
           },
-          "required": ["id", "callApi"],
+          "required": [
+            "id",
+            "callApi"
+          ],
           "additionalProperties": false
         }
       ]
@@ -891,7 +908,10 @@
                 "additionalProperties": {}
               }
             },
-            "required": ["type", "assert"],
+            "required": [
+              "type",
+              "assert"
+            ],
             "additionalProperties": false
           },
           {
@@ -1049,7 +1069,11 @@
             },
             {
               "type": "string",
-              "enum": ["select-best", "human", "max-score"]
+              "enum": [
+                "select-best",
+                "human",
+                "max-score"
+              ]
             },
             {}
           ]
@@ -1078,9 +1102,14 @@
         },
         "contextTransform": {
           "type": "string"
+        },
+        "normalizeUnicode": {
+          "type": "boolean"
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     },
     "__schema24": {
@@ -1136,7 +1165,10 @@
                     "type": "string"
                   }
                 },
-                "required": ["role", "content"],
+                "required": [
+                  "role",
+                  "content"
+                ],
                 "additionalProperties": false
               }
             }
@@ -1266,7 +1298,9 @@
           }
         }
       },
-      "required": ["path"],
+      "required": [
+        "path"
+      ],
       "additionalProperties": false
     },
     "__schema29": {
@@ -1375,7 +1409,10 @@
                 }
               }
             },
-            "required": ["config", "tests"],
+            "required": [
+              "config",
+              "tests"
+            ],
             "additionalProperties": false
           }
         ]
@@ -1508,7 +1545,10 @@
             ]
           }
         },
-        "required": ["name", "value"],
+        "required": [
+          "name",
+          "value"
+        ],
         "additionalProperties": false
       }
     },
@@ -1610,17 +1650,27 @@
                           },
                           "type": {
                             "type": "string",
-                            "enum": ["text", "pdf", "docx", "image"]
+                            "enum": [
+                              "text",
+                              "pdf",
+                              "docx",
+                              "image"
+                            ]
                           }
                         },
-                        "required": ["description"],
+                        "required": [
+                          "description"
+                        ],
                         "additionalProperties": false
                       }
                     ]
                   }
                 }
               },
-              "required": ["id", "callApi"],
+              "required": [
+                "id",
+                "callApi"
+              ],
               "additionalProperties": false
             },
             {
@@ -2112,10 +2162,17 @@
                           },
                           "type": {
                             "type": "string",
-                            "enum": ["text", "pdf", "docx", "image"]
+                            "enum": [
+                              "text",
+                              "pdf",
+                              "docx",
+                              "image"
+                            ]
                           }
                         },
-                        "required": ["description"],
+                        "required": [
+                          "description"
+                        ],
                         "additionalProperties": false
                       }
                     ]
@@ -2197,7 +2254,9 @@
                 }
               }
             },
-            "required": ["id"],
+            "required": [
+              "id"
+            ],
             "additionalProperties": false
           }
         },
@@ -2833,10 +2892,18 @@
                   "severity": {
                     "description": "Severity level for this plugin",
                     "type": "string",
-                    "enum": ["critical", "high", "medium", "low", "informational"]
+                    "enum": [
+                      "critical",
+                      "high",
+                      "medium",
+                      "low",
+                      "informational"
+                    ]
                   }
                 },
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -2844,7 +2911,9 @@
           "description": "Plugins to use for redteam generation"
         },
         "strategies": {
-          "default": ["default"],
+          "default": [
+            "default"
+          ],
           "type": "array",
           "items": {
             "anyOf": [
@@ -2964,7 +3033,9 @@
                     "additionalProperties": {}
                   }
                 },
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "additionalProperties": false
               }
             ]
@@ -3020,12 +3091,20 @@
                 "type": "string"
               }
             },
-            "required": ["output", "pass", "score", "reason"],
+            "required": [
+              "output",
+              "pass",
+              "score",
+              "reason"
+            ],
             "additionalProperties": false
           }
         }
       },
-      "required": ["plugins", "strategies"],
+      "required": [
+        "plugins",
+        "strategies"
+      ],
       "additionalProperties": false,
       "definitions": {
         "__schema0": {
@@ -3127,7 +3206,10 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "enum": ["protobuf", "json"]
+                    "enum": [
+                      "protobuf",
+                      "json"
+                    ]
                   }
                 },
                 "redactAttributes": {
@@ -3137,7 +3219,12 @@
                   }
                 }
               },
-              "required": ["enabled", "port", "host", "acceptFormats"],
+              "required": [
+                "enabled",
+                "port",
+                "host",
+                "acceptFormats"
+              ],
               "additionalProperties": false
             },
             "grpc": {
@@ -3150,7 +3237,10 @@
                   "type": "number"
                 }
               },
-              "required": ["enabled", "port"],
+              "required": [
+                "enabled",
+                "port"
+              ],
               "additionalProperties": false
             }
           },
@@ -3161,13 +3251,18 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["sqlite"]
+              "enum": [
+                "sqlite"
+              ]
             },
             "retentionDays": {
               "type": "number"
             }
           },
-          "required": ["type", "retentionDays"],
+          "required": [
+            "type",
+            "retentionDays"
+          ],
           "additionalProperties": false
         },
         "forwarding": {
@@ -3189,7 +3284,10 @@
               }
             }
           },
-          "required": ["enabled", "endpoint"],
+          "required": [
+            "enabled",
+            "endpoint"
+          ],
           "additionalProperties": false
         },
         "provider": {
@@ -3234,7 +3332,10 @@
                   "maximum": 300000
                 }
               },
-              "required": ["id", "endpoint"],
+              "required": [
+                "id",
+                "endpoint"
+              ],
               "additionalProperties": false
             },
             {
@@ -3260,7 +3361,9 @@
                       "minLength": 1
                     }
                   },
-                  "required": ["token"],
+                  "required": [
+                    "token"
+                  ],
                   "additionalProperties": false
                 },
                 "headers": {
@@ -3278,7 +3381,12 @@
                   "maximum": 300000
                 }
               },
-              "required": ["id", "endpoint", "projectId", "auth"],
+              "required": [
+                "id",
+                "endpoint",
+                "projectId",
+                "auth"
+              ],
               "additionalProperties": false
             },
             {
@@ -3306,7 +3414,10 @@
                       "not": {}
                     }
                   },
-                  "required": ["username", "password"],
+                  "required": [
+                    "username",
+                    "password"
+                  ],
                   "additionalProperties": false
                 },
                 "headers": {
@@ -3324,7 +3435,11 @@
                   "maximum": 300000
                 }
               },
-              "required": ["id", "endpoint", "auth"],
+              "required": [
+                "id",
+                "endpoint",
+                "auth"
+              ],
               "additionalProperties": false
             }
           ]
@@ -3335,7 +3450,9 @@
           "maximum": 300000
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     },
     "__schema41": {

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -68,9 +68,7 @@
           "$ref": "#/definitions/__schema48"
         }
       },
-      "required": [
-        "prompts"
-      ],
+      "required": ["prompts"],
       "additionalProperties": false
     },
     "__schema0": {
@@ -620,9 +618,7 @@
                 "$ref": "#/definitions/__schema12"
               }
             },
-            "required": [
-              "description"
-            ],
+            "required": ["description"],
             "additionalProperties": false
           }
         ]
@@ -658,12 +654,7 @@
     },
     "__schema12": {
       "type": "string",
-      "enum": [
-        "text",
-        "pdf",
-        "docx",
-        "image"
-      ]
+      "enum": ["text", "pdf", "docx", "image"]
     },
     "__schema13": {
       "anyOf": [
@@ -690,9 +681,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "additionalProperties": false
               },
               {
@@ -716,10 +705,7 @@
                   "function": {},
                   "config": {}
                 },
-                "required": [
-                  "raw",
-                  "label"
-                ],
+                "required": ["raw", "label"],
                 "additionalProperties": false
               }
             ]
@@ -836,10 +822,7 @@
               ]
             }
           },
-          "required": [
-            "id",
-            "callApi"
-          ],
+          "required": ["id", "callApi"],
           "additionalProperties": false
         }
       ]
@@ -908,10 +891,7 @@
                 "additionalProperties": {}
               }
             },
-            "required": [
-              "type",
-              "assert"
-            ],
+            "required": ["type", "assert"],
             "additionalProperties": false
           },
           {
@@ -1069,11 +1049,7 @@
             },
             {
               "type": "string",
-              "enum": [
-                "select-best",
-                "human",
-                "max-score"
-              ]
+              "enum": ["select-best", "human", "max-score"]
             },
             {}
           ]
@@ -1107,9 +1083,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "additionalProperties": false
     },
     "__schema24": {
@@ -1165,10 +1139,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "role",
-                  "content"
-                ],
+                "required": ["role", "content"],
                 "additionalProperties": false
               }
             }
@@ -1298,9 +1269,7 @@
           }
         }
       },
-      "required": [
-        "path"
-      ],
+      "required": ["path"],
       "additionalProperties": false
     },
     "__schema29": {
@@ -1409,10 +1378,7 @@
                 }
               }
             },
-            "required": [
-              "config",
-              "tests"
-            ],
+            "required": ["config", "tests"],
             "additionalProperties": false
           }
         ]
@@ -1545,10 +1511,7 @@
             ]
           }
         },
-        "required": [
-          "name",
-          "value"
-        ],
+        "required": ["name", "value"],
         "additionalProperties": false
       }
     },
@@ -1650,27 +1613,17 @@
                           },
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "text",
-                              "pdf",
-                              "docx",
-                              "image"
-                            ]
+                            "enum": ["text", "pdf", "docx", "image"]
                           }
                         },
-                        "required": [
-                          "description"
-                        ],
+                        "required": ["description"],
                         "additionalProperties": false
                       }
                     ]
                   }
                 }
               },
-              "required": [
-                "id",
-                "callApi"
-              ],
+              "required": ["id", "callApi"],
               "additionalProperties": false
             },
             {
@@ -2162,17 +2115,10 @@
                           },
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "text",
-                              "pdf",
-                              "docx",
-                              "image"
-                            ]
+                            "enum": ["text", "pdf", "docx", "image"]
                           }
                         },
-                        "required": [
-                          "description"
-                        ],
+                        "required": ["description"],
                         "additionalProperties": false
                       }
                     ]
@@ -2254,9 +2200,7 @@
                 }
               }
             },
-            "required": [
-              "id"
-            ],
+            "required": ["id"],
             "additionalProperties": false
           }
         },
@@ -2892,18 +2836,10 @@
                   "severity": {
                     "description": "Severity level for this plugin",
                     "type": "string",
-                    "enum": [
-                      "critical",
-                      "high",
-                      "medium",
-                      "low",
-                      "informational"
-                    ]
+                    "enum": ["critical", "high", "medium", "low", "informational"]
                   }
                 },
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "additionalProperties": false
               }
             ]
@@ -2911,9 +2847,7 @@
           "description": "Plugins to use for redteam generation"
         },
         "strategies": {
-          "default": [
-            "default"
-          ],
+          "default": ["default"],
           "type": "array",
           "items": {
             "anyOf": [
@@ -3033,9 +2967,7 @@
                     "additionalProperties": {}
                   }
                 },
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "additionalProperties": false
               }
             ]
@@ -3091,20 +3023,12 @@
                 "type": "string"
               }
             },
-            "required": [
-              "output",
-              "pass",
-              "score",
-              "reason"
-            ],
+            "required": ["output", "pass", "score", "reason"],
             "additionalProperties": false
           }
         }
       },
-      "required": [
-        "plugins",
-        "strategies"
-      ],
+      "required": ["plugins", "strategies"],
       "additionalProperties": false,
       "definitions": {
         "__schema0": {
@@ -3206,10 +3130,7 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "protobuf",
-                      "json"
-                    ]
+                    "enum": ["protobuf", "json"]
                   }
                 },
                 "redactAttributes": {
@@ -3219,12 +3140,7 @@
                   }
                 }
               },
-              "required": [
-                "enabled",
-                "port",
-                "host",
-                "acceptFormats"
-              ],
+              "required": ["enabled", "port", "host", "acceptFormats"],
               "additionalProperties": false
             },
             "grpc": {
@@ -3237,10 +3153,7 @@
                   "type": "number"
                 }
               },
-              "required": [
-                "enabled",
-                "port"
-              ],
+              "required": ["enabled", "port"],
               "additionalProperties": false
             }
           },
@@ -3251,18 +3164,13 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": [
-                "sqlite"
-              ]
+              "enum": ["sqlite"]
             },
             "retentionDays": {
               "type": "number"
             }
           },
-          "required": [
-            "type",
-            "retentionDays"
-          ],
+          "required": ["type", "retentionDays"],
           "additionalProperties": false
         },
         "forwarding": {
@@ -3284,10 +3192,7 @@
               }
             }
           },
-          "required": [
-            "enabled",
-            "endpoint"
-          ],
+          "required": ["enabled", "endpoint"],
           "additionalProperties": false
         },
         "provider": {
@@ -3332,10 +3237,7 @@
                   "maximum": 300000
                 }
               },
-              "required": [
-                "id",
-                "endpoint"
-              ],
+              "required": ["id", "endpoint"],
               "additionalProperties": false
             },
             {
@@ -3361,9 +3263,7 @@
                       "minLength": 1
                     }
                   },
-                  "required": [
-                    "token"
-                  ],
+                  "required": ["token"],
                   "additionalProperties": false
                 },
                 "headers": {
@@ -3381,12 +3281,7 @@
                   "maximum": 300000
                 }
               },
-              "required": [
-                "id",
-                "endpoint",
-                "projectId",
-                "auth"
-              ],
+              "required": ["id", "endpoint", "projectId", "auth"],
               "additionalProperties": false
             },
             {
@@ -3414,10 +3309,7 @@
                       "not": {}
                     }
                   },
-                  "required": [
-                    "username",
-                    "password"
-                  ],
+                  "required": ["username", "password"],
                   "additionalProperties": false
                 },
                 "headers": {
@@ -3435,11 +3327,7 @@
                   "maximum": 300000
                 }
               },
-              "required": [
-                "id",
-                "endpoint",
-                "auth"
-              ],
+              "required": ["id", "endpoint", "auth"],
               "additionalProperties": false
             }
           ]
@@ -3450,9 +3338,7 @@
           "maximum": 300000
         }
       },
-      "required": [
-        "enabled"
-      ],
+      "required": ["enabled"],
       "additionalProperties": false
     },
     "__schema41": {

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -1080,7 +1080,15 @@
           "type": "string"
         },
         "normalizeUnicode": {
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": ["NFC", "NFD", "NFKC", "NFKD"]
+            }
+          ]
         }
       },
       "required": ["type"],

--- a/src/assertions/contains.ts
+++ b/src/assertions/contains.ts
@@ -1,7 +1,7 @@
 import invariant from '../util/invariant';
+import { normalizeForComparison } from './normalize';
 
 import type { AssertionParams, GradingResult } from '../types/index';
-import { normalizeForComparison } from './normalize';
 
 interface ParsedField {
   field: string;
@@ -126,9 +126,8 @@ export const handleContains = ({
   invariant(isContainsValue(value), '"contains" assertion type must have a string or number value');
   const n = assertion.normalizeUnicode;
   const pass =
-    normalizeForComparison(outputString, n).includes(
-      normalizeForComparison(String(value), n),
-    ) !== inverse;
+    normalizeForComparison(outputString, n).includes(normalizeForComparison(String(value), n)) !==
+    inverse;
   return {
     pass,
     score: pass ? 1 : 0,

--- a/src/assertions/contains.ts
+++ b/src/assertions/contains.ts
@@ -1,6 +1,7 @@
 import invariant from '../util/invariant';
 
 import type { AssertionParams, GradingResult } from '../types/index';
+import { normalizeForComparison } from './normalize';
 
 interface ParsedField {
   field: string;
@@ -123,7 +124,11 @@ export const handleContains = ({
 }: AssertionParams): GradingResult => {
   const value = valueFromScript ?? renderedValue;
   invariant(isContainsValue(value), '"contains" assertion type must have a string or number value');
-  const pass = outputString.includes(String(value)) !== inverse;
+  const n = assertion.normalizeUnicode;
+  const pass =
+    normalizeForComparison(outputString, n).includes(
+      normalizeForComparison(String(value), n),
+    ) !== inverse;
   return {
     pass,
     score: pass ? 1 : 0,

--- a/src/assertions/equals.ts
+++ b/src/assertions/equals.ts
@@ -1,7 +1,8 @@
 import util from 'util';
 
-import type { AssertionParams, GradingResult } from '../types/index';
 import { normalizeForComparison } from './normalize';
+
+import type { AssertionParams, GradingResult } from '../types/index';
 
 export const handleEquals = async ({
   assertion,
@@ -30,7 +31,8 @@ export const handleEquals = async ({
     const normalize = assertion.normalizeUnicode;
     pass =
       (normalizeForComparison(String(renderedValue), normalize) ===
-        normalizeForComparison(outputString, normalize)) !== inverse;
+        normalizeForComparison(outputString, normalize)) !==
+      inverse;
   }
 
   return {

--- a/src/assertions/equals.ts
+++ b/src/assertions/equals.ts
@@ -1,6 +1,7 @@
 import util from 'util';
 
 import type { AssertionParams, GradingResult } from '../types/index';
+import { normalizeForComparison } from './normalize';
 
 export const handleEquals = async ({
   assertion,
@@ -23,7 +24,13 @@ export const handleEquals = async ({
     }
     renderedValue = JSON.stringify(renderedValue);
   } else {
-    pass = (String(renderedValue) === outputString) !== inverse;
+    // Opt-in Unicode normalization. Off by default so existing assertions are
+    // unchanged; when enabled it folds NFC/NFD, ligatures and non-breaking
+    // spaces, which are false negatives rather than real mismatches.
+    const normalize = assertion.normalizeUnicode;
+    pass =
+      (normalizeForComparison(String(renderedValue), normalize) ===
+        normalizeForComparison(outputString, normalize)) !== inverse;
   }
 
   return {

--- a/src/assertions/equals.ts
+++ b/src/assertions/equals.ts
@@ -26,8 +26,9 @@ export const handleEquals = async ({
     renderedValue = JSON.stringify(renderedValue);
   } else {
     // Opt-in Unicode normalization. Off by default so existing assertions are
-    // unchanged; when enabled it folds NFC/NFD, ligatures and non-breaking
-    // spaces, which are false negatives rather than real mismatches.
+    // unchanged. `true` is NFC, which folds only canonical differences such as
+    // NFC/NFD accents; the compatibility forms must be named, because NFKC
+    // would score "x2" as equal to "x²".
     const normalize = assertion.normalizeUnicode;
     pass =
       (normalizeForComparison(String(renderedValue), normalize) ===

--- a/src/assertions/normalize.ts
+++ b/src/assertions/normalize.ts
@@ -1,0 +1,20 @@
+/**
+ * Unicode normalization for string assertions.
+ *
+ * `equals`, `contains` and their variants compare raw strings, so an output that
+ * is *correct* but differs from the expected value only in Unicode form scores 0.
+ * These are all false negatives:
+ *
+ *   - "café" in NFC vs the same word in NFD (e + combining acute) — visually identical
+ *   - "ﬁle" with a U+FB01 ligature vs "file" — common in text extracted from PDFs
+ *   - a non-breaking space (U+00A0) vs an ordinary space
+ *
+ * NFKC folds all three. It is deliberately *not* applied by default: changing the
+ * meaning of an existing assertion silently would be worse than the bug.
+ *
+ * This normalizes form only — it never relaxes wording. "$8.540" and "$9.540"
+ * remain different strings under every setting.
+ */
+export function normalizeForComparison(text: string, normalizeUnicode?: boolean): string {
+  return normalizeUnicode ? text.normalize('NFKC') : text;
+}

--- a/src/assertions/normalize.ts
+++ b/src/assertions/normalize.ts
@@ -2,19 +2,66 @@
  * Unicode normalization for string assertions.
  *
  * `equals`, `contains` and their variants compare raw strings, so an output that
- * is *correct* but differs from the expected value only in Unicode form scores 0.
- * These are all false negatives:
+ * is *correct* but differs from the expected value only in Unicode form scores 0:
  *
  *   - "café" in NFC vs the same word in NFD (e + combining acute) — visually identical
  *   - "ﬁle" with a U+FB01 ligature vs "file" — common in text extracted from PDFs
  *   - a non-breaking space (U+00A0) vs an ordinary space
  *
- * NFKC folds all three. It is deliberately *not* applied by default: changing the
- * meaning of an existing assertion silently would be worse than the bug.
+ * All three are false negatives. But the two families of normalization form are
+ * not equally safe, and the difference matters more here than almost anywhere
+ * else:
  *
- * This normalizes form only — it never relaxes wording. "$8.540" and "$9.540"
- * remain different strings under every setting.
+ * **Canonical (NFC/NFD) is meaning-preserving.** It only composes or decomposes
+ * sequences that Unicode defines as the same character. "café" written either way
+ * is the same word.
+ *
+ * **Compatibility (NFKC/NFKD) is not.** It folds characters that merely *look*
+ * related, and several of those distinctions are the answer:
+ *
+ * | Input | NFKC | What is lost |
+ * |---|---|---|
+ * | `x²`  | `x2`  | the exponent |
+ * | `½`   | `1⁄2` | a single character becomes three |
+ * | `Ⅳ`   | `IV`  | a Roman numeral |
+ * | `①`   | `1`   | an enumeration marker |
+ * | `Ａ`   | `A`   | full-width form |
+ *
+ * In an assertion library that asymmetry decides the default. A missed match is
+ * a false negative: the run is marked failed, someone looks, and the truth comes
+ * out. **A wrong answer folded into a right one is a false positive, and nobody
+ * ever looks again.** `equals` with NFKC would score "x2" as a correct answer to
+ * a question whose answer is "x²".
+ *
+ * So `normalizeUnicode: true` means **NFC** — safe, and it fixes the composition
+ * case that motivated this. The compatibility forms remain available and must be
+ * asked for by name, which is the point: `normalizeUnicode: 'NFKC'` is a
+ * deliberate statement that in *this* comparison, a superscript two and a two are
+ * the same answer.
+ *
+ * Normalization changes form, never wording. "$8.540" and "$9.540" are different
+ * strings under every setting.
  */
-export function normalizeForComparison(text: string, normalizeUnicode?: boolean): string {
-  return normalizeUnicode ? text.normalize('NFKC') : text;
+
+/** Unicode normalization forms, as accepted by `String.prototype.normalize`. */
+export type NormalizationForm = 'NFC' | 'NFD' | 'NFKC' | 'NFKD';
+
+/**
+ * What an assertion's `normalizeUnicode` may be set to.
+ *
+ * `true` is a synonym for `'NFC'` rather than for `'NFKC'`: see above.
+ */
+export type NormalizeUnicodeOption = boolean | NormalizationForm;
+
+export const DEFAULT_NORMALIZATION_FORM: NormalizationForm = 'NFC';
+
+export function normalizeForComparison(
+  text: string,
+  normalizeUnicode?: NormalizeUnicodeOption,
+): string {
+  if (!normalizeUnicode) {
+    return text;
+  }
+  const form = normalizeUnicode === true ? DEFAULT_NORMALIZATION_FORM : normalizeUnicode;
+  return text.normalize(form);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -747,6 +747,12 @@ export const AssertionSchema = z.object({
 
   // Extract context from the output using a transform
   contextTransform: StringOrFunctionSchema.optional(),
+
+  // Apply Unicode NFKC normalization before string comparison. Off by default.
+  // Folds forms that are visually identical but differ in codepoints — NFC vs
+  // NFD accents, ligatures such as U+FB01, non-breaking spaces — which cause
+  // false negatives on correct output. Normalizes form only, never wording.
+  normalizeUnicode: z.boolean().optional(),
 });
 
 export type Assertion = z.infer<typeof AssertionSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -748,11 +748,12 @@ export const AssertionSchema = z.object({
   // Extract context from the output using a transform
   contextTransform: StringOrFunctionSchema.optional(),
 
-  // Apply Unicode NFKC normalization before string comparison. Off by default.
-  // Folds forms that are visually identical but differ in codepoints — NFC vs
-  // NFD accents, ligatures such as U+FB01, non-breaking spaces — which cause
-  // false negatives on correct output. Normalizes form only, never wording.
-  normalizeUnicode: z.boolean().optional(),
+  // Apply Unicode normalization before string comparison. Off by default, so
+  // existing assertions are byte-for-byte unchanged.
+  // `true` means NFC — canonical, meaning-preserving. The compatibility
+  // forms fold distinctions that can be the answer (NFKC turns `x²` into
+  // `x2`), so they must be named explicitly. See src/assertions/normalize.ts.
+  normalizeUnicode: z.union([z.boolean(), z.enum(['NFC', 'NFD', 'NFKC', 'NFKD'])]).optional(),
 });
 
 export type Assertion = z.infer<typeof AssertionSchema>;

--- a/test/assertions/normalize.test.ts
+++ b/test/assertions/normalize.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { normalizeForComparison } from '../../src/assertions/normalize';
 
 describe('normalizeForComparison', () => {
@@ -27,11 +28,7 @@ describe('normalizeForComparison', () => {
   it('never relaxes wording', () => {
     // The point of an exact assertion survives: normalization changes form, not
     // meaning. A changed digit is still a different string.
-    expect(normalizeForComparison('$8.540', true)).not.toBe(
-      normalizeForComparison('$9.540', true),
-    );
-    expect(normalizeForComparison('Paris', true)).not.toBe(
-      normalizeForComparison('paris', true),
-    );
+    expect(normalizeForComparison('$8.540', true)).not.toBe(normalizeForComparison('$9.540', true));
+    expect(normalizeForComparison('Paris', true)).not.toBe(normalizeForComparison('paris', true));
   });
 });

--- a/test/assertions/normalize.test.ts
+++ b/test/assertions/normalize.test.ts
@@ -1,0 +1,37 @@
+import { normalizeForComparison } from '../../src/assertions/normalize';
+
+describe('normalizeForComparison', () => {
+  it('leaves text untouched when the option is off', () => {
+    // Default behaviour must be byte-for-byte unchanged.
+    const nfd = 'café';
+    expect(normalizeForComparison(nfd)).toBe(nfd);
+    expect(normalizeForComparison(nfd, false)).toBe(nfd);
+  });
+
+  it('folds NFC and NFD to the same string', () => {
+    const nfc = 'café'; // café, precomposed
+    const nfd = 'café'; // café, e + combining acute
+    expect(nfc).not.toBe(nfd);
+    expect(normalizeForComparison(nfc, true)).toBe(normalizeForComparison(nfd, true));
+  });
+
+  it('expands ligatures', () => {
+    // U+FB01 appears routinely in text extracted from PDFs.
+    expect(normalizeForComparison('ﬁle', true)).toBe('file');
+  });
+
+  it('folds a non-breaking space to an ordinary space', () => {
+    expect(normalizeForComparison('2 items', true)).toBe('2 items');
+  });
+
+  it('never relaxes wording', () => {
+    // The point of an exact assertion survives: normalization changes form, not
+    // meaning. A changed digit is still a different string.
+    expect(normalizeForComparison('$8.540', true)).not.toBe(
+      normalizeForComparison('$9.540', true),
+    );
+    expect(normalizeForComparison('Paris', true)).not.toBe(
+      normalizeForComparison('paris', true),
+    );
+  });
+});

--- a/test/assertions/normalize.test.ts
+++ b/test/assertions/normalize.test.ts
@@ -1,34 +1,174 @@
 import { describe, expect, it } from 'vitest';
+import { handleContains } from '../../src/assertions/contains';
+import { handleEquals } from '../../src/assertions/equals';
 import { normalizeForComparison } from '../../src/assertions/normalize';
+import { createMockProvider, createProviderResponse } from '../factories/provider';
+
+import type { AssertionParams, AssertionValue, AtomicTestCase } from '../../src/types/index';
+
+// Fixtures are CONSTRUCTED, never written as literals.
+//
+// Every tool between a keyboard and a disk is entitled to normalize a source
+// file: editors on save, formatters, git filters, the browser an example was
+// copied from. A test whose subject is invisible codepoint differences cannot
+// survive that. Writing the decomposed form as a literal and trusting it to
+// stay decomposed is how this file silently stopped testing anything.
+// Written as escapes so the file is pure ASCII on disk and no tool downstream
+// can quietly rewrite the very characters under test. Editing this block in a
+// normalising editor is how it broke the first time.
+const NFC_CAFE = 'caf\u00e9'; // e-acute as ONE codepoint
+const NFD_CAFE = 'cafe\u0301'; // e + U+0301 COMBINING ACUTE
+const LIGATURE_FILE = '\ufb01le'; // U+FB01 LATIN SMALL LIGATURE FI
+const NBSP_TEXT = '2\u00a0items'; // U+00A0 NO-BREAK SPACE
+const X_SUPERSCRIPT_TWO = 'x\u00b2'; // x + U+00B2 SUPERSCRIPT TWO
+const X_DIGIT_TWO = 'x2';
+
+const mockProvider = createMockProvider({
+  id: 'mock',
+  response: createProviderResponse({ output: 'mock' }),
+});
+
+const defaultParams = {
+  assertionValueContext: {
+    vars: {},
+    test: {} as AtomicTestCase,
+    prompt: 'test prompt',
+    logProbs: undefined,
+    provider: mockProvider,
+    providerResponse: { output: '' },
+  },
+  test: {} as AtomicTestCase,
+  inverse: false,
+};
+
+function equalsParams(
+  expected: string,
+  output: string,
+  normalizeUnicode?: AssertionParams['assertion']['normalizeUnicode'],
+): AssertionParams {
+  return {
+    ...defaultParams,
+    baseType: 'equals' as const,
+    assertion: { type: 'equals', value: expected, normalizeUnicode },
+    renderedValue: expected as AssertionValue,
+    outputString: output,
+    output,
+    providerResponse: { output },
+  } as AssertionParams;
+}
+
+function containsParams(
+  expected: string,
+  output: string,
+  normalizeUnicode?: AssertionParams['assertion']['normalizeUnicode'],
+): AssertionParams {
+  return {
+    ...defaultParams,
+    baseType: 'contains' as const,
+    assertion: { type: 'contains', value: expected, normalizeUnicode },
+    renderedValue: expected as AssertionValue,
+    outputString: output,
+    output,
+    providerResponse: { output },
+  } as AssertionParams;
+}
+
+describe('the fixtures themselves', () => {
+  // The precondition of every test below. If the pair does not genuinely differ
+  // there is nothing to detect, and the suite would pass while proving nothing.
+  it('holds pairs that really do differ in codepoints', () => {
+    expect(NFC_CAFE).not.toBe(NFD_CAFE);
+    expect(LIGATURE_FILE).not.toBe('file');
+    expect(X_SUPERSCRIPT_TWO).not.toBe(X_DIGIT_TWO);
+  });
+
+  it('holds pairs that really do look the same', () => {
+    expect(NFC_CAFE.normalize('NFC')).toBe(NFD_CAFE.normalize('NFC'));
+  });
+});
 
 describe('normalizeForComparison', () => {
-  it('leaves text untouched when the option is off', () => {
-    // Default behaviour must be byte-for-byte unchanged.
-    const nfd = 'café';
-    expect(normalizeForComparison(nfd)).toBe(nfd);
-    expect(normalizeForComparison(nfd, false)).toBe(nfd);
+  it('leaves text untouched when the option is absent or false', () => {
+    expect(normalizeForComparison(NFD_CAFE)).toBe(NFD_CAFE);
+    expect(normalizeForComparison(NFD_CAFE, false)).toBe(NFD_CAFE);
   });
 
-  it('folds NFC and NFD to the same string', () => {
-    const nfc = 'café'; // café, precomposed
-    const nfd = 'café'; // café, e + combining acute
-    expect(nfc).not.toBe(nfd);
-    expect(normalizeForComparison(nfc, true)).toBe(normalizeForComparison(nfd, true));
+  it('treats `true` as NFC, not NFKC', () => {
+    // The distinction this whole module turns on. NFC folds the accent; it must
+    // NOT fold a superscript two into a digit two.
+    expect(normalizeForComparison(NFC_CAFE, true)).toBe(normalizeForComparison(NFD_CAFE, true));
+    expect(normalizeForComparison(X_SUPERSCRIPT_TWO, true)).not.toBe(
+      normalizeForComparison(X_DIGIT_TWO, true),
+    );
+    expect(normalizeForComparison(LIGATURE_FILE, true)).not.toBe('file');
   });
 
-  it('expands ligatures', () => {
-    // U+FB01 appears routinely in text extracted from PDFs.
-    expect(normalizeForComparison('ﬁle', true)).toBe('file');
+  it('applies a compatibility form when one is named', () => {
+    expect(normalizeForComparison(LIGATURE_FILE, 'NFKC')).toBe('file');
+    expect(normalizeForComparison(NBSP_TEXT, 'NFKC')).toBe('2 items');
   });
 
-  it('folds a non-breaking space to an ordinary space', () => {
-    expect(normalizeForComparison('2 items', true)).toBe('2 items');
+  it('never relaxes wording, under any form', () => {
+    for (const form of [true, 'NFC', 'NFD', 'NFKC', 'NFKD'] as const) {
+      expect(normalizeForComparison('$8.540', form)).not.toBe(
+        normalizeForComparison('$9.540', form),
+      );
+      expect(normalizeForComparison('Paris', form)).not.toBe(normalizeForComparison('paris', form));
+    }
+  });
+});
+
+// These go through the assertion handlers rather than the helper. Testing only
+// `normalizeForComparison` would leave the suite green if the wiring in either
+// handler were reverted, which is to say it would not test the feature at all.
+describe('handleEquals with normalizeUnicode', () => {
+  it('fails a form-only difference by default', async () => {
+    const result = await handleEquals(equalsParams(NFC_CAFE, NFD_CAFE));
+    expect(result.pass).toBe(false);
   });
 
-  it('never relaxes wording', () => {
-    // The point of an exact assertion survives: normalization changes form, not
-    // meaning. A changed digit is still a different string.
-    expect(normalizeForComparison('$8.540', true)).not.toBe(normalizeForComparison('$9.540', true));
-    expect(normalizeForComparison('Paris', true)).not.toBe(normalizeForComparison('paris', true));
+  it('passes a form-only difference when enabled', async () => {
+    const result = await handleEquals(equalsParams(NFC_CAFE, NFD_CAFE, true));
+    expect(result.pass).toBe(true);
+  });
+
+  it('still fails a wrong exponent when enabled', async () => {
+    // The failure that decided the default. Under NFKC this passes, which would
+    // mean an assertion library scoring a wrong answer as correct.
+    const result = await handleEquals(equalsParams(X_SUPERSCRIPT_TWO, X_DIGIT_TWO, true));
+    expect(result.pass).toBe(false);
+  });
+
+  it('accepts the wrong exponent only when NFKC is named explicitly', async () => {
+    const result = await handleEquals(equalsParams(X_SUPERSCRIPT_TWO, X_DIGIT_TWO, 'NFKC'));
+    expect(result.pass).toBe(true);
+  });
+
+  it('still fails a genuinely different value when enabled', async () => {
+    const result = await handleEquals(equalsParams('$8.540', '$9.540', true));
+    expect(result.pass).toBe(false);
+  });
+
+  it('respects inverse', async () => {
+    const params = equalsParams(NFC_CAFE, NFD_CAFE, true);
+    const result = await handleEquals({ ...params, inverse: true });
+    expect(result.pass).toBe(false);
+  });
+});
+
+describe('handleContains with normalizeUnicode', () => {
+  it('fails a form-only difference by default', () => {
+    const result = handleContains(containsParams(NFC_CAFE, `at the ${NFD_CAFE} today`));
+    expect(result.pass).toBe(false);
+  });
+
+  it('passes a form-only difference when enabled', () => {
+    const result = handleContains(containsParams(NFC_CAFE, `at the ${NFD_CAFE} today`, true));
+    expect(result.pass).toBe(true);
+  });
+
+  it('does not match a ligature unless a compatibility form is named', () => {
+    expect(handleContains(containsParams('file', LIGATURE_FILE, true)).pass).toBe(false);
+    expect(handleContains(containsParams('file', LIGATURE_FILE, 'NFKC')).pass).toBe(true);
   });
 });


### PR DESCRIPTION
`equals` and `contains` compare raw strings, so output that is correct but differs from the expected value only in Unicode form scores 0. These are false negatives rather than real mismatches:

  - "café" in NFC vs NFD (e + combining acute) — visually identical
  - "ﬁle" with a U+FB01 ligature vs "file" — common in text extracted from PDFs
  - a non-breaking space (U+00A0) vs an ordinary space

Adds an optional `normalizeUnicode` flag on the assertion, defaulting to false so existing behaviour is unchanged. When enabled, both sides are NFKC-normalized before comparison.

This follows the existing precedent of `icontains` as a sibling of `contains`: the project already accepts that string matching needs opt-in tolerance for differences that are not real. Case is deliberately left to `icontains`.

Normalization changes form only, never wording — "$8.540" and "$9.540" remain different strings with the flag enabled, as does "Paris" vs "paris".

Tests cover both directions: defaults untouched, each fold verified, and a changed digit asserted still to differ.