### PR TITLE
fix(scheduler): detect transient network errors in nested error causes for native fetch

### DIFF
--- a/src/scheduler/retryPolicy.ts
+++ b/src/scheduler/retryPolicy.ts
@@ -1,4 +1,8 @@
-import { isHttpRateLimitError, isTransientConnectionError } from '../util/fetch/errors';
+import {
+  isHttpRateLimitError,
+  isTransientConnectionError,
+  type SystemError,
+} from '../util/fetch/errors';
 
 export interface RetryPolicy {
   maxRetries: number;
@@ -68,19 +72,35 @@ export function shouldRetry(
 
   // Retry transient errors.
   // isTransientConnectionError covers TLS/socket-level failures (bad record
-  // mac, EPROTO, ECONNRESET, socket hang up).  The inline patterns below
+  // mac, EPROTO, ECONNRESET, socket hang up). The inline patterns below
   // cover higher-level transient failures (DNS, HTTP status codes, timeouts)
-  // that are distinct from those low-level connection errors.
+  // across the error and nested cause.
   if (error) {
-    const message = (error.message ?? '').toLowerCase();
+    const cause = (error as SystemError).cause as SystemError | undefined;
+    const causeCode = cause?.code ?? '';
+    const causeMessage = (cause as Error | undefined)?.message ?? '';
+    const message = `${error.message ?? ''} ${causeMessage}`.toLowerCase();
+    const code = (error as SystemError).code ?? '';
+
     return (
       isTransientConnectionError(error) ||
+      code === 'ETIMEDOUT' ||
+      code === 'ECONNREFUSED' ||
+      code === 'EAI_AGAIN' ||
+      code === 'UND_ERR_CONNECT_TIMEOUT' ||
+      code === 'UND_ERR_SOCKET' ||
+      causeCode === 'ETIMEDOUT' ||
+      causeCode === 'ECONNREFUSED' ||
+      causeCode === 'EAI_AGAIN' ||
+      causeCode === 'UND_ERR_CONNECT_TIMEOUT' ||
+      causeCode === 'UND_ERR_SOCKET' ||
       message.includes('timeout') ||
       message.includes('econnrefused') ||
       message.includes('network') ||
       message.includes('503') ||
       message.includes('502') ||
-      message.includes('504')
+      message.includes('504') ||
+      message.includes('fetch failed')
     );
   }
 

--- a/src/util/fetch/errors.ts
+++ b/src/util/fetch/errors.ts
@@ -290,14 +290,17 @@ export function isTransientConnectionError(error: Error | undefined): boolean {
     return false;
   }
 
-  // Check error.code first — more robust across Node.js versions than
-  // parsing error messages, since system errors always set .code.
-  const code = (error as SystemError).code;
+  // Check error.code first (and nested cause.code for Node native fetch/undici errors)
+  // — more robust across Node.js versions than parsing error messages, since system errors
+  // always set .code.
+  const code =
+    (error as SystemError).code || ((error as SystemError).cause as SystemError | undefined)?.code;
   if (code === 'ECONNRESET' || code === 'EPIPE') {
     return true;
   }
 
-  const message = (error.message ?? '').toLowerCase();
+  const causeMessage = ((error as SystemError).cause as Error | undefined)?.message ?? '';
+  const message = `${error.message ?? ''} ${causeMessage}`.toLowerCase();
   // EPROTO can wrap permanent TLS misconfigs. Exclude when paired with
   // known permanent error phrases to avoid futile retries.
   if (

--- a/test/scheduler/retryPolicy.test.ts
+++ b/test/scheduler/retryPolicy.test.ts
@@ -128,4 +128,44 @@ describe('shouldRetry', () => {
     });
     expect(shouldRetry(0, error, true, DEFAULT_RETRY_POLICY)).toBe(true);
   });
+
+  describe('Nested error cause and Node.js native fetch error detection', () => {
+    it('should retry TypeError: fetch failed with ETIMEDOUT cause code', () => {
+      const cause = new Error('Connect timeout');
+      (cause as { code?: string }).code = 'ETIMEDOUT';
+      const error = new TypeError('fetch failed', { cause });
+
+      expect(shouldRetry(0, error, false, DEFAULT_RETRY_POLICY)).toBe(true);
+    });
+
+    it('should retry TypeError: fetch failed with undici UND_ERR_CONNECT_TIMEOUT cause code', () => {
+      const cause = new Error('Connect Timeout');
+      (cause as { code?: string }).code = 'UND_ERR_CONNECT_TIMEOUT';
+      const error = new TypeError('fetch failed', { cause });
+
+      expect(shouldRetry(0, error, false, DEFAULT_RETRY_POLICY)).toBe(true);
+    });
+
+    it('should retry TypeError: fetch failed with temporary DNS failure EAI_AGAIN cause code', () => {
+      const cause = new Error('getaddrinfo EAI_AGAIN api.openai.com');
+      (cause as { code?: string }).code = 'EAI_AGAIN';
+      const error = new TypeError('fetch failed', { cause });
+
+      expect(shouldRetry(0, error, false, DEFAULT_RETRY_POLICY)).toBe(true);
+    });
+
+    it('should retry when cause message contains transient network phrase', () => {
+      const cause = new Error('connect ECONNREFUSED 127.0.0.1:11434');
+      const error = new TypeError('fetch failed', { cause });
+
+      expect(shouldRetry(0, error, false, DEFAULT_RETRY_POLICY)).toBe(true);
+    });
+
+    it('should not retry when cause represents a non-transient user error', () => {
+      const cause = new Error('Invalid JSON format');
+      const error = new Error('Request validation failed', { cause });
+
+      expect(shouldRetry(0, error, false, DEFAULT_RETRY_POLICY)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Expands transient error detection in `shouldRetry` and `isTransientConnectionError` to inspect nested `error.cause` properties.

In Node.js 20+ and `undici`, native `fetch` wraps socket timeouts and network drops as `TypeError: fetch failed` with the actual system error code (`ETIMEDOUT`, `ECONNRESET`, `UND_ERR_CONNECT_TIMEOUT`, `EAI_AGAIN`) attached to `error.cause`. Previously, the scheduler only inspected top-level `error.code` and `error.message`, causing transient `fetch failed` connection timeouts during long evaluation runs to fail immediately without retrying.

### Key Changes
* Updated `isTransientConnectionError` in `src/util/fetch/errors.ts` to inspect `error.code` and `error.cause.code`.
* Updated `shouldRetry` in `src/scheduler/retryPolicy.ts` to inspect transient system codes (`ETIMEDOUT`, `EAI_AGAIN`, `ECONNREFUSED`, `UND_ERR_*`) across both top-level error and nested `cause`.
* Added comprehensive unit test coverage in `test/scheduler/retryPolicy.test.ts`.

### Tests
- [x] Unit tests for `TypeError: fetch failed` with `ETIMEDOUT` cause
- [x] Unit tests for `TypeError: fetch failed` with `UND_ERR_CONNECT_TIMEOUT` cause
- [x] Unit tests for `TypeError: fetch failed` with temporary DNS failure `EAI_AGAIN` cause
- [x] Unit tests verifying non-transient user errors with cause are not retried