### PR TITLE
fix: suppress telemetry beacon on disable and prevent slug misidentification as image

### DIFF
--- a/src/app/src/utils/media.test.ts
+++ b/src/app/src/utils/media.test.ts
@@ -721,6 +721,19 @@ describe('resolveImageSource security', () => {
     expect(resolveImageSource('short-string')).toBeUndefined();
   });
 
+  it('should not misidentify slug text with hyphens or underscores as base64 image data URI', () => {
+    const slugWithHyphens =
+      'test-case-description-with-many-words-and-hyphens-long-slug-identifier';
+    expect(resolveImageSource(slugWithHyphens)).toBeUndefined();
+
+    const slugWithUnderscores =
+      'test_case_description_with_many_words_and_underscores_long_slug_identifier';
+    expect(resolveImageSource(slugWithUnderscores)).toBeUndefined();
+
+    const mixedSlug = 'test-slug_with-both_hyphens-and_underscores_test_case_identifier_123456';
+    expect(resolveImageSource(mixedSlug)).toBeUndefined();
+  });
+
   it('should resolve blobRef from image object', () => {
     const result = resolveImageSource({
       blobRef: 'promptfoo://blob/abc123def456789012345678901234567890',

--- a/src/app/src/utils/media.ts
+++ b/src/app/src/utils/media.ts
@@ -153,9 +153,10 @@ export function resolveImageSource(
     if (image.startsWith('data:')) {
       return image;
     }
-    // Allow base64-ish payloads that are purely non-whitespace and use common base64/url-safe chars
+    // Allow base64 payloads that are purely non-whitespace and use standard base64 characters.
     // Require a minimum length to avoid misclassifying short strings (e.g., session IDs) as images.
-    if (image.length >= 60 && /^[A-Za-z0-9+/=_-]+$/.test(image)) {
+    // Ensure slug text with hyphens/underscores is not misidentified as a base64 image.
+    if (image.length >= 60 && /^[A-Za-z0-9+/]+={0,2}$/.test(image)) {
       return `data:image/png;base64,${image}`;
     }
     return undefined;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -12,6 +12,10 @@ export { TELEMETRY_EVENTS, TelemetryEventSchema } from './telemetryEvents';
 
 export type { EventProperties, TelemetryEventTypes } from './telemetryEvents';
 
+export function isTelemetryEnabled(): boolean {
+  return !getEnvBool('PROMPTFOO_DISABLE_TELEMETRY');
+}
+
 let posthogClient: PostHog | null = null;
 let isShuttingDown = false;
 
@@ -51,7 +55,6 @@ function getRuntimeMetadata() {
 }
 
 export class Telemetry {
-  private telemetryDisabledRecorded = false;
   private id: string | null = null;
 
   constructor(initializeImmediately: boolean = true) {
@@ -61,6 +64,9 @@ export class Telemetry {
   }
 
   initialize(): void {
+    if (this.disabled || !this.isTelemetryEnabled()) {
+      return;
+    }
     if (this.id !== null) {
       return;
     }
@@ -82,7 +88,7 @@ export class Telemetry {
   }
 
   async identify() {
-    if (this.disabled || getEnvBool('IS_TESTING')) {
+    if (this.disabled || !this.isTelemetryEnabled() || getEnvBool('IS_TESTING')) {
       return;
     }
 
@@ -107,23 +113,22 @@ export class Telemetry {
     return getEnvBool('PROMPTFOO_DISABLE_TELEMETRY');
   }
 
-  private recordTelemetryDisabled() {
-    if (!this.telemetryDisabledRecorded) {
-      this.sendEvent('feature_used', { feature: 'telemetry disabled' });
-      this.telemetryDisabledRecorded = true;
-    }
+  isTelemetryEnabled(): boolean {
+    return !this.disabled;
   }
 
   record(eventName: TelemetryEventTypes, properties: EventProperties): void {
-    this.initialize();
-    if (this.disabled) {
-      this.recordTelemetryDisabled();
-    } else {
-      this.sendEvent(eventName, properties);
+    if (this.disabled || !this.isTelemetryEnabled()) {
+      return;
     }
+    this.initialize();
+    this.sendEvent(eventName, properties);
   }
 
   private sendEvent(eventName: TelemetryEventTypes, properties: EventProperties): void {
+    if (this.disabled || !this.isTelemetryEnabled()) {
+      return;
+    }
     const ciFlag = isCI();
     const personProperties = this.getPersonProperties(ciFlag);
     const propertiesWithMetadata = {

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -326,12 +326,7 @@ describe('Telemetry', () => {
 
     telemetryInstance.record('eval_ran', { foo: 'bar' });
 
-    // When telemetry is disabled, sendEvent is called with the "telemetry disabled" event
-    // but NOT with the user's event ('eval_ran')
-    expect(localSendEventSpy).toHaveBeenCalledWith('feature_used', {
-      feature: 'telemetry disabled',
-    });
-    expect(localSendEventSpy).not.toHaveBeenCalledWith('eval_ran', expect.anything());
+    expect(localSendEventSpy).not.toHaveBeenCalled();
     localSendEventSpy.mockRestore();
   });
 
@@ -720,17 +715,31 @@ describe('Telemetry', () => {
   });
 
   describe('telemetry disabled recording', () => {
-    it('should record telemetry disabled event only once', () => {
+    it('should immediately suppress all events and beacon requests when telemetry is disabled', () => {
       mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
       const telemetry = new Telemetry();
 
       telemetry.record('eval_ran', { foo: 'bar' });
-      expect(sendEventSpy).toHaveBeenCalledWith('feature_used', { feature: 'telemetry disabled' });
-      expect(sendEventSpy).toHaveBeenCalledTimes(1);
+      expect(sendEventSpy).not.toHaveBeenCalled();
+      expect(fetchWithProxySpy).not.toHaveBeenCalled();
 
-      sendEventSpy.mockClear();
       telemetry.record('command_used', { name: 'test' });
       expect(sendEventSpy).not.toHaveBeenCalled();
+      expect(fetchWithProxySpy).not.toHaveBeenCalled();
+    });
+
+    it('should return false for isTelemetryEnabled when disabled', () => {
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '1' });
+      const telemetry = new Telemetry();
+      expect(telemetry.isTelemetryEnabled()).toBe(false);
+      expect(telemetry.disabled).toBe(true);
+    });
+
+    it('should return true for isTelemetryEnabled when enabled', () => {
+      mockProcessEnv({ PROMPTFOO_DISABLE_TELEMETRY: '0' });
+      const telemetry = new Telemetry();
+      expect(telemetry.isTelemetryEnabled()).toBe(true);
+      expect(telemetry.disabled).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Description

1. **Telemetry suppression (Fixes #9968)**:
   - Added `isTelemetryEnabled` helper/method in [`src/telemetry.ts`](file:///Users/abhipra/Developer/Github/promptfoo/src/telemetry.ts).
   - Ensured that when `PROMPTFOO_DISABLE_TELEMETRY` is set, all telemetry events and beacon requests (`fetchWithProxy(R_ENDPOINT)`) are immediately suppressed without sending `feature_used` / `telemetry disabled` beacons.
   - Updated unit tests in [`test/telemetry.test.ts`](file:///Users/abhipra/Developer/Github/promptfoo/test/telemetry.test.ts) to verify complete suppression when telemetry is disabled.

2. **Slug image rendering (Fixes #10284)**:
   - Updated base64 detection in `resolveImageSource` within [`src/app/src/utils/media.ts`](file:///Users/abhipra/Developer/Github/promptfoo/src/app/src/utils/media.ts) to adhere to standard base64 format (`[A-Za-z0-9+/]` with optional `=` padding).
   - Prevented text slugs containing hyphens (`-`) and underscores (`_`) from being misidentified as base64 image data URIs in output cells and table rendering.
   - Added unit tests in [`src/app/src/utils/media.test.ts`](file:///Users/abhipra/Developer/Github/promptfoo/src/app/src/utils/media.test.ts).

## Testing
- Ran `npm test test/telemetry.test.ts` -> all 27 tests passed.
- Ran `npm run test:app -- src/utils/media.test.ts` -> all 131 tests passed.