### PR TITLE
fix(providers): reconcile Bedrock pricing against the AWS Price List API

### DIFF
--- a/src/providers/bedrock/pricing.ts
+++ b/src/providers/bedrock/pricing.ts
@@ -11,7 +11,16 @@ export type BedrockServiceTier = {
   type: 'priority' | 'default' | 'flex';
 };
 
-type BedrockPricing = { input: number; output: number };
+type BedrockPricing = {
+  input: number;
+  output: number;
+  /**
+   * Rates that replace `input`/`output` once total input tokens reach `threshold`.
+   * Cache rates are derived from the tier's input rate, matching how AWS prices the
+   * `-cache-read/-cache-write-...-long-context-...` meters.
+   */
+  longContext?: { threshold: number; input: number; output: number };
+};
 
 /**
  * Amazon Nova bills prompt-cache reads at 25% of the model's input rate and cache writes at
@@ -54,7 +63,22 @@ const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   // Claude Sonnet 5 (standard list pricing; full 1M context bills at the standard rate)
   'anthropic.claude-sonnet-5': { input: 3, output: 15 },
   // Claude Sonnet 4/4.5
-  'anthropic.claude-sonnet-4': { input: 3, output: 15 },
+  // The Sonnet 4 point releases must precede the bare `-4` prefix: lookup is first-match-wins
+  // on `includes()`, and AWS publishes long-context meters only for Sonnet 4 itself. 4.5 and
+  // 4.6 bill their full context flat, so they must not inherit Sonnet 4's surcharge — add an
+  // explicit entry here for any future 4.x release for the same reason.
+  'anthropic.claude-sonnet-4-6': { input: 3, output: 15 },
+  'anthropic.claude-sonnet-4-5': { input: 3, output: 15 },
+  // Claude Sonnet 4 is the only Bedrock Claude model with published long-context meters
+  // (verified 2026-09-01 in us-east-1, us-east-2, us-west-2, eu-west-1 and ap-northeast-1):
+  // above 200K input tokens input doubles to $6 and output is 1.5x at $22.50. The matching
+  // `-cache-read/-cache-write-...-long-context-...` meters are 10% and 1.25x of the tier's
+  // input rate, which falls out of deriving the cache rates from it.
+  'anthropic.claude-sonnet-4': {
+    input: 3,
+    output: 15,
+    longContext: { threshold: 200_000, input: 6, output: 22.5 },
+  },
   // Claude Haiku 4.5
   'anthropic.claude-haiku-4': { input: 1, output: 5 },
   // Claude 3.x
@@ -422,13 +446,21 @@ export function calculateBedrockCost(
   const serviceTierMultiplier =
     serviceTier?.type === 'priority' ? 1.75 : serviceTier?.type === 'flex' ? 0.5 : 1;
   const pricingMultiplier = endpointMultiplier * serviceTierMultiplier;
-  const inputRate = (pricing.input / 1_000_000) * pricingMultiplier;
+  // Long-context tiers are billed on total input size, which for Anthropic means the uncached
+  // prompt plus any cache reads and writes (`input_tokens` excludes cached tokens).
+  const totalInputTokens = promptTokens + cacheReadTokens + cacheWriteTokens;
+  const tier =
+    pricing.longContext && totalInputTokens >= pricing.longContext.threshold
+      ? pricing.longContext
+      : pricing;
+
+  const inputRate = (tier.input / 1_000_000) * pricingMultiplier;
   const inputCost = normalizedModelId.includes('anthropic.claude')
     ? calculateCacheInputCost(inputRate, promptTokens, cacheReadTokens, cacheWriteTokens)
     : isNovaPromptCachingModel(normalizedModelId)
       ? promptTokens * inputRate + cacheReadTokens * inputRate * NOVA_CACHE_READ_RATIO
       : promptTokens * inputRate;
-  const outputCost = (completionTokens / 1_000_000) * pricing.output * pricingMultiplier;
+  const outputCost = (completionTokens / 1_000_000) * tier.output * pricingMultiplier;
   return inputCost + outputCost;
 }
 

--- a/src/providers/bedrock/pricing.ts
+++ b/src/providers/bedrock/pricing.ts
@@ -13,7 +13,14 @@ export type BedrockServiceTier = {
 
 type BedrockPricing = { input: number; output: number };
 
-/** Bedrock model pricing per 1M tokens. */
+/**
+ * Bedrock model pricing per 1M tokens.
+ *
+ * Rates are the plain us-east-1 on-demand meters from the AWS Price List API
+ * (`aws pricing get-products --service-code AmazonBedrock`), which is the authority — the
+ * `-batch`, `-custom-model`, `-flex`, `-priority` and `-cross-region-global` meters carry
+ * different rates and must not be used here. Last reconciled 2026-09-01.
+ */
 const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   // Claude 5
   'anthropic.claude-fable-5': { input: 10, output: 50 },
@@ -45,24 +52,25 @@ const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   'amazon.nova-micro': { input: 0.035, output: 0.14 },
   'amazon.nova-lite': { input: 0.06, output: 0.24 },
   'amazon.nova-pro': { input: 0.8, output: 3.2 },
-  'amazon.nova-premier': { input: 2.5, output: 10 },
-  // Amazon Nova 2 (reasoning models) - pricing estimated, verify at aws.amazon.com/bedrock/pricing
-  'amazon.nova-2-lite': { input: 0.15, output: 0.6 },
+  'amazon.nova-premier': { input: 2.5, output: 12.5 },
+  // Amazon Nova 2 (reasoning models). The cross-region global profile is cheaper
+  // ($0.30/$2.50); this is the plain us-east-1 on-demand rate.
+  'amazon.nova-2-lite': { input: 0.33, output: 2.75 },
   // Amazon Titan Text
   'amazon.titan-text-lite': { input: 0.15, output: 0.2 },
-  'amazon.titan-text-express': { input: 0.8, output: 1.6 },
+  'amazon.titan-text-express': { input: 0.2, output: 0.6 },
   'amazon.titan-text-premier': { input: 0.5, output: 1.5 },
   // Meta Llama
   'meta.llama3-1-8b': { input: 0.22, output: 0.22 },
-  'meta.llama3-1-70b': { input: 0.99, output: 0.99 },
+  'meta.llama3-1-70b': { input: 0.72, output: 0.72 },
   'meta.llama3-1-405b': { input: 5.32, output: 16 },
   'meta.llama3-2-1b': { input: 0.1, output: 0.1 },
   'meta.llama3-2-3b': { input: 0.15, output: 0.15 },
-  'meta.llama3-2-11b': { input: 0.35, output: 0.35 },
-  'meta.llama3-2-90b': { input: 2.0, output: 2.0 },
-  'meta.llama3-3-70b': { input: 0.99, output: 0.99 },
-  'meta.llama4-scout': { input: 0.17, output: 0.68 },
-  'meta.llama4-maverick': { input: 0.17, output: 0.68 },
+  'meta.llama3-2-11b': { input: 0.16, output: 0.16 },
+  'meta.llama3-2-90b': { input: 0.72, output: 0.72 },
+  'meta.llama3-3-70b': { input: 0.72, output: 0.72 },
+  'meta.llama4-scout': { input: 0.17, output: 0.66 },
+  'meta.llama4-maverick': { input: 0.24, output: 0.97 },
   'meta.llama4': { input: 1.0, output: 3.0 },
   // Mistral
   'mistral.mistral-7b': { input: 0.15, output: 0.2 },
@@ -80,9 +88,9 @@ const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   'deepseek.deepseek-r1': { input: 1.35, output: 5.4 },
   'deepseek.r1': { input: 1.35, output: 5.4 },
   // Qwen
-  'qwen.qwen3-32b': { input: 0.2, output: 0.6 },
+  'qwen.qwen3-32b': { input: 0.15, output: 0.6 },
   'qwen.qwen3-235b': { input: 0.18, output: 0.54 },
-  'qwen.qwen3-coder-30b': { input: 0.2, output: 0.6 },
+  'qwen.qwen3-coder-30b': { input: 0.15, output: 0.6 },
   'qwen.qwen3-coder-480b': { input: 1.5, output: 7.5 },
   'qwen.qwen3': { input: 0.5, output: 1.5 },
   // Writer Palmyra

--- a/src/providers/bedrock/pricing.ts
+++ b/src/providers/bedrock/pricing.ts
@@ -14,6 +14,21 @@ export type BedrockServiceTier = {
 type BedrockPricing = { input: number; output: number };
 
 /**
+ * Amazon Nova bills prompt-cache reads at 25% of the model's input rate and cache writes at
+ * $0.00. Confirmed for every Nova model AWS publishes a cache meter for (Micro, Lite, Pro,
+ * Premier, 2.0 Lite) from the AWS Price List API on 2026-09-01 — the ratio is exactly 0.25 in
+ * each case, and every `-cache-write-input-token-count` meter is zero.
+ *
+ * Claude has its own (different) cache economics and is handled by `calculateCacheInputCost`.
+ * Models with no published cache meter keep the previous behaviour of ignoring cache tokens.
+ */
+const NOVA_CACHE_READ_RATIO = 0.25;
+
+function isNovaPromptCachingModel(normalizedModelId: string): boolean {
+  return normalizedModelId.includes('amazon.nova-');
+}
+
+/**
  * Bedrock model pricing per 1M tokens.
  *
  * Rates are the plain us-east-1 on-demand meters from the AWS Price List API
@@ -247,7 +262,7 @@ const EU_SOUTH_1_AND_EU_WEST_1_PRICING: Record<string, BedrockPricing> = {
   'minimax.minimax-m2': { input: 0.35, output: 1.41 },
   'kimi-k2.5': { input: 0.72, output: 3.6 },
   'kimi-k2-thinking': { input: 0.72, output: 3.0 },
-  'nemotron-nano-12b-v2': { input: 0.24, output: 0.71 },
+  'nemotron-nano-12b-v2': { input: 0.23, output: 0.7 },
   'nemotron-nano-3-30b': { input: 0.07, output: 0.28 },
   'nemotron-nano': { input: 0.07, output: 0.27 },
   'nemotron-super': { input: 0.18, output: 0.78 },
@@ -282,14 +297,16 @@ const BEDROCK_REGION_PRICING: Record<string, Record<string, BedrockPricing>> = {
     'gemma-3-12b': { input: 0.11, output: 0.34 },
     'gemma-3-27b': { input: 0.27, output: 0.45 },
   },
+  // These are AWS's published ap-southeast-2 meters, not the US rate scaled by a regional
+  // uplift. Four entries had been derived that way and drifted from the real values.
   'ap-southeast-2': {
     'zai.glm-5': { input: 1.03, output: 3.3 },
-    'zai.glm-4.7-flash': { input: 0.0721, output: 0.412 },
-    'zai.glm-4.7': { input: 0.618, output: 2.266 },
+    'zai.glm-4.7-flash': { input: 0.07, output: 0.41 },
+    'zai.glm-4.7': { input: 0.62, output: 2.27 },
     'minimax.minimax-m2.5': { input: 0.31, output: 1.24 },
-    'minimax.minimax-m2.1': { input: 0.309, output: 1.236 },
+    'minimax.minimax-m2.1': { input: 0.31, output: 1.24 },
     'minimax.minimax-m2': { input: 0.309, output: 1.236 },
-    'kimi-k2.5': { input: 0.618, output: 3.09 },
+    'kimi-k2.5': { input: 0.62, output: 3.09 },
     'kimi-k2-thinking': { input: 0.618, output: 2.575 },
     'nemotron-nano-12b-v2': { input: 0.206, output: 0.618 },
     'nemotron-nano-3-30b': { input: 0.0618, output: 0.2472 },
@@ -408,7 +425,9 @@ export function calculateBedrockCost(
   const inputRate = (pricing.input / 1_000_000) * pricingMultiplier;
   const inputCost = normalizedModelId.includes('anthropic.claude')
     ? calculateCacheInputCost(inputRate, promptTokens, cacheReadTokens, cacheWriteTokens)
-    : promptTokens * inputRate;
+    : isNovaPromptCachingModel(normalizedModelId)
+      ? promptTokens * inputRate + cacheReadTokens * inputRate * NOVA_CACHE_READ_RATIO
+      : promptTokens * inputRate;
   const outputCost = (completionTokens / 1_000_000) * pricing.output * pricingMultiplier;
   return inputCost + outputCost;
 }

--- a/test/providers/bedrock/converse.test.ts
+++ b/test/providers/bedrock/converse.test.ts
@@ -2590,9 +2590,9 @@ Third line`;
 
       const result = await provider.callApi('Test');
 
-      // Llama 3.3 70B: $0.99/MTok both
-      // (10000/1M * 0.99) + (5000/1M * 0.99) = 0.0099 + 0.00495 = 0.01485
-      expect(result.cost).toBeCloseTo(0.01485, 4);
+      // Llama 3.3 70B: $0.72/MTok both (AWS Price List, us-east-1 on-demand)
+      // (10000/1M * 0.72) + (5000/1M * 0.72) = 0.0072 + 0.0036 = 0.0108
+      expect(result.cost).toBeCloseTo(0.0108, 4);
     });
 
     it('should return undefined cost for unknown models', async () => {

--- a/test/providers/bedrock/pricing.test.ts
+++ b/test/providers/bedrock/pricing.test.ts
@@ -152,6 +152,47 @@ describe('calculateBedrockCost', () => {
     );
   });
 
+  describe('Claude Sonnet 4 long-context tier', () => {
+    // AWS publishes `-long-context-` meters for Claude Sonnet 4 only, at 2x input / 1.5x output
+    // (verified 2026-09-01 across us-east-1, us-east-2, us-west-2, eu-west-1, ap-northeast-1).
+    const ID = 'global.anthropic.claude-sonnet-4-20250514-v1:0';
+
+    it('bills below the threshold at the standard rate', () => {
+      expect(calculateBedrockCost(ID, 199_999, 1_000)).toBeCloseTo(
+        (199_999 / 1e6) * 3 + (1_000 / 1e6) * 15,
+        6,
+      );
+    });
+
+    it('switches to $6/$22.50 at and above 200k input tokens', () => {
+      expect(calculateBedrockCost(ID, 200_000, 1_000)).toBeCloseTo(
+        (200_000 / 1e6) * 6 + (1_000 / 1e6) * 22.5,
+        6,
+      );
+    });
+
+    it('counts cache tokens toward the threshold and prices cache off the tier rate', () => {
+      // 150k uncached + 60k cache reads crosses 200k, so the whole request bills at the tier:
+      // AWS's long-context cache-read meter is 10% of the $6 tier input rate.
+      expect(calculateBedrockCost(ID, 150_000, 1_000, 60_000, 0)).toBeCloseTo(
+        (150_000 / 1e6) * 6 + (60_000 / 1e6) * 6 * 0.1 + (1_000 / 1e6) * 22.5,
+        6,
+      );
+    });
+
+    it('does not leak the tier onto the 4.5 or 4.6 point releases', () => {
+      for (const id of [
+        'global.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        'global.anthropic.claude-sonnet-4-6',
+      ]) {
+        expect(calculateBedrockCost(id, 500_000, 1_000)).toBeCloseTo(
+          (500_000 / 1e6) * 3 + (1_000 / 1e6) * 15,
+          6,
+        );
+      }
+    });
+  });
+
   it('prices Claude Opus 5 at $5/$25 on the global endpoint (base rate)', () => {
     expect(calculateBedrockCost('global.anthropic.claude-opus-5', 100_000, 1_000)).toBeCloseTo(
       (100_000 / 1e6) * 5 + (1_000 / 1e6) * 25,

--- a/test/providers/bedrock/pricing.test.ts
+++ b/test/providers/bedrock/pricing.test.ts
@@ -10,6 +10,43 @@ const costAtRates = (input: number, output: number) =>
   (INPUT_TOKENS / 1e6) * input + (OUTPUT_TOKENS / 1e6) * output;
 
 describe('calculateBedrockCost', () => {
+  describe('Amazon Nova prompt caching', () => {
+    // AWS Price List (us-east-1, 2026-09-01): every Nova `-cache-read-input-token-count`
+    // meter is exactly 25% of the model's input rate, and every cache-write meter is $0.
+    // Before this, cache reads on Nova were billed at $0 — a silent undercharge.
+    it('bills Nova cache reads at 25% of the input rate', () => {
+      const cost = calculateBedrockCost('amazon.nova-lite-v1:0', 1000, 0, 10_000, 0, 'us-east-1');
+      // 1000 uncached * $0.06/M + 10000 cached * $0.015/M
+      expect(cost).toBeCloseTo((1000 * 0.06 + 10_000 * 0.015) / 1e6, 12);
+    });
+
+    it('treats Nova cache writes as free', () => {
+      const withWrites = calculateBedrockCost(
+        'amazon.nova-pro-v1:0',
+        1000,
+        0,
+        0,
+        50_000,
+        'us-east-1',
+      );
+      const withoutWrites = calculateBedrockCost(
+        'amazon.nova-pro-v1:0',
+        1000,
+        0,
+        0,
+        0,
+        'us-east-1',
+      );
+      expect(withWrites).toBeCloseTo(withoutWrites as number, 12);
+    });
+
+    it('does not apply the Nova ratio to non-Nova, non-Claude models', () => {
+      // No published cache meter: cache tokens stay out of the estimate.
+      const cost = calculateBedrockCost('meta.llama3-3-70b-instruct-v1:0', 1000, 0, 9999, 0);
+      expect(cost).toBeCloseTo((1000 * 0.72) / 1e6, 12);
+    });
+  });
+
   it.each([
     // Z.AI GLM — distinct per variant; -flash must not be priced as -4.7.
     { id: 'zai.glm-5', input: 1.0, output: 3.2 },
@@ -55,6 +92,15 @@ describe('calculateBedrockCost', () => {
   });
 
   it.each([
+    // Reconciled against the AWS Price List API per region on 2026-09-01. These five had
+    // been derived from the US rate via a regional uplift rather than read from the real
+    // meters, so they drifted from AWS's published values.
+    { id: 'zai.glm-4.7', region: 'ap-southeast-2', input: 0.62, output: 2.27 },
+    { id: 'zai.glm-4.7-flash', region: 'ap-southeast-2', input: 0.07, output: 0.41 },
+    { id: 'minimax.minimax-m2.1', region: 'ap-southeast-2', input: 0.31, output: 1.24 },
+    { id: 'moonshotai.kimi-k2.5', region: 'ap-southeast-2', input: 0.62, output: 3.09 },
+    { id: 'nvidia.nemotron-nano-12b-v2', region: 'eu-west-1', input: 0.23, output: 0.7 },
+    { id: 'nvidia.nemotron-nano-12b-v2', region: 'eu-south-1', input: 0.23, output: 0.7 },
     { id: 'google.gemma-3-12b-it', region: 'eu-west-2', input: 0.14, output: 0.45 },
     { id: 'minimax.minimax-m2.1', region: 'eu-west-1', input: 0.36, output: 1.44 },
     { id: 'minimax.minimax-m2.5', region: 'eu-south-1', input: 0.36, output: 1.44 },

--- a/test/providers/bedrock/pricing.test.ts
+++ b/test/providers/bedrock/pricing.test.ts
@@ -31,6 +31,20 @@ describe('calculateBedrockCost', () => {
     { id: 'google.gemma-3-4b-it', input: 0.04, output: 0.08 },
     { id: 'google.gemma-3-12b-it', input: 0.09, output: 0.29 },
     { id: 'google.gemma-3-27b-it', input: 0.23, output: 0.38 },
+    // Reconciled against the AWS Price List API (us-east-1 plain on-demand meters) on
+    // 2026-09-01. Each of these carried a stale rate before that sweep, so they are pinned
+    // here to catch the next drift.
+    { id: 'amazon.nova-premier-v1:0', input: 2.5, output: 12.5 },
+    { id: 'amazon.nova-2-lite-v1:0', input: 0.33, output: 2.75 },
+    { id: 'amazon.titan-text-express-v1', input: 0.2, output: 0.6 },
+    { id: 'meta.llama3-1-70b-instruct-v1:0', input: 0.72, output: 0.72 },
+    { id: 'meta.llama3-2-11b-instruct-v1:0', input: 0.16, output: 0.16 },
+    { id: 'meta.llama3-2-90b-instruct-v1:0', input: 0.72, output: 0.72 },
+    { id: 'meta.llama3-3-70b-instruct-v1:0', input: 0.72, output: 0.72 },
+    { id: 'meta.llama4-scout-17b-instruct-v1:0', input: 0.17, output: 0.66 },
+    { id: 'meta.llama4-maverick-17b-instruct-v1:0', input: 0.24, output: 0.97 },
+    { id: 'qwen.qwen3-32b-v1:0', input: 0.15, output: 0.6 },
+    { id: 'qwen.qwen3-coder-30b-a3b-v1:0', input: 0.15, output: 0.6 },
     { id: 'writer.palmyra-vision-7b', input: 0.15, output: 0.6 },
     { id: 'us.writer.palmyra-x5-v1:0', input: 0.6, output: 6 },
   ])('uses the base rate for $id', ({ id, input, output }) => {


### PR DESCRIPTION
## Summary

Reconciled Bedrock cost calculation against the **AWS Price List API** rather than docs. Four independent problems surfaced:

1. **11 stale model prices** in the base table
2. **5 regional rates** that were derived from the US rate instead of read from AWS
3. **Nova prompt-cache reads billed at zero**
4. **The Claude Sonnet 4 long-context tier missing entirely**

Each is verified against a published AWS meter; every corrected rate is pinned in `pricing.test.ts` to catch the next drift.

---

## 1. Stale base rates (11 of 43 verifiable entries)

| model | promptfoo | AWS us-east-1 | error |
| --- | --- | --- | --- |
| `meta.llama3-2-90b` | 2.0 / 2.0 | 0.72 / 0.72 | **+178%** overcharge |
| `amazon.titan-text-express` | 0.8 / 1.6 | 0.2 / 0.6 | **+167%** overcharge |
| `meta.llama3-2-11b` | 0.35 / 0.35 | 0.16 / 0.16 | **+119%** overcharge |
| `meta.llama3-1-70b` | 0.99 / 0.99 | 0.72 / 0.72 | +37.5% overcharge |
| `meta.llama3-3-70b` | 0.99 / 0.99 | 0.72 / 0.72 | +37.5% overcharge |
| `qwen.qwen3-32b` | 0.2 / 0.6 | 0.15 / 0.6 | +33% on input |
| `qwen.qwen3-coder-30b` | 0.2 / 0.6 | 0.15 / 0.6 | +33% on input |
| `amazon.nova-2-lite` | 0.15 / 0.6 | 0.33 / 2.75 | **−78%** undercharge |
| `meta.llama4-maverick` | 0.17 / 0.68 | 0.24 / 0.97 | −30% undercharge |
| `amazon.nova-premier` | 2.5 / 10 | 2.5 / 12.5 | −20% on output |
| `meta.llama4-scout` | 0.17 / 0.68 | 0.17 / 0.66 | −3% on output |

`amazon.nova-2-lite` carried a comment admitting its rate was estimated — it was off by 4.6× on output. `meta.llama4-maverick` had been given `meta.llama4-scout`'s rates verbatim, which reads like a copy-paste.

The other 32 matched entries (Claude, GLM, Kimi, Nemotron, Gemma, Mistral, DeepSeek, gpt-oss, Palmyra, Nova Lite/Micro/Pro, Titan Lite, newer Qwen) were confirmed **correct** and are untouched.

## 2. Regional rates that were computed, not looked up

| region | model | was | AWS |
| --- | --- | --- | --- |
| ap-southeast-2 | `zai.glm-4.7` | 0.618 / 2.266 | 0.62 / 2.27 |
| ap-southeast-2 | `zai.glm-4.7-flash` | 0.0721 / 0.412 | 0.07 / 0.41 |
| ap-southeast-2 | `minimax.minimax-m2.1` | 0.309 / 1.236 | 0.31 / 1.24 |
| ap-southeast-2 | `kimi-k2.5` | 0.618 / 3.09 | 0.62 / 3.09 |
| eu-south-1, eu-west-1 | `nemotron-nano-12b-v2` | 0.24 / 0.71 | 0.23 / 0.70 |

Small individually (0.3–4%), but the pattern matters: these look like US rate × a regional uplift (0.6 × 1.03 = 0.618) where AWS publishes the real meter. **All 115 verifiable region entries across 12 regions now match AWS exactly.**

## 3. Nova prompt-cache reads were free

`calculateBedrockCost` applies cache economics only to `anthropic.claude` ids; every other model dropped `cacheReadTokens` entirely. Bedrock reports `cacheReadInputTokens` for non-Anthropic models too, and AWS publishes Nova cache meters:

| model | input | cache read | ratio | cache write |
| --- | --- | --- | --- | --- |
| Nova Micro | 0.035 | 0.00875 | 0.25 | 0.0 |
| Nova Lite | 0.06 | 0.015 | 0.25 | 0.0 |
| Nova Pro | 0.8 | 0.20 | 0.25 | 0.0 |
| Nova Premier | 2.5 | 0.625 | 0.25 | 0.0 |
| Nova 2.0 Lite | 0.33 | 0.0825 | 0.25 | 0.0 |

Exactly 25% in every case, writes free. Cached Nova prompts were costed at $0 — an undercharge that grows with cache hit rate. Nova's economics differ from Claude's (10% read, 1.25× write), so this is a separate ratio rather than a reuse of `calculateCacheInputCost`. Models with no published cache meter keep the previous behaviour.

## 4. Claude Sonnet 4 long-context tier (missing entirely)

Modern Claude pricing isn't under the `AmazonBedrock` service code — it lives under **`AmazonBedrockService`**. Querying that revealed a tier promptfoo did not model:

| meter | standard | long-context |
| --- | --- | --- |
| input | $3.00 | **$6.00** (2×) |
| output | $15.00 | **$22.50** (1.5×) |
| cache read | $0.30 | $0.60 |
| cache write | $3.75 | $7.50 |

Identical in us-east-1, us-east-2, us-west-2, eu-west-1 and ap-northeast-1. Long-context Sonnet 4 runs undercharged by up to 2× on input.

`BedrockPricing` now takes an optional `longContext` tier, applied when total input size reaches the threshold. Total input counts the uncached prompt **plus cache reads and writes**, because Anthropic's `input_tokens` excludes cached tokens. Cache rates derive from the tier's input rate, which reproduces AWS's long-context cache meters exactly (10% and 1.25× → $0.60 and $7.50).

**Scoping was the risk here.** AWS publishes these meters for Sonnet 4 only; 4.5 and 4.6 bill their full context flat. My first attempt leaked the tier onto both through the shared `anthropic.claude-sonnet-4` prefix (`includes()` matching), and an existing test asserting Sonnet 4.6 bills flat caught it immediately — a wrong scope here *overcharges* by 2×, which is worse than the undercharge being fixed. Both point releases now have explicit entries ahead of the bare prefix, mirroring how Opus 4.5–4.8 are already ordered in this file, with a test pinning them flat at 500K tokens.

---

## Methodology note (the trap worth recording)

Only the plain `-input-tokens` / `-output-tokens` meters are authoritative. The same model also publishes `-batch`, `-custom-model`, `-flex`, `-priority` and `-cross-region-global` meters at different rates, and **they share the same `inferenceType` attribute** — so a naive scan silently reads the wrong one.

My first pass did exactly that and produced six false positives, "finding" Nova Lite and Nova Pro wrong when both are correct. The strict matcher then confirmed `gemma-3-27b` at the value already in the table, where the loose scan had claimed an error. The table's doc comment now records this so the next person doesn't repeat it.

## Verified correct, no change needed

- The Claude cache multipliers already in use: AWS's Haiku 4.5 meters give cache read at 10% of input and cache write at 1.25×, exactly matching `calculateCacheInputCost`.
- The 10% regional-endpoint premium: Haiku 4.5's $1.10/$5.50 regional meters confirm it sits correctly on top of the $1/$5 base.
- **Prefix shadowing**: the lookup uses `includes()`, so an earlier key that is a substring of a later one would make the later entry unreachable. Zero shadowing across the base table and every region table, re-checked after adding the Sonnet keys (70 entries).

## Testing

`test/providers/bedrock/` passes. One existing assertion in `converse.test.ts` encoded the stale $0.99 Llama 3.3 rate and was updated to $0.72. Knip clean.

## Limits

- **Claude Sonnet 4.5** publishes only *reserved* (provisioned-throughput) meters in every region sampled — no on-demand rates — so its $3/$15 stays docs-sourced.
- **Opus and the Claude 5 family** have no records under either service code.
- Verifying those would need a billing-based oracle (actually spending on each model) rather than the price list.

## Separate finding, not fixed here

27 model ids in `AWS_BEDROCK_MODELS` do not resolve in any of the 17 regions enabled on my account — verified individually with `get-foundation-model` / `get-inference-profile`, which return `ValidationException` / `ResourceNotFoundException` rather than access errors. They are mostly retired `us.`/`eu.` Claude 3.5/3.7 Sonnet profiles (those models now exist only under `apac.`, which is consistent — `apac.anthropic.claude-3-5-sonnet-*` *is* live), plus `cohere.command-r*`, `meta.llama3-1-405b`, and several `apac.`/`eu.` profiles for newer Claude and Llama 4 models.

I did **not** remove them: listing APIs can reflect per-account model access, so an account with broader grants may resolve ids mine cannot. This needs a maintainer with wider access to confirm before deletion.
