### PR TITLE
test(eval): stop watch-path tests depending on the default-config cache

### DIFF
--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -557,19 +557,23 @@ describe('evalCommand', () => {
     // (`path.dirname(configPaths[0])`), not from the resolveConfigs mock.
     const watchBase = path.dirname(defaultConfigPath);
 
-    // doEval() also probes the default config filenames via loadDefaultConfig(), which
-    // shares this module-level mock and memoizes into a module-level cache. Whether that
-    // probe reaches the mock at all depends on which sibling test warmed the cache first,
-    // so `not.toHaveBeenCalled()` on the raw mock passes or fails by test order alone.
-    // The watch-path recovery branch resolves through globSync() before reading, so only
-    // its reads carry an absolute path -- count those and ignore the discovery probe.
-    const configRecoveryReads = () =>
-      vi
-        .mocked(maybeReadConfig)
-        .mock.calls.map(([configPath]) => String(configPath))
-        .filter((configPath) => path.isAbsolute(configPath));
+    // doEval() -> runEvaluation() calls loadDefaultConfig(), which probes the default
+    // config filenames through the same `maybeReadConfig` mock these tests assert on and
+    // memoizes the answer in a module-level cache. Whether that probe runs at all -- and
+    // whether it "finds" the mocked config and rewrites cmdObj.config with it -- then
+    // depends on which sibling test warmed the cache first. Pin it to "no default config
+    // found" so every test here drives the same path and only the watch-path recovery
+    // branch under test can reach `maybeReadConfig`.
+    let loadDefaultConfigSpy: ReturnType<typeof vi.spyOn>;
+
+    afterEach(() => {
+      loadDefaultConfigSpy.mockRestore();
+    });
 
     beforeEach(() => {
+      loadDefaultConfigSpy = vi
+        .spyOn(defaultConfigModule, 'loadDefaultConfig')
+        .mockResolvedValue({ defaultConfig: {}, defaultConfigPath: undefined });
       // Sibling tests queue `mockReturnValueOnce` values on this shared mock and
       // restore only its default in `finally`, which leaves the queue intact if the
       // test bails early. A leftover "missing API keys" value fails the run before it
@@ -687,7 +691,7 @@ describe('evalCommand', () => {
         {},
       );
 
-      expect(configRecoveryReads()).toEqual([]);
+      expect(maybeReadConfig).not.toHaveBeenCalled();
     });
 
     it('expands a --config glob before recovering raw tests', async () => {
@@ -744,7 +748,7 @@ describe('evalCommand', () => {
         {},
       );
 
-      expect(configRecoveryReads()).toEqual([]);
+      expect(maybeReadConfig).not.toHaveBeenCalled();
       const lastCall = chokidarMocks.watch.mock.calls.at(-1) as unknown as [string[]] | undefined;
       expect(lastCall?.[0] ?? []).toContain(path.resolve(process.cwd(), 'cli-cases.csv'));
     });
@@ -781,7 +785,7 @@ describe('evalCommand', () => {
         {},
       );
 
-      expect(configRecoveryReads()).toEqual([]);
+      expect(maybeReadConfig).not.toHaveBeenCalled();
       const watched = (chokidarMocks.watch.mock.calls.at(-1) as unknown as [string[]])[0];
       expect(watched).toContain(path.resolve(watchBase, 'cli-cases.csv'));
       expect(watched).not.toContain(path.resolve(watchBase, 'config-cases.yaml'));

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -557,6 +557,18 @@ describe('evalCommand', () => {
     // (`path.dirname(configPaths[0])`), not from the resolveConfigs mock.
     const watchBase = path.dirname(defaultConfigPath);
 
+    // doEval() also probes the default config filenames via loadDefaultConfig(), which
+    // shares this module-level mock and memoizes into a module-level cache. Whether that
+    // probe reaches the mock at all depends on which sibling test warmed the cache first,
+    // so `not.toHaveBeenCalled()` on the raw mock passes or fails by test order alone.
+    // The watch-path recovery branch resolves through globSync() before reading, so only
+    // its reads carry an absolute path -- count those and ignore the discovery probe.
+    const configRecoveryReads = () =>
+      vi
+        .mocked(maybeReadConfig)
+        .mock.calls.map(([configPath]) => String(configPath))
+        .filter((configPath) => path.isAbsolute(configPath));
+
     beforeEach(() => {
       // Sibling tests queue `mockReturnValueOnce` values on this shared mock and
       // restore only its default in `finally`, which leaves the queue intact if the
@@ -675,7 +687,7 @@ describe('evalCommand', () => {
         {},
       );
 
-      expect(maybeReadConfig).not.toHaveBeenCalled();
+      expect(configRecoveryReads()).toEqual([]);
     });
 
     it('expands a --config glob before recovering raw tests', async () => {
@@ -732,7 +744,7 @@ describe('evalCommand', () => {
         {},
       );
 
-      expect(maybeReadConfig).not.toHaveBeenCalled();
+      expect(configRecoveryReads()).toEqual([]);
       const lastCall = chokidarMocks.watch.mock.calls.at(-1) as unknown as [string[]] | undefined;
       expect(lastCall?.[0] ?? []).toContain(path.resolve(process.cwd(), 'cli-cases.csv'));
     });
@@ -769,7 +781,7 @@ describe('evalCommand', () => {
         {},
       );
 
-      expect(maybeReadConfig).not.toHaveBeenCalled();
+      expect(configRecoveryReads()).toEqual([]);
       const watched = (chokidarMocks.watch.mock.calls.at(-1) as unknown as [string[]])[0];
       expect(watched).toContain(path.resolve(watchBase, 'cli-cases.csv'));
       expect(watched).not.toContain(path.resolve(watchBase, 'config-cases.yaml'));


### PR DESCRIPTION
## Summary

Three `watch paths for tests` cases in `test/commands/eval.test.ts` asserted `expect(maybeReadConfig).not.toHaveBeenCalled()`. That mock is shared with `loadDefaultConfig()`, which `doEval()` also calls and which memoizes into a module-level cache in `src/util/config/default.ts`:

```
doEval (src/node/doEval.ts:1032)
  → runEvaluation (src/node/doEval.ts:303)
    → loadDefaultConfig (src/util/config/default.ts:33)
      → maybeReadConfig('config.yaml')
```

So the assertion passed only when an earlier sibling had already warmed that cache. **Run any of the three alone and all three fail.**

Worse than a noisy assertion: with a cold cache `loadDefaultConfig()` doesn't merely *call* `maybeReadConfig`, it **finds** the config these tests mock and rewrites `cmdObj.config` with it — so the whole block took a different code path depending on which sibling ran first.

Under CI's shuffled order this reddens the full-suite job at random. It failed `Test on Node 22.22 and ubuntu-latest` on an unrelated dependency PR (#10571), and reproduces on `main` **and on its parent** with `--sequence.seed=1788240841646` — pre-existing, not introduced by any recent change.

## Fix

Pin `loadDefaultConfig()` to "no default config found" for the whole block, matching how the rest of this file already stubs it. Every test then drives the same path, only the watch-path recovery branch under test can reach `maybeReadConfig`, and **the original strict assertions stay exactly as they were on `main`** — the net diff is the pin, not looser expectations.

<details>
<summary>Why not just narrow the assertion?</summary>

The first pass filtered the shared mock's calls down to absolute paths (the recovery branch resolves through `globSync()` before reading, so only its reads are absolute). That worked, but it coupled the test to an implementation detail and left the real nondeterminism — the `cmdObj.config` rewrite — in place. Pinning the source fixes the behavior, not just the assertion.

</details>

## Regression power preserved

| Mutation | Result |
|---|---|
| force the `cliTests` branch off (recovery always runs) | `--tests` and `--vars` tests fail ✅ |
| stub out `isDeclarativeConfig` (executable config re-read) | executable-config test fails ✅ |

## Validation

- Each of the three previously order-dependent tests passes **alone** (all three failed alone before)
- Full file passes at seed `1788240841646` (previously failing), in natural order, and across **12 seeds**
- `test/commands/**` + `test-hygiene` → **854 passed**
- `npx tsc --noEmit` clean; `biome ci` clean