### PR TITLE
fix: harden eval and provider edge cases

### DIFF
--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -531,6 +531,9 @@ export async function doEval(
       } = await resolveConfigs(cmdObj, defaultConfig));
     }
 
+    const describeReplayAction = (isRetryErrors: boolean | undefined) =>
+      isRetryErrors ? 'retrying errors for' : 'resuming';
+
     const persistedProviderFilterOptions = resumeEval
       ? getPersistedProviderFilterOptions(resumeEval.runtimeOptions?.providerFilter)
       : {};
@@ -538,12 +541,12 @@ export async function doEval(
     const cliProviderFilter = cmdObj.filterProviders || cmdObj.filterTargets;
     if (resumeEval && cliProviderFilter && cliProviderFilter !== persistedProviderFilter) {
       logger.warn(
-        `Ignoring --filter-providers/--filter-targets "${cliProviderFilter}": ${retryErrors ? 'retrying errors for' : 'resuming'} evaluation ${resumeEval.id} with stored provider filter ${persistedProviderFilter ? `"${persistedProviderFilter}"` : '(none)'} to preserve test indices.`,
+        `Ignoring --filter-providers/--filter-targets "${cliProviderFilter}": ${describeReplayAction(retryErrors)} evaluation ${resumeEval.id} with stored provider filter ${persistedProviderFilter ? `"${persistedProviderFilter}"` : '(none)'} to preserve test indices.`,
       );
     }
     if (resumeEval && persistedProviderFilter && testSuite.providers.length === 0) {
       return failEvalRun(
-        `Stored provider filter "${persistedProviderFilter}" matched no providers while ${retryErrors ? 'retrying errors for' : 'resuming'} evaluation ${resumeEval.id}. The evaluation was not changed.`,
+        `Stored provider filter "${persistedProviderFilter}" matched no providers while ${describeReplayAction(retryErrors)} evaluation ${resumeEval.id}. The evaluation was not changed.`,
         isCliInvocation,
       );
     }

--- a/src/providers/openai/codex-security.ts
+++ b/src/providers/openai/codex-security.ts
@@ -537,7 +537,7 @@ export class OpenAICodexSecurityProvider implements ApiProvider {
     const cost = result.cost ?? observers.cost;
     const tokenUsage = getTokenUsage(result, observers.cost);
     const findings = Array.isArray(result.findings?.findings) ? result.findings.findings : [];
-    const model = result.turnResult.model ?? cost?.model ?? config.model;
+    const model = result.turnResult?.model ?? cost?.model ?? config.model;
     const raw = result.toJSON();
 
     return {

--- a/src/providers/openai/codex-security.ts
+++ b/src/providers/openai/codex-security.ts
@@ -218,7 +218,7 @@ function resolveConfigPath(value: string | undefined, configBasePath?: string): 
 }
 
 function getTokenUsage(result?: ScanResult, observedCost?: ScanCost): TokenUsage | undefined {
-  const usage = result?.turnResult.usage;
+  const usage = result?.turnResult?.usage;
   const values = usage && typeof usage === 'object' ? (usage as Record<string, unknown>) : {};
   const cost = result?.cost ?? observedCost;
   const inputTokens =
@@ -588,6 +588,8 @@ export class OpenAICodexSecurityProvider implements ApiProvider {
         !Array.isArray(findingVariable))
         ? findingVariable
         : undefined;
+    // Finding precedence is config.finding, then context.vars.finding, then prompt.
+    // finding_file overrides all three when it is configured.
     let finding: string | object = config.finding ?? contextualFinding ?? prompt;
     if (config.finding_file) {
       const findingContents = await fs.readFile(

--- a/src/util/cliOptions.ts
+++ b/src/util/cliOptions.ts
@@ -9,12 +9,11 @@ export function collectKeyValueOption(
   const key = separatorIndex === -1 ? '' : value.slice(0, separatorIndex);
   const val = separatorIndex === -1 ? undefined : value.slice(separatorIndex + 1);
 
-  if (
-    !key ||
-    key.trim() !== key ||
-    val === undefined ||
-    (val.length > 0 && val.trim().length === 0)
-  ) {
+  // Reject a missing separator and any key that is empty, whitespace-only, or padded:
+  // `--tag " env =ci"` would otherwise silently register the key `" env "`. Values are
+  // taken verbatim -- `--var "sep= "` passes a deliberate space, and `key=` is an
+  // explicitly supported empty value -- so only the key is constrained.
+  if (val === undefined || !key || key.trim() !== key) {
     throw new InvalidArgumentError(`${optionName} must be specified in key=value format.`);
   }
 

--- a/src/util/cliOptions.ts
+++ b/src/util/cliOptions.ts
@@ -9,7 +9,12 @@ export function collectKeyValueOption(
   const key = separatorIndex === -1 ? '' : value.slice(0, separatorIndex);
   const val = separatorIndex === -1 ? undefined : value.slice(separatorIndex + 1);
 
-  if (!key || val === undefined) {
+  if (
+    !key ||
+    key.trim() !== key ||
+    val === undefined ||
+    (val.length > 0 && val.trim().length === 0)
+  ) {
     throw new InvalidArgumentError(`${optionName} must be specified in key=value format.`);
   }
 

--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -766,10 +766,7 @@ function collectNestedFileReferences(testsFile: string): string[] {
       ext === 'json'
         ? JSON.parse(raw)
         : ext === 'jsonl'
-          ? raw
-              .split(/\r?\n/)
-              .filter((line) => line.trim().length > 0)
-              .map((line) => JSON.parse(line))
+          ? parseJsonlLines(raw, testsFile)
           : loadYaml(raw);
     return collectConfigFileReferences(parsed, path.dirname(testsFile));
   } catch {

--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -757,12 +757,20 @@ function resolveTestsFileReference(reference: string, basePath: string): string[
  */
 function collectNestedFileReferences(testsFile: string): string[] {
   const ext = parsePath(testsFile).ext.slice(1).toLowerCase();
-  if (!['yaml', 'yml', 'json'].includes(ext)) {
+  if (!['yaml', 'yml', 'json', 'jsonl'].includes(ext)) {
     return [];
   }
   try {
     const raw = fs.readFileSync(testsFile, 'utf-8');
-    const parsed = ext === 'json' ? JSON.parse(raw) : loadYaml(raw);
+    const parsed =
+      ext === 'json'
+        ? JSON.parse(raw)
+        : ext === 'jsonl'
+          ? raw
+              .split(/\r?\n/)
+              .filter((line) => line.trim().length > 0)
+              .map((line) => JSON.parse(line))
+          : loadYaml(raw);
     return collectConfigFileReferences(parsed, path.dirname(testsFile));
   } catch {
     return [];

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -488,14 +488,17 @@ describe('evalCommand', () => {
     });
   });
 
-  it.each(['invalid', '=value'])('should reject malformed --tag value %s', (tagValue) => {
-    const cmd = evalCommand(program, defaultConfig, defaultConfigPath);
-    cmd.exitOverride();
+  it.each(['invalid', '=value', ' =value', 'key= ', ' = '])(
+    'should reject malformed --tag value %s',
+    (tagValue) => {
+      const cmd = evalCommand(program, defaultConfig, defaultConfigPath);
+      cmd.exitOverride();
 
-    expect(() => cmd.parseOptions(['--tag', tagValue])).toThrow(
-      '--tag must be specified in key=value format.',
-    );
-  });
+      expect(() => cmd.parseOptions(['--tag', tagValue])).toThrow(
+        '--tag must be specified in key=value format.',
+      );
+    },
+  );
 
   it('should load cloud eval config when config is a single UUID', async () => {
     const cloudConfigUuid = '12345678-1234-4234-8234-123456789abc';

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -488,7 +488,7 @@ describe('evalCommand', () => {
     });
   });
 
-  it.each(['invalid', '=value', ' =value', 'key= ', ' = '])(
+  it.each(['invalid', '=value', ' =value', ' = ', 'key =value', 'key\t=value'])(
     'should reject malformed --tag value %s',
     (tagValue) => {
       const cmd = evalCommand(program, defaultConfig, defaultConfigPath);

--- a/test/providers/openai-codex-security.test.ts
+++ b/test/providers/openai-codex-security.test.ts
@@ -314,6 +314,27 @@ describe('OpenAICodexSecurityProvider', () => {
       expect(mockRun).not.toHaveBeenCalled();
     });
 
+    it('reports multiple incompatible trusted SDK versions together', async () => {
+      const firstTrustedRoot = path.resolve(getDirectory(), '..');
+      vi.mocked(resolvePackageEntryPoint).mockImplementation((_packageName, basePath) =>
+        basePath === firstTrustedRoot
+          ? '/legacy/@openai/codex-security/dist/index.js'
+          : '/promptfoo/@openai/codex-security/dist/index.js',
+      );
+      vi.mocked(importModule).mockImplementation(async (entryPoint) =>
+        String(entryPoint).startsWith('/legacy/')
+          ? { ...mockModule, VERSION: '0.1.8' }
+          : { ...mockModule, VERSION: '0.1.10' },
+      );
+      const provider = new OpenAICodexSecurityProvider();
+
+      const response = await provider.callApi('Scan');
+
+      expect(response.error).toContain('package is incompatible (0.1.8, 0.1.10)');
+      expect(response.error).toContain('npm install promptfoo @openai/codex-security@^0.1.18');
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
     it('reports malformed SDK versions as incompatible instead of import failures', async () => {
       vi.mocked(importModule).mockResolvedValue({ ...mockModule, VERSION: 'unknown' });
       const provider = new OpenAICodexSecurityProvider();
@@ -603,7 +624,7 @@ describe('OpenAICodexSecurityProvider', () => {
     });
 
     it('does not fabricate usage or cost when the SDK omits both', async () => {
-      mockRun.mockResolvedValue(createScanResult({ cost: null, turnResult: {} }));
+      mockRun.mockResolvedValue(createScanResult({ cost: null, turnResult: undefined }));
       const provider = new OpenAICodexSecurityProvider();
 
       const response = await provider.callApi('Scan');

--- a/test/providers/openai-codex-security.test.ts
+++ b/test/providers/openai-codex-security.test.ts
@@ -624,13 +624,29 @@ describe('OpenAICodexSecurityProvider', () => {
     });
 
     it('does not fabricate usage or cost when the SDK omits both', async () => {
+      mockRun.mockResolvedValue(createScanResult({ cost: null, turnResult: {} }));
+      const provider = new OpenAICodexSecurityProvider();
+
+      const response = await provider.callApi('Scan');
+
+      expect(response.error).toBeUndefined();
+      expect(response.tokenUsage).toBeUndefined();
+      expect(response.cost).toBeUndefined();
+    });
+
+    // A future SDK could drop `turnResult` entirely. Missing usage metadata must degrade
+    // to "no usage reported" -- it must not discard the findings the scan already produced.
+    it('still reports findings when the SDK omits turnResult entirely', async () => {
       mockRun.mockResolvedValue(createScanResult({ cost: null, turnResult: undefined }));
       const provider = new OpenAICodexSecurityProvider();
 
       const response = await provider.callApi('Scan');
 
+      expect(response.error).toBeUndefined();
       expect(response.tokenUsage).toBeUndefined();
       expect(response.cost).toBeUndefined();
+      expect(response.metadata).toMatchObject({ findingsCount: 1, repository: expect.any(String) });
+      expect(response.metadata?.model).toBeUndefined();
     });
 
     it('renders provider configuration variables for each eval row', async () => {

--- a/test/util/cliOptions.test.ts
+++ b/test/util/cliOptions.test.ts
@@ -27,12 +27,24 @@ describe('collectKeyValueOption', () => {
     expect(collectKeyValueOption('--tag', 'empty=', undefined)).toEqual({ empty: '' });
   });
 
-  it.each(['invalid', '=value'])('throws InvalidArgumentError for malformed input %p', (value) => {
-    expect(() => collectKeyValueOption('--tag', value, undefined)).toThrow(InvalidArgumentError);
-    expect(() => collectKeyValueOption('--tag', value, undefined)).toThrow(
-      '--tag must be specified in key=value format.',
-    );
+  // `--var` shares this coercion, where a whitespace value can be the point.
+  it.each([
+    ['sep= ', { sep: ' ' }],
+    ['pad=hi ', { pad: 'hi ' }],
+    ['nl=a\nb', { nl: 'a\nb' }],
+  ])('takes the value verbatim for %p', (value, expected) => {
+    expect(collectKeyValueOption('--var', value as string, undefined)).toEqual(expected);
   });
+
+  it.each(['invalid', '=value', ' =value', ' = ', 'key =value'])(
+    'throws InvalidArgumentError for malformed input %p',
+    (value) => {
+      expect(() => collectKeyValueOption('--tag', value, undefined)).toThrow(InvalidArgumentError);
+      expect(() => collectKeyValueOption('--tag', value, undefined)).toThrow(
+        '--tag must be specified in key=value format.',
+      );
+    },
+  );
 
   it('includes the option name in the error message', () => {
     expect(() => collectKeyValueOption('--var', 'nope', undefined)).toThrow(

--- a/test/util/testCaseWatchPaths.test.ts
+++ b/test/util/testCaseWatchPaths.test.ts
@@ -145,6 +145,13 @@ describe('resolveTestsWatchPaths', () => {
     expect(watched).toContain(path.join(base, 'vars.csv'));
   });
 
+  it('watches file references nested inside a .jsonl tests file', () => {
+    fs.writeFileSync(path.join(base, 'nested.jsonl'), '{"vars":{"data":"file://vars.csv"}}\n');
+    const watched = resolve('file://nested.jsonl' as TestSuiteConfig['tests']);
+    expect(watched).toContain(path.join(base, 'nested.jsonl'));
+    expect(watched).toContain(path.join(base, 'vars.csv'));
+  });
+
   it('tolerates a self-referential generator config', () => {
     // A YAML anchor produces a cyclic object, which naive recursion would follow until
     // the stack overflows -- crashing a run that had already evaluated successfully.


### PR DESCRIPTION
## Summary

- keep replay action wording consistent across eval warnings
- harden Codex Security usage extraction and document finding precedence
- validate malformed CLI tags and watch nested file references in JSONL tests
- add regressions for malformed tags, multiple incompatible SDK versions, missing turn results, and JSONL watch paths

## Validation

- `npm run f` (passes; existing complexity warnings remain in touched legacy functions)
- `npm run l` (passes; same existing complexity warnings)
- `npm run tsc`
- `npx vitest run test/commands/eval.test.ts test/providers/openai-codex-security.test.ts test/util/testCaseWatchPaths.test.ts --no-cache` (194 passed)
