### PR TITLE
ci(release): advance release-please drift floor

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "include-v-in-release-name": false,
   "commit-batch-size": 25,
   "commit-search-depth": 500,
-  "last-release-sha": "af7ec0b5f1072685a919015faf5799cc0886d71e",
+  "last-release-sha": "89052308bce06f53645b1f189ada5ac9d1897347",
   "separate-pull-requests": true,
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary

- advance release-please’s static history floor to the oldest current package release boundary
- restore the scheduled SHA-drift guard after it crossed its 400-commit threshold

## Why this SHA

The root package’s current `0.122.2` release is `89052308…`, while code-scan-action’s current `0.2.0` release is later at `2c45764c…`. Using `89052308…` preserves unreleased commits for both packages and leaves the floor only 17 commits behind current `main`.

## Verification

- reproduced the failing guard calculation: old floor `af7ec0b5…` was 499 commits behind `main` (> 400)
- verified the new floor is reachable and 17 commits behind `main` (<= 400)
- `jq empty release-please-config.json`
- `git diff --check`

Note: focused Vitest startup was blocked by an incomplete local dependency tree (`vitest/dist/cli.js` missing), so the workflow’s exact guard calculation was validated directly.