### PR TITLE
fix(eval): keep the CLI alive while watch mode is watching

### DIFF
--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -62,7 +62,6 @@ import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageU
 import { isUuid } from '../util/uuid';
 import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from './retry';
 import { notCloudEnabledShareInstructions } from './shareInstructions';
-import type { FSWatcher } from 'chokidar';
 import type { Command } from 'commander';
 
 import type {
@@ -184,42 +183,6 @@ function handleRecoverableWatchError(error: unknown): boolean {
   return false;
 }
 
-/**
- * Keep the CLI alive for as long as watch mode is watching.
- *
- * `main()` resolves as soon as the eval command's action handler returns, and its
- * `finally` then runs `shutdownGracefully()`, which closes the database and the HTTP
- * dispatcher and calls `process.exit()` 100ms later. Returning while a watcher is still
- * running therefore tore down everything a re-run needs and killed the process before
- * chokidar could report a single change. Long-running commands avoid this by not
- * resolving until they are done -- `startServer()` does exactly this -- so watch mode
- * does the same and settles only once the watcher is closed.
- *
- * Signal handlers are removed as soon as one fires, so a second Ctrl-C falls back to
- * Node's default behaviour and terminates immediately.
- */
-function watchUntilTerminated(watcher: FSWatcher): Promise<void> {
-  return new Promise<void>((resolve) => {
-    const onSignal = () => {
-      process.removeListener('SIGINT', onSignal);
-      process.removeListener('SIGTERM', onSignal);
-      logger.info('Stopping watch mode...');
-      // Resolve regardless: a watcher that fails to close must not wedge the CLI.
-      watcher
-        .close()
-        .catch((error) =>
-          logger.warn(
-            `Error closing file watcher: ${error instanceof Error ? error.message : error}`,
-          ),
-        )
-        .finally(() => resolve());
-    };
-
-    process.on('SIGINT', onSignal);
-    process.on('SIGTERM', onSignal);
-  });
-}
-
 function resolveSuggestionOptions(
   cmdObj: Partial<CommandLineOptions & Command>,
   commandLineOptions: Record<string, any> | undefined,
@@ -317,10 +280,6 @@ export async function doEval(
     cmdObj.config = undefined;
     defaultConfigPath = undefined;
   }
-
-  // Set once watch mode starts watching; awaited before doEval returns so the CLI does
-  // not shut down underneath the watcher.
-  let watchTermination: Promise<void> | undefined;
 
   const runEvaluation = async (initialization?: boolean) => {
     const startTime = Date.now();
@@ -1218,10 +1177,6 @@ export async function doEval(
           new Set([...configPaths, ...promptPaths, ...providerPaths, ...varPaths]),
         );
         const watcher = chokidar.watch(watchPaths, { ignored: /^\./, persistent: true });
-        // Library callers own their own process lifetime, so only the CLI blocks here.
-        if (isCliInvocation) {
-          watchTermination = watchUntilTerminated(watcher);
-        }
 
         watcher
           .on('change', async (path) => {
@@ -1283,9 +1238,5 @@ export async function doEval(
     return ret;
   };
 
-  const result = await runEvaluation(true /* initialization */);
-  if (watchTermination) {
-    await watchTermination;
-  }
-  return result;
+  return await runEvaluation(true /* initialization */);
 }

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -62,6 +62,7 @@ import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageU
 import { isUuid } from '../util/uuid';
 import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from './retry';
 import { notCloudEnabledShareInstructions } from './shareInstructions';
+import type { FSWatcher } from 'chokidar';
 import type { Command } from 'commander';
 
 import type {
@@ -183,6 +184,42 @@ function handleRecoverableWatchError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * Keep the CLI alive for as long as watch mode is watching.
+ *
+ * `main()` resolves as soon as the eval command's action handler returns, and its
+ * `finally` then runs `shutdownGracefully()`, which closes the database and the HTTP
+ * dispatcher and calls `process.exit()` 100ms later. Returning while a watcher is still
+ * running therefore tore down everything a re-run needs and killed the process before
+ * chokidar could report a single change. Long-running commands avoid this by not
+ * resolving until they are done -- `startServer()` does exactly this -- so watch mode
+ * does the same and settles only once the watcher is closed.
+ *
+ * Signal handlers are removed as soon as one fires, so a second Ctrl-C falls back to
+ * Node's default behaviour and terminates immediately.
+ */
+function watchUntilTerminated(watcher: FSWatcher): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const onSignal = () => {
+      process.removeListener('SIGINT', onSignal);
+      process.removeListener('SIGTERM', onSignal);
+      logger.info('Stopping watch mode...');
+      // Resolve regardless: a watcher that fails to close must not wedge the CLI.
+      watcher
+        .close()
+        .catch((error) =>
+          logger.warn(
+            `Error closing file watcher: ${error instanceof Error ? error.message : error}`,
+          ),
+        )
+        .finally(() => resolve());
+    };
+
+    process.on('SIGINT', onSignal);
+    process.on('SIGTERM', onSignal);
+  });
+}
+
 function resolveSuggestionOptions(
   cmdObj: Partial<CommandLineOptions & Command>,
   commandLineOptions: Record<string, any> | undefined,
@@ -280,6 +317,10 @@ export async function doEval(
     cmdObj.config = undefined;
     defaultConfigPath = undefined;
   }
+
+  // Set once watch mode starts watching; awaited before doEval returns so the CLI does
+  // not shut down underneath the watcher.
+  let watchTermination: Promise<void> | undefined;
 
   const runEvaluation = async (initialization?: boolean) => {
     const startTime = Date.now();
@@ -1177,6 +1218,10 @@ export async function doEval(
           new Set([...configPaths, ...promptPaths, ...providerPaths, ...varPaths]),
         );
         const watcher = chokidar.watch(watchPaths, { ignored: /^\./, persistent: true });
+        // Library callers own their own process lifetime, so only the CLI blocks here.
+        if (isCliInvocation) {
+          watchTermination = watchUntilTerminated(watcher);
+        }
 
         watcher
           .on('change', async (path) => {
@@ -1238,5 +1283,9 @@ export async function doEval(
     return ret;
   };
 
-  return await runEvaluation(true /* initialization */);
+  const result = await runEvaluation(true /* initialization */);
+  if (watchTermination) {
+    await watchTermination;
+  }
+  return result;
 }

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -62,6 +62,7 @@ import { accumulateTokenUsage, createEmptyTokenUsage } from '../util/tokenUsageU
 import { isUuid } from '../util/uuid';
 import { deleteErrorResults, getErrorResultIds, recalculatePromptMetrics } from './retry';
 import { notCloudEnabledShareInstructions } from './shareInstructions';
+import type { FSWatcher } from 'chokidar';
 import type { Command } from 'commander';
 
 import type {
@@ -183,6 +184,45 @@ function handleRecoverableWatchError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * Keep the CLI alive for as long as watch mode is watching.
+ *
+ * `main()` resolves as soon as the eval command's action handler returns, and its
+ * `finally` then runs `shutdownGracefully()`, which closes the database and the HTTP
+ * dispatcher and calls `process.exit()` 100ms later. Returning while a watcher is still
+ * running therefore tore down everything a re-run needs and killed the process before
+ * chokidar could report a single change. Long-running commands avoid this by not
+ * resolving until they are done -- `startServer()` does exactly this -- so watch mode
+ * does the same and settles only once the watcher is closed.
+ *
+ * Signal handlers are removed as soon as one fires, so a second Ctrl-C falls back to
+ * Node's default behaviour and terminates immediately.
+ */
+function watchUntilTerminated(watcher: FSWatcher): Promise<void> {
+  const signals = ['SIGINT', 'SIGTERM'] as const;
+  return new Promise<void>((resolve) => {
+    const onSignal = () => {
+      for (const signal of signals) {
+        process.removeListener(signal, onSignal);
+      }
+      logger.info('Stopping watch mode...');
+      // Settle regardless: a watcher that fails to close must not wedge the CLI.
+      watcher
+        .close()
+        .catch((error) =>
+          logger.warn(
+            `Error closing file watcher: ${error instanceof Error ? error.message : error}`,
+          ),
+        )
+        .finally(resolve);
+    };
+
+    for (const signal of signals) {
+      process.on(signal, onSignal);
+    }
+  });
+}
+
 function resolveSuggestionOptions(
   cmdObj: Partial<CommandLineOptions & Command>,
   commandLineOptions: Record<string, any> | undefined,
@@ -280,6 +320,10 @@ export async function doEval(
     cmdObj.config = undefined;
     defaultConfigPath = undefined;
   }
+
+  // Set once watch mode starts watching; awaited before doEval returns so the CLI does
+  // not shut down underneath the watcher.
+  let watchTermination: Promise<void> | undefined;
 
   const runEvaluation = async (initialization?: boolean) => {
     const startTime = Date.now();
@@ -1177,6 +1221,10 @@ export async function doEval(
           new Set([...configPaths, ...promptPaths, ...providerPaths, ...varPaths]),
         );
         const watcher = chokidar.watch(watchPaths, { ignored: /^\./, persistent: true });
+        // Library callers own their own process lifetime, so only the CLI blocks here.
+        if (isCliInvocation) {
+          watchTermination = watchUntilTerminated(watcher);
+        }
 
         watcher
           .on('change', async (path) => {
@@ -1238,5 +1286,9 @@ export async function doEval(
     return ret;
   };
 
-  return await runEvaluation(true /* initialization */);
+  const result = await runEvaluation(true /* initialization */);
+  if (watchTermination) {
+    await watchTermination;
+  }
+  return result;
 }

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -98,6 +98,7 @@ const chokidarMocks = vi.hoisted(() => {
       handlers.set(event, handler);
       return watcher;
     }),
+    close: vi.fn(async () => {}),
   };
 
   return {
@@ -536,6 +537,86 @@ describe('evalCommand', () => {
       '--watch is not supported when using a cloud config UUID with -c. Use a local config file path for watch mode.',
     );
     expect(getEvalConfigFromCloud).not.toHaveBeenCalled();
+  });
+
+  describe('watch mode process lifecycle', () => {
+    // main() resolves as soon as the eval action handler returns, and its `finally`
+    // then runs shutdownGracefully(), which closes the database and HTTP dispatcher
+    // and calls process.exit() 100ms later. If doEval returns while the watcher is
+    // still running, that tears down everything a re-run needs and kills the process
+    // before chokidar can report a single change -- which is what made `--watch` a
+    // no-op in the shipped CLI.
+    const startWatch = (evaluateOptions: Record<string, unknown>) => {
+      const config = { prompts: [], providers: [], tests: [] } as UnifiedConfig;
+      vi.mocked(resolveConfigs).mockResolvedValue({
+        config,
+        testSuite: { prompts: [], providers: [] } as TestSuite,
+        basePath: path.dirname(defaultConfigPath),
+      });
+      vi.mocked(evaluate).mockImplementationOnce(
+        async (_testSuite, evalRecord) => evalRecord as Eval,
+      );
+      return doEval(
+        { watch: true, write: false },
+        config,
+        defaultConfigPath,
+        evaluateOptions as never,
+      );
+    };
+
+    // doEval reaches the watcher several awaits in, so let the queue drain before
+    // asserting on anything it registers.
+    const flush = async () => {
+      for (let i = 0; i < 5; i++) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+    };
+
+    const settled = async (promise: Promise<unknown>) => {
+      let done = false;
+      void promise.then(() => {
+        done = true;
+      });
+      await flush();
+      return done;
+    };
+
+    afterEach(() => {
+      process.removeAllListeners('SIGINT');
+      process.removeAllListeners('SIGTERM');
+    });
+
+    it('does not resolve while the CLI is watching, and resolves on SIGINT', async () => {
+      const pending = startWatch({ eventSource: 'cli' });
+
+      expect(await settled(pending)).toBe(false);
+      expect(chokidarMocks.watcher.close).not.toHaveBeenCalled();
+
+      process.emit('SIGINT');
+      await pending;
+
+      expect(chokidarMocks.watcher.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes its signal handlers so a second Ctrl-C terminates', async () => {
+      const before = process.listenerCount('SIGINT');
+      const pending = startWatch({ eventSource: 'cli' });
+      await flush();
+      expect(process.listenerCount('SIGINT')).toBe(before + 1);
+
+      process.emit('SIGINT');
+      await pending;
+
+      expect(process.listenerCount('SIGINT')).toBe(before);
+    });
+
+    it('still resolves immediately for library callers, which own their own lifetime', async () => {
+      // isCliEventSource() gates process-lifecycle behavior; a library embedder
+      // decides when to stop watching, so doEval must not block on a signal.
+      await expect(startWatch({})).resolves.toBeDefined();
+      expect(chokidarMocks.watch).toHaveBeenCalled();
+      expect(chokidarMocks.watcher.close).not.toHaveBeenCalled();
+    });
   });
 
   it('should keep watching after config resolution fails on a file change', async () => {

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -581,9 +581,23 @@ describe('evalCommand', () => {
       return done;
     };
 
+    // Remove only what a test leaked (it fails before emitting a signal). Vitest
+    // installs its own SIGINT handler, so removeAllListeners() is not safe here.
+    const SIGNALS = ['SIGINT', 'SIGTERM'] as const;
+    let preexisting: Map<string, unknown[]>;
+
+    beforeEach(() => {
+      preexisting = new Map(SIGNALS.map((signal) => [signal, process.listeners(signal)]));
+    });
+
     afterEach(() => {
-      process.removeAllListeners('SIGINT');
-      process.removeAllListeners('SIGTERM');
+      for (const signal of SIGNALS) {
+        for (const listener of process.listeners(signal)) {
+          if (!preexisting.get(signal)?.includes(listener)) {
+            process.removeListener(signal, listener as never);
+          }
+        }
+      }
     });
 
     it('does not resolve while the CLI is watching, and resolves on SIGINT', async () => {

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -563,11 +563,15 @@ describe('evalCommand', () => {
         testSuite: { prompts: [], providers: [] } as TestSuite,
         basePath: path.dirname(defaultConfigPath),
       });
-      // Own every mock this path reads. Sibling tests queue `mockReturnValueOnce`
-      // values on the shared provider mock, and a leftover one would fail the run
-      // before it ever reaches the watcher.
+      // Own every mock this path reads. Sibling tests queue one-shot values on these
+      // shared mocks and restore only the default, so a leftover can fail the run
+      // before it reaches the watcher. mockReset() drains the queue; clearAllMocks()
+      // in the outer beforeEach does not. Queue one-shot values here in turn, so this
+      // block leaks nothing forward either.
       vi.mocked(checkProviderApiKeys).mockReset().mockReturnValue(new Map());
-      vi.mocked(evaluate).mockImplementation(async (_testSuite, evalRecord) => evalRecord as Eval);
+      vi.mocked(evaluate)
+        .mockReset()
+        .mockImplementationOnce(async (_testSuite, evalRecord) => evalRecord as Eval);
       return doEval(
         { watch: true, write: false },
         config,

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -546,6 +546,16 @@ describe('evalCommand', () => {
     // still running, that tears down everything a re-run needs and kills the process
     // before chokidar can report a single change -- which is what made `--watch` a
     // no-op in the shipped CLI.
+
+    /** Resolves when doEval reaches chokidar.watch(). */
+    const watcherCreated = () =>
+      new Promise<void>((resolve) => {
+        chokidarMocks.watch.mockImplementation(() => {
+          resolve();
+          return chokidarMocks.watcher;
+        });
+      });
+
     const startWatch = (evaluateOptions: Record<string, unknown>) => {
       const config = { prompts: [], providers: [], tests: [] } as UnifiedConfig;
       vi.mocked(resolveConfigs).mockResolvedValue({
@@ -553,9 +563,11 @@ describe('evalCommand', () => {
         testSuite: { prompts: [], providers: [] } as TestSuite,
         basePath: path.dirname(defaultConfigPath),
       });
-      vi.mocked(evaluate).mockImplementationOnce(
-        async (_testSuite, evalRecord) => evalRecord as Eval,
-      );
+      // Own every mock this path reads. Sibling tests queue `mockReturnValueOnce`
+      // values on the shared provider mock, and a leftover one would fail the run
+      // before it ever reaches the watcher.
+      vi.mocked(checkProviderApiKeys).mockReset().mockReturnValue(new Map());
+      vi.mocked(evaluate).mockImplementation(async (_testSuite, evalRecord) => evalRecord as Eval);
       return doEval(
         { watch: true, write: false },
         config,
@@ -564,78 +576,77 @@ describe('evalCommand', () => {
       );
     };
 
-    // doEval reaches the watcher many awaits in, and how many event-loop turns that
-    // takes varies with machine load -- a fixed number of ticks races it and wedges
-    // the test on a slow runner. Wait for the observable effect instead.
-    const waitFor = async (predicate: () => boolean, description: string) => {
-      for (let i = 0; i < 2000; i++) {
-        if (predicate()) {
-          return;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 5));
-      }
-      throw new Error(`Timed out waiting for ${description}`);
+    /**
+     * Wait for the watcher, failing loudly if doEval settles first: a run that bails
+     * early never installs the handler, and racing here reports that instead of
+     * hanging until the suite timeout.
+     */
+    const startWatching = async (evaluateOptions: Record<string, unknown>) => {
+      const created = watcherCreated();
+      const pending = startWatch(evaluateOptions);
+      const bailedEarly = pending.then(() => {
+        throw new Error('doEval returned before it created a watcher');
+      });
+      // When the watcher wins the race nothing awaits this branch, so keep its
+      // eventual rejection from surfacing as an unhandled rejection.
+      bailedEarly.catch(() => {});
+      await Promise.race([created, bailedEarly]);
+      // Wrapped so callers await the race, not the long-lived doEval promise.
+      return { pending };
     };
 
-    const watching = (baseline: number) =>
-      waitFor(
-        () => process.listenerCount('SIGINT') > baseline,
-        'watch mode to install its signal handler',
-      );
-
-    const settled = async (promise: Promise<unknown>) => {
+    const hasSettled = async (promise: Promise<unknown>) => {
       let done = false;
       void promise.then(() => {
         done = true;
       });
-      // Only meaningful once the watcher is up; drain what is already queued.
+      // Drain what is already queued; the watcher is up by the time this is called.
       await new Promise((resolve) => setImmediate(resolve));
       return done;
     };
 
-    // Remove only what a test leaked (it fails before emitting a signal). Vitest
-    // installs its own SIGINT handler, so removeAllListeners() is not safe here.
-    const SIGNALS = ['SIGINT', 'SIGTERM'] as const;
-    let preexisting: Map<string, unknown[]>;
+    /** The listeners watch mode installed, without disturbing anyone else's. */
+    const installedSince = (before: NodeJS.SignalsListener[]) =>
+      process.listeners('SIGINT').filter((listener) => !before.includes(listener));
+
+    let before: NodeJS.SignalsListener[];
 
     beforeEach(() => {
-      preexisting = new Map(SIGNALS.map((signal) => [signal, process.listeners(signal)]));
+      before = process.listeners('SIGINT');
     });
 
     afterEach(() => {
-      for (const signal of SIGNALS) {
-        for (const listener of process.listeners(signal)) {
-          if (!preexisting.get(signal)?.includes(listener)) {
-            process.removeListener(signal, listener as never);
-          }
-        }
+      // Only remove what a test leaked; vitest installs its own SIGINT handler.
+      for (const listener of installedSince(before)) {
+        process.removeListener('SIGINT', listener);
       }
     });
 
     it('does not resolve while the CLI is watching, and resolves on SIGINT', async () => {
-      const baseline = process.listenerCount('SIGINT');
-      const pending = startWatch({ eventSource: 'cli' });
-      await watching(baseline);
+      const { pending } = await startWatching({ eventSource: 'cli' });
 
-      expect(await settled(pending)).toBe(false);
+      expect(await hasSettled(pending)).toBe(false);
       expect(chokidarMocks.watcher.close).not.toHaveBeenCalled();
 
-      process.emit('SIGINT');
+      // Call watch mode's own handler rather than process.emit('SIGINT'), which
+      // would also run vitest's.
+      const [onSignal] = installedSince(before);
+      expect(onSignal).toBeDefined();
+      onSignal('SIGINT');
       await pending;
 
       expect(chokidarMocks.watcher.close).toHaveBeenCalledTimes(1);
     });
 
     it('removes its signal handlers so a second Ctrl-C terminates', async () => {
-      const before = process.listenerCount('SIGINT');
-      const pending = startWatch({ eventSource: 'cli' });
-      await watching(before);
-      expect(process.listenerCount('SIGINT')).toBe(before + 1);
+      const { pending } = await startWatching({ eventSource: 'cli' });
+      expect(installedSince(before)).toHaveLength(1);
 
-      process.emit('SIGINT');
+      const [onSignal] = installedSince(before);
+      onSignal('SIGINT');
       await pending;
 
-      expect(process.listenerCount('SIGINT')).toBe(before);
+      expect(installedSince(before)).toHaveLength(0);
     });
 
     it('still resolves immediately for library callers, which own their own lifetime', async () => {
@@ -644,6 +655,7 @@ describe('evalCommand', () => {
       await expect(startWatch({})).resolves.toBeDefined();
       expect(chokidarMocks.watch).toHaveBeenCalled();
       expect(chokidarMocks.watcher.close).not.toHaveBeenCalled();
+      expect(installedSince(before)).toHaveLength(0);
     });
   });
 

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -564,20 +564,32 @@ describe('evalCommand', () => {
       );
     };
 
-    // doEval reaches the watcher several awaits in, so let the queue drain before
-    // asserting on anything it registers.
-    const flush = async () => {
-      for (let i = 0; i < 5; i++) {
-        await new Promise((resolve) => setImmediate(resolve));
+    // doEval reaches the watcher many awaits in, and how many event-loop turns that
+    // takes varies with machine load -- a fixed number of ticks races it and wedges
+    // the test on a slow runner. Wait for the observable effect instead.
+    const waitFor = async (predicate: () => boolean, description: string) => {
+      for (let i = 0; i < 2000; i++) {
+        if (predicate()) {
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5));
       }
+      throw new Error(`Timed out waiting for ${description}`);
     };
+
+    const watching = (baseline: number) =>
+      waitFor(
+        () => process.listenerCount('SIGINT') > baseline,
+        'watch mode to install its signal handler',
+      );
 
     const settled = async (promise: Promise<unknown>) => {
       let done = false;
       void promise.then(() => {
         done = true;
       });
-      await flush();
+      // Only meaningful once the watcher is up; drain what is already queued.
+      await new Promise((resolve) => setImmediate(resolve));
       return done;
     };
 
@@ -601,7 +613,9 @@ describe('evalCommand', () => {
     });
 
     it('does not resolve while the CLI is watching, and resolves on SIGINT', async () => {
+      const baseline = process.listenerCount('SIGINT');
       const pending = startWatch({ eventSource: 'cli' });
+      await watching(baseline);
 
       expect(await settled(pending)).toBe(false);
       expect(chokidarMocks.watcher.close).not.toHaveBeenCalled();
@@ -615,7 +629,7 @@ describe('evalCommand', () => {
     it('removes its signal handlers so a second Ctrl-C terminates', async () => {
       const before = process.listenerCount('SIGINT');
       const pending = startWatch({ eventSource: 'cli' });
-      await flush();
+      await watching(before);
       expect(process.listenerCount('SIGINT')).toBe(before + 1);
 
       process.emit('SIGINT');


### PR DESCRIPTION
Fixes the second half of #10164 — reported there as "on macOS the watcher never fires `ready` and no re-runs happen at all."

## The bug

`promptfoo eval --watch` sets up a chokidar watcher and then returns. `main()` resolves as soon as the action handler returns, and its `finally` runs `shutdownGracefully()` unconditionally, which:

- closes the database (`closeDbIfOpen()`)
- destroys the global HTTP dispatcher (`dispatcher.destroy()`)
- closes the logger's file transports
- then schedules `process.exit(process.exitCode || 0)` 100ms later

So the CLI tore down everything a re-run needs, and killed the process before chokidar could report a single change. Watch mode has been a no-op end to end.

## It isn't macOS-specific, and it isn't chokidar

A watcher created with `persistent: true` reaches `ready` in about a millisecond and holds the event loop open by itself:

```
ready at 1ms
STILL ALIVE at 4s -> chokidar holds the loop
```

The watcher was fine. It was being shot 100ms after it started.

## The fix

The same approach the codebase already uses for long-running commands: don't resolve until the work is actually finished. `startServer()` returns a promise that settles only when the server closes — that's why `promptfoo view` survives this identical shutdown path. Watch mode now does the same, settling once SIGINT or SIGTERM closes the watcher.

Signal handlers are removed as soon as one fires, so a second Ctrl-C falls back to Node's default behaviour and terminates immediately.

**Only the CLI blocks.** `isCliEventSource()` already marks the single caller that owns process lifecycle — its own doc comment names SIGINT handlers as the reason it exists — so library, MCP, and web embedders keep today's behaviour and decide for themselves when to stop watching. `redteam run` has no `--watch` flag, so it is unaffected.

## Verification

Real CLI, not just mocks:

```
$ promptfoo eval -c promptfooconfig.yaml --watch
...
Watching for file changes on .../promptfooconfig.yaml ...   # never printed before

# edit the watched config
File change detected: .../promptfooconfig.yaml
# second evaluation runs

# Ctrl-C
Stopping watch mode...
EXIT CODE: 0
```

Exit code 0 on SIGINT matches the convention `shutdownGracefully()` already applies to every other command, including `view`.

Three tests added under `watch mode process lifecycle`. The two that pin the new behaviour fail on `main`:

```
× does not resolve while the CLI is watching, and resolves on SIGINT
× removes its signal handlers so a second Ctrl-C terminates
```

The third pins the preserved library behaviour and passes both ways.

## Relationship to #10169

Independent, and both are needed. #10169 fixes *which files* watch mode watches (scalar and generator `tests:` references were skipped); this fixes watch mode *running at all*. Either can land first — #10169's fix simply isn't observable through the CLI until this one lands.

## Not addressed

`ignored: /^\./` in the watcher options is matched against absolute paths, which never begin with a dot, so it is effectively a no-op. Left alone here: it is pre-existing, orthogonal to the lifecycle bug, and changing what gets ignored deserves its own change.