### PR TITLE
test: make the moonshot and example-README suites hermetic

### DIFF
--- a/test/examples/readme.test.ts
+++ b/test/examples/readme.test.ts
@@ -7,27 +7,42 @@ import { describe, expect, it } from 'vitest';
 const rootDir = path.join(__dirname, '../..');
 const examplesDir = path.join(rootDir, 'examples');
 
-const readmeFiles = globSync('**/README.md', { cwd: examplesDir }).sort();
+// Examples with their own dependencies get a node_modules directory when run
+// locally; those vendored READMEs are not promptfoo examples.
+const IGNORE_VENDORED = ['**/node_modules/**'];
+
+const readmeFiles = globSync('**/README.md', {
+  cwd: examplesDir,
+  ignore: IGNORE_VENDORED,
+}).sort();
 
 function getExampleName(readmePath: string): string {
   return path.dirname(readmePath).split(path.sep).join('/');
 }
 
 function isLeafExample(dirPath: string): boolean {
-  return globSync('promptfooconfig.*', { cwd: dirPath }).length > 0;
+  return globSync('promptfooconfig.*', { cwd: dirPath, ignore: IGNORE_VENDORED }).length > 0;
 }
 
 function hasSubExamples(dirPath: string): boolean {
   const entries = fs.readdirSync(dirPath, { withFileTypes: true });
   return entries.some(
-    (e) => e.isDirectory() && fs.existsSync(path.join(dirPath, e.name, 'README.md')),
+    (e) =>
+      e.isDirectory() &&
+      e.name !== 'node_modules' &&
+      fs.existsSync(path.join(dirPath, e.name, 'README.md')),
   );
 }
 
 function getSubExampleDirs(dirPath: string): string[] {
   const entries = fs.readdirSync(dirPath, { withFileTypes: true });
   return entries
-    .filter((e) => e.isDirectory() && fs.existsSync(path.join(dirPath, e.name, 'README.md')))
+    .filter(
+      (e) =>
+        e.isDirectory() &&
+        e.name !== 'node_modules' &&
+        fs.existsSync(path.join(dirPath, e.name, 'README.md')),
+    )
     .map((e) => e.name);
 }
 

--- a/test/providers/moonshot.test.ts
+++ b/test/providers/moonshot.test.ts
@@ -121,6 +121,10 @@ describe('MoonshotProvider key resolution', () => {
 
   it('does NOT fall back to OPENAI_API_KEY or forward the OpenAI organization', () => {
     const restore = mockProcessEnv({
+      // Clear the real key: a developer with MOONSHOT_API_KEY set (or a .env in
+      // the repo) would otherwise see the provider resolve it and the
+      // no-fallback assertion fail.
+      MOONSHOT_API_KEY: undefined,
       OPENAI_API_KEY: 'sk-openai-secret',
       OPENAI_ORGANIZATION: 'org-openai-secret',
     });


### PR DESCRIPTION
## Summary

Two test suites fail on a developer machine but pass in CI, so the failures read as flakes and get ignored. Both are non-hermetic in ways that only bite locally.

## `test/providers/moonshot.test.ts`

The test *"does NOT fall back to OPENAI_API_KEY or forward the OpenAI organization"* sets the OpenAI variables but leaves the ambient `MOONSHOT_API_KEY` in place. Anyone with that key exported — or with the repo's gitignored `.env` present — has the provider resolve a real key, so the assertion that it finds none fails.

Cleared explicitly via the `undefined` form `mockProcessEnv` already supports.

## `test/examples/readme.test.ts`

The suite globs `**/README.md` under `examples/`, which walks any `node_modules` an example installed when someone ran it locally, then asserts promptfoo's example conventions against vendored package READMEs:

```
FAIL  Example README standards > ts-config/node_modules/zod/README.md
  > should have correct H1 format: # <folder-name> (<Human Readable Name>)
  Expected: /^# ts-config\/node_modules\/zod \(.+\)$/
  Received: "<p align=\"center\">"
```

`node_modules` is now ignored in the glob and in the sub-example directory walk.

## Verification

Reverting each fix confirms it is load-bearing:

| Suite | Without fix | With fix |
| --- | --- | --- |
| `moonshot.test.ts` | 1 failed | 36 passed |
| `readme.test.ts` | **3,378 failed** | 1,758 passed |

The README suite alone accounts for essentially all local test noise — it was drowning real failures.

Neither change touches production code, and neither affects CI behavior (CI starts from a clean checkout with no `.env` and no example `node_modules`, which is why both already pass there).

## Test plan

- [x] `npx vitest run test/providers/moonshot.test.ts test/examples` — 1,836 passing
- [x] Reverted each fix individually to confirm the failure returns
- [x] Biome clean