### PR TITLE
feat(providers): add Claude Fable and Mythos 5.1

### DIFF
--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -55,6 +55,8 @@ The `anthropic` provider supports the following models via the messages API:
 
 | Model ID                                                            | Description            |
 | ------------------------------------------------------------------- | ---------------------- |
+| `anthropic:messages:claude-fable-5-1`                               | Claude Fable 5.1       |
+| `anthropic:messages:claude-mythos-5-1`                              | Claude Mythos 5.1      |
 | `anthropic:messages:claude-fable-5`                                 | Claude Fable 5         |
 | `anthropic:messages:claude-mythos-5`                                | Claude Mythos 5        |
 | `anthropic:messages:claude-opus-5`                                  | Claude Opus 5          |
@@ -95,6 +97,8 @@ Claude models are available across multiple platforms. Here's how the model name
 
 | Model             | Anthropic API                                  | Azure AI Foundry ([docs](/docs/providers/azure/#using-claude-models)) | AWS Bedrock ([docs](/docs/providers/aws-bedrock)) | GCP Vertex AI ([docs](/docs/providers/vertex)) |
 | ----------------- | ---------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------- | ---------------------------------------------- |
+| Claude Fable 5.1  | claude-fable-5-1                               | claude-fable-5-1                                                      | anthropic.claude-fable-5-1                        | claude-fable-5-1                               |
+| Claude Mythos 5.1 | claude-mythos-5-1                              | claude-mythos-5-1 (limited)                                           | anthropic.claude-mythos-5-1 (limited)             | claude-mythos-5-1 (limited)                    |
 | Claude Fable 5    | claude-fable-5                                 | claude-fable-5                                                        | anthropic.claude-fable-5                          | claude-fable-5                                 |
 | Claude Mythos 5   | claude-mythos-5                                | Not available                                                         | anthropic.claude-mythos-5 (limited)               | Limited availability; ID not public            |
 | Claude Opus 5     | claude-opus-5                                  | claude-opus-5                                                         | anthropic.claude-opus-5                           | claude-opus-5                                  |
@@ -557,6 +561,35 @@ tests:
   - vars:
       pdf_base64: file://document.pdf
 ```
+
+### Claude Fable 5.1 and Mythos 5.1
+
+Use the pinned model IDs below. Mythos 5.1 requires Project Glasswing access and
+provider approval.
+
+```yaml
+providers:
+  - id: anthropic:messages:claude-fable-5-1
+    config:
+      max_tokens: 4096
+      effort: high
+  - id: anthropic:messages:claude-mythos-5-1
+    config:
+      max_tokens: 4096
+      effort: high
+```
+
+Both models have a 1M-token context window and support up to 128K output tokens.
+Input and output cost $10 and $50 per million tokens, respectively. Cache reads cost
+**$0.25 per million tokens**, down from $1 on Fable 5 and Mythos 5; promptfoo includes
+this discount in its cost estimates. See [Anthropic's pricing](https://platform.claude.com/docs/en/about-claude/pricing).
+
+Thinking is always on, and the sampling and thinking normalization described below
+also applies to 5.1. Unlike Fable 5, 5.1 rejects forced tool use: promptfoo omits
+`tool_choice` with type `any` or `tool` and warns. Use `auto` or `none` instead.
+When replaying Fable 5.1 thinking blocks, keep earlier messages, system prompts,
+and tools unchanged; edited prefixes can cause API errors. See
+[Anthropic's migration notes](https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1).
 
 ### Claude Fable 5 and Mythos 5 notes
 

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -825,6 +825,19 @@ For Claude models (e.g., `anthropic.claude-fable-5`, `anthropic.claude-sonnet-5`
 
 #### Claude Fable and Mythos models
 
+[Claude Fable 5.1](https://aws.amazon.com/blogs/machine-learning/introducing-claude-fable-5-1-on-aws/)
+supports InvokeModel and Converse with the `global.anthropic.claude-fable-5-1` and
+`us.anthropic.claude-fable-5-1` inference profiles. For example, use
+`bedrock:global.anthropic.claude-fable-5-1` or
+`bedrock:converse:global.anthropic.claude-fable-5-1`.
+The explicit `bedrock:messages:anthropic.claude-fable-5-1` route uses the
+Anthropic-compatible Messages endpoint in `us-east-1`.
+
+Use `bedrock:anthropic.claude-mythos-5-1` for Mythos 5.1 through the Messages
+endpoint, with the API key configuration shown below. Mythos access requires
+provider approval. Both 5.1 models retain always-on thinking and use a lower
+cache-read price of $0.25 per million tokens before regional premiums.
+
 [Claude Fable 5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html)
 supports Bedrock Runtime and Converse. Use the `global.anthropic.claude-fable-5`
 inference profile — on-demand invocation of the base `anthropic.claude-fable-5` ID

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -831,7 +831,9 @@ supports InvokeModel and Converse with the `global.anthropic.claude-fable-5-1` a
 `bedrock:global.anthropic.claude-fable-5-1` or
 `bedrock:converse:global.anthropic.claude-fable-5-1`.
 The explicit `bedrock:messages:anthropic.claude-fable-5-1` route uses the
-Anthropic-compatible Messages endpoint in `us-east-1`.
+Anthropic-compatible Messages endpoint in `us-east-1`. For another provisioned
+endpoint, including AWS GovCloud, set `config.apiBaseUrl` to the Anthropic base
+URL supplied by AWS.
 
 Use `bedrock:anthropic.claude-mythos-5-1` for Mythos 5.1 through the Messages
 endpoint, with the API key configuration shown below. Mythos access requires

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -825,20 +825,31 @@ For Claude models (e.g., `anthropic.claude-fable-5`, `anthropic.claude-sonnet-5`
 
 #### Claude Fable and Mythos models
 
-[Claude Fable 5.1](https://aws.amazon.com/blogs/machine-learning/introducing-claude-fable-5-1-on-aws/)
-supports InvokeModel and Converse with the `global.anthropic.claude-fable-5-1` and
-`us.anthropic.claude-fable-5-1` inference profiles. For example, use
-`bedrock:global.anthropic.claude-fable-5-1` or
-`bedrock:converse:global.anthropic.claude-fable-5-1`.
-The explicit `bedrock:messages:anthropic.claude-fable-5-1` route uses the
-Anthropic-compatible Messages endpoint in `us-east-1`. For another provisioned
-endpoint, including AWS GovCloud, set `config.apiBaseUrl` to the Anthropic base
-URL supplied by AWS.
+[Claude Fable 5.1](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5-1.html)
+and [Claude Mythos 5.1](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-mythos-5-1.html)
+support InvokeModel, Converse, and the Anthropic-compatible Messages API on
+**Bedrock Runtime**. Use a `us.` or `global.` inference profile:
 
-Use `bedrock:anthropic.claude-mythos-5-1` for Mythos 5.1 through the Messages
-endpoint, with the API key configuration shown below. Mythos access requires
-provider approval. Both 5.1 models retain always-on thinking and use a lower
-cache-read price of $0.25 per million tokens before regional premiums.
+```yaml
+providers:
+  - bedrock:us.anthropic.claude-fable-5-1
+  - bedrock:converse:us.anthropic.claude-mythos-5-1
+  - id: bedrock:messages:global.anthropic.claude-mythos-5-1
+    config:
+      region: us-east-1
+      apiKey: '{{env.AWS_BEARER_TOKEN_BEDROCK}}'
+```
+
+The `us.` profile keeps routing within its geography; `global.` permits worldwide
+routing. The Messages route uses
+`https://bedrock-runtime.<region>.amazonaws.com/anthropic` and requires a Bedrock
+API key. Mythos 5.1 requires provider approval. Both 5.1 models retain always-on
+thinking and use a cache-read price of $0.25 per million tokens before regional
+premiums.
+
+Fable 5.1 also supports Mantle in **GovCloud West**: use
+`bedrock:messages:anthropic.claude-fable-5-1` with `region: us-gov-west-1`.
+Set `config.apiBaseUrl` when AWS provides a custom Anthropic endpoint.
 
 [Claude Fable 5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5.html)
 supports Bedrock Runtime and Converse. Use the `global.anthropic.claude-fable-5`

--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -1011,6 +1011,7 @@ Available Claude deployments on Azure AI Foundry:
 
 | Model                        | Description       |
 | ---------------------------- | ----------------- |
+| `claude-fable-5-1`           | Claude Fable 5.1  |
 | `claude-fable-5`             | Claude Fable 5    |
 | `claude-opus-5`              | Claude Opus 5     |
 | `claude-opus-4-8`            | Claude Opus 4.8   |

--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -802,6 +802,7 @@ These properties can be set under the provider `config` key:
 | o1                    | Set to `true` if your Azure deployment uses an o1 model. **(Deprecated, use `isReasoningModel` instead)**                                                                            |
 | isReasoningModel      | Treat the deployment as reasoning-capable. Set to `true` for custom deployment names; recognizable reasoning model names are auto-detected.                                          |
 | isClaudeOpus47OrLater | Set to `true` for a custom-named Claude Opus 4.7 or 4.8 chat deployment so unsupported sampling parameters are omitted.                                                              |
+| modelName             | Underlying Claude model ID for `azure:chat` compatibility and cost estimates when your deployment uses a custom alias. The deployment name is still sent to Azure.                   |
 | max_completion_tokens | Maximum tokens for `azure:chat` and `azure:completion` reasoning models. Use `max_output_tokens` for `azure:responses`.                                                              |
 | max_output_tokens     | Maximum output tokens for `azure:responses`, including reasoning deployments.                                                                                                        |
 | reasoning_effort      | Controls reasoning depth: 'minimal', 'low', 'medium', 'high', 'xhigh', or 'max' (model-dependent). Sent directly for chat/completion and as `reasoning.effort` by `azure:responses`. |
@@ -991,7 +992,9 @@ providers:
       max_tokens: 4096
 ```
 
-Fable 5 and Opus 4.7/4.8 deployments whose names contain the model identifier automatically omit `temperature` and `top_p` from the request body on this path too. If your Azure deployment uses a custom alias, set `isClaudeOpus47OrLater: true`:
+Fable and Mythos 5.1, Fable 5, and Opus 4.7/4.8 deployments whose names contain the model identifier automatically omit unsupported sampling parameters. Fable and Mythos 5.1 also omit forced `tool_choice` values; use `auto` or `none` instead.
+
+If your Azure deployment uses a custom alias, set `modelName` to the underlying Claude model ID. Promptfoo uses it for request compatibility and cost estimates while continuing to send the deployment name to Azure:
 
 ```yaml
 providers:
@@ -999,31 +1002,32 @@ providers:
     config:
       apiHost: 'your-deployment.services.ai.azure.com'
       apiVersion: '2025-04-01-preview'
-      isClaudeOpus47OrLater: true
+      modelName: claude-fable-5-1
       max_tokens: 4096
 ```
 
 :::note
-The `azure:chat:` provider and `isClaudeOpus47OrLater` only apply to Azure Claude deployments that expose the OpenAI-compatible chat-completions API. Some Azure AI Foundry models-as-a-service Claude deployments only support the Anthropic Messages API and return `api_not_supported` for chat completions; those deployments are not reachable via `azure:chat:`. Use Option 1 (the Anthropic Messages API endpoint) for them.
+The `azure:chat:` provider only applies to Azure Claude deployments that expose the OpenAI-compatible chat-completions API. Some Azure AI Foundry models-as-a-service Claude deployments only support the Anthropic Messages API and return `api_not_supported` for chat completions; those deployments are not reachable via `azure:chat:`. Use Option 1 (the Anthropic Messages API endpoint) for them. The existing `isClaudeOpus47OrLater: true` option remains available for sampling compatibility only.
 :::
 
 Available Claude deployments on Azure AI Foundry:
 
-| Model                        | Description       |
-| ---------------------------- | ----------------- |
-| `claude-fable-5-1`           | Claude Fable 5.1  |
-| `claude-fable-5`             | Claude Fable 5    |
-| `claude-opus-5`              | Claude Opus 5     |
-| `claude-opus-4-8`            | Claude Opus 4.8   |
-| `claude-opus-4-7`            | Claude Opus 4.7   |
-| `claude-opus-4-6-20260205`   | Claude Opus 4.6   |
-| `claude-sonnet-5`            | Claude Sonnet 5   |
-| `claude-sonnet-4-6`          | Claude Sonnet 4.6 |
-| `claude-opus-4-5-20251101`   | Claude Opus 4.5   |
-| `claude-sonnet-4-5-20250929` | Claude Sonnet 4.5 |
-| `claude-haiku-4-5-20251001`  | Claude Haiku 4.5  |
-| `claude-3-5-sonnet-20241022` | Claude 3.5 Sonnet |
-| `claude-3-5-haiku-20241022`  | Claude 3.5 Haiku  |
+| Model                        | Description                                    |
+| ---------------------------- | ---------------------------------------------- |
+| `claude-fable-5-1`           | Claude Fable 5.1                               |
+| `claude-mythos-5-1`          | Claude Mythos 5.1 (provider approval required) |
+| `claude-fable-5`             | Claude Fable 5                                 |
+| `claude-opus-5`              | Claude Opus 5                                  |
+| `claude-opus-4-8`            | Claude Opus 4.8                                |
+| `claude-opus-4-7`            | Claude Opus 4.7                                |
+| `claude-opus-4-6-20260205`   | Claude Opus 4.6                                |
+| `claude-sonnet-5`            | Claude Sonnet 5                                |
+| `claude-sonnet-4-6`          | Claude Sonnet 4.6                              |
+| `claude-opus-4-5-20251101`   | Claude Opus 4.5                                |
+| `claude-sonnet-4-5-20250929` | Claude Sonnet 4.5                              |
+| `claude-haiku-4-5-20251001`  | Claude Haiku 4.5                               |
+| `claude-3-5-sonnet-20241022` | Claude 3.5 Sonnet                              |
+| `claude-3-5-haiku-20241022`  | Claude 3.5 Haiku                               |
 
 :::note
 Anthropic deployments on Azure require `modelProviderData` (`industry`,

--- a/site/docs/providers/vertex.md
+++ b/site/docs/providers/vertex.md
@@ -62,6 +62,8 @@ Anthropic's Claude models are available with the following versions:
 
 **Claude 5:**
 
+- `vertex:claude-fable-5-1` - Claude Fable 5.1 with always-on adaptive thinking and $0.25/MTok cache reads
+- `vertex:claude-mythos-5-1` - Claude Mythos 5.1 (provider approval required)
 - `vertex:claude-fable-5` - Claude Fable 5 with a 1M-token context window and always-on adaptive thinking
 
 Promptfoo omits unsupported `temperature`, `top_p`, and `top_k` values for the adaptive-only

--- a/src/app/src/pages/redteam/setup/components/constants.test.ts
+++ b/src/app/src/pages/redteam/setup/components/constants.test.ts
@@ -6,6 +6,8 @@ describe('predefinedTargets', () => {
     const values = predefinedTargets.map((target) => target.value);
 
     expect(values).toContain('claude-opus-4-6');
+    expect(values).toContain('claude-fable-5-1');
+    expect(values).toContain('claude-mythos-5-1');
     expect(values).not.toContain('claude-opus-4-1-20250805');
   });
 

--- a/src/app/src/pages/redteam/setup/components/constants.ts
+++ b/src/app/src/pages/redteam/setup/components/constants.ts
@@ -20,6 +20,8 @@ export const predefinedTargets: RedteamUITarget[] = [
   { value: 'openai:gpt-4o', label: 'OpenAI GPT-4o' },
   { value: 'openai:gpt-4.1', label: 'OpenAI GPT-4.1' },
   { value: 'openai:gpt-4.1-mini', label: 'OpenAI GPT-4.1 Mini' },
+  { value: 'claude-fable-5-1', label: 'Anthropic Claude Fable 5.1' },
+  { value: 'claude-mythos-5-1', label: 'Anthropic Claude Mythos 5.1 (limited access)' },
   { value: 'claude-fable-5', label: 'Anthropic Claude Fable 5' },
   { value: 'claude-opus-5', label: 'Anthropic Claude Opus 5' },
   { value: 'claude-opus-4-8', label: 'Anthropic Claude 4.8 Opus' },

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -39,6 +39,7 @@ import {
   getTokenUsage,
   isAlwaysOnAdaptiveThinkingClaudeModel,
   isDisabledThinkingRejectedAtEffort,
+  isForcedToolChoiceUnsupportedClaudeModel,
   isSamplingParamsDeprecatedClaudeModel,
   normalizeAnthropicModelName,
   normalizeClaudeThinkingConfig,
@@ -629,7 +630,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
       if (!this.manualThinkingConversionWarned) {
         logger.warn(
           alwaysOnAdaptiveThinking
-            ? 'Claude Fable 5 and Claude Mythos 5 always use adaptive thinking. Manual thinking budgets have been removed; use effort to control reasoning depth.'
+            ? `${modelWarningName} always use adaptive thinking. Manual thinking budgets have been removed; use effort to control reasoning depth.`
             : `Manual extended thinking (thinking.type "enabled") is not supported on ${modelWarningName} and has been converted to adaptive thinking. Use thinking: { type: "adaptive" } with effort to control reasoning depth.`,
         );
         this.manualThinkingConversionWarned = true;
@@ -637,7 +638,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
     } else if (requested?.type === 'disabled' && !this.disabledThinkingRemovalWarned) {
       if (alwaysOnAdaptiveThinking) {
         logger.warn(
-          'Adaptive thinking is always on for Claude Fable 5 and Claude Mythos 5. thinking.type "disabled" has been omitted.',
+          `Adaptive thinking is always on for ${modelWarningName}. thinking.type "disabled" has been omitted.`,
         );
         this.disabledThinkingRemovalWarned = true;
       } else if (isDisabledThinkingRejectedAtEffort(this.modelName, effort)) {
@@ -780,15 +781,12 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
       }
     }
 
-    // Resolve tool_choice, suppressing forced tool use only for legacy budget-based thinking.
-    //
-    // The incompatibility is specific to `thinking: { type: 'enabled' }` — the API rejects
-    // that pairing with "Thinking may not be enabled when tool_choice forces tool use."
-    // Adaptive thinking is compatible: verified live that `adaptive` + a forced `any` or
-    // named tool_choice returns 200 on Opus 5, Opus 4.8, Opus 4.6, Sonnet 4.6, Sonnet 5, and
-    // Fable 5. Keying this off "is thinking on at all" silently dropped the user's
-    // tool_choice on every adaptive config, quietly changing tool-routing evals.
-    const forcedToolChoiceRejected = resolvedThinking?.type === 'enabled';
+    // Legacy budget-based thinking and Fable/Mythos 5.1 reject forced tool use.
+    // Earlier adaptive models, including Fable 5, accept forced choices. Do not gate
+    // this on thinkingEnabled: doing so would silently change their tool-routing evals.
+    const modelRejectsForcedToolChoice = isForcedToolChoiceUnsupportedClaudeModel(this.modelName);
+    const forcedToolChoiceRejected =
+      resolvedThinking?.type === 'enabled' || modelRejectsForcedToolChoice;
     let resolvedToolChoice: Anthropic.Messages.ToolChoice | undefined;
     if (config.tool_choice) {
       const transformed = transformToolChoice(
@@ -797,7 +795,9 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
       ) as Anthropic.Messages.ToolChoice;
       if (forcedToolChoiceRejected && (transformed.type === 'any' || transformed.type === 'tool')) {
         logger.warn(
-          `tool_choice type '${transformed.type}' (forced tool use) is incompatible with extended thinking and will be omitted. Use 'auto' or remove tool_choice.`,
+          modelRejectsForcedToolChoice
+            ? `tool_choice type '${transformed.type}' (forced tool use) is not supported on ${modelWarningName} and will be omitted. Use 'auto' or 'none' instead.`
+            : `tool_choice type '${transformed.type}' (forced tool use) is incompatible with extended thinking and will be omitted. Use 'auto' or remove tool_choice.`,
         );
       } else {
         resolvedToolChoice = transformed;
@@ -848,7 +848,7 @@ export class AnthropicMessagesProvider extends AnthropicGenericProvider {
     ) {
       logger.warn(
         alwaysOnAdaptiveThinking
-          ? 'temperature, top_p, and top_k are not supported on Claude Fable 5 or Claude Mythos 5 and will be omitted. Remove these sampling parameters from your config (or unset ANTHROPIC_TEMPERATURE) to silence this warning.'
+          ? `temperature, top_p, and top_k are not supported on ${modelWarningName} and will be omitted. Remove these sampling parameters from your config (or unset ANTHROPIC_TEMPERATURE) to silence this warning.`
           : `temperature is deprecated on ${modelWarningName} and will be omitted (along with top_p and top_k). Remove these sampling parameters from your config (or unset ANTHROPIC_TEMPERATURE) to silence this warning.`,
       );
       this.samplingParamsDeprecationWarned = true;

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -14,13 +14,15 @@ import type {
 // Model definitions with cost information
 export const ANTHROPIC_MODELS = [
   // Claude 5 models. These are pinned IDs, not `-latest` aliases.
-  ...['claude-fable-5', 'claude-mythos-5'].map((model) => ({
-    id: model,
-    cost: {
-      input: 10 / 1e6, // $10 / MTok
-      output: 50 / 1e6, // $50 / MTok
-    },
-  })),
+  ...['claude-fable-5-1', 'claude-mythos-5-1', 'claude-fable-5', 'claude-mythos-5'].map(
+    (model) => ({
+      id: model,
+      cost: {
+        input: 10 / 1e6, // $10 / MTok
+        output: 50 / 1e6, // $50 / MTok
+      },
+    }),
+  ),
   // Claude Opus 5 — the Opus-tier Claude 5 model. 1M context window (both the default
   // and the maximum) with the full low→max effort ladder, at the same list pricing as
   // Opus 4.8 ($5/$25), so it is a drop-in cost swap. The full 1M context bills at this
@@ -191,6 +193,7 @@ export const ANTHROPIC_MODELS = [
 // `claude-sonnet-5x` is not Sonnet 5) while still matching dated snapshots like
 // `claude-opus-4-8-20260528`.
 const CLAUDE_FABLE_MYTHOS_5_PATTERN = /(^|[^a-z0-9])claude-(?:fable|mythos)-5(?![a-z0-9])/i;
+const CLAUDE_FABLE_MYTHOS_51_PATTERN = /(^|[^a-z0-9])claude-(?:fable|mythos)-5-1(?![a-z0-9])/i;
 const CLAUDE_OPUS_5_PATTERN = /(^|[^a-z0-9])claude-opus-5(?![a-z0-9])/i;
 const CLAUDE_SONNET_5_PATTERN = /(^|[^a-z0-9])claude-sonnet-5(?![a-z0-9])/i;
 const CLAUDE_OPUS_48_PATTERN = /(^|[^a-z0-9])claude-opus-4-8(?![0-9])/i;
@@ -218,6 +221,8 @@ interface ClaudeModelFamily {
   samplingParamsDeprecated?: boolean;
   /** Thinking is always on; `thinking: { type: 'disabled' }` is rejected. */
   alwaysOnAdaptiveThinking?: boolean;
+  /** Rejects forced tool use even with adaptive thinking (Fable/Mythos 5.1). */
+  forcedToolChoiceUnsupported?: boolean;
   /**
    * Omitting `thinking` runs adaptive thinking rather than no thinking (Opus 5), so requests
    * that never set `thinking` still spend thinking tokens against `max_tokens`.
@@ -241,6 +246,14 @@ interface ClaudeModelFamily {
  * every later model); Opus 4.1 and earlier retain base pricing on all endpoints.
  */
 const CLAUDE_MODEL_FAMILIES: readonly ClaudeModelFamily[] = [
+  {
+    match: CLAUDE_FABLE_MYTHOS_51_PATTERN,
+    warningName: 'Claude Fable 5.1 and Claude Mythos 5.1',
+    samplingParamsDeprecated: true,
+    alwaysOnAdaptiveThinking: true,
+    forcedToolChoiceUnsupported: true,
+    regionalPremium: true,
+  },
   {
     match: CLAUDE_FABLE_MYTHOS_5_PATTERN,
     warningName: 'Claude Fable 5 and Claude Mythos 5',
@@ -305,6 +318,10 @@ export function isClaudeFableOrMythos5Model(modelId: string): boolean {
 /** Matches Claude Sonnet 5 model IDs (not `claude-sonnet-4-5`, not `claude-sonnet-50`). */
 export function isClaudeSonnet5Model(modelId: string): boolean {
   return CLAUDE_SONNET_5_PATTERN.test(modelId);
+}
+
+export function isForcedToolChoiceUnsupportedClaudeModel(modelId: string): boolean {
+  return hasClaudeCapability(modelId, 'forcedToolChoiceUnsupported');
 }
 
 /**
@@ -639,17 +656,20 @@ export function parseMessages(messages: string): {
 /**
  * Compute input cost with Anthropic cache pricing applied.
  * Anthropic docs: input_tokens is the non-cached portion; cache_read and cache_creation are additive.
- * Cache reads cost 10% of base rate (90% discount), cache writes cost 125% of base rate (25% surcharge).
+ * Cache reads cost 2.5% of base rate on Fable/Mythos 5.1 and 10% on other models.
+ * Five-minute cache writes cost 125% of base rate (25% surcharge).
  */
 export function calculateCacheInputCost(
   baseInputRate: number,
   uncachedInputTokens: number,
   cacheRead: number,
   cacheCreation: number,
+  modelId = '',
 ): number {
+  const cacheReadMultiplier = CLAUDE_FABLE_MYTHOS_51_PATTERN.test(modelId) ? 0.025 : 0.1;
   return (
     uncachedInputTokens * baseInputRate +
-    cacheRead * baseInputRate * 0.1 +
+    cacheRead * baseInputRate * cacheReadMultiplier +
     cacheCreation * baseInputRate * 1.25
   );
 }
@@ -703,7 +723,7 @@ export function calculateAnthropicCost(
     const inputCost = effectiveConfig.inputCost ?? effectiveConfig.cost ?? modelInfo.cost.input;
     const outputCost = effectiveConfig.outputCost ?? effectiveConfig.cost ?? modelInfo.cost.output;
     return withRegionalPremium(
-      calculateCacheInputCost(inputCost, promptTokens, cacheRead, cacheCreation) +
+      calculateCacheInputCost(inputCost, promptTokens, cacheRead, cacheCreation, pricingModelName) +
         completionTokens * outputCost,
     );
   }

--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -15,7 +15,10 @@ import {
   renderVarsInObject,
 } from '../../util/index';
 import invariant from '../../util/invariant';
-import { isSamplingParamsDeprecatedClaudeModel } from '../anthropic/util';
+import {
+  isForcedToolChoiceUnsupportedClaudeModel,
+  isSamplingParamsDeprecatedClaudeModel,
+} from '../anthropic/util';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { MCPClient } from '../mcp/client';
 import { transformMCPToolsToOpenAi } from '../mcp/transform';
@@ -284,6 +287,18 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
       ...(config.stop && !grokSamplingRestricted ? { stop: config.stop } : {}),
       ...(config.passthrough || {}),
     };
+
+    if (
+      isForcedToolChoiceUnsupportedClaudeModel(this.deploymentName) &&
+      body.tool_choice &&
+      body.tool_choice !== 'auto' &&
+      body.tool_choice !== 'none'
+    ) {
+      logger.warn(
+        `Forced tool choice is not supported on ${this.deploymentName} and will be omitted. Use 'auto' or 'none' instead.`,
+      );
+      delete body.tool_choice;
+    }
 
     return { body, config };
   }

--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -140,10 +140,10 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
    * `max_completion_tokens`) and do not accept `reasoning_effort`, so we only
    * strip the sampling params here and leave the rest of the chat body intact.
    */
-  protected isSamplingParamsDeprecatedClaudeModel(): boolean {
+  protected isSamplingParamsDeprecatedClaudeModel(config = this.config): boolean {
     return (
-      Boolean(this.config.isClaudeOpus47OrLater) ||
-      isSamplingParamsDeprecatedClaudeModel(this.deploymentName, {
+      Boolean(config.isClaudeOpus47OrLater) ||
+      isSamplingParamsDeprecatedClaudeModel(config.modelName ?? this.deploymentName, {
         allowGenerationFallback: false,
       })
     );
@@ -197,7 +197,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
 
     // Check if this is configured as a reasoning model
     const isReasoningModel = this.isReasoningModel();
-    const samplingParamsDeprecated = this.isSamplingParamsDeprecatedClaudeModel();
+    const samplingParamsDeprecated = this.isSamplingParamsDeprecatedClaudeModel(config);
     const grokSamplingRestricted = this.isGrok4OrNewerModel();
 
     // Get max tokens based on model type
@@ -289,7 +289,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
     };
 
     if (
-      isForcedToolChoiceUnsupportedClaudeModel(this.deploymentName) &&
+      isForcedToolChoiceUnsupportedClaudeModel(config.modelName ?? this.deploymentName) &&
       body.tool_choice &&
       body.tool_choice !== 'auto' &&
       body.tool_choice !== 'none'
@@ -577,7 +577,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
         logProbs,
         finishReason,
         cost: calculateAzureCost(
-          this.deploymentName,
+          config.modelName ?? this.deploymentName,
           config,
           data.usage?.prompt_tokens,
           data.usage?.completion_tokens,

--- a/src/providers/azure/defaults.ts
+++ b/src/providers/azure/defaults.ts
@@ -916,6 +916,14 @@ export const AZURE_MODELS: AzureModelCost[] = [
   // Anthropic Claude Models (via Azure AI Foundry)
   // =============================================================================
   {
+    id: 'claude-fable-5-1',
+    cost: { input: 10 / 1000000, output: 50 / 1000000, cacheRead: 0.25 / 1000000 },
+  },
+  {
+    id: 'claude-mythos-5-1',
+    cost: { input: 10 / 1000000, output: 50 / 1000000, cacheRead: 0.25 / 1000000 },
+  },
+  {
     id: 'claude-fable-5',
     cost: { input: 10 / 1000000, output: 50 / 1000000 },
   },

--- a/src/providers/azure/types.ts
+++ b/src/providers/azure/types.ts
@@ -114,6 +114,8 @@ export interface AzureCompletionOptions {
  * Options shared by Azure chat and responses providers.
  */
 export interface AzureChatResponsesOptions extends AzureCompletionOptions {
+  /** Underlying Claude model ID for azure:chat compatibility and cost estimates when the deployment is aliased. */
+  modelName?: string;
   /**
    * When true, omit hardcoded defaults for temperature, max_tokens, top_p, etc.
    * Only values explicitly set via config or environment variables will be sent.

--- a/src/providers/bedrock/anthropicMessages.ts
+++ b/src/providers/bedrock/anthropicMessages.ts
@@ -12,14 +12,19 @@ import type { ProviderOptions } from '../../types/providers';
 export const DEFAULT_BEDROCK_ANTHROPIC_REGION = 'us-east-1';
 const FABLE_MANTLE_REGIONS = new Set(['us-east-1', 'eu-north-1']);
 
-const BEDROCK_ANTHROPIC_MESSAGES_MODELS = ['anthropic.claude-fable-5', 'anthropic.claude-mythos-5'];
+const BEDROCK_ANTHROPIC_MESSAGES_MODELS = [
+  'anthropic.claude-fable-5',
+  'anthropic.claude-mythos-5',
+  'anthropic.claude-fable-5-1',
+  'anthropic.claude-mythos-5-1',
+];
 
 export function isBedrockAnthropicMessagesModel(modelName: string): boolean {
   return BEDROCK_ANTHROPIC_MESSAGES_MODELS.includes(modelName);
 }
 
 export function requiresBedrockAnthropicMessagesModel(modelName: string): boolean {
-  return modelName === 'anthropic.claude-mythos-5';
+  return modelName === 'anthropic.claude-mythos-5' || modelName === 'anthropic.claude-mythos-5-1';
 }
 
 export function getBedrockAnthropicBaseUrl(region: string): string {
@@ -66,11 +71,7 @@ export function createBedrockAnthropicMessagesProvider(
     );
   }
 
-  if (
-    !config.apiBaseUrl &&
-    requiresBedrockAnthropicMessagesModel(modelName) &&
-    region !== 'us-east-1'
-  ) {
+  if (!config.apiBaseUrl && modelName === 'anthropic.claude-mythos-5' && region !== 'us-east-1') {
     throw new Error(
       `Amazon Bedrock model "${modelName}" is only available in us-east-1. ` +
         `Set config.region or AWS_BEDROCK_REGION to us-east-1.`,

--- a/src/providers/bedrock/anthropicMessages.ts
+++ b/src/providers/bedrock/anthropicMessages.ts
@@ -11,12 +11,18 @@ import type { ProviderOptions } from '../../types/providers';
 
 export const DEFAULT_BEDROCK_ANTHROPIC_REGION = 'us-east-1';
 const FABLE_MANTLE_REGIONS = new Set(['us-east-1', 'eu-north-1']);
+const RUNTIME_MESSAGES_MODELS = new Set([
+  'us.anthropic.claude-fable-5-1',
+  'global.anthropic.claude-fable-5-1',
+  'us.anthropic.claude-mythos-5-1',
+  'global.anthropic.claude-mythos-5-1',
+]);
 
 const BEDROCK_ANTHROPIC_MESSAGES_MODELS = [
   'anthropic.claude-fable-5',
   'anthropic.claude-mythos-5',
   'anthropic.claude-fable-5-1',
-  'anthropic.claude-mythos-5-1',
+  ...RUNTIME_MESSAGES_MODELS,
 ];
 
 export function isBedrockAnthropicMessagesModel(modelName: string): boolean {
@@ -24,18 +30,22 @@ export function isBedrockAnthropicMessagesModel(modelName: string): boolean {
 }
 
 export function requiresBedrockAnthropicMessagesModel(modelName: string): boolean {
-  return modelName === 'anthropic.claude-mythos-5' || modelName === 'anthropic.claude-mythos-5-1';
+  return modelName === 'anthropic.claude-mythos-5';
 }
 
-export function getBedrockAnthropicBaseUrl(region: string): string {
-  return `${getBedrockMantleOrigin(region)}/anthropic`;
+export function getBedrockAnthropicBaseUrl(region: string, useRuntime = false): string {
+  // Validate the region before interpolating either host, which receives an API key.
+  const mantleOrigin = getBedrockMantleOrigin(region);
+  return useRuntime
+    ? `https://bedrock-runtime.${region}.amazonaws.com/anthropic`
+    : `${mantleOrigin}/anthropic`;
 }
 
 export class BedrockAnthropicMessagesProvider extends AnthropicMessagesProvider {
   // Bedrock's Anthropic-compatible endpoint authenticates with an API key via
   // x-api-key (the factory guarantees one). Never fall back to a local Claude
   // Code OAuth session — that would send an Anthropic OAuth token to the
-  // Bedrock mantle host.
+  // Bedrock host.
   static override readonly SUPPORTS_CLAUDE_CODE_OAUTH = false;
 
   protected override buildAnthropicClientOptions(options: ClientOptions): ClientOptions {
@@ -71,15 +81,25 @@ export function createBedrockAnthropicMessagesProvider(
     );
   }
 
-  if (
-    !config.apiBaseUrl &&
-    (modelName === 'anthropic.claude-mythos-5' || modelName === 'anthropic.claude-fable-5-1') &&
-    region !== 'us-east-1'
-  ) {
+  if (!config.apiBaseUrl && modelName === 'anthropic.claude-mythos-5' && region !== 'us-east-1') {
     throw new Error(
       `Amazon Bedrock model "${modelName}" is only available in us-east-1 through the default ` +
         `Anthropic Messages endpoint. Set config.region or AWS_BEDROCK_REGION to us-east-1, ` +
         `or set config.apiBaseUrl for another provisioned endpoint.`,
+    );
+  }
+
+  // AWS's Fable 5.1 model card lists Mantle only in GovCloud West. Commercial
+  // regions use the Runtime Messages endpoint with a US or global inference profile.
+  if (
+    !config.apiBaseUrl &&
+    modelName === 'anthropic.claude-fable-5-1' &&
+    region !== 'us-gov-west-1'
+  ) {
+    throw new Error(
+      `Amazon Bedrock model "${modelName}" uses Mantle only in us-gov-west-1. ` +
+        `For other regions, use "bedrock:messages:us.${modelName}" or ` +
+        `"bedrock:messages:global.${modelName}" with the Runtime Messages endpoint.`,
     );
   }
 
@@ -95,7 +115,8 @@ export function createBedrockAnthropicMessagesProvider(
     );
   }
 
-  const apiBaseUrl = config.apiBaseUrl || getBedrockAnthropicBaseUrl(region);
+  const apiBaseUrl =
+    config.apiBaseUrl || getBedrockAnthropicBaseUrl(region, RUNTIME_MESSAGES_MODELS.has(modelName));
 
   return new BedrockAnthropicMessagesProvider(modelName, {
     ...providerOptions,

--- a/src/providers/bedrock/anthropicMessages.ts
+++ b/src/providers/bedrock/anthropicMessages.ts
@@ -71,10 +71,15 @@ export function createBedrockAnthropicMessagesProvider(
     );
   }
 
-  if (!config.apiBaseUrl && modelName === 'anthropic.claude-mythos-5' && region !== 'us-east-1') {
+  if (
+    !config.apiBaseUrl &&
+    (modelName === 'anthropic.claude-mythos-5' || modelName === 'anthropic.claude-fable-5-1') &&
+    region !== 'us-east-1'
+  ) {
     throw new Error(
-      `Amazon Bedrock model "${modelName}" is only available in us-east-1. ` +
-        `Set config.region or AWS_BEDROCK_REGION to us-east-1.`,
+      `Amazon Bedrock model "${modelName}" is only available in us-east-1 through the default ` +
+        `Anthropic Messages endpoint. Set config.region or AWS_BEDROCK_REGION to us-east-1, ` +
+        `or set config.apiBaseUrl for another provisioned endpoint.`,
     );
   }
 

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -2346,6 +2346,7 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   'anthropic.claude-3-haiku-20240307-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-fable-5': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-fable-5-1': BEDROCK_MODEL.CLAUDE_MESSAGES,
+  'anthropic.claude-mythos-5-1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-opus-4-1-20250805-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-opus-4-6-v1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-opus-4-7': BEDROCK_MODEL.CLAUDE_MESSAGES,
@@ -2449,6 +2450,7 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   'us.anthropic.claude-3-haiku-20240307-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-fable-5': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-fable-5-1': BEDROCK_MODEL.CLAUDE_MESSAGES,
+  'us.anthropic.claude-mythos-5-1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-opus-4-1-20250805-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-opus-4-6-v1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-opus-4-7': BEDROCK_MODEL.CLAUDE_MESSAGES,
@@ -2553,6 +2555,7 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   // Claude Fable 5 base, global, and geo inference profiles.
   'global.anthropic.claude-fable-5': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'global.anthropic.claude-fable-5-1': BEDROCK_MODEL.CLAUDE_MESSAGES,
+  'global.anthropic.claude-mythos-5-1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   // Claude Sonnet 5 uses the global endpoint like the other Claude 5-generation
   // models (Fable 5, Opus 4.7/4.8) rather than the older `apac.` prefix.
   'global.anthropic.claude-sonnet-5': BEDROCK_MODEL.CLAUDE_MESSAGES,
@@ -2563,7 +2566,7 @@ export function getHandlerForModel(
   modelName: string,
   config?: BedrockInvokeModelOptions,
 ): IBedrockModel {
-  const messagesOnlyModel = modelName.match(/^(?:[^.]+\.)?(anthropic\.claude-mythos-5(?:-1)?)$/);
+  const messagesOnlyModel = modelName.match(/^(?:[^.]+\.)?(anthropic\.claude-mythos-5)$/);
   if (messagesOnlyModel) {
     // Mythos has no geo/global inference profiles, so always point at the bare
     // canonical ID — suggesting a prefixed `bedrock:${modelName}` would only
@@ -2901,9 +2904,15 @@ export class AwsBedrockCompletionProvider extends AwsBedrockGenericProvider impl
         tokenUsage.numRequests = 1;
       }
 
+      // Claude's displayed prompt count includes cache reads and writes. Billing
+      // needs the API's uncached input count because cache tokens are priced separately.
+      const billablePromptTokens =
+        model === BEDROCK_MODEL.CLAUDE_MESSAGES
+          ? coerceStrToNum(output.usage?.input_tokens ?? output.usage?.prompt_tokens)
+          : tokenUsage.prompt;
       const cost = calculateBedrockInvokeModelCost(
         this.modelName,
-        tokenUsage.prompt,
+        billablePromptTokens,
         tokenUsage.completion,
         tokenUsage.completionDetails?.cacheReadInputTokens ??
           coerceStrToNum(output.usage?.cache_read_input_tokens),

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -2345,6 +2345,7 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   'anthropic.claude-3-7-sonnet-20250219-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-3-haiku-20240307-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-fable-5': BEDROCK_MODEL.CLAUDE_MESSAGES,
+  'anthropic.claude-fable-5-1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-opus-4-1-20250805-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-opus-4-6-v1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-opus-4-7': BEDROCK_MODEL.CLAUDE_MESSAGES,
@@ -2447,6 +2448,7 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   'us.anthropic.claude-3-7-sonnet-20250219-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-3-haiku-20240307-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-fable-5': BEDROCK_MODEL.CLAUDE_MESSAGES,
+  'us.anthropic.claude-fable-5-1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-opus-4-1-20250805-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-opus-4-6-v1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-opus-4-7': BEDROCK_MODEL.CLAUDE_MESSAGES,
@@ -2550,6 +2552,7 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
 
   // Claude Fable 5 base, global, and geo inference profiles.
   'global.anthropic.claude-fable-5': BEDROCK_MODEL.CLAUDE_MESSAGES,
+  'global.anthropic.claude-fable-5-1': BEDROCK_MODEL.CLAUDE_MESSAGES,
   // Claude Sonnet 5 uses the global endpoint like the other Claude 5-generation
   // models (Fable 5, Opus 4.7/4.8) rather than the older `apac.` prefix.
   'global.anthropic.claude-sonnet-5': BEDROCK_MODEL.CLAUDE_MESSAGES,
@@ -2560,13 +2563,14 @@ export function getHandlerForModel(
   modelName: string,
   config?: BedrockInvokeModelOptions,
 ): IBedrockModel {
-  if (/^(?:[^.]+\.)?anthropic\.claude-mythos-5$/.test(modelName)) {
+  const messagesOnlyModel = modelName.match(/^(?:[^.]+\.)?(anthropic\.claude-mythos-5(?:-1)?)$/);
+  if (messagesOnlyModel) {
     // Mythos has no geo/global inference profiles, so always point at the bare
     // canonical ID — suggesting a prefixed `bedrock:${modelName}` would only
     // bounce the user into the factory's prefixed-Mythos rejection.
     throw new Error(
       `Amazon Bedrock model "${modelName}" uses Bedrock's Anthropic Messages API, not ` +
-        `InvokeModel. Load it as "bedrock:anthropic.claude-mythos-5" instead.`,
+        `InvokeModel. Load it as "bedrock:${messagesOnlyModel[1]}" instead.`,
     );
   }
 

--- a/src/providers/bedrock/pricing.ts
+++ b/src/providers/bedrock/pricing.ts
@@ -47,6 +47,7 @@ function isNovaPromptCachingModel(normalizedModelId: string): boolean {
  */
 const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   // Claude 5
+  'anthropic.claude-fable-5-1': { input: 10, output: 50 },
   'anthropic.claude-fable-5': { input: 10, output: 50 },
   // Claude Opus 5 (same list rates as Opus 4.8; full 1M context bills at the standard rate)
   'anthropic.claude-opus-5': { input: 5, output: 25 },
@@ -455,7 +456,13 @@ export function calculateBedrockCost(
 
   const inputRate = (tier.input / 1_000_000) * pricingMultiplier;
   const inputCost = normalizedModelId.includes('anthropic.claude')
-    ? calculateCacheInputCost(inputRate, promptTokens, cacheReadTokens, cacheWriteTokens)
+    ? calculateCacheInputCost(
+        inputRate,
+        promptTokens,
+        cacheReadTokens,
+        cacheWriteTokens,
+        normalizedModelId,
+      )
     : isNovaPromptCachingModel(normalizedModelId)
       ? promptTokens * inputRate + cacheReadTokens * inputRate * NOVA_CACHE_READ_RATIO
       : promptTokens * inputRate;

--- a/src/providers/bedrock/pricing.ts
+++ b/src/providers/bedrock/pricing.ts
@@ -48,6 +48,7 @@ function isNovaPromptCachingModel(normalizedModelId: string): boolean {
 const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   // Claude 5
   'anthropic.claude-fable-5-1': { input: 10, output: 50 },
+  'anthropic.claude-mythos-5-1': { input: 10, output: 50 },
   'anthropic.claude-fable-5': { input: 10, output: 50 },
   // Claude Opus 5 (same list rates as Opus 4.8; full 1M context bills at the standard rate)
   'anthropic.claude-opus-5': { input: 5, output: 25 },

--- a/src/providers/families/aws.ts
+++ b/src/providers/families/aws.ts
@@ -12,9 +12,8 @@ export const awsProviderFactories: ProviderFactory[] = [
       const modelType = splits[1];
       const modelName = splits.slice(2).join(':');
 
-      // Mythos is only available through Bedrock's Anthropic-compatible
-      // Messages endpoint. Fable also supports that endpoint when explicitly
-      // selected, while its bare form continues through Bedrock Runtime below.
+      // Mythos 5 requires Mantle's Messages endpoint. Both 5.1 models support
+      // Runtime, including an explicit Messages route with US/global profiles.
       const isLegacyType = modelType === 'converse' || modelType === 'completion';
       const anthropicModel =
         modelType === 'messages'
@@ -24,16 +23,14 @@ export const awsProviderFactories: ProviderFactory[] = [
             : isLegacyType
               ? modelName
               : undefined;
-      const prefixedMythosModel = anthropicModel?.match(
-        /^[^.]+\.(anthropic\.claude-mythos-5(?:-1)?)$/,
-      );
+      const prefixedMythosModel = anthropicModel?.match(/^[^.]+\.(anthropic\.claude-mythos-5)$/);
       if (prefixedMythosModel) {
         throw new Error(
           `Amazon Bedrock model "${anthropicModel}" is not a valid Mythos model ID. ` +
             `Use "bedrock:${prefixedMythosModel[1]}"; Mythos does not support geo or global inference IDs.`,
         );
       }
-      if (anthropicModel?.startsWith('anthropic.claude-')) {
+      if (anthropicModel && /^(?:(?:us|global)\.)?anthropic\.claude-/.test(anthropicModel)) {
         const {
           createBedrockAnthropicMessagesProvider,
           isBedrockAnthropicMessagesModel,
@@ -59,8 +56,9 @@ export const awsProviderFactories: ProviderFactory[] = [
       if (modelType === 'messages') {
         throw new Error(
           `Amazon Bedrock model "${modelName}" is not supported by the Anthropic Messages ` +
-            `provider. Supported models: anthropic.claude-fable-5, anthropic.claude-fable-5-1, ` +
-            `anthropic.claude-mythos-5, and anthropic.claude-mythos-5-1.`,
+            `provider. Use a us. or global. inference profile for Fable/Mythos 5.1. ` +
+            `Mantle supports anthropic.claude-fable-5, anthropic.claude-mythos-5, and ` +
+            `anthropic.claude-fable-5-1 (GovCloud West).`,
         );
       }
 

--- a/src/providers/families/aws.ts
+++ b/src/providers/families/aws.ts
@@ -24,10 +24,13 @@ export const awsProviderFactories: ProviderFactory[] = [
             : isLegacyType
               ? modelName
               : undefined;
-      if (/^[^.]+\.anthropic\.claude-mythos-5$/.test(anthropicModel ?? '')) {
+      const prefixedMythosModel = anthropicModel?.match(
+        /^[^.]+\.(anthropic\.claude-mythos-5(?:-1)?)$/,
+      );
+      if (prefixedMythosModel) {
         throw new Error(
           `Amazon Bedrock model "${anthropicModel}" is not a valid Mythos model ID. ` +
-            `Use "bedrock:anthropic.claude-mythos-5"; Mythos does not support geo or global inference IDs.`,
+            `Use "bedrock:${prefixedMythosModel[1]}"; Mythos does not support geo or global inference IDs.`,
         );
       }
       if (anthropicModel?.startsWith('anthropic.claude-')) {
@@ -56,7 +59,8 @@ export const awsProviderFactories: ProviderFactory[] = [
       if (modelType === 'messages') {
         throw new Error(
           `Amazon Bedrock model "${modelName}" is not supported by the Anthropic Messages ` +
-            `provider. Supported models: anthropic.claude-fable-5 and anthropic.claude-mythos-5.`,
+            `provider. Supported models: anthropic.claude-fable-5, anthropic.claude-fable-5-1, ` +
+            `anthropic.claude-mythos-5, and anthropic.claude-mythos-5-1.`,
         );
       }
 

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -3912,70 +3912,110 @@ describe('AnthropicMessagesProvider', () => {
     });
   });
 
-  describe.each(['claude-fable-5', 'claude-mythos-5'])('%s model', (model) => {
-    const mockResponse = (modelName: string) =>
-      ({
-        content: [{ type: 'text', text: 'Response' }],
-        model: modelName,
-        id: 'test-id',
-        role: 'assistant',
-        stop_reason: 'end_turn',
-        stop_details: null,
-        stop_sequence: null,
-        type: 'message',
-        usage: { input_tokens: 10, output_tokens: 5 },
-      }) as Anthropic.Messages.Message;
+  describe.each(['claude-fable-5', 'claude-mythos-5', 'claude-fable-5-1', 'claude-mythos-5-1'])(
+    '%s model',
+    (model) => {
+      const mockResponse = (modelName: string) =>
+        ({
+          content: [{ type: 'text', text: 'Response' }],
+          model: modelName,
+          id: 'test-id',
+          role: 'assistant',
+          stop_reason: 'end_turn',
+          stop_details: null,
+          stop_sequence: null,
+          type: 'message',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        }) as Anthropic.Messages.Message;
 
-    it('is accepted as a known model and uses adaptive-safe request parameters', async () => {
-      const warnSpy = vi.spyOn(logger, 'warn');
+      it('is accepted as a known model and uses adaptive-safe request parameters', async () => {
+        const warnSpy = vi.spyOn(logger, 'warn');
+        const provider = createProvider(model, {
+          config: {
+            max_tokens: 4096,
+            temperature: 0.5,
+            top_p: 0.9,
+            top_k: 40,
+            thinking: { type: 'enabled', budget_tokens: 2048, display: 'summarized' },
+          },
+        });
+        const createSpy = vi
+          .spyOn(provider.anthropic.messages, 'create')
+          .mockResolvedValue(mockResponse(model));
+
+        await provider.callApi('Test prompt');
+
+        const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
+        expect(params.model).toBe(model);
+        expect(params.thinking).toEqual({ type: 'adaptive', display: 'summarized' });
+        expect(params).not.toHaveProperty('temperature');
+        expect(params).not.toHaveProperty('top_p');
+        expect(params).not.toHaveProperty('top_k');
+        expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Using unknown'));
+        // The per-call thinking-incompatibility warnings ("temperature/top_k is
+        // incompatible with extended thinking...") must not fire when sampling
+        // params are deprecated at the model level — the deduped model-level
+        // warning below covers the omission instead.
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining('incompatible with extended thinking'),
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'temperature, top_p, and top_k are not supported on Claude Fable',
+          ),
+        );
+      });
+
+      it('omits unsupported disabled thinking and treats adaptive thinking as always on', async () => {
+        const provider = createProvider(model, { config: { thinking: { type: 'disabled' } } });
+        const createSpy = vi
+          .spyOn(provider.anthropic.messages, 'create')
+          .mockResolvedValue(mockResponse(model));
+
+        await provider.callApi('Test prompt');
+
+        const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
+        expect(params).not.toHaveProperty('thinking');
+        expect(params).not.toHaveProperty('temperature');
+        expect(params.max_tokens).toBe(2048);
+      });
+    },
+  );
+
+  describe.each(['claude-fable-5-1', 'claude-mythos-5-1'])('%s tool choice', (model) => {
+    it.each([
+      { type: 'any' as const },
+      { type: 'tool' as const, name: 'get_weather' },
+      { type: 'auto' as const },
+      { type: 'none' as const },
+    ])('omits only unsupported forced tool choice: %j', async (tool_choice) => {
       const provider = createProvider(model, {
         config: {
-          max_tokens: 4096,
-          temperature: 0.5,
-          top_p: 0.9,
-          top_k: 40,
-          thinking: { type: 'enabled', budget_tokens: 2048, display: 'summarized' },
+          tools: [{ name: 'get_weather', input_schema: { type: 'object', properties: {} } }],
+          tool_choice,
+          thinking: { type: 'adaptive' },
         },
       });
-      const createSpy = vi
-        .spyOn(provider.anthropic.messages, 'create')
-        .mockResolvedValue(mockResponse(model));
+      const createSpy = vi.spyOn(provider.anthropic.messages, 'create').mockResolvedValue({
+        id: 'msg-51',
+        type: 'message',
+        role: 'assistant',
+        model,
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      } as Anthropic.Messages.Message);
 
-      await provider.callApi('Test prompt');
+      await provider.callApi('Check the weather');
 
-      const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
-      expect(params.model).toBe(model);
-      expect(params.thinking).toEqual({ type: 'adaptive', display: 'summarized' });
-      expect(params).not.toHaveProperty('temperature');
-      expect(params).not.toHaveProperty('top_p');
-      expect(params).not.toHaveProperty('top_k');
-      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Using unknown'));
-      // The per-call thinking-incompatibility warnings ("temperature/top_k is
-      // incompatible with extended thinking...") must not fire when sampling
-      // params are deprecated at the model level — the deduped model-level
-      // warning below covers the omission instead.
-      expect(warnSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('incompatible with extended thinking'),
-      );
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'temperature, top_p, and top_k are not supported on Claude Fable 5 or Claude Mythos 5',
-        ),
-      );
-    });
-
-    it('omits unsupported disabled thinking and treats adaptive thinking as always on', async () => {
-      const provider = createProvider(model, { config: { thinking: { type: 'disabled' } } });
-      const createSpy = vi
-        .spyOn(provider.anthropic.messages, 'create')
-        .mockResolvedValue(mockResponse(model));
-
-      await provider.callApi('Test prompt');
-
-      const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
-      expect(params).not.toHaveProperty('thinking');
-      expect(params).not.toHaveProperty('temperature');
-      expect(params.max_tokens).toBe(2048);
+      const params = createSpy.mock.calls[0][0];
+      expect(params.tools).toHaveLength(1);
+      if (tool_choice.type === 'any' || tool_choice.type === 'tool') {
+        expect(params).not.toHaveProperty('tool_choice');
+      } else {
+        expect(params.tool_choice).toEqual(tool_choice);
+      }
     });
   });
 

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -1889,6 +1889,38 @@ describe('Anthropic utilities', () => {
     });
   });
 
+  describe.each(['claude-fable-5-1', 'claude-mythos-5-1'])(
+    'calculateAnthropicCost for %s',
+    (model) => {
+      it('prices cache reads at 2.5% of input and keeps the existing write and output rates', () => {
+        expect(calculateAnthropicCost(model, {}, 1000, 500, 200, 100)).toBeCloseTo(0.0363, 8);
+        expect(calculateAnthropicCost(model, {}, 900_000, 10_000)).toBeCloseTo(9.5, 8);
+      });
+
+      it('composes cache pricing with regional premiums and explicit per-token rates', () => {
+        expect(calculateAnthropicCost(`anthropic.${model}`, {}, 1000, 500, 200, 100)).toBeCloseTo(
+          0.03993,
+          8,
+        );
+        expect(
+          calculateAnthropicCost(
+            model,
+            { inputCost: 20 / 1e6, outputCost: 100 / 1e6 },
+            1000,
+            500,
+            200,
+            100,
+          ),
+        ).toBeCloseTo(0.0726, 8);
+      });
+
+      it('does not invent latest aliases or dated snapshots', () => {
+        expect(calculateAnthropicCost(`${model}-latest`, {}, 1000, 500)).toBeUndefined();
+        expect(calculateAnthropicCost(`${model}-20260901`, {}, 1000, 500)).toBeUndefined();
+      });
+    },
+  );
+
   describe.each(['claude-fable-5', 'claude-mythos-5'])('calculateAnthropicCost for %s', (model) => {
     it('uses Claude 5 input and output pricing', () => {
       expect(calculateAnthropicCost(model, {}, 1000, 500)).toBeCloseTo(0.035, 6);

--- a/test/providers/azure/chat.test.ts
+++ b/test/providers/azure/chat.test.ts
@@ -859,22 +859,47 @@ describe('AzureChatCompletionProvider', () => {
       expect(body).not.toHaveProperty('reasoning_effort');
     });
 
-    it('omits sampling params for Claude Fable 5 while keeping the standard chat body', async () => {
-      const provider = new AzureChatCompletionProvider('claude-fable-5', {
-        config: {
-          apiHost: 'test.azure.com',
-          apiKey: 'test-key',
-          max_tokens: 512,
-          temperature: 0.5,
-          top_p: 0.9,
-        },
-      });
-      const { body } = await (provider as any).getOpenAiBody('hi');
-      expect(body).toHaveProperty('max_tokens', 512);
-      expect(body).not.toHaveProperty('temperature');
-      expect(body).not.toHaveProperty('top_p');
-      expect(body).not.toHaveProperty('reasoning_effort');
-    });
+    it.each(['claude-fable-5', 'claude-fable-5-1', 'claude-mythos-5-1'])(
+      'omits sampling params for %s while keeping the standard chat body',
+      async (model) => {
+        const provider = new AzureChatCompletionProvider(model, {
+          config: {
+            apiHost: 'test.azure.com',
+            apiKey: 'test-key',
+            max_tokens: 512,
+            temperature: 0.5,
+            top_p: 0.9,
+          },
+        });
+        const { body } = await (provider as any).getOpenAiBody('hi');
+        expect(body).toHaveProperty('max_tokens', 512);
+        expect(body).not.toHaveProperty('temperature');
+        expect(body).not.toHaveProperty('top_p');
+        expect(body).not.toHaveProperty('reasoning_effort');
+      },
+    );
+
+    it.each(['claude-fable-5-1', 'claude-mythos-5-1'])(
+      'omits forced tool choice for %s',
+      async (model) => {
+        const provider = new AzureChatCompletionProvider(model, {
+          config: {
+            apiHost: 'test.azure.com',
+            apiKey: 'test-key',
+            tools: [
+              {
+                type: 'function',
+                function: { name: 'get_weather', parameters: { type: 'object', properties: {} } },
+              },
+            ],
+            tool_choice: 'required',
+          },
+        });
+        const { body } = await provider.getOpenAiBody('Check the weather');
+        expect(body.tools).toHaveLength(1);
+        expect(body).not.toHaveProperty('tool_choice');
+      },
+    );
 
     it('omits sampling params for a custom Claude deployment when configured explicitly', async () => {
       const provider = new AzureChatCompletionProvider('prod-claude-deployment', {

--- a/test/providers/azure/chat.test.ts
+++ b/test/providers/azure/chat.test.ts
@@ -366,6 +366,39 @@ describe('AzureChatCompletionProvider', () => {
       expect(result.cost).toBeCloseTo((1_500 * 5 + 500 * 0.5 + 1_000 * 30) / 1e6, 12);
     });
 
+    it.each(['claude-fable-5-1', 'claude-mythos-5-1'])(
+      'uses modelName for %s cache pricing without changing the Azure deployment',
+      async (modelName) => {
+        provider = new AzureChatCompletionProvider('prod-claude', {
+          config: { apiHost: 'test.azure.com', apiKey: 'test-key', modelName },
+        });
+        setAuthHeaders(provider);
+        vi.mocked(fetchWithCache).mockResolvedValueOnce({
+          data: {
+            choices: [
+              { index: 0, message: { role: 'assistant', content: 'hello' }, finish_reason: 'stop' },
+            ],
+            usage: {
+              prompt_tokens: 1_000,
+              prompt_tokens_details: { cached_tokens: 500 },
+              completion_tokens: 500,
+              total_tokens: 1_500,
+            },
+          },
+          cached: false,
+          status: 200,
+          statusText: 'OK',
+        });
+
+        const result = await provider.callApi('test prompt');
+
+        expect(result.cost).toBeCloseTo(0.030125, 8);
+        const request = JSON.parse(vi.mocked(fetchWithCache).mock.calls[0][1]?.body as string);
+        expect(request.model).toBe('prod-claude');
+        expect(request).not.toHaveProperty('modelName');
+      },
+    );
+
     it('should parse JSON response with json_schema format when finish_reason is not content_filter', async () => {
       const mockResponse = {
         id: 'mock-id',
@@ -900,6 +933,56 @@ describe('AzureChatCompletionProvider', () => {
         expect(body).not.toHaveProperty('tool_choice');
       },
     );
+
+    it.each([
+      { modelName: 'claude-fable-5-1', tool_choice: 'required', expected: undefined },
+      {
+        modelName: 'claude-mythos-5-1',
+        tool_choice: { type: 'function', function: { name: 'get_weather' } },
+        expected: undefined,
+      },
+      { modelName: 'claude-fable-5-1', tool_choice: 'auto', expected: 'auto' },
+      { modelName: 'claude-mythos-5-1', tool_choice: 'none', expected: 'none' },
+    ] as const)(
+      'uses $modelName compatibility for an aliased deployment with $tool_choice',
+      async ({ modelName, tool_choice, expected }) => {
+        const provider = new AzureChatCompletionProvider('prod-claude', {
+          config: {
+            apiHost: 'test.azure.com',
+            apiKey: 'test-key',
+            modelName,
+            temperature: 0.5,
+            top_p: 0.9,
+            tools: [
+              {
+                type: 'function',
+                function: { name: 'get_weather', parameters: { type: 'object' } },
+              },
+            ],
+            tool_choice,
+          },
+        });
+        const { body } = await provider.getOpenAiBody('Check the weather');
+        expect(body.model).toBe('prod-claude');
+        expect(body.tools).toHaveLength(1);
+        expect(body.tool_choice).toEqual(expected);
+        expect(body).not.toHaveProperty('temperature');
+        expect(body).not.toHaveProperty('top_p');
+      },
+    );
+
+    it('keeps forced tool choice for an aliased older adaptive model', async () => {
+      const provider = new AzureChatCompletionProvider('prod-claude', {
+        config: {
+          apiHost: 'test.azure.com',
+          apiKey: 'test-key',
+          modelName: 'claude-fable-5',
+          tool_choice: 'required',
+        },
+      });
+      const { body } = await provider.getOpenAiBody('hi');
+      expect(body.tool_choice).toBe('required');
+    });
 
     it('omits sampling params for a custom Claude deployment when configured explicitly', async () => {
       const provider = new AzureChatCompletionProvider('prod-claude-deployment', {

--- a/test/providers/azure/util.test.ts
+++ b/test/providers/azure/util.test.ts
@@ -540,6 +540,13 @@ describe('calculateAzureCost', () => {
     expect(calculateAzureCost('claude-fable-5', {}, 1000, 500)).toBeCloseTo(0.035, 6);
   });
 
+  it.each(['claude-fable-5-1', 'claude-mythos-5-1'])(
+    'calculates cached input cost for %s',
+    (model) => {
+      expect(calculateAzureCost(model, {}, 1000, 500, 500)).toBeCloseTo(0.030125, 8);
+    },
+  );
+
   it('returns undefined for unknown model', () => {
     const cost = calculateAzureCost('unknown-model', {}, 100, 50);
     expect(cost).toBeUndefined();

--- a/test/providers/bedrock/anthropicMessages.test.ts
+++ b/test/providers/bedrock/anthropicMessages.test.ts
@@ -22,7 +22,9 @@ describe('Bedrock Anthropic Messages provider', () => {
     expect(isBedrockAnthropicMessagesModel('anthropic.claude-fable-5')).toBe(true);
     expect(isBedrockAnthropicMessagesModel('anthropic.claude-mythos-5')).toBe(true);
     expect(isBedrockAnthropicMessagesModel('anthropic.claude-fable-5-1')).toBe(true);
-    expect(isBedrockAnthropicMessagesModel('anthropic.claude-mythos-5-1')).toBe(true);
+    expect(isBedrockAnthropicMessagesModel('global.anthropic.claude-mythos-5-1')).toBe(true);
+    expect(isBedrockAnthropicMessagesModel('us.anthropic.claude-fable-5-1')).toBe(true);
+    expect(isBedrockAnthropicMessagesModel('anthropic.claude-mythos-5-1')).toBe(false);
     expect(isBedrockAnthropicMessagesModel('anthropic.claude-mythos-preview')).toBe(false);
     expect(isBedrockAnthropicMessagesModel('anthropic.claude-opus-4-8')).toBe(false);
   });
@@ -32,6 +34,10 @@ describe('Bedrock Anthropic Messages provider', () => {
       'https://bedrock-mantle.us-east-1.api.aws/anthropic',
     );
     expect(() => getBedrockAnthropicBaseUrl('evil.example/x')).toThrow(/Invalid AWS region/);
+    expect(getBedrockAnthropicBaseUrl('us-west-2', true)).toBe(
+      'https://bedrock-runtime.us-west-2.amazonaws.com/anthropic',
+    );
+    expect(() => getBedrockAnthropicBaseUrl('evil.example/x', true)).toThrow(/Invalid AWS region/);
   });
 
   it('requires a Bedrock API key', () => {
@@ -59,18 +65,39 @@ describe('Bedrock Anthropic Messages provider', () => {
     ).toThrow(/only in us-east-1 and eu-north-1/);
   });
 
-  it('rejects an unsupported default Fable 5.1 Messages region', () => {
+  it('rejects a Fable 5.1 Mantle ID outside GovCloud West', () => {
     expect(() =>
       createBedrockAnthropicMessagesProvider('anthropic.claude-fable-5-1', {
         config: { region: 'us-west-2', apiKey: 'bedrock-key' },
       }),
-    ).toThrow(/only available in us-east-1/);
+    ).toThrow(/uses Mantle only in us-gov-west-1/);
+  });
+
+  it('uses Mantle for the Fable 5.1 GovCloud West deployment', () => {
+    const provider = createBedrockAnthropicMessagesProvider('anthropic.claude-fable-5-1', {
+      config: { region: 'us-gov-west-1', apiKey: 'bedrock-key' },
+    });
+    expect(provider.getApiBaseUrl()).toBe('https://bedrock-mantle.us-gov-west-1.api.aws/anthropic');
+  });
+
+  it.each([
+    'global.anthropic.claude-fable-5-1',
+    'us.anthropic.claude-fable-5-1',
+    'global.anthropic.claude-mythos-5-1',
+    'us.anthropic.claude-mythos-5-1',
+  ])('uses the requested Runtime region for %s', (model) => {
+    const provider = createBedrockAnthropicMessagesProvider(model, {
+      config: { region: 'us-west-2', apiKey: 'bedrock-key' },
+    });
+    expect(provider.getApiBaseUrl()).toBe(
+      'https://bedrock-runtime.us-west-2.amazonaws.com/anthropic',
+    );
   });
 
   it('allows a provisioned Fable 5.1 endpoint to override the default region restriction', () => {
     const provider = createBedrockAnthropicMessagesProvider('anthropic.claude-fable-5-1', {
       config: {
-        region: 'us-gov-west-1',
+        region: 'us-west-2',
         apiKey: 'bedrock-key',
         apiBaseUrl: 'https://provisioned.example/anthropic',
       },
@@ -212,8 +239,8 @@ describe('Bedrock Anthropic Messages provider', () => {
   it.each([
     'anthropic.claude-fable-5',
     'anthropic.claude-mythos-5',
-    'anthropic.claude-fable-5-1',
-    'anthropic.claude-mythos-5-1',
+    'us.anthropic.claude-fable-5-1',
+    'us.anthropic.claude-mythos-5-1',
   ])('sends %s while reusing Anthropic compatibility and billing logic', async (bedrockModel) => {
     disableCache();
     const provider = createBedrockAnthropicMessagesProvider(bedrockModel, {

--- a/test/providers/bedrock/anthropicMessages.test.ts
+++ b/test/providers/bedrock/anthropicMessages.test.ts
@@ -59,6 +59,25 @@ describe('Bedrock Anthropic Messages provider', () => {
     ).toThrow(/only in us-east-1 and eu-north-1/);
   });
 
+  it('rejects an unsupported default Fable 5.1 Messages region', () => {
+    expect(() =>
+      createBedrockAnthropicMessagesProvider('anthropic.claude-fable-5-1', {
+        config: { region: 'us-west-2', apiKey: 'bedrock-key' },
+      }),
+    ).toThrow(/only available in us-east-1/);
+  });
+
+  it('allows a provisioned Fable 5.1 endpoint to override the default region restriction', () => {
+    const provider = createBedrockAnthropicMessagesProvider('anthropic.claude-fable-5-1', {
+      config: {
+        region: 'us-gov-west-1',
+        apiKey: 'bedrock-key',
+        apiBaseUrl: 'https://provisioned.example/anthropic',
+      },
+    });
+    expect(provider.getApiBaseUrl()).toBe('https://provisioned.example/anthropic');
+  });
+
   it('uses promptfoo env overrides for the key and region', async () => {
     restoreEnv = mockProcessEnv({
       AWS_BEARER_TOKEN_BEDROCK: undefined,

--- a/test/providers/bedrock/anthropicMessages.test.ts
+++ b/test/providers/bedrock/anthropicMessages.test.ts
@@ -21,6 +21,8 @@ describe('Bedrock Anthropic Messages provider', () => {
   it('recognizes only the Anthropic models served by the Bedrock Messages endpoint', () => {
     expect(isBedrockAnthropicMessagesModel('anthropic.claude-fable-5')).toBe(true);
     expect(isBedrockAnthropicMessagesModel('anthropic.claude-mythos-5')).toBe(true);
+    expect(isBedrockAnthropicMessagesModel('anthropic.claude-fable-5-1')).toBe(true);
+    expect(isBedrockAnthropicMessagesModel('anthropic.claude-mythos-5-1')).toBe(true);
     expect(isBedrockAnthropicMessagesModel('anthropic.claude-mythos-preview')).toBe(false);
     expect(isBedrockAnthropicMessagesModel('anthropic.claude-opus-4-8')).toBe(false);
   });
@@ -188,47 +190,49 @@ describe('Bedrock Anthropic Messages provider', () => {
     expect(create).toHaveBeenCalledTimes(1);
   });
 
-  it.each(['anthropic.claude-fable-5', 'anthropic.claude-mythos-5'])(
-    'sends %s while reusing Anthropic compatibility and billing logic',
-    async (bedrockModel) => {
-      disableCache();
-      const provider = createBedrockAnthropicMessagesProvider(bedrockModel, {
-        id: `bedrock:${bedrockModel}`,
-        config: {
-          region: 'us-east-1',
-          apiKey: 'bedrock-key',
-          max_tokens: 4096,
-          temperature: 0.5,
-          top_p: 0.9,
-          top_k: 40,
-          thinking: { type: 'disabled' },
-        },
-      });
-      const response = {
-        content: [{ type: 'text', text: 'ok' }],
-        model: bedrockModel,
-        id: 'msg-1',
-        role: 'assistant',
-        stop_reason: 'end_turn',
-        stop_details: null,
-        stop_sequence: null,
-        type: 'message',
-        usage: { input_tokens: 5, output_tokens: 1 },
-      } as Anthropic.Messages.Message;
-      const createSpy = vi.spyOn(provider.anthropic.messages, 'create').mockResolvedValue(response);
+  it.each([
+    'anthropic.claude-fable-5',
+    'anthropic.claude-mythos-5',
+    'anthropic.claude-fable-5-1',
+    'anthropic.claude-mythos-5-1',
+  ])('sends %s while reusing Anthropic compatibility and billing logic', async (bedrockModel) => {
+    disableCache();
+    const provider = createBedrockAnthropicMessagesProvider(bedrockModel, {
+      id: `bedrock:${bedrockModel}`,
+      config: {
+        region: 'us-east-1',
+        apiKey: 'bedrock-key',
+        max_tokens: 4096,
+        temperature: 0.5,
+        top_p: 0.9,
+        top_k: 40,
+        thinking: { type: 'disabled' },
+      },
+    });
+    const response = {
+      content: [{ type: 'text', text: 'ok' }],
+      model: bedrockModel,
+      id: 'msg-1',
+      role: 'assistant',
+      stop_reason: 'end_turn',
+      stop_details: null,
+      stop_sequence: null,
+      type: 'message',
+      usage: { input_tokens: 5, output_tokens: 1 },
+    } as Anthropic.Messages.Message;
+    const createSpy = vi.spyOn(provider.anthropic.messages, 'create').mockResolvedValue(response);
 
-      const result = await provider.callApi('hello');
+    const result = await provider.callApi('hello');
 
-      const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
-      expect(provider.id()).toBe(`bedrock:${bedrockModel}`);
-      expect(provider['getGenAISystem']()).toBe('bedrock');
-      expect(params.model).toBe(bedrockModel);
-      expect(params).not.toHaveProperty('temperature');
-      expect(params).not.toHaveProperty('top_p');
-      expect(params).not.toHaveProperty('top_k');
-      expect(params).not.toHaveProperty('thinking');
-      expect(result.output).toBe('ok');
-      expect(result.cost).toBeCloseTo(0.00011, 8);
-    },
-  );
+    const params = createSpy.mock.calls[0][0] as unknown as Record<string, unknown>;
+    expect(provider.id()).toBe(`bedrock:${bedrockModel}`);
+    expect(provider['getGenAISystem']()).toBe('bedrock');
+    expect(params.model).toBe(bedrockModel);
+    expect(params).not.toHaveProperty('temperature');
+    expect(params).not.toHaveProperty('top_p');
+    expect(params).not.toHaveProperty('top_k');
+    expect(params).not.toHaveProperty('thinking');
+    expect(result.output).toBe('ok');
+    expect(result.cost).toBeCloseTo(0.00011, 8);
+  });
 });

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -3451,6 +3451,19 @@ describe('BEDROCK_MODEL token counting functionality', () => {
 });
 
 describe('AWS_BEDROCK_MODELS mapping', () => {
+  it('maps Fable 5.1 base, US, and global IDs while keeping Mythos 5.1 on Messages', () => {
+    for (const prefix of ['', 'us.', 'global.']) {
+      const model = `${prefix}anthropic.claude-fable-5-1`;
+      expect(AWS_BEDROCK_MODELS[model]).toBe(BEDROCK_MODEL.CLAUDE_MESSAGES);
+      expect(getHandlerForModel(model)).toBe(BEDROCK_MODEL.CLAUDE_MESSAGES);
+    }
+    expect(AWS_BEDROCK_MODELS['eu.anthropic.claude-fable-5-1']).toBeUndefined();
+    expect(AWS_BEDROCK_MODELS['anthropic.claude-mythos-5-1']).toBeUndefined();
+    expect(() => getHandlerForModel('anthropic.claude-mythos-5-1')).toThrow(
+      /Anthropic Messages API/,
+    );
+  });
+
   it('maps Fable to Runtime and keeps Messages-only Mythos out of the registry', () => {
     expect(AWS_BEDROCK_MODELS['anthropic.claude-fable-5']).toBe(BEDROCK_MODEL.CLAUDE_MESSAGES);
     expect(AWS_BEDROCK_MODELS['us.anthropic.claude-fable-5']).toBe(BEDROCK_MODEL.CLAUDE_MESSAGES);

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -3451,17 +3451,13 @@ describe('BEDROCK_MODEL token counting functionality', () => {
 });
 
 describe('AWS_BEDROCK_MODELS mapping', () => {
-  it('maps Fable 5.1 base, US, and global IDs while keeping Mythos 5.1 on Messages', () => {
+  it.each(['fable', 'mythos'])('maps %s 5.1 base, US, and global Runtime IDs', (family) => {
     for (const prefix of ['', 'us.', 'global.']) {
-      const model = `${prefix}anthropic.claude-fable-5-1`;
+      const model = `${prefix}anthropic.claude-${family}-5-1`;
       expect(AWS_BEDROCK_MODELS[model]).toBe(BEDROCK_MODEL.CLAUDE_MESSAGES);
       expect(getHandlerForModel(model)).toBe(BEDROCK_MODEL.CLAUDE_MESSAGES);
     }
-    expect(AWS_BEDROCK_MODELS['eu.anthropic.claude-fable-5-1']).toBeUndefined();
-    expect(AWS_BEDROCK_MODELS['anthropic.claude-mythos-5-1']).toBeUndefined();
-    expect(() => getHandlerForModel('anthropic.claude-mythos-5-1')).toThrow(
-      /Anthropic Messages API/,
-    );
+    expect(AWS_BEDROCK_MODELS[`eu.anthropic.claude-${family}-5-1`]).toBeUndefined();
   });
 
   it('maps Fable to Runtime and keeps Messages-only Mythos out of the registry', () => {
@@ -3889,6 +3885,38 @@ describe('AwsBedrockCompletionProvider', () => {
     expect(result.output).toBe('ok');
     expect(result.cost).toBeCloseTo(0.00385, 6);
   });
+
+  it.each([
+    ['global.anthropic.claude-fable-5-1', 1000, 0.0363],
+    ['global.anthropic.claude-mythos-5-1', 0, 0.0263],
+    ['global.anthropic.claude-fable-5', 0, 0.02645],
+  ] as const)(
+    'prices Claude Runtime cache tokens once for %s',
+    async (modelName, inputTokens, expectedCost) => {
+      const responseJson = JSON.stringify({
+        content: [{ type: 'text', text: 'ok' }],
+        usage: {
+          input_tokens: inputTokens,
+          output_tokens: 500,
+          cache_read_input_tokens: 200,
+          cache_creation_input_tokens: 100,
+        },
+      });
+      mockInvokeModel.mockResolvedValueOnce({
+        body: Object.assign(new TextEncoder().encode(responseJson), {
+          transformToString: () => responseJson,
+        }),
+      });
+      const provider = new AwsBedrockCompletionProvider(modelName, {
+        config: { region: 'us-west-2' },
+      });
+
+      const result = await provider.callApi('hello');
+
+      expect(result.tokenUsage?.prompt).toBe(inputTokens + 300);
+      expect(result.cost).toBeCloseTo(expectedCost, 8);
+    },
+  );
 
   it('calculates pricing for OpenAI-compatible Runtime responses', async () => {
     const responseJson = JSON.stringify({

--- a/test/providers/bedrock/pricing.test.ts
+++ b/test/providers/bedrock/pricing.test.ts
@@ -220,6 +220,13 @@ describe('calculateBedrockCost', () => {
     ).toBeCloseTo(15, 6);
   });
 
+  it.each(['global.', 'us.'])('prices Fable 5.1 cache reads on the %s endpoint', (prefix) => {
+    const model = `${prefix}anthropic.claude-fable-5-1`;
+    const expected = 0.0363 * (prefix === 'global.' ? 1 : 1.1);
+    expect(calculateBedrockCost(model, 1000, 500, 200, 100)).toBeCloseTo(expected, 8);
+    expect(calculateBedrockInvokeModelCost(model, 1000, 500, 200, 100)).toBeCloseTo(expected, 8);
+  });
+
   it('prices Claude Sonnet 5 at $3/$15 on the global endpoint (base rate)', () => {
     // The global endpoint bills at the base rate; regional profiles add a premium (below).
     expect(calculateBedrockCost('global.anthropic.claude-sonnet-5', 100_000, 1_000)).toBeCloseTo(

--- a/test/providers/bedrock/pricing.test.ts
+++ b/test/providers/bedrock/pricing.test.ts
@@ -220,9 +220,13 @@ describe('calculateBedrockCost', () => {
     ).toBeCloseTo(15, 6);
   });
 
-  it.each(['global.', 'us.'])('prices Fable 5.1 cache reads on the %s endpoint', (prefix) => {
-    const model = `${prefix}anthropic.claude-fable-5-1`;
-    const expected = 0.0363 * (prefix === 'global.' ? 1 : 1.1);
+  it.each([
+    'global.anthropic.claude-fable-5-1',
+    'us.anthropic.claude-fable-5-1',
+    'global.anthropic.claude-mythos-5-1',
+    'us.anthropic.claude-mythos-5-1',
+  ])('prices 5.1 cache reads for %s', (model) => {
+    const expected = 0.0363 * (model.startsWith('global.') ? 1 : 1.1);
     expect(calculateBedrockCost(model, 1000, 500, 200, 100)).toBeCloseTo(expected, 8);
     expect(calculateBedrockInvokeModelCost(model, 1000, 500, 200, 100)).toBeCloseTo(expected, 8);
   });

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -407,6 +407,8 @@ describe('ClaudeCodeSDKProvider', () => {
       const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(function () {});
 
       new ClaudeCodeSDKProvider({ config: { model: 'claude-3-5-sonnet-20241022' } });
+      new ClaudeCodeSDKProvider({ config: { model: 'claude-fable-5-1' } });
+      new ClaudeCodeSDKProvider({ config: { model: 'claude-mythos-5-1' } });
       new ClaudeCodeSDKProvider({ config: { fallback_model: 'claude-3-5-haiku-20241022' } });
 
       expect(warnSpy).not.toHaveBeenCalled();

--- a/test/providers/families/aws.test.ts
+++ b/test/providers/families/aws.test.ts
@@ -149,9 +149,15 @@ describe('aws bedrock provider factory routing', () => {
     expect(provider.id()).toBe('bedrock:anthropic.claude-mythos-5');
   });
 
-  it('keeps Fable 5.1 on Bedrock Runtime', async () => {
+  it.each([
+    'anthropic.claude-mythos-5-1',
+    'global.anthropic.claude-fable-5-1',
+    'us.anthropic.claude-fable-5-1',
+    'global.anthropic.claude-mythos-5-1',
+    'us.anthropic.claude-mythos-5-1',
+  ])('keeps %s on Bedrock Runtime', async (model) => {
     const provider = await bedrockFactory.create(
-      'bedrock:global.anthropic.claude-fable-5-1',
+      `bedrock:${model}`,
       { config: { region: 'us-east-1' } },
       ctx,
     );
@@ -159,9 +165,10 @@ describe('aws bedrock provider factory routing', () => {
   });
 
   it.each([
-    'bedrock:anthropic.claude-mythos-5-1',
-    'bedrock:messages:anthropic.claude-mythos-5-1',
-    'bedrock:messages:anthropic.claude-fable-5-1',
+    'bedrock:messages:global.anthropic.claude-mythos-5-1',
+    'bedrock:messages:us.anthropic.claude-mythos-5-1',
+    'bedrock:messages:global.anthropic.claude-fable-5-1',
+    'bedrock:messages:us.anthropic.claude-fable-5-1',
   ])('routes %s through Anthropic Messages', async (providerPath) => {
     const provider = await bedrockFactory.create(
       providerPath,
@@ -170,12 +177,24 @@ describe('aws bedrock provider factory routing', () => {
     );
     expect(provider).toBeInstanceOf(BedrockAnthropicMessagesProvider);
     expect(provider.id()).toBe(providerPath);
+    expect((provider as BedrockAnthropicMessagesProvider).getApiBaseUrl()).toBe(
+      'https://bedrock-runtime.us-east-1.amazonaws.com/anthropic',
+    );
   });
 
-  it.each(['converse', 'completion'])('rejects %s for Mythos 5.1', async (api) => {
+  it.each(['fable', 'mythos'])('routes %s 5.1 through Converse', async (family) => {
+    const provider = await bedrockFactory.create(
+      `bedrock:converse:global.anthropic.claude-${family}-5-1`,
+      {},
+      ctx,
+    );
+    expect(provider).toBeInstanceOf(AwsBedrockConverseProvider);
+  });
+
+  it('requires an inference profile for Mythos 5.1 Messages', async () => {
     await expect(
-      bedrockFactory.create(`bedrock:${api}:anthropic.claude-mythos-5-1`, {}, ctx),
-    ).rejects.toThrow(/Anthropic Messages API/);
+      bedrockFactory.create('bedrock:messages:anthropic.claude-mythos-5-1', {}, ctx),
+    ).rejects.toThrow(/Use a us. or global. inference profile/);
   });
 
   it('supports the explicit messages form for Bedrock Fable', async () => {
@@ -224,8 +243,6 @@ describe('aws bedrock provider factory routing', () => {
     'bedrock:us.anthropic.claude-mythos-5',
     'bedrock:converse:global.anthropic.claude-mythos-5',
     'bedrock:completion:us.anthropic.claude-mythos-5',
-    'bedrock:us.anthropic.claude-mythos-5-1',
-    'bedrock:messages:global.anthropic.claude-mythos-5-1',
   ])('rejects unsupported prefixed Mythos ID %s', async (providerPath) => {
     await expect(
       bedrockFactory.create(providerPath, { config: { apiKey: 'bedrock-key' } }, ctx),

--- a/test/providers/families/aws.test.ts
+++ b/test/providers/families/aws.test.ts
@@ -149,6 +149,35 @@ describe('aws bedrock provider factory routing', () => {
     expect(provider.id()).toBe('bedrock:anthropic.claude-mythos-5');
   });
 
+  it('keeps Fable 5.1 on Bedrock Runtime', async () => {
+    const provider = await bedrockFactory.create(
+      'bedrock:global.anthropic.claude-fable-5-1',
+      { config: { region: 'us-east-1' } },
+      ctx,
+    );
+    expect(provider).toBeInstanceOf(AwsBedrockCompletionProvider);
+  });
+
+  it.each([
+    'bedrock:anthropic.claude-mythos-5-1',
+    'bedrock:messages:anthropic.claude-mythos-5-1',
+    'bedrock:messages:anthropic.claude-fable-5-1',
+  ])('routes %s through Anthropic Messages', async (providerPath) => {
+    const provider = await bedrockFactory.create(
+      providerPath,
+      { config: { region: 'us-east-1', apiKey: 'bedrock-key' } },
+      ctx,
+    );
+    expect(provider).toBeInstanceOf(BedrockAnthropicMessagesProvider);
+    expect(provider.id()).toBe(providerPath);
+  });
+
+  it.each(['converse', 'completion'])('rejects %s for Mythos 5.1', async (api) => {
+    await expect(
+      bedrockFactory.create(`bedrock:${api}:anthropic.claude-mythos-5-1`, {}, ctx),
+    ).rejects.toThrow(/Anthropic Messages API/);
+  });
+
   it('supports the explicit messages form for Bedrock Fable', async () => {
     const provider = await bedrockFactory.create(
       'bedrock:messages:anthropic.claude-fable-5',
@@ -195,6 +224,8 @@ describe('aws bedrock provider factory routing', () => {
     'bedrock:us.anthropic.claude-mythos-5',
     'bedrock:converse:global.anthropic.claude-mythos-5',
     'bedrock:completion:us.anthropic.claude-mythos-5',
+    'bedrock:us.anthropic.claude-mythos-5-1',
+    'bedrock:messages:global.anthropic.claude-mythos-5-1',
   ])('rejects unsupported prefixed Mythos ID %s', async (providerPath) => {
     await expect(
       bedrockFactory.create(providerPath, { config: { apiKey: 'bedrock-key' } }, ctx),

--- a/test/providers/google/vertex.test.ts
+++ b/test/providers/google/vertex.test.ts
@@ -3146,87 +3146,91 @@ describe('VertexChatProvider.callClaudeApi', () => {
     },
   );
 
-  it('supports Claude Fable 5 with adaptive-safe parameters and regional pricing', async () => {
-    const model = 'claude-fable-5';
-    provider = new VertexChatProvider(model, {
-      config: { max_tokens: 32, temperature: 0.5, top_p: 0.9, top_k: 40 },
-    });
-    const mockRequest = vi.fn().mockResolvedValue({
-      data: {
-        id: 'test-id',
-        type: 'message',
-        role: 'assistant',
-        model,
-        content: [{ type: 'text', text: 'ok' }],
-        stop_reason: 'end_turn',
-        stop_sequence: null,
-        usage: {
-          input_tokens: 5,
-          output_tokens: 1,
-          cache_creation_input_tokens: 0,
-          cache_read_input_tokens: 0,
+  it.each(['claude-fable-5', 'claude-fable-5-1', 'claude-mythos-5-1'])(
+    'supports %s with adaptive-safe parameters and regional pricing',
+    async (model) => {
+      provider = new VertexChatProvider(model, {
+        config: { max_tokens: 32, temperature: 0.5, top_p: 0.9, top_k: 40 },
+      });
+      const mockRequest = vi.fn().mockResolvedValue({
+        data: {
+          id: 'test-id',
+          type: 'message',
+          role: 'assistant',
+          model,
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: {
+            input_tokens: 5,
+            output_tokens: 1,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
         },
-      },
-    });
-    vi.spyOn(vertexUtil, 'getGoogleClient').mockResolvedValue({
-      client: { request: mockRequest } as unknown as JSONClient,
-      projectId: 'test-project-id',
-    });
-    vi.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) =>
-      typeof creds === 'object' ? JSON.stringify(creds) : creds,
-    );
-    vi.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
+      });
+      vi.spyOn(vertexUtil, 'getGoogleClient').mockResolvedValue({
+        client: { request: mockRequest } as unknown as JSONClient,
+        projectId: 'test-project-id',
+      });
+      vi.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) =>
+        typeof creds === 'object' ? JSON.stringify(creds) : creds,
+      );
+      vi.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
-    const result = await provider.callClaudeApi('test prompt');
+      const result = await provider.callClaudeApi('test prompt');
 
-    const request = mockRequest.mock.calls[0][0];
-    const sentBody = request.data as Record<string, unknown>;
-    expect(request.url).toContain(`/publishers/anthropic/models/${model}:rawPredict`);
-    expect(sentBody.temperature).toBeUndefined();
-    expect(sentBody.top_p).toBeUndefined();
-    expect(sentBody.top_k).toBeUndefined();
-    expect(result.cost).toBeCloseTo(0.00011, 8);
-  });
+      const request = mockRequest.mock.calls[0][0];
+      const sentBody = request.data as Record<string, unknown>;
+      expect(request.url).toContain(`/publishers/anthropic/models/${model}:rawPredict`);
+      expect(sentBody.temperature).toBeUndefined();
+      expect(sentBody.top_p).toBeUndefined();
+      expect(sentBody.top_k).toBeUndefined();
+      expect(result.cost).toBeCloseTo(0.00011, 8);
+    },
+  );
 
-  it('uses base Claude 5 pricing for Fable on the global Vertex region', async () => {
-    const model = 'claude-fable-5';
-    provider = new VertexChatProvider(model, {
-      config: { region: 'global', max_tokens: 32 },
-    });
-    const mockRequest = vi.fn().mockResolvedValue({
-      data: {
-        id: 'test-id',
-        type: 'message',
-        role: 'assistant',
-        model,
-        content: [{ type: 'text', text: 'ok' }],
-        stop_reason: 'end_turn',
-        stop_sequence: null,
-        usage: {
-          input_tokens: 5,
-          output_tokens: 1,
-          cache_creation_input_tokens: 0,
-          cache_read_input_tokens: 0,
+  it.each(['claude-fable-5', 'claude-fable-5-1', 'claude-mythos-5-1'])(
+    'uses base pricing for %s on the global Vertex region',
+    async (model) => {
+      provider = new VertexChatProvider(model, {
+        config: { region: 'global', max_tokens: 32 },
+      });
+      const mockRequest = vi.fn().mockResolvedValue({
+        data: {
+          id: 'test-id',
+          type: 'message',
+          role: 'assistant',
+          model,
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: {
+            input_tokens: 5,
+            output_tokens: 1,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+          },
         },
-      },
-    });
-    vi.spyOn(vertexUtil, 'getGoogleClient').mockResolvedValue({
-      client: { request: mockRequest } as unknown as JSONClient,
-      projectId: 'test-project-id',
-    });
-    vi.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) =>
-      typeof creds === 'object' ? JSON.stringify(creds) : creds,
-    );
-    vi.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
+      });
+      vi.spyOn(vertexUtil, 'getGoogleClient').mockResolvedValue({
+        client: { request: mockRequest } as unknown as JSONClient,
+        projectId: 'test-project-id',
+      });
+      vi.spyOn(vertexUtil, 'loadCredentials').mockImplementation((creds) =>
+        typeof creds === 'object' ? JSON.stringify(creds) : creds,
+      );
+      vi.spyOn(vertexUtil, 'resolveProjectId').mockResolvedValue('test-project-id');
 
-    const result = await provider.callClaudeApi('test prompt');
+      const result = await provider.callClaudeApi('test prompt');
 
-    const request = mockRequest.mock.calls[0][0];
-    expect(request.url).toContain('/locations/global/');
-    // Global region bills at the base Claude 5 rate (no 10% regional premium):
-    // 5 input * $10/MTok + 1 output * $50/MTok = $0.0001
-    expect(result.cost).toBeCloseTo(0.0001, 8);
-  });
+      const request = mockRequest.mock.calls[0][0];
+      expect(request.url).toContain('/locations/global/');
+      // Global region bills at the base Claude 5 rate (no 10% regional premium):
+      // 5 input * $10/MTok + 1 output * $50/MTok = $0.0001
+      expect(result.cost).toBeCloseTo(0.0001, 8);
+    },
+  );
 
   it('does not stack the Vertex regional premium on a user-provided cost override for Fable', async () => {
     const model = 'claude-fable-5';

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -536,6 +536,8 @@ describe('Provider Registry', () => {
       for (const model of [
         'claude-fable-5',
         'claude-mythos-5',
+        'claude-fable-5-1',
+        'claude-mythos-5-1',
         'claude-opus-5',
         'claude-sonnet-5',
       ]) {


### PR DESCRIPTION
Adds `claude-fable-5-1` and `claude-mythos-5-1` to Promptfoo's provider catalogs and redteam model picker, with documentation for Anthropic, Bedrock, Vertex AI, and Azure.

The new models retain always-on adaptive thinking and $10/$50 per-million-token input/output pricing, but cache reads now cost $0.25 per million tokens. Requests omit unsupported forced tool choices for 5.1 while preserving forced tool use on older adaptive models. Bedrock InvokeModel pricing now uses Claude's uncached input count so cached tokens are not charged twice.

Both 5.1 models support Bedrock Runtime InvokeModel, Converse, and Messages using the published `us.` and `global.` inference profiles. Fable 5.1 also supports Mantle in GovCloud West. Mythos 5.1 requires provider approval. Custom Azure chat deployment names can set `modelName` to apply the underlying Claude model's compatibility rules and pricing without changing the deployment sent to Azure.

Validation:

- Provider regression suites covering Anthropic, Bedrock, Azure, Vertex, provider loading, and Claude Agent SDK; model-picker tests.
- `npm run tsc`, `npm run build`, `npm run knip -- --no-progress`, `npm run l`, and `npm run f`.
- Source and built CLI evaluations with `--no-cache` against local mock endpoints: eleven cases each across Anthropic, Bedrock Messages/InvokeModel/Converse, and aliased Azure deployments. Checks cover exported success/score/error, request normalization, cache costs, cloud routing, and preserved Fable 5 behavior. Live model calls were not made.

Sources: [Anthropic migration notes](https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1), [pricing](https://platform.claude.com/docs/en/about-claude/pricing), and AWS's model cards for [Fable 5.1](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-fable-5-1.html) and [Mythos 5.1](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-mythos-5-1.html).
