### PR TITLE
test(eval): isolate watch config fixtures

### DIFF
--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -657,6 +657,7 @@ describe('evalCommand', () => {
       // vm.runInContext() for CommonJS and is not cached. Reading it again here to
       // recover the raw `tests` value would execute the user's config a second time,
       // so executable formats are skipped.
+      defaultConfigModule.clearConfigCache();
       const config = { prompts: [], providers: [], tests: [] } as UnifiedConfig;
       vi.mocked(resolveConfigs).mockResolvedValue({
         config,
@@ -671,10 +672,11 @@ describe('evalCommand', () => {
       await doEval(
         { watch: true, write: false, config: ['promptfooconfig.js'] },
         config,
-        defaultConfigPath,
+        undefined,
         {},
       );
 
+      expect(chokidarMocks.watch).toHaveBeenCalledOnce();
       expect(maybeReadConfig).not.toHaveBeenCalled();
     });
 

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -558,11 +558,16 @@ describe('evalCommand', () => {
     const watchBase = path.dirname(defaultConfigPath);
 
     beforeEach(() => {
+      defaultConfigModule.clearConfigCache();
       // Sibling tests queue `mockReturnValueOnce` values on this shared mock and
       // restore only its default in `finally`, which leaves the queue intact if the
       // test bails early. A leftover "missing API keys" value fails the run before it
       // reaches the watcher, which file order hides and CI's shuffled order does not.
       vi.mocked(checkProviderApiKeys).mockReset().mockReturnValue(new Map());
+    });
+
+    afterEach(() => {
+      defaultConfigModule.clearConfigCache();
     });
 
     async function watchedPathsFor(
@@ -657,7 +662,6 @@ describe('evalCommand', () => {
       // vm.runInContext() for CommonJS and is not cached. Reading it again here to
       // recover the raw `tests` value would execute the user's config a second time,
       // so executable formats are skipped.
-      defaultConfigModule.clearConfigCache();
       const config = { prompts: [], providers: [], tests: [] } as UnifiedConfig;
       vi.mocked(resolveConfigs).mockResolvedValue({
         config,
@@ -723,14 +727,15 @@ describe('evalCommand', () => {
         testSuite: { prompts: [], providers: [] } as TestSuite,
         basePath: watchBase,
       });
+      vi.mocked(globSync).mockImplementation((pattern) => [String(pattern)]);
       vi.mocked(evaluate).mockImplementationOnce(
         async (_testSuite, evalRecord) => evalRecord as Eval,
       );
 
       await doEval(
-        { watch: true, write: false, tests: 'file://cli-cases.csv' },
+        { watch: true, write: false, config: [defaultConfigPath], tests: 'file://cli-cases.csv' },
         config,
-        defaultConfigPath,
+        undefined,
         {},
       );
 
@@ -765,9 +770,9 @@ describe('evalCommand', () => {
       );
 
       await doEval(
-        { watch: true, write: false, vars: 'cli-cases.csv' },
+        { watch: true, write: false, config: [defaultConfigPath], vars: 'cli-cases.csv' },
         config,
-        defaultConfigPath,
+        undefined,
         {},
       );
 


### PR DESCRIPTION
## Summary

- Isolate the executable-config and CLI test-override fixtures from unrelated default-config discovery by using explicit config paths with no default path.
- Clear the default-config cache before and after each watch-path fixture so tests do not rely on earlier reads, and verify that the executable-config test reaches the watcher.
- Make the `--tests` fixture's config re-read reachable so its no-read assertion actually verifies the override guard.
- Keep the existing assertion that executable configs are never re-read; no production behavior changes.

## Why

Main CI run [33475240233](https://github.com/promptfoo/promptfoo/actions/runs/33475240233) failed in the executable-config fixture on Node 26 Linux and Node 24 Windows. The fixture supplied an unrelated default config path, so a cold cache legitimately triggered discovery reads before the watcher logic. It passed only when an earlier test had warmed the cache. The neighboring `--tests` / `--vars` fixtures had the same dependency, confirmed by the first PR CI run's macOS shuffle seed. These tests and the implementation are unchanged by the Rollup dependency merge.

## Validation

- Reproduced on unmodified main with shuffle seed `1788242009228`: 131 passed, one failed.
- Reproduced the remaining `--vars` fixture failure with PR CI seed `1788242880264`.
- Follow-up verification is running against all three CI seeds plus seven additional seeds, then the full backend suite.
