### PR TITLE
feat(providers): add llmman

### DIFF
--- a/src/providers/llmman.ts
+++ b/src/providers/llmman.ts
@@ -1,0 +1,52 @@
+import { OpenAiChatCompletionProvider } from './openai/chat';
+
+import type { EnvOverrides } from '../types/env';
+import type { ApiProvider, ProviderOptions } from '../types/providers';
+
+const LLMMAN_API_BASE = 'http://localhost:17434/v1';
+
+export class LlmmanProvider extends OpenAiChatCompletionProvider {
+  constructor(modelName: string, providerOptions: ProviderOptions = {}) {
+    super(modelName, {
+      ...providerOptions,
+      config: {
+        ...providerOptions.config,
+        apiBaseUrl: providerOptions.config?.apiBaseUrl || LLMMAN_API_BASE,
+        apiKeyEnvar: providerOptions.config?.apiKeyEnvar || 'LLMMAN_API_KEY',
+        // llmman is local and unauthenticated by default, but the OpenAI
+        // client requires some key to be present.
+        apiKey: providerOptions.config?.apiKey || 'llmman',
+      },
+    });
+  }
+
+  id(): string {
+    return `llmman:${this.modelName}`;
+  }
+
+  toString(): string {
+    return `[llmman Provider ${this.modelName}]`;
+  }
+
+  toJSON() {
+    return {
+      provider: 'llmman',
+      model: this.modelName,
+      config: {
+        ...this.config,
+        ...(this.config.apiKey && { apiKey: undefined }),
+      },
+    };
+  }
+}
+
+export function createLlmmanProvider(
+  providerPath: string,
+  options: { config?: ProviderOptions; env?: EnvOverrides } = {},
+): ApiProvider {
+  const modelName = providerPath.split(':').slice(1).join(':');
+  return new LlmmanProvider(modelName, {
+    ...options.config,
+    env: options.config?.env ?? options.env,
+  });
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -57,6 +57,7 @@ import {
 import { JfrogMlChatCompletionProvider } from './jfrog';
 import { LlamaProvider } from './llama';
 import { createLlamaApiProvider } from './llamaApi';
+import { createLlmmanProvider } from './llmman';
 import {
   LocalAiChatProvider,
   LocalAiCompletionProvider,
@@ -781,6 +782,19 @@ export const providerMap: ProviderFactory[] = [
     ) => {
       const { createLiteLLMProvider } = await import('./litellm');
       return createLiteLLMProvider(providerPath, {
+        config: providerOptions,
+        env: context.env,
+      });
+    },
+  },
+  {
+    test: (providerPath: string) => providerPath.startsWith('llmman:'),
+    create: async (
+      providerPath: string,
+      providerOptions: ProviderOptions,
+      context: LoadApiProviderContext,
+    ) => {
+      return createLlmmanProvider(providerPath, {
         config: providerOptions,
         env: context.env,
       });

--- a/test/providers/llmman.test.ts
+++ b/test/providers/llmman.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createLlmmanProvider, LlmmanProvider } from '../../src/providers/llmman';
+
+const LLMMAN_API_BASE = 'http://localhost:17434/v1';
+
+describe('llmman', () => {
+  it('defaults to the llmman port', () => {
+    const provider = new LlmmanProvider('qwen3.8');
+    expect(provider.config.apiBaseUrl).toBe(LLMMAN_API_BASE);
+  });
+
+  it('respects an explicit apiBaseUrl', () => {
+    const provider = new LlmmanProvider('qwen3.8', {
+      config: { apiBaseUrl: 'http://192.168.1.10:17434/v1' },
+    });
+    expect(provider.config.apiBaseUrl).toBe('http://192.168.1.10:17434/v1');
+  });
+
+  it('supplies a placeholder key, since llmman is unauthenticated by default', () => {
+    const provider = new LlmmanProvider('qwen3.8');
+    expect(provider.config.apiKey).toBe('llmman');
+  });
+
+  it('does not override a user-supplied key', () => {
+    const provider = new LlmmanProvider('qwen3.8', { config: { apiKey: 'secret' } });
+    expect(provider.config.apiKey).toBe('secret');
+  });
+
+  it('builds an id from the model name', () => {
+    expect(new LlmmanProvider('qwen3.8').id()).toBe('llmman:qwen3.8');
+  });
+
+  it('keeps colons in model names when parsing the provider path', () => {
+    const provider = createLlmmanProvider('llmman:qwen3.8:q4');
+    expect(provider.id()).toBe('llmman:qwen3.8:q4');
+  });
+
+  it('redacts the api key in toJSON', () => {
+    const json = new LlmmanProvider('qwen3.8', { config: { apiKey: 'secret' } }).toJSON();
+    expect(json.config.apiKey).toBeUndefined();
+    expect(json.provider).toBe('llmman');
+  });
+});


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), which runs local models distributed as OCI artifacts and serves an OpenAI-compatible API on port 17434.

Usable as `llmman:qwen3.8`.

**Which pattern I followed.** There are two in the codebase for OpenAI-compatible endpoints: the hand-rolled client in `localai.ts` (~170 lines of bespoke `fetchWithCache` calls) and the thin subclass in `atlascloud.ts`. llmman needs no bespoke request handling, so it follows `atlascloud.ts` — the provider is a `OpenAiChatCompletionProvider` subclass that sets a default `apiBaseUrl`.

One wrinkle: llmman is unauthenticated by default, but the OpenAI client requires a key to be present, so the provider supplies a placeholder unless the user sets one. There's a test covering that a user-supplied key isn't clobbered.

### Testing

```
$ npx vitest run test/providers/llmman.test.ts
7 passed

$ npx vitest run test/providers/registry.test.ts
106 passed
```

The 7 new tests cover the default base URL, an explicit `apiBaseUrl` override, the placeholder key, not overriding a user key, id construction, **colons surviving in model names** (`llmman:qwen3.8:q4` — the provider path is split on `:`, so this is the case most likely to break), and key redaction in `toJSON`.

I also wrote a scratch test that resolves `llmman:qwen3.8` through `loadApiProvider` end-to-end and asserted the returned provider's `id()` and `toString()` — it passes. I didn't include it in the diff since `registry.test.ts` doesn't enumerate providers individually, but say the word if you'd like it added.

`tsc --noEmit` reports nothing mentioning llmman; prettier and the biome pre-commit hook are clean on all three files. (The hook flagged a pre-existing complexity warning on the `openai:` loader at `registry.ts:970` — untouched by this PR.)

Not verified: no request against a live llmman server.

> AI-assisted, reviewed before submitting.
