### PR TITLE
fix(providers): normalize typed Responses messages

### DIFF
--- a/src/providers/responses/input.ts
+++ b/src/providers/responses/input.ts
@@ -66,9 +66,9 @@ function normalizeContentPart(part: unknown, role: unknown): unknown {
  * 'input_image', ..."), so multimodal prompts fail on every `*:responses:*` provider. Rewriting
  * the chat parts here lets the same prompt file target both surfaces.
  *
- * Only role-bearing message objects are touched. Items that carry their own `type` are
- * non-message input items (function calls, tool outputs, reasoning items) whose shape must be
- * preserved verbatim. A non-array input (a plain string prompt) is returned unchanged.
+ * Only role-bearing message objects are touched. Explicit `type: 'message'` input items are
+ * messages too; other typed items (function calls, tool outputs, reasoning items) must keep
+ * their shape verbatim. A non-array input (a plain string prompt) is returned unchanged.
  */
 export function normalizeResponsesInput<T>(input: T): T {
   if (!Array.isArray(input)) {
@@ -80,7 +80,11 @@ export function normalizeResponsesInput<T>(input: T): T {
       return item;
     }
     const message = item as UnknownRecord;
-    if (message.type !== undefined || !('role' in message) || !Array.isArray(message.content)) {
+    if (
+      (message.type !== undefined && message.type !== 'message') ||
+      !('role' in message) ||
+      !Array.isArray(message.content)
+    ) {
       return item;
     }
     return {

--- a/test/providers/responses/input.test.ts
+++ b/test/providers/responses/input.test.ts
@@ -78,15 +78,19 @@ describe('normalizeResponsesInput', () => {
     expect(normalizeResponsesInput(input)).toEqual(input);
   });
 
-  it('does not touch non-message items that carry their own type', () => {
-    // Function calls, tool outputs and reasoning items are input items, not chat messages;
-    // rewriting their shape would corrupt the request.
+  it('normalizes explicitly typed message items but preserves other typed input items', () => {
+    // Responses input messages commonly carry `type: "message"`, while function calls,
+    // tool outputs and reasoning items are not chat messages and must stay verbatim.
     const input = [
       { type: 'function_call', call_id: 'call_1', name: 'lookup', arguments: '{}' },
       { type: 'function_call_output', call_id: 'call_1', output: 'done' },
-      { type: 'message', role: 'user', content: [{ type: 'text', text: 'untouched' }] },
+      { type: 'message', role: 'user', content: [{ type: 'text', text: 'hello' }] },
     ];
-    expect(normalizeResponsesInput(input)).toEqual(input);
+    expect(normalizeResponsesInput(input)).toEqual([
+      { type: 'function_call', call_id: 'call_1', name: 'lookup', arguments: '{}' },
+      { type: 'function_call_output', call_id: 'call_1', output: 'done' },
+      { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+    ]);
   });
 
   it('leaves string content and unrecognized parts alone', () => {


### PR DESCRIPTION
## Summary
- normalize chat-format content inside explicit Responses `type: message` input items
- preserve function calls, tool outputs, and other non-message typed items unchanged
- add regression coverage for the typed-message boundary

## Verification
- failing-before/passing-after runtime repro with Node type stripping
- `node node_modules/typescript/bin/tsc --noEmit --pretty false`
- `node node_modules/prettier/bin/prettier.cjs --check src/providers/responses/input.ts test/providers/responses/input.test.ts`
- focused Vitest/Biome were blocked locally by corrupted native optional-dependency binaries in this worktree; CI will run from a clean install