### PR TITLE
fix(matchers): strip leading headers in context relevance grading

### DIFF
--- a/src/matchers/rag.ts
+++ b/src/matchers/rag.ts
@@ -20,6 +20,7 @@ import {
   normalizeMatcherTokenUsage,
   splitIntoSentences,
   splitTextIntoSentences,
+  stripLeadingHeaders,
   tryParse,
 } from './shared';
 
@@ -279,11 +280,13 @@ export async function matchesContextRelevance(
   // sentence when it is a single prose block. A retrieved context is typically a
   // single paragraph with no newlines; splitting on newlines alone would yield one
   // unit, forcing the score to ~1.0 regardless of relevance.
+  const cleanedContext = typeof context === 'string' ? stripLeadingHeaders(context) : context;
   const contextIsPreSegmented =
-    Array.isArray(context) || context.split('\n').filter((line) => line.trim() !== '').length > 1;
-  const contextUnits = Array.isArray(context)
-    ? context.filter((chunk) => chunk.trim().length > 0)
-    : splitTextIntoSentences(context);
+    Array.isArray(cleanedContext) ||
+    cleanedContext.split('\n').filter((line) => line.trim() !== '').length > 1;
+  const contextUnits = Array.isArray(cleanedContext)
+    ? cleanedContext.filter((chunk) => chunk.trim().length > 0)
+    : splitTextIntoSentences(cleanedContext);
   const totalContextUnits = contextUnits.length;
 
   // Numerator (relevant units): segment the grader output into the SAME kind of

--- a/src/matchers/shared.ts
+++ b/src/matchers/shared.ts
@@ -99,7 +99,87 @@ export function tryParse(content: string) {
 }
 
 export function splitIntoSentences(text: string) {
-  return text.split('\n').filter((sentence) => sentence.trim() !== '');
+  const cleaned = stripLeadingHeaders(text);
+  if (!cleaned) {
+    return [];
+  }
+  return cleaned.split('\n').filter((sentence) => sentence.trim() !== '');
+}
+
+const PREAMBLE_LABEL_PATTERN =
+  /^(?:#{1,6}\s+)?(?:\*{1,2}|_{1,2}|`+)?\s*(?:(?:candidate|extracted|relevant|selected)\s+(?:(?:sentences?|context|passages?|information|units?)\b(?:\([sS]\))?)|context\s+relevance\b)(?:\s*[:])?(?:\*{1,2}|_{1,2}|`+)?\s*:?\s*/i;
+
+const MARKDOWN_HEADER_LINE_PATTERN = /^#{1,6}\s+(.*)$/;
+
+/**
+ * Strips leading markdown headers and preamble labels (e.g., "# Extracted sentences",
+ * "## Relevant Context:", "**Candidate sentences:**", "Extracted sentences:") from text
+ * before sentence extraction, preventing grader or context preambles from inflating sentence counts.
+ */
+export function stripLeadingHeaders(text: string): string {
+  if (!text || typeof text !== 'string') {
+    return '';
+  }
+
+  const lines = text.split('\n');
+  let startIdx = 0;
+
+  // Skip leading empty lines
+  while (startIdx < lines.length && lines[startIdx].trim() === '') {
+    startIdx++;
+  }
+
+  while (startIdx < lines.length) {
+    const line = lines[startIdx].trim();
+    if (line === '') {
+      startIdx++;
+      continue;
+    }
+
+    // Check if line starts with a preamble label (e.g. "Extracted sentences:", "# Relevant Context:", "**Candidate sentences:**")
+    const preambleMatch = line.match(PREAMBLE_LABEL_PATTERN);
+    if (preambleMatch) {
+      const rest = line.slice(preambleMatch[0].length).trim();
+      if (rest.length > 0) {
+        // Preamble was inline; replace current line with the content after the preamble label
+        lines[startIdx] = rest;
+        break;
+      } else {
+        // Entire line was just a preamble label; skip it and check next line
+        startIdx++;
+        continue;
+      }
+    }
+
+    // Check if line is a markdown header line (e.g., "# Extracted sentences", "## Analysis")
+    const headerMatch = line.match(MARKDOWN_HEADER_LINE_PATTERN);
+    if (headerMatch) {
+      const hasSubsequentContent = lines.slice(startIdx + 1).some((l) => l.trim().length > 0);
+      if (hasSubsequentContent) {
+        startIdx++;
+        continue;
+      } else {
+        // Single line remaining with markdown header marker
+        const headerContent = headerMatch[1].trim();
+        if (
+          /^(?:candidate|extracted|relevant|context|sentences?|results?|analysis|output)$/i.test(
+            headerContent.replace(/[:*`_#]/g, '').trim(),
+          )
+        ) {
+          startIdx++;
+          continue;
+        } else {
+          lines[startIdx] = headerContent;
+          break;
+        }
+      }
+    }
+
+    // Not a header or preamble label
+    break;
+  }
+
+  return lines.slice(startIdx).join('\n').trim();
 }
 
 /**
@@ -135,8 +215,12 @@ export function splitIntoSentences(text: string) {
 const ENUMERATION_MARKER_ONLY = /^\d+[.)]$/;
 
 export function splitTextIntoSentences(text: string): string[] {
-  const lines = text.split('\n').filter((line) => line.trim() !== '');
-  const segments = lines.length > 1 ? lines : text.split(/(?<=[.!?])\s+/);
+  const cleaned = stripLeadingHeaders(text);
+  if (!cleaned) {
+    return [];
+  }
+  const lines = cleaned.split('\n').filter((line) => line.trim() !== '');
+  const segments = lines.length > 1 ? lines : cleaned.split(/(?<=[.!?])\s+/);
   return segments
     .map((sentence) => sentence.trim())
     .filter((sentence) => sentence.length > 0 && !ENUMERATION_MARKER_ONLY.test(sentence));

--- a/test/matchers/context-relevance.test.ts
+++ b/test/matchers/context-relevance.test.ts
@@ -438,4 +438,94 @@ This policy excludes all staff going on any outgoing structured programs, short 
       expect(result.metadata?.relevantSentenceCount).toBe(1);
     });
   });
+
+  describe('Header and Preamble Handling (Issue #10245)', () => {
+    it('should not count leading markdown header as an extracted sentence in prose response', async () => {
+      const input = 'What is the capital of France?';
+      const context =
+        'Paris is the capital of France. France is in Europe. The weather is nice today.';
+      const threshold = 0.3;
+
+      // Grader outputs a leading markdown header followed by 1 relevant sentence
+      const mockCallApi = vi.fn().mockResolvedValue({
+        output: '# Extracted sentences\nParis is the capital of France.',
+        tokenUsage: { total: 10, prompt: 5, completion: 5 },
+      });
+      vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+      const result = await matchesContextRelevance(input, context, threshold);
+
+      // 1 relevant sentence out of 3 context sentences → score = 1/3 ≈ 0.33 (not 2/3 ≈ 0.67)
+      expect(result.score).toBeCloseTo(0.33, 2);
+      expect(result.pass).toBe(true);
+      expect(result.metadata?.extractedSentences).toEqual(['Paris is the capital of France.']);
+      expect(result.metadata?.totalContextUnits).toBe(3);
+      expect(result.metadata?.relevantSentenceCount).toBe(1);
+    });
+
+    it('should not count leading markdown header in numbered list grader response', async () => {
+      const input = 'What is the capital of France?';
+      const context =
+        'Paris is the capital of France. France is in Europe. The weather is nice today.';
+      const threshold = 0.5;
+
+      // Grader outputs markdown header followed by a numbered list
+      const mockCallApi = vi.fn().mockResolvedValue({
+        output: '## Relevant Context:\n1. Paris is the capital of France.\n2. France is in Europe.',
+        tokenUsage: { total: 10, prompt: 5, completion: 5 },
+      });
+      vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+      const result = await matchesContextRelevance(input, context, threshold);
+
+      // 2 relevant sentences out of 3 → score = 2/3 ≈ 0.67 (not 3/3 = 1.0)
+      expect(result.score).toBeCloseTo(0.67, 2);
+      expect(result.pass).toBe(true);
+      expect(result.metadata?.extractedSentences).toEqual([
+        '1. Paris is the capital of France.',
+        '2. France is in Europe.',
+      ]);
+      expect(result.metadata?.totalContextUnits).toBe(3);
+      expect(result.metadata?.relevantSentenceCount).toBe(2);
+    });
+
+    it('should handle bold preamble labels and inline headers', async () => {
+      const input = 'What is the capital of France?';
+      const context =
+        'Paris is the capital of France. France is in Europe. The weather is nice today.';
+      const threshold = 0.3;
+
+      const mockCallApi = vi.fn().mockResolvedValue({
+        output: '**Extracted sentences:** Paris is the capital of France.',
+        tokenUsage: { total: 10, prompt: 5, completion: 5 },
+      });
+      vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+      const result = await matchesContextRelevance(input, context, threshold);
+
+      expect(result.score).toBeCloseTo(0.33, 2);
+      expect(result.metadata?.extractedSentences).toEqual(['Paris is the capital of France.']);
+      expect(result.metadata?.relevantSentenceCount).toBe(1);
+    });
+
+    it('should not inflate context units denominator when context includes leading header', async () => {
+      const input = 'What is the capital of France?';
+      const context =
+        '# Context\nParis is the capital of France. France is in Europe. The weather is nice today.';
+      const threshold = 0.3;
+
+      const mockCallApi = vi.fn().mockResolvedValue({
+        output: 'Paris is the capital of France.',
+        tokenUsage: { total: 10, prompt: 5, completion: 5 },
+      });
+      vi.spyOn(DefaultGradingProvider, 'callApi').mockImplementation(mockCallApi);
+
+      const result = await matchesContextRelevance(input, context, threshold);
+
+      // Total context units should be 3 (not 4 or 2 pre-segmented lines)
+      expect(result.metadata?.totalContextUnits).toBe(3);
+      expect(result.score).toBeCloseTo(0.33, 2);
+      expect(result.pass).toBe(true);
+    });
+  });
 });

--- a/test/matchers/shared.test.ts
+++ b/test/matchers/shared.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeMatcherTokenUsage,
   splitIntoSentences,
   splitTextIntoSentences,
+  stripLeadingHeaders,
 } from '../../src/matchers/shared';
 
 describe('normalizeMatcherTokenUsage', () => {
@@ -77,6 +78,79 @@ describe('normalizeMatcherTokenUsage', () => {
   });
 });
 
+describe('stripLeadingHeaders', () => {
+  it('strips leading markdown headers on standalone lines', () => {
+    expect(stripLeadingHeaders('# Extracted sentences\nParis is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+    expect(stripLeadingHeaders('## Relevant Context:\nParis is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+    expect(stripLeadingHeaders('### Candidate Sentences:\n1. First sentence.')).toBe(
+      '1. First sentence.',
+    );
+  });
+
+  it('strips leading preamble labels with markdown formatting or colons', () => {
+    expect(stripLeadingHeaders('**Extracted sentences:**\nParis is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+    expect(stripLeadingHeaders('*Relevant context:*\nParis is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+    expect(stripLeadingHeaders('Candidate sentences:\nParis is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+    expect(stripLeadingHeaders('Extracted sentences\nParis is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+    expect(stripLeadingHeaders('Candidate sentence(s):\nParis is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+  });
+
+  it('strips inline leading headers and labels on the same line', () => {
+    expect(stripLeadingHeaders('# Extracted sentences: Paris is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+    expect(stripLeadingHeaders('## Relevant Context: Paris is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+    expect(stripLeadingHeaders('**Candidate sentences:** Paris is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+    expect(stripLeadingHeaders('Candidate sentences: Paris is the capital.')).toBe(
+      'Paris is the capital.',
+    );
+  });
+
+  it('strips multiple leading headers and blank lines', () => {
+    expect(
+      stripLeadingHeaders(
+        '# Context Relevance\n\n## Extracted sentences:\n\nParis is the capital.',
+      ),
+    ).toBe('Paris is the capital.');
+  });
+
+  it('returns empty string when input contains only headers and labels', () => {
+    expect(stripLeadingHeaders('# Extracted sentences')).toBe('');
+    expect(stripLeadingHeaders('## Relevant Context:')).toBe('');
+    expect(stripLeadingHeaders('**Candidate sentences:**')).toBe('');
+    expect(stripLeadingHeaders('')).toBe('');
+    expect(stripLeadingHeaders('   \n  \n  ')).toBe('');
+  });
+
+  it('preserves regular content, numbers, and sentences without leading headers', () => {
+    expect(stripLeadingHeaders('Paris is the capital of France. France is in Europe.')).toBe(
+      'Paris is the capital of France. France is in Europe.',
+    );
+    expect(stripLeadingHeaders('1. First item\n2. Second item')).toBe(
+      '1. First item\n2. Second item',
+    );
+    expect(stripLeadingHeaders('Insufficient Information')).toBe('Insufficient Information');
+  });
+});
+
 describe('splitIntoSentences', () => {
   it('splits on newlines and drops blank lines', () => {
     expect(splitIntoSentences('a\n\nb\n  \nc')).toEqual(['a', 'b', 'c']);
@@ -92,6 +166,17 @@ describe('splitIntoSentences', () => {
       '2. France is in Europe.',
     ]);
   });
+
+  it('strips leading markdown headers and labels before splitting', () => {
+    expect(
+      splitIntoSentences(
+        '# Extracted sentences\n1. Paris is the capital.\n2. France is in Europe.',
+      ),
+    ).toEqual(['1. Paris is the capital.', '2. France is in Europe.']);
+    expect(
+      splitIntoSentences('## Relevant Context:\nParis is the capital.\nFrance is in Europe.'),
+    ).toEqual(['Paris is the capital.', 'France is in Europe.']);
+  });
 });
 
 describe('splitTextIntoSentences', () => {
@@ -99,6 +184,29 @@ describe('splitTextIntoSentences', () => {
     expect(
       splitTextIntoSentences('Paris is the capital of France. France is in Europe. Nice weather.'),
     ).toEqual(['Paris is the capital of France.', 'France is in Europe.', 'Nice weather.']);
+  });
+
+  it('strips leading markdown headers without polluting extracted sentences or splitting', () => {
+    expect(
+      splitTextIntoSentences(
+        '# Extracted sentences\nParis is the capital of France. France is in Europe.',
+      ),
+    ).toEqual(['Paris is the capital of France.', 'France is in Europe.']);
+    expect(
+      splitTextIntoSentences(
+        '## Relevant Context:\n1. Paris is the capital.\n2. France is in Europe.',
+      ),
+    ).toEqual(['1. Paris is the capital.', '2. France is in Europe.']);
+    expect(
+      splitTextIntoSentences(
+        '# Extracted sentences: Paris is the capital of France. France is in Europe.',
+      ),
+    ).toEqual(['Paris is the capital of France.', 'France is in Europe.']);
+    expect(
+      splitTextIntoSentences(
+        '**Candidate sentences:**\nParis is the capital of France. France is in Europe.',
+      ),
+    ).toEqual(['Paris is the capital of France.', 'France is in Europe.']);
   });
 
   it('is unaffected by an incidental leading/trailing newline (regression for the prose fix)', () => {


### PR DESCRIPTION
## Description

Strip leading markdown headers and preamble labels (e.g., `# Extracted sentences`, `## Relevant Context:`, `**Candidate sentences:**`, `Candidate sentences:`, etc.) before splitting sentences so that grader response headers or context headers do not artificially inflate the sentence count denominator or score.

Fixes #10245

## Testing
- Added unit tests in `test/matchers/shared.test.ts` for `stripLeadingHeaders`, `splitIntoSentences`, and `splitTextIntoSentences`.
- Added test suite in `test/matchers/context-relevance.test.ts` verifying context relevance scores without header pollution.