### PR TITLE
test(eval): stop a watch-mode test stranding doEval past its own test

### DIFF
--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -795,6 +795,9 @@ describe('evalCommand', () => {
         });
       });
 
+    /** Every doEval this block starts, so afterEach can guarantee none outlives its test. */
+    let started: Promise<unknown>[] = [];
+
     const startWatch = (evaluateOptions: Record<string, unknown>) => {
       const config = { prompts: [], providers: [], tests: [] } as UnifiedConfig;
       vi.mocked(resolveConfigs).mockResolvedValue({
@@ -811,12 +814,14 @@ describe('evalCommand', () => {
       vi.mocked(evaluate)
         .mockReset()
         .mockImplementationOnce(async (_testSuite, evalRecord) => evalRecord as Eval);
-      return doEval(
+      const run = doEval(
         { watch: true, write: false },
         config,
         defaultConfigPath,
         evaluateOptions as never,
       );
+      started.push(run);
+      return run;
     };
 
     /**
@@ -856,10 +861,21 @@ describe('evalCommand', () => {
 
     beforeEach(() => {
       before = process.listeners('SIGINT');
+      started = [];
     });
 
-    afterEach(() => {
-      // Only remove what a test leaked; vitest installs its own SIGINT handler.
+    afterEach(async () => {
+      // Signal rather than just unregister. Watch mode only returns on a signal, so
+      // removing the listener would strand doEval forever -- and a stranded run keeps
+      // executing, landing its mock calls inside whichever test comes next. A failing
+      // test never reaches its own signal, so this has to happen here.
+      for (const listener of installedSince(before)) {
+        listener('SIGINT');
+      }
+      await Promise.allSettled(started);
+      // Anything still registered after that is not going to settle; drop it so it
+      // cannot fire during another test. vitest installs its own handler, so only
+      // remove what this block added.
       for (const listener of installedSince(before)) {
         process.removeListener('SIGINT', listener);
       }


### PR DESCRIPTION
Follow-up to #10562. Hardens a test-only leak; no production code changes.

## The defect

The `watch mode process lifecycle` block's `afterEach` only *unregistered* the SIGINT listener it had leaked:

```js
for (const listener of installedSince(before)) {
  process.removeListener('SIGINT', listener);
}
```

Watch mode returns **solely** on a signal (that's the whole point of #10562), so unregistering the listener strands `doEval` forever. A stranded run keeps executing, and its mock calls land inside whichever test runs next. A test that fails before reaching its own signal hits this every time.

Now the `afterEach` signals the leaked listeners, awaits every `doEval` the block started, and only then unregisters.

## Why

`main` went red once after #10562 merged:

```
FAIL test/commands/eval.test.ts > watch paths for tests > does not re-read an executable config
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 9 times
```

That test expects `maybeReadConfig` to be called zero times, and every mock is reset in the outer `beforeEach` — so a non-zero count requires a `doEval` running *outside* its own test. The leak above is the only mechanism I found that produces that.

## Honest limits

**This is not a confirmed root cause.** Re-running the job passed, so the failure is non-deterministic. I could not reproduce it locally in file order, across 8 shuffled seeds, or in three full-suite runs. I also injected a test that bails before signalling, and it passed both with and without this change.

So: a stranded `doEval` is a real defect worth fixing on its own merits, and it is the only mechanism consistent with the observed failure — but I'm not claiming it is proven to be the one that fired.

The blocks are ordered `watch paths for tests` (#10169) then `watch mode process lifecycle` (#10562) in file order, which is why local runs pass; CI shuffles.

## Verification

`tsc` clean, `biome ci` clean, 128 tests pass across five shuffle seeds.