### PR TITLE
fix(matchers): warn on self-grading via defaultTest.provider

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -230,6 +230,10 @@ Mistral, GitHub Models, Azure OpenAI, and Codex login credentials can each activ
 default. If you do not have access to the selected default or prefer a different judge, you can
 override the grader. There are several ways to do this, depending on your preferred workflow:
 
+:::note
+When none of these overrides is set, the grader falls back to `defaultTest.provider` — the provider that also generates the test responses — before the built-in default, so the same model grades its own output. Promptfoo prints a warning when it resolves this way; set an explicit grader at any level to silence it.
+:::
+
 1. Using the `--grader` CLI option:
 
    ```

--- a/src/matchers/providers.ts
+++ b/src/matchers/providers.ts
@@ -151,6 +151,24 @@ function isSimulatedUserProviderConfig(provider: GradingConfig['provider']): boo
   );
 }
 
+// Self-grading via the generator slot is usually a misconfiguration: with no
+// --grader, defaultTest.options.provider, or assertion-level provider, the
+// grader silently resolves to the same provider that produced the output.
+let hasWarnedAboutGeneratorSlotGrading = false;
+
+function warnAboutGeneratorSlotGradingOnce(providerId: string): void {
+  if (hasWarnedAboutGeneratorSlotGrading) {
+    return;
+  }
+  hasWarnedAboutGeneratorSlotGrading = true;
+  logger.warn(
+    `[Grading] Model-graded assertions are grading with defaultTest.provider ("${providerId}"), ` +
+      'the same provider that generates responses for tests without their own provider. ' +
+      'Grade with a different model via the --grader flag, defaultTest.options.provider, ' +
+      'or an assertion-level provider.',
+  );
+}
+
 export async function getGradingProvider(
   type: ProviderType,
   provider: GradingConfig['provider'],
@@ -222,6 +240,11 @@ export async function getGradingProvider(
         logger.debug('[Grading] Using provider from defaultTest fallback', {
           providerId: finalProvider.id(),
         });
+        // Only the generator slot overlaps the producer; options.provider is
+        // a deliberate grading choice and stays silent.
+        if (cfg === defaultTestObj?.provider) {
+          warnAboutGeneratorSlotGradingOnce(finalProvider.id());
+        }
       }
     } else {
       finalProvider = defaultProvider;

--- a/test/matchers/getGradingProvider.test.ts
+++ b/test/matchers/getGradingProvider.test.ts
@@ -398,4 +398,73 @@ describe('getGradingProvider', () => {
       expect(result).toBe(explicitProvider);
     });
   });
+
+  describe('generator-slot grading warn (#10581)', () => {
+    it('warns once when the grader falls back to defaultTest.provider', async () => {
+      vi.resetModules();
+      const { getGradingProvider: freshGetGradingProvider } = await import(
+        '../../src/matchers/providers'
+      );
+      const { default: freshLogger } = await import('../../src/logger');
+      const provider = createMockProvider({ id: 'openai:chat:gpt-4' });
+
+      (cliState as any).config = {
+        defaultTest: {
+          provider: 'openai:chat:gpt-4',
+        },
+      };
+      vi.mocked(loadApiProvider).mockResolvedValue(provider);
+      const warnSpy = vi.spyOn(freshLogger, 'warn').mockImplementation(() => freshLogger);
+
+      await freshGetGradingProvider('text', undefined, null);
+      await freshGetGradingProvider('text', undefined, null);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('openai:chat:gpt-4');
+    });
+
+    it('stays silent when grading comes from defaultTest.options.provider', async () => {
+      vi.resetModules();
+      const { getGradingProvider: freshGetGradingProvider } = await import(
+        '../../src/matchers/providers'
+      );
+      const { default: freshLogger } = await import('../../src/logger');
+      const provider = createMockProvider({ id: 'openai:chat:gpt-4o' });
+
+      (cliState as any).config = {
+        defaultTest: {
+          options: {
+            provider: 'openai:chat:gpt-4o',
+          },
+        },
+      };
+      vi.mocked(loadApiProvider).mockResolvedValue(provider);
+      const warnSpy = vi.spyOn(freshLogger, 'warn').mockImplementation(() => freshLogger);
+
+      await freshGetGradingProvider('text', undefined, null);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('stays silent with an explicit assertion provider', async () => {
+      vi.resetModules();
+      const { getGradingProvider: freshGetGradingProvider } = await import(
+        '../../src/matchers/providers'
+      );
+      const { default: freshLogger } = await import('../../src/logger');
+      const provider = createMockProvider({ id: 'openai:chat:gpt-4o-mini' });
+
+      (cliState as any).config = {
+        defaultTest: {
+          provider: 'openai:chat:gpt-4',
+        },
+      };
+      vi.mocked(loadApiProvider).mockResolvedValue(provider);
+      const warnSpy = vi.spyOn(freshLogger, 'warn').mockImplementation(() => freshLogger);
+
+      await freshGetGradingProvider('text', 'openai:chat:gpt-4o-mini', null);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #10581

With no `--grader`, no `defaultTest.options.provider`, and no assertion-level provider, `getGradingProvider` silently resolves the grader from `defaultTest.provider`, which is also the provider that generated the response, so the generator grades its own output and nothing says so.

This adds a warn-once when the generator slot is the one picked, naming the resolved provider and pointing at the three explicit overrides. A pick from `defaultTest.options.provider` is a deliberate grading choice and stays silent, as do explicit providers at any level. The model-graded metrics doc now records the fallback order.

## Test plan

- `test/matchers/getGradingProvider.test.ts` gains three cases: warns exactly once across repeated fallback resolutions, silent for `defaultTest.options.provider`, silent for an explicit provider. 26/26 pass, `test/matchers/` 365/365, `test/matchers/utils.test.ts` green, `npm run l && npm run f` clean, `npm run tsc` clean.
- The existing `defaultTest.provider` fallback behavior is unchanged; only the warning is new.
