### PR TITLE
fix(assertions): set default threshold for answer-relevance to 0.7

### DIFF
--- a/src/assertions/answerRelevance.ts
+++ b/src/assertions/answerRelevance.ts
@@ -22,7 +22,7 @@ export const handleAnswerRelevance = async ({
     ...(await matchesAnswerRelevance(
       input,
       output,
-      assertion.threshold ?? 0,
+      assertion.threshold ?? 0.7,
       test.options,
       providerCallContext,
     )),

--- a/test/assertions/answerRelevance.test.ts
+++ b/test/assertions/answerRelevance.test.ts
@@ -162,7 +162,7 @@ describe('handleAnswerRelevance', () => {
     ).rejects.toThrow('answer-relevance assertion type must have a prompt');
   });
 
-  it('should use default threshold of 0 if not specified', async () => {
+  it('should use default threshold of 0.7 if not specified', async () => {
     const mockMatchesAnswerRelevance = vi.mocked(matchesAnswerRelevance);
     mockMatchesAnswerRelevance.mockResolvedValue({
       pass: true,
@@ -193,7 +193,7 @@ describe('handleAnswerRelevance', () => {
     expect(mockMatchesAnswerRelevance).toHaveBeenCalledWith(
       'test prompt',
       'test output',
-      0,
+      0.7,
       {},
       undefined,
     );


### PR DESCRIPTION
## Description

Previously, `handleAnswerRelevance` defaulted undefined assertion thresholds to `0`. Because `answer-relevance` scores range from 0 to 1, a threshold of 0 caused tests without an explicit threshold to trivially pass regardless of actual relevancy.

This change sets the default threshold to `0.7` (aligning with sensible defaults across promptfoo's model-graded assertions and documented examples) when no threshold is specified, and updates the unit tests accordingly.

Fixes #9848