### PR TITLE
feat(scheduler): support multi-tenant deployment, project, and host differentiation in rateLimitKey

### DIFF
--- a/src/scheduler/rateLimitKey.ts
+++ b/src/scheduler/rateLimitKey.ts
@@ -14,17 +14,46 @@ export function getRateLimitKey(provider: ApiProvider): string {
   const relevantConfig: Record<string, string> = {};
 
   // Use last 4 chars of API key for differentiation (safe partial identifier)
-  if (config.apiKey && config.apiKey.length > 4) {
+  if (typeof config.apiKey === 'string' && config.apiKey.length > 4) {
     relevantConfig.apiKeyTail = config.apiKey.slice(-4);
   }
-  if (config.apiBaseUrl) {
-    relevantConfig.apiBaseUrl = config.apiBaseUrl;
+
+  // Base URL / custom host differentiation (Ollama, LiteLLM, LocalAI, OpenAI-compatible)
+  const baseUrl = config.apiBaseUrl || config.baseUrl || config.apiHost || config.host;
+  if (typeof baseUrl === 'string' && baseUrl.length > 0) {
+    relevantConfig.baseUrl = baseUrl;
   }
-  if (config.region) {
-    relevantConfig.region = config.region;
+
+  // Region / location differentiation (AWS Bedrock, Google Vertex AI, Azure)
+  const region = config.region || config.location;
+  if (typeof region === 'string' && region.length > 0) {
+    relevantConfig.region = region;
   }
-  if (config.organization) {
-    relevantConfig.organization = config.organization;
+
+  // Organization differentiation (OpenAI, Anthropic)
+  const org = config.organization || config.orgId;
+  if (typeof org === 'string' && org.length > 0) {
+    relevantConfig.organization = org;
+  }
+
+  // Project differentiation (Google Cloud Vertex AI)
+  const project = config.projectId || config.project;
+  if (typeof project === 'string' && project.length > 0) {
+    relevantConfig.projectId = project;
+  }
+
+  // Azure deployment & resource differentiation
+  if (typeof config.deploymentName === 'string' && config.deploymentName.length > 0) {
+    relevantConfig.deploymentName = config.deploymentName;
+  }
+  if (typeof config.resourceName === 'string' && config.resourceName.length > 0) {
+    relevantConfig.resourceName = config.resourceName;
+  }
+
+  // Account differentiation (Cloudflare Workers AI, AWS)
+  const account = config.account || config.accountId;
+  if (typeof account === 'string' && account.length > 0) {
+    relevantConfig.account = account;
   }
 
   // Filter out undefined values and create stable hash

--- a/test/scheduler/rateLimitKey.test.ts
+++ b/test/scheduler/rateLimitKey.test.ts
@@ -273,4 +273,77 @@ describe('getRateLimitKey', () => {
       expect(key).toMatch(/^custom:model\/v1\.2-beta\[.{12}\]$/);
     });
   });
+
+  describe('Multi-tenant and cloud provider differentiation', () => {
+    it('should generate different keys for different baseUrl, apiHost, or host aliases', () => {
+      const provider1 = createMockProvider('ollama:llama3', {
+        baseUrl: 'http://localhost:11434',
+      });
+      const provider2 = createMockProvider('ollama:llama3', {
+        baseUrl: 'http://remote-gpu:11434',
+      });
+      const providerHost = createMockProvider('ollama:llama3', {
+        host: 'http://remote-gpu:11434',
+      });
+
+      const key1 = getRateLimitKey(provider1);
+      const key2 = getRateLimitKey(provider2);
+      const keyHost = getRateLimitKey(providerHost);
+
+      expect(key1).not.toBe(key2);
+      expect(key2).toBe(keyHost);
+    });
+
+    it('should differentiate Azure OpenAI deployments and resources', () => {
+      const prodDeployment = createMockProvider('azure:gpt-4o', {
+        resourceName: 'my-resource',
+        deploymentName: 'gpt-4o-prod',
+      });
+      const devDeployment = createMockProvider('azure:gpt-4o', {
+        resourceName: 'my-resource',
+        deploymentName: 'gpt-4o-dev',
+      });
+      const otherResource = createMockProvider('azure:gpt-4o', {
+        resourceName: 'other-resource',
+        deploymentName: 'gpt-4o-prod',
+      });
+
+      const prodKey = getRateLimitKey(prodDeployment);
+      const devKey = getRateLimitKey(devDeployment);
+      const otherKey = getRateLimitKey(otherResource);
+
+      expect(prodKey).not.toBe(devKey);
+      expect(prodKey).not.toBe(otherKey);
+    });
+
+    it('should differentiate Google Cloud Vertex AI projects', () => {
+      const proj1 = createMockProvider('vertex:gemini-1.5-pro', {
+        projectId: 'project-corp-prod',
+        location: 'us-central1',
+      });
+      const proj2 = createMockProvider('vertex:gemini-1.5-pro', {
+        project: 'project-corp-dev',
+        location: 'us-central1',
+      });
+
+      const key1 = getRateLimitKey(proj1);
+      const key2 = getRateLimitKey(proj2);
+
+      expect(key1).not.toBe(key2);
+    });
+
+    it('should differentiate Cloudflare Workers AI accounts and organizations', () => {
+      const account1 = createMockProvider('cloudflare:llama3', {
+        account: 'account-123',
+      });
+      const account2 = createMockProvider('cloudflare:llama3', {
+        accountId: 'account-456',
+      });
+
+      const key1 = getRateLimitKey(account1);
+      const key2 = getRateLimitKey(account2);
+
+      expect(key1).not.toBe(key2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Expands `getRateLimitKey` to distinguish independent rate-limit pools across multi-tenant deployments, cloud projects, and custom endpoints.

Previously, `getRateLimitKey` only inspected `apiKey`, `apiBaseUrl`, `region`, and `organization`. Evaluations comparing multiple Azure OpenAI deployments, Google Cloud Vertex AI projects, Cloudflare accounts, or separate Ollama/proxy hosts collapsed into the same rate-limit key and throttled each other.

### Key Changes
* Added support for `baseUrl` / `apiHost` / `host` aliases (Ollama, LiteLLM, OpenAI-compatible proxies).
* Added support for `deploymentName` and `resourceName` (Azure OpenAI).
* Added support for `projectId` / `project` (Google Cloud Vertex AI) and `location`.
* Added support for `account` / `accountId` (Cloudflare Workers AI).
* Added comprehensive unit test coverage in `test/scheduler/rateLimitKey.test.ts`.

### Tests
- [x] Unit tests for Ollama / custom proxy baseUrl and host aliases
- [x] Unit tests for Azure OpenAI deployment and resource differentiation
- [x] Unit tests for Google Cloud Vertex AI project differentiation
- [x] Unit tests for Cloudflare Workers AI account differentiation