### PR TITLE
fix(providers): thread per-call traceparent to the OpenCode server

### DIFF
--- a/site/docs/providers/opencode-sdk.md
+++ b/site/docs/providers/opencode-sdk.md
@@ -646,6 +646,13 @@ Set `restart_server_per_call: true` to give each call its own server, booted wit
 traceparent:
 
 ```yaml
+# Required: without tracing there is no per-call traceparent to hand the server.
+tracing:
+  enabled: true
+  otlp:
+    http:
+      enabled: true
+
 providers:
   - id: opencode:sdk
     config:
@@ -661,6 +668,9 @@ tests:
       - type: trajectory:tool-used
         value: grep
 ```
+
+If the flag is set while tracing is off, promptfoo warns once: the restarted server has no
+trace context to be tagged with, so you pay the cost below for no correlation.
 
 ### Trade-offs
 

--- a/site/docs/providers/opencode-sdk.md
+++ b/site/docs/providers/opencode-sdk.md
@@ -188,29 +188,30 @@ When enabling write/edit/bash tools, consider how you will reset files after eac
 
 ## Supported Parameters
 
-| Parameter           | Type    | Description                                                                | Default                                |
-| ------------------- | ------- | -------------------------------------------------------------------------- | -------------------------------------- |
-| `apiKey`            | string  | Inject API key into a spawned OpenCode server for `provider_id`            | Environment variable                   |
-| `baseUrl`           | string  | URL for an existing OpenCode server                                        | Auto-start server                      |
-| `hostname`          | string  | Server hostname when starting a new server                                 | `127.0.0.1`                            |
-| `port`              | number  | Server port when starting a new server                                     | Auto-select                            |
-| `timeout`           | number  | Server startup timeout in milliseconds                                     | `30000`                                |
-| `log_level`         | string  | OpenCode server log level (`debug`, `info`, `warn`, `error`, `off`)        | Provider default                       |
-| `working_dir`       | string  | Directory for file operations and read-only default tools                  | Temporary directory                    |
-| `workspace`         | string  | Workspace identifier for workspace-aware OpenCode requests                 | None                                   |
-| `provider_id`       | string  | LLM provider (`anthropic`, `openai`, `google`, `ollama`, etc.)             | OpenCode default                       |
-| `model`             | string  | Model to use for this request                                              | OpenCode default                       |
-| `format`            | object  | Output format, including JSON Schema structured output                     | Text                                   |
-| `variant`           | string  | Provider/model variant defined in OpenCode config                          | Default variant                        |
-| `tools`             | object  | Tool configuration                                                         | None; read-only with `working_dir`     |
-| `permission`        | object  | Permission configuration for tools                                         | No extra rules; wildcard-deny baseline |
-| `agent`             | string  | Built-in or preconfigured agent to use                                     | Default agent                          |
-| `custom_agent`      | object  | Custom agent configuration when promptfoo starts the OpenCode server       | None                                   |
-| `session_id`        | string  | Resume an existing session                                                 | Create new session                     |
-| `parent_session_id` | string  | Fork from an existing session (v2 server only); inherits compacted history | None                                   |
-| `persist_sessions`  | boolean | Reuse the same session for repeated calls with the same provider config    | `false`                                |
-| `mcp`               | object  | MCP server configuration when promptfoo starts the OpenCode server         | None                                   |
-| `cache_mcp`         | boolean | Enable caching when MCP is configured                                      | `false`                                |
+| Parameter                 | Type    | Description                                                                | Default                                |
+| ------------------------- | ------- | -------------------------------------------------------------------------- | -------------------------------------- |
+| `apiKey`                  | string  | Inject API key into a spawned OpenCode server for `provider_id`            | Environment variable                   |
+| `baseUrl`                 | string  | URL for an existing OpenCode server                                        | Auto-start server                      |
+| `hostname`                | string  | Server hostname when starting a new server                                 | `127.0.0.1`                            |
+| `port`                    | number  | Server port when starting a new server                                     | Auto-select                            |
+| `timeout`                 | number  | Server startup timeout in milliseconds                                     | `30000`                                |
+| `log_level`               | string  | OpenCode server log level (`debug`, `info`, `warn`, `error`, `off`)        | Provider default                       |
+| `working_dir`             | string  | Directory for file operations and read-only default tools                  | Temporary directory                    |
+| `workspace`               | string  | Workspace identifier for workspace-aware OpenCode requests                 | None                                   |
+| `provider_id`             | string  | LLM provider (`anthropic`, `openai`, `google`, `ollama`, etc.)             | OpenCode default                       |
+| `model`                   | string  | Model to use for this request                                              | OpenCode default                       |
+| `format`                  | object  | Output format, including JSON Schema structured output                     | Text                                   |
+| `variant`                 | string  | Provider/model variant defined in OpenCode config                          | Default variant                        |
+| `tools`                   | object  | Tool configuration                                                         | None; read-only with `working_dir`     |
+| `permission`              | object  | Permission configuration for tools                                         | No extra rules; wildcard-deny baseline |
+| `agent`                   | string  | Built-in or preconfigured agent to use                                     | Default agent                          |
+| `custom_agent`            | object  | Custom agent configuration when promptfoo starts the OpenCode server       | None                                   |
+| `session_id`              | string  | Resume an existing session                                                 | Create new session                     |
+| `parent_session_id`       | string  | Fork from an existing session (v2 server only); inherits compacted history | None                                   |
+| `persist_sessions`        | boolean | Reuse the same session for repeated calls with the same provider config    | `false`                                |
+| `mcp`                     | object  | MCP server configuration when promptfoo starts the OpenCode server         | None                                   |
+| `cache_mcp`               | boolean | Enable caching when MCP is configured                                      | `false`                                |
+| `restart_server_per_call` | boolean | Restart the server per call so spans correlate to each test case           | `false`                                |
 
 ## Supported Providers
 
@@ -608,7 +609,7 @@ MCP configurations containing environment variables, positional command argument
 OAuth, URL credentials, or query strings remain uncached so secrets are not included in persistent
 cache keys. Positional command arguments can contain opaque credentials such as database URLs.
 Response caching is also disabled for credential-bearing or signed `baseUrl` values, explicit
-permission rules, `session_id`, and `persist_sessions`. API credentials use a non-secret,
+permission rules, `session_id`, `persist_sessions`, and `restart_server_per_call`. API credentials use a non-secret,
 process-local cache scope so different provider instances cannot share responses. Repeated calls
 through one locally started server retain a stable scope without storing or hashing its credentials
 or environment into the persistent cache key.
@@ -627,6 +628,64 @@ tests:
     options:
       bustCache: true
 ```
+
+## Trace Correlation (`trajectory:*` assertions)
+
+OpenCode ships no built-in OpenTelemetry support. Per-tool-call spans come from a third-party
+plugin (for example `@devtheops/opencode-plugin-otel`) that you install into OpenCode and point at
+promptfoo's OTLP receiver. That plugin reads its trace-correlation context from the
+`OPENCODE_TRACEPARENT` environment variable **once, at process boot**.
+
+That boot-time read is the catch. Because promptfoo starts one `opencode serve` process and reuses
+it for the whole evaluation, every span the server emits carries whichever traceparent was current
+when the server started. Spans from test case 12 land under test case 1's trace, so `trajectory:*`
+assertions — `trajectory:tool-used`, `trajectory:tool-args-match`, `trajectory:step-count` — have
+nothing they can correlate back to the case under test.
+
+Set `restart_server_per_call: true` to give each call its own server, booted with that call's
+traceparent:
+
+```yaml
+providers:
+  - id: opencode:sdk
+    config:
+      provider_id: anthropic
+      model: claude-sonnet-4-20250514
+      working_dir: ./my-project
+      restart_server_per_call: true
+
+tests:
+  - vars:
+      question: Which files define the login flow?
+    assert:
+      - type: trajectory:tool-used
+        value: grep
+```
+
+### Trade-offs
+
+Restarting the server on every call is not free, which is why it is opt-in:
+
+- **Cost:** a full OpenCode server start per test case. On a large suite this dominates runtime.
+- **Caching is disabled.** A cache hit returns without running the agent, so it emits no spans and
+  a `trajectory:*` assertion would have nothing to read. Per-call traces require per-call execution.
+- **Calls are serialized.** The server is per-call state, so promptfoo runs one call at a time on a
+  provider instance with this flag set, regardless of `--max-concurrency`. Use separate provider
+  instances if you need parallelism.
+
+### Incompatible options
+
+promptfoo rejects these combinations rather than silently emitting uncorrelated traces:
+
+| Option             | Why it conflicts                                                                 |
+| ------------------ | -------------------------------------------------------------------------------- |
+| `baseUrl`          | The server belongs to you, not promptfoo, so it cannot be restarted or re-tagged |
+| `persist_sessions` | A restart discards the server-side session the setting exists to preserve        |
+| `session_id`       | The resumed session lives on the server the restart just stopped                 |
+
+Leave the flag off if you only need a single well-formed root trace per run rather than per-call
+correlation: promptfoo still seeds `OPENCODE_TRACEPARENT` at server boot when the ambient
+environment has not already set it.
 
 ## Managing Side Effects
 

--- a/src/providers/opencode-sdk.ts
+++ b/src/providers/opencode-sdk.ts
@@ -902,6 +902,7 @@ export class OpenCodeSDKProvider implements ApiProvider {
   private sessionQueues = new Map<string, Promise<void>>();
   private readonly credentialCacheScope = crypto.randomUUID();
   private streamingWarningEmitted = false;
+  private missingTraceparentWarningEmitted = false;
   /** Traceparent the currently-running server was booted with, if any. */
   private activeTraceparent?: string;
 
@@ -1952,6 +1953,19 @@ export class OpenCodeSDKProvider implements ApiProvider {
         this.streamingWarningEmitted = true;
         logger.warn(
           '[OpenCode SDK] enable_streaming is currently a no-op for this provider; the prompt will run to completion before returning.',
+        );
+      }
+
+      // The flag costs serialized, uncached calls and buys nothing without trace context, so
+      // say so rather than letting the user pay for a silent no-op.
+      if (
+        this.restartsServerPerCall(config) &&
+        !isValidTraceparent(context?.traceparent) &&
+        !this.missingTraceparentWarningEmitted
+      ) {
+        this.missingTraceparentWarningEmitted = true;
+        logger.warn(
+          '[OpenCode SDK] restart_server_per_call is set but this call carries no trace context, so the restarted server cannot be tagged with one. Enable tracing (tracing.enabled: true) to correlate spans, or unset the flag to avoid paying for serialized, uncached calls.',
         );
       }
 

--- a/src/providers/opencode-sdk.ts
+++ b/src/providers/opencode-sdk.ts
@@ -359,6 +359,22 @@ export interface OpenCodeSDKConfig {
   persist_sessions?: boolean;
 
   /**
+   * Restart the OpenCode server whenever the per-call W3C traceparent changes, so spans
+   * emitted by `opencode serve` are parented under the test case that produced them.
+   *
+   * OpenCode's OpenTelemetry plugin reads `OPENCODE_TRACEPARENT` exactly once, at process
+   * boot, so a single long-lived server can only ever report one trace. Restarting is the
+   * only way to give it a fresh one. Required for `trajectory:*` assertions to correlate.
+   *
+   * This costs a full server restart per test case, so it is opt-in. Incompatible with
+   * `baseUrl` (promptfoo does not own that server), and with `persist_sessions` /
+   * `session_id` (a restart discards server-side session state).
+   *
+   * @default false
+   */
+  restart_server_per_call?: boolean;
+
+  /**
    * MCP server configuration
    */
   mcp?: Record<string, OpenCodeMCPServerConfig>;
@@ -781,6 +797,47 @@ function normalizeStructuredText(value: string): string | undefined {
   return tryParseJson(fencedJsonMatch[1]);
 }
 
+const ZERO_TRACE_ID = '00000000000000000000000000000000';
+const ZERO_SPAN_ID = '0000000000000000';
+
+/**
+ * Mirrors the check the other agentic providers use (see `openai/codex-sdk.ts`): a traceparent
+ * is only useful for correlation if it carries a non-zero trace id and span id.
+ */
+function isValidTraceparent(traceparent: string | undefined): traceparent is string {
+  if (!traceparent) {
+    return false;
+  }
+  const [, traceId, spanId] = traceparent.split('-');
+  return Boolean(traceId && spanId && traceId !== ZERO_TRACE_ID && spanId !== ZERO_SPAN_ID);
+}
+
+/**
+ * Env var read by OpenCode's OpenTelemetry plugin at process boot to parent its spans.
+ * OpenCode ships no built-in tracing, so this is the only trace-correlation hook available
+ * for the spawned `opencode serve` process.
+ */
+const OPENCODE_TRACEPARENT_ENV = 'OPENCODE_TRACEPARENT';
+
+/**
+ * Writes a single `process.env` entry, using the same `Object.assign` / `Reflect.deleteProperty`
+ * mechanics as the repo's env helpers (`test/util/utils.ts`). See `spawnWithServerEnv()` for why
+ * mutating the real environment is unavoidable here.
+ */
+function setProcessEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(process.env, key);
+  } else {
+    Object.assign(process.env, { [key]: value });
+  }
+}
+
+/**
+ * Queue key used to serialize the entire server lifecycle (start -> session -> prompt) when
+ * `restart_server_per_call` swaps the shared server between calls.
+ */
+const SERVER_LIFECYCLE_QUEUE_KEY = 'opencode:sdk:server-lifecycle';
+
 /**
  * Helper to load the OpenCode SDK ESM module
  *
@@ -836,6 +893,7 @@ export class OpenCodeSDKProvider implements ApiProvider {
 
   private providerId = 'opencode:sdk';
   private opencodeModule?: LoadedOpenCodeSDKModule;
+  private opencodeModuleLoad?: Promise<LoadedOpenCodeSDKModule>;
   private client?: OpenCodeClient;
   private clientInitialization?: Promise<void>;
   private server?: OpenCodeServer;
@@ -844,6 +902,8 @@ export class OpenCodeSDKProvider implements ApiProvider {
   private sessionQueues = new Map<string, Promise<void>>();
   private readonly credentialCacheScope = crypto.randomUUID();
   private streamingWarningEmitted = false;
+  /** Traceparent the currently-running server was booted with, if any. */
+  private activeTraceparent?: string;
 
   constructor(
     options: {
@@ -913,6 +973,18 @@ export class OpenCodeSDKProvider implements ApiProvider {
     this.sessionOrder = [];
     this.sessionQueues.clear();
 
+    await this.closeServer();
+  }
+
+  /**
+   * Tears down the client and, if we started one, the server. Leaves session bookkeeping to
+   * the caller: `cleanup()` deletes sessions over the wire first, while a per-call restart
+   * just drops the now-dangling handles.
+   */
+  private async closeServer(): Promise<void> {
+    await this.clientInitialization?.catch(() => undefined);
+    this.clientInitialization = undefined;
+
     // Close server if we started one
     if (this.server) {
       try {
@@ -923,6 +995,7 @@ export class OpenCodeSDKProvider implements ApiProvider {
       this.server = undefined;
     }
     this.client = undefined;
+    this.activeTraceparent = undefined;
   }
 
   /**
@@ -1055,8 +1128,18 @@ export class OpenCodeSDKProvider implements ApiProvider {
     });
   }
 
-  private buildServerEnv(config: OpenCodeSDKConfig): Record<string, string> {
-    const serverEnv: Record<string, string> = {};
+  /**
+   * Builds the environment the spawned `opencode serve` process should see.
+   *
+   * A `undefined` value means "unset this variable for the child", which matters for
+   * `OPENCODE_TRACEPARENT`: a stale value inherited from the ambient environment would
+   * silently mis-parent every span the server emits.
+   */
+  private buildServerEnv(
+    config: OpenCodeSDKConfig,
+    traceparent?: string,
+  ): Record<string, string | undefined> {
+    const serverEnv: Record<string, string | undefined> = {};
 
     for (const [key, value] of Object.entries(process.env)) {
       if (value !== undefined) {
@@ -1083,6 +1166,17 @@ export class OpenCodeSDKProvider implements ApiProvider {
     if (!serverEnv.PATH?.includes(opencodeBinPath)) {
       serverEnv.PATH = `${opencodeBinPath}:${serverEnv.PATH ?? ''}`;
       logger.debug(`Added ${opencodeBinPath} to PATH for OpenCode CLI`);
+    }
+
+    // When restarting per call, promptfoo owns the traceparent: set it for this call, or clear
+    // it so the server never inherits a stale one. Otherwise seed it only if the ambient
+    // environment has not already set it, matching claude-agent-sdk's precedence.
+    if (config.restart_server_per_call) {
+      serverEnv[OPENCODE_TRACEPARENT_ENV] = isValidTraceparent(traceparent)
+        ? traceparent
+        : undefined;
+    } else if (isValidTraceparent(traceparent) && !serverEnv[OPENCODE_TRACEPARENT_ENV]) {
+      serverEnv[OPENCODE_TRACEPARENT_ENV] = traceparent;
     }
 
     return serverEnv;
@@ -1248,6 +1342,8 @@ export class OpenCodeSDKProvider implements ApiProvider {
       throw new Error('OpenCode SDK workspace support requires either baseUrl or working_dir');
     }
 
+    this.validateTraceRestartConfiguration(config);
+
     if (config.apiKey && !config.provider_id && !config.baseUrl) {
       logger.warn(
         '[OpenCode SDK] apiKey is set without provider_id. Prefer setting provider_id so promptfoo can wire the credential into the spawned OpenCode server.',
@@ -1289,20 +1385,120 @@ export class OpenCodeSDKProvider implements ApiProvider {
     };
   }
 
-  private async ensureOpenCodeModule(): Promise<LoadedOpenCodeSDKModule> {
-    if (!this.opencodeModule) {
-      this.opencodeModule = await loadOpenCodeSDK();
+  /**
+   * Whether this call should get its own freshly-booted server. Guarded on `baseUrl` as well as
+   * the flag because promptfoo cannot restart a server it did not start.
+   */
+  private restartsServerPerCall(config: OpenCodeSDKConfig): boolean {
+    return Boolean(config.restart_server_per_call) && !config.baseUrl;
+  }
+
+  /**
+   * `restart_server_per_call` swaps the server between calls, which only makes sense for a
+   * server promptfoo owns and whose session state it is free to discard. Rejecting the
+   * conflicting combinations is better than silently emitting uncorrelated traces.
+   */
+  private validateTraceRestartConfiguration(config: OpenCodeSDKConfig): void {
+    if (!config.restart_server_per_call) {
+      return;
     }
+
+    if (config.baseUrl) {
+      throw new Error(
+        'OpenCode SDK restart_server_per_call requires a server promptfoo manages and cannot be combined with baseUrl. Remove baseUrl so the provider starts its own server, or drop restart_server_per_call and accept that every span shares the traceparent captured when that server booted.',
+      );
+    }
+
+    const conflicting = [
+      config.persist_sessions ? 'persist_sessions' : undefined,
+      config.session_id ? 'session_id' : undefined,
+    ].filter(Boolean);
+    if (conflicting.length > 0) {
+      throw new Error(
+        `OpenCode SDK restart_server_per_call discards server-side session state on every restart, so it cannot be combined with: ${conflicting.join(', ')}.`,
+      );
+    }
+  }
+
+  private async ensureOpenCodeModule(): Promise<LoadedOpenCodeSDKModule> {
+    if (this.opencodeModule) {
+      return this.opencodeModule;
+    }
+
+    // Concurrent calls have to share a single load. `loadOpenCodeSDK()` walks several import
+    // strategies in turn, so letting two of them race is last-writer-wins on the cached module
+    // and a partially-resolved namespace can win.
+    if (!this.opencodeModuleLoad) {
+      this.opencodeModuleLoad = loadOpenCodeSDK().catch((err) => {
+        // Drop the memo so a later call can retry the resolution.
+        this.opencodeModuleLoad = undefined;
+        throw err;
+      });
+    }
+    this.opencodeModule = await this.opencodeModuleLoad;
     return this.opencodeModule;
   }
 
-  private async ensureClient(config: OpenCodeSDKConfig): Promise<void> {
+  /**
+   * Applies `serverEnv` to `process.env` for exactly as long as it takes `spawn()` to reach the
+   * child-process launch, then restores it.
+   *
+   * `@opencode-ai/sdk`'s `createOpencodeServer()` spawns `opencode serve` with a hard-coded
+   * `{ ...process.env, OPENCODE_CONFIG_CONTENT }` and never reads the `env` option it is handed
+   * — its `ServerOptions` type has no `env` field at all (still true as of 1.18.26). The only
+   * environment the child actually inherits is this process's `process.env` at the instant of
+   * the spawn, so everything `buildServerEnv()` computed was previously discarded in full.
+   *
+   * `createOpencode()` reaches `cross-spawn` synchronously: it awaits `createOpencodeServer()`,
+   * whose body runs straight through to `launch()` before its own first `await`. So we invoke
+   * `spawn()` *without* awaiting it and restore `process.env` in a `finally` that therefore runs
+   * before any suspension point. Because the mutation window spans no `await`, concurrently
+   * running providers can neither observe these values nor leak them into their own children.
+   *
+   * The `env` option is still passed through in the server options so that this collapses into a
+   * harmless no-op if upstream ever starts honoring it.
+   */
+  private spawnWithServerEnv<T>(
+    serverEnv: Record<string, string | undefined>,
+    spawn: () => Promise<T>,
+  ): Promise<T> {
+    const restore: [string, string | undefined][] = [];
+    for (const [key, value] of Object.entries(serverEnv)) {
+      if (process.env[key] === value) {
+        continue;
+      }
+      restore.push([key, process.env[key]]);
+      setProcessEnvValue(key, value);
+    }
+
+    try {
+      return spawn();
+    } finally {
+      for (const [key, value] of restore) {
+        setProcessEnvValue(key, value);
+      }
+    }
+  }
+
+  private async ensureClient(config: OpenCodeSDKConfig, traceparent?: string): Promise<void> {
     const opencodeModule = await this.ensureOpenCodeModule();
 
     this.validateSessionPolicyConfiguration(config);
 
+    const desiredTraceparent = isValidTraceparent(traceparent) ? traceparent : undefined;
+    const restartsPerCall = this.restartsServerPerCall(config);
+
     if (this.client) {
-      return;
+      if (!restartsPerCall || this.activeTraceparent === desiredTraceparent) {
+        return;
+      }
+      logger.debug(
+        `[OpenCode SDK] Restarting server to re-parent spans (traceparent ${this.activeTraceparent ?? 'none'} -> ${desiredTraceparent ?? 'none'})`,
+      );
+      await this.closeServer();
+      // Sessions lived on the server we just stopped; their handles are now dangling.
+      this.sessions.clear();
+      this.sessionOrder = [];
     }
     if (this.clientInitialization !== undefined) {
       return this.clientInitialization;
@@ -1318,6 +1514,14 @@ export class OpenCodeSDKProvider implements ApiProvider {
         return;
       }
 
+      const serverEnv = this.buildServerEnv(config, desiredTraceparent);
+      const passThroughEnv: Record<string, string> = {};
+      for (const [key, value] of Object.entries(serverEnv)) {
+        if (value !== undefined) {
+          passThroughEnv[key] = value;
+        }
+      }
+
       const serverOptions: {
         hostname: string;
         port: number;
@@ -1328,7 +1532,7 @@ export class OpenCodeSDKProvider implements ApiProvider {
         hostname: config.hostname ?? '127.0.0.1',
         port: config.port ?? 0,
         timeout: config.timeout ?? 30000,
-        env: this.buildServerEnv(config),
+        env: passThroughEnv,
       };
 
       const serverConfig = this.buildServerConfig(config);
@@ -1336,9 +1540,12 @@ export class OpenCodeSDKProvider implements ApiProvider {
         serverOptions.config = serverConfig;
       }
 
-      const opencode = await createOpencode(serverOptions);
+      const opencode = await this.spawnWithServerEnv(serverEnv, () =>
+        createOpencode(serverOptions),
+      );
       this.client = opencode.client;
       this.server = opencode.server;
+      this.activeTraceparent = desiredTraceparent;
       logger.debug(`OpenCode server started at ${opencode.server.url}`);
     })();
     this.clientInitialization = initialization;
@@ -1753,8 +1960,16 @@ export class OpenCodeSDKProvider implements ApiProvider {
       const hasPermissionRules = this.buildConfiguredPermissionRules(config).length > 0;
       const sensitiveMcpConfig = openCodeMcpContainsCacheSensitiveData(mcpConfig);
       const sensitiveBaseUrl = openCodeBaseUrlContainsCacheSensitiveData(config.baseUrl);
+      // A cache hit short-circuits the agent entirely, so no spans are emitted and the
+      // trajectory:* assertions this flag exists to serve would have nothing to read. Per-call
+      // traces require per-call execution.
+      const perCallTracing = this.restartsServerPerCall(config);
       const cacheResult =
-        statefulSession || hasPermissionRules || sensitiveMcpConfig || sensitiveBaseUrl
+        statefulSession ||
+        hasPermissionRules ||
+        sensitiveMcpConfig ||
+        sensitiveBaseUrl ||
+        perCallTracing
           ? { shouldCache: false, shouldReadCache: false, shouldWriteCache: false }
           : await initializeAgenticCache(
               {
@@ -1779,12 +1994,17 @@ export class OpenCodeSDKProvider implements ApiProvider {
         return { error: 'OpenCode SDK call aborted before it started' };
       }
 
-      await this.ensureClient(config);
-      const sessionQueueKey = this.getSessionQueueKey(config, workingDir);
+      // When the server is restarted per call it is itself per-call state, so the whole
+      // start -> session -> prompt lifecycle has to be serialized on this provider instance;
+      // the session queue alone starts too late to protect a server swap.
+      const sessionQueueKey = this.restartsServerPerCall(config)
+        ? SERVER_LIFECYCLE_QUEUE_KEY
+        : this.getSessionQueueKey(config, workingDir);
       return await this.runSerializedSessionCall(
         sessionQueueKey,
         callOptions?.abortSignal,
         async () => {
+          await this.ensureClient(config, context?.traceparent);
           const session = await this.getOrCreateSession(config, workingDir);
           ephemeralSession = session.ephemeralSession;
           if (callOptions?.abortSignal?.aborted) {

--- a/src/providers/opencode-sdk.ts
+++ b/src/providers/opencode-sdk.ts
@@ -833,6 +833,47 @@ function setProcessEnvValue(key: string, value: string | undefined): void {
 }
 
 /**
+ * Applies `serverEnv` to `process.env` for exactly as long as it takes `spawn()` to reach the
+ * child-process launch, then restores it.
+ *
+ * `@opencode-ai/sdk`'s `createOpencodeServer()` spawns `opencode serve` with a hard-coded
+ * `{ ...process.env, OPENCODE_CONFIG_CONTENT }` and never reads the `env` option it is handed
+ * — its `ServerOptions` type has no `env` field at all (still true as of 1.18.26). The only
+ * environment the child actually inherits is this process's `process.env` at the instant of
+ * the spawn, so everything `buildServerEnv()` computed was previously discarded in full.
+ *
+ * `createOpencode()` reaches `cross-spawn` synchronously: it awaits `createOpencodeServer()`,
+ * whose body runs straight through to `launch()` before its own first `await`. So we invoke
+ * `spawn()` *without* awaiting it and restore `process.env` in a `finally` that therefore runs
+ * before any suspension point. Because the mutation window spans no `await`, concurrently
+ * running providers can neither observe these values nor leak them into their own children.
+ *
+ * The `env` option is still passed through in the server options so that this collapses into a
+ * harmless no-op if upstream ever starts honoring it.
+ */
+export function spawnWithServerEnv<T>(
+  serverEnv: Record<string, string | undefined>,
+  spawn: () => Promise<T>,
+): Promise<T> {
+  const restore: [string, string | undefined][] = [];
+  for (const [key, value] of Object.entries(serverEnv)) {
+    if (process.env[key] === value) {
+      continue;
+    }
+    restore.push([key, process.env[key]]);
+    setProcessEnvValue(key, value);
+  }
+
+  try {
+    return spawn();
+  } finally {
+    for (const [key, value] of restore) {
+      setProcessEnvValue(key, value);
+    }
+  }
+}
+
+/**
  * Queue key used to serialize the entire server lifecycle (start -> session -> prompt) when
  * `restart_server_per_call` swaps the shared server between calls.
  */
@@ -1440,47 +1481,6 @@ export class OpenCodeSDKProvider implements ApiProvider {
     return this.opencodeModule;
   }
 
-  /**
-   * Applies `serverEnv` to `process.env` for exactly as long as it takes `spawn()` to reach the
-   * child-process launch, then restores it.
-   *
-   * `@opencode-ai/sdk`'s `createOpencodeServer()` spawns `opencode serve` with a hard-coded
-   * `{ ...process.env, OPENCODE_CONFIG_CONTENT }` and never reads the `env` option it is handed
-   * — its `ServerOptions` type has no `env` field at all (still true as of 1.18.26). The only
-   * environment the child actually inherits is this process's `process.env` at the instant of
-   * the spawn, so everything `buildServerEnv()` computed was previously discarded in full.
-   *
-   * `createOpencode()` reaches `cross-spawn` synchronously: it awaits `createOpencodeServer()`,
-   * whose body runs straight through to `launch()` before its own first `await`. So we invoke
-   * `spawn()` *without* awaiting it and restore `process.env` in a `finally` that therefore runs
-   * before any suspension point. Because the mutation window spans no `await`, concurrently
-   * running providers can neither observe these values nor leak them into their own children.
-   *
-   * The `env` option is still passed through in the server options so that this collapses into a
-   * harmless no-op if upstream ever starts honoring it.
-   */
-  private spawnWithServerEnv<T>(
-    serverEnv: Record<string, string | undefined>,
-    spawn: () => Promise<T>,
-  ): Promise<T> {
-    const restore: [string, string | undefined][] = [];
-    for (const [key, value] of Object.entries(serverEnv)) {
-      if (process.env[key] === value) {
-        continue;
-      }
-      restore.push([key, process.env[key]]);
-      setProcessEnvValue(key, value);
-    }
-
-    try {
-      return spawn();
-    } finally {
-      for (const [key, value] of restore) {
-        setProcessEnvValue(key, value);
-      }
-    }
-  }
-
   private async ensureClient(config: OpenCodeSDKConfig, traceparent?: string): Promise<void> {
     const opencodeModule = await this.ensureOpenCodeModule();
 
@@ -1541,9 +1541,7 @@ export class OpenCodeSDKProvider implements ApiProvider {
         serverOptions.config = serverConfig;
       }
 
-      const opencode = await this.spawnWithServerEnv(serverEnv, () =>
-        createOpencode(serverOptions),
-      );
+      const opencode = await spawnWithServerEnv(serverEnv, () => createOpencode(serverOptions));
       this.client = opencode.client;
       this.server = opencode.server;
       this.activeTraceparent = desiredTraceparent;

--- a/test/providers/opencode-sdk.spawn-env.test.ts
+++ b/test/providers/opencode-sdk.spawn-env.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Contract test for the environment promptfoo hands to the spawned `opencode serve` process.
+ *
+ * The rest of the OpenCode suite mocks `createOpencode`, so it cannot see this contract break --
+ * and it can break with no change to our code at all. `@opencode-ai/sdk` ignores the `env` option
+ * it is handed (its `ServerOptions` type has no `env` field) and spawns with `{ ...process.env }`,
+ * so promptfoo applies the computed env to `process.env` around the spawn and depends on
+ * `createOpencode()` reaching `cross-spawn` synchronously.
+ *
+ * This runs against the REAL SDK with a stub `opencode` on PATH and asserts the *outcome* rather
+ * than the mechanism:
+ * - if an upgrade inserts an `await` before the spawn, our restore runs too early and this fails,
+ *   which is exactly the signal we want;
+ * - if an upgrade starts honoring the `env` option, this still passes, because nothing is broken.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spawnWithServerEnv } from '../../src/providers/opencode-sdk';
+import { mockProcessEnv } from '../util/utils';
+
+// Resolved through a variable so TypeScript does not require the optional dependency to be
+// present, matching how the provider itself loads it.
+const OPENCODE_V2_SPECIFIER = '@opencode-ai/sdk/v2';
+
+interface StubOpenCodeModule {
+  createOpencode: (options: {
+    hostname?: string;
+    port?: number;
+    timeout?: number;
+  }) => Promise<{ server: { url: string; close(): void } }>;
+}
+
+const hasSdk = fs.existsSync(
+  path.resolve(process.cwd(), 'node_modules/@opencode-ai/sdk/package.json'),
+);
+// The stub server is a POSIX shell script; Windows would need a separate shim.
+const canSpawnStub = process.platform !== 'win32';
+
+const TRACEPARENT = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+
+/**
+ * Writes a stand-in for the `opencode` CLI that records the environment it was given, then emits
+ * the one stdout line the SDK waits for.
+ */
+function createStubOpenCodeCli(): { binDir: string; probeLog: string } {
+  const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-opencode-stub-'));
+  const probeLog = path.join(binDir, 'probe.txt');
+
+  fs.writeFileSync(
+    path.join(binDir, 'opencode'),
+    [
+      '#!/bin/sh',
+      '{',
+      '  echo "TRACEPARENT=${OPENCODE_TRACEPARENT:-<unset>}"',
+      '  echo "PROBE=${PROMPTFOO_SPAWN_PROBE:-<unset>}"',
+      '} > "$PROMPTFOO_SPAWN_PROBE_LOG"',
+      'echo "opencode server listening on http://127.0.0.1:4096"',
+      '# Stay alive until the test closes us, but bounded so an orphan cannot linger.',
+      'sleep 10',
+      '',
+    ].join('\n'),
+    { mode: 0o755 },
+  );
+
+  return { binDir, probeLog };
+}
+
+const describeSpawnContract = hasSdk && canSpawnStub ? describe : describe.skip;
+
+describeSpawnContract('OpenCode SDK spawn environment contract', () => {
+  let restoreEnv: (() => void) | undefined;
+  const tempDirs: string[] = [];
+
+  beforeEach(() => {
+    restoreEnv = mockProcessEnv({
+      OPENCODE_TRACEPARENT: undefined,
+      PROMPTFOO_SPAWN_PROBE: undefined,
+      PROMPTFOO_SPAWN_PROBE_LOG: undefined,
+    });
+  });
+
+  afterEach(() => {
+    restoreEnv?.();
+    restoreEnv = undefined;
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('delivers the computed environment to the real spawned server process', async () => {
+    const { binDir, probeLog } = createStubOpenCodeCli();
+    tempDirs.push(binDir);
+
+    const { createOpencode } = (await import(
+      /* @vite-ignore */ OPENCODE_V2_SPECIFIER
+    )) as StubOpenCodeModule;
+
+    const serverEnv = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      OPENCODE_TRACEPARENT: TRACEPARENT,
+      PROMPTFOO_SPAWN_PROBE: 'from-buildServerEnv',
+      PROMPTFOO_SPAWN_PROBE_LOG: probeLog,
+    };
+
+    const pending = spawnWithServerEnv(serverEnv, () =>
+      createOpencode({ hostname: '127.0.0.1', port: 4096, timeout: 15000 }),
+    );
+
+    // Restored before the first suspension point, so a concurrently spawning provider can
+    // neither observe these values nor inherit them.
+    expect(process.env.OPENCODE_TRACEPARENT).toBeUndefined();
+    expect(process.env.PROMPTFOO_SPAWN_PROBE).toBeUndefined();
+
+    const opencode = await pending;
+    try {
+      const probe = fs.readFileSync(probeLog, 'utf8');
+      expect(probe).toContain(`TRACEPARENT=${TRACEPARENT}`);
+      expect(probe).toContain('PROBE=from-buildServerEnv');
+    } finally {
+      opencode.server.close();
+    }
+  });
+
+  it('restores a pre-existing ambient value instead of dropping it', async () => {
+    mockProcessEnv({ OPENCODE_TRACEPARENT: 'ambient-value' });
+    const { binDir, probeLog } = createStubOpenCodeCli();
+    tempDirs.push(binDir);
+
+    const { createOpencode } = (await import(
+      /* @vite-ignore */ OPENCODE_V2_SPECIFIER
+    )) as StubOpenCodeModule;
+
+    const opencode = await spawnWithServerEnv(
+      {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+        OPENCODE_TRACEPARENT: TRACEPARENT,
+        PROMPTFOO_SPAWN_PROBE_LOG: probeLog,
+      },
+      () => createOpencode({ hostname: '127.0.0.1', port: 4096, timeout: 15000 }),
+    );
+
+    try {
+      expect(fs.readFileSync(probeLog, 'utf8')).toContain(`TRACEPARENT=${TRACEPARENT}`);
+      expect(process.env.OPENCODE_TRACEPARENT).toBe('ambient-value');
+    } finally {
+      opencode.server.close();
+    }
+  });
+});

--- a/test/providers/opencode-sdk.test.ts
+++ b/test/providers/opencode-sdk.test.ts
@@ -2892,6 +2892,39 @@ describe('OpenCodeSDKProvider', () => {
         expect(mockServerClose).toHaveBeenCalledTimes(1);
       });
 
+      it('warns once when the flag is set but calls carry no trace context', async () => {
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+        captureSpawnEnv();
+        const provider = new OpenCodeSDKProvider({
+          config: { restart_server_per_call: true },
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('first', contextWith(undefined));
+        await provider.callApi('second', contextWith(TRACEPARENT_ZERO));
+
+        const warnings = warnSpy.mock.calls.filter((call) =>
+          String(call[0] ?? '').includes('carries no trace context'),
+        );
+        expect(warnings).toHaveLength(1);
+      });
+
+      it('does not warn when the call carries a usable traceparent', async () => {
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+        captureSpawnEnv();
+        const provider = new OpenCodeSDKProvider({
+          config: { restart_server_per_call: true },
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+
+        const warnings = warnSpy.mock.calls.filter((call) =>
+          String(call[0] ?? '').includes('carries no trace context'),
+        );
+        expect(warnings).toHaveLength(0);
+      });
+
       it('bypasses the response cache so every call produces spans', async () => {
         enableCache();
         try {

--- a/test/providers/opencode-sdk.test.ts
+++ b/test/providers/opencode-sdk.test.ts
@@ -2847,20 +2847,26 @@ describe('OpenCodeSDKProvider', () => {
       });
 
       it('serializes concurrent calls so server swaps never interleave', async () => {
-        const spawnOrder: string[] = [];
-        const promptOrder: string[] = [];
+        const spawnedTraceparents: string[] = [];
         mockCreateOpencode.mockImplementation(async () => {
-          spawnOrder.push(`spawn:${process.env.OPENCODE_TRACEPARENT}`);
+          spawnedTraceparents.push(process.env.OPENCODE_TRACEPARENT ?? 'none');
           return {
             client: mockClient,
             server: { url: 'http://127.0.0.1:4096', close: mockServerClose },
           };
         });
+
+        // Hold the first prompt open so the second call has every chance to race ahead and
+        // swap the server out from under it.
+        const firstPromptStarted = createDeferred<void>();
+        const releaseFirstPrompt = createDeferred<void>();
+        let promptCalls = 0;
         mockSessionPrompt.mockImplementation(async () => {
-          // Whatever server this prompt lands on must still be the one booted for it, so
-          // record the boundary and yield to give an interleaving a chance to show up.
-          promptOrder.push(`prompt:${spawnOrder.length}`);
-          await new Promise((resolve) => setTimeout(resolve, 5));
+          promptCalls += 1;
+          if (promptCalls === 1) {
+            firstPromptStarted.resolve();
+            await releaseFirstPrompt.promise;
+          }
           return createMockPromptResponse([{ type: 'text', text: 'Test response' }]);
         });
 
@@ -2869,14 +2875,21 @@ describe('OpenCodeSDKProvider', () => {
           env: { ANTHROPIC_API_KEY: 'test-api-key' },
         });
 
-        await Promise.all([
+        const calls = Promise.all([
           provider.callApi('Test prompt', contextWith(TRACEPARENT_A)),
           provider.callApi('Test prompt', contextWith(TRACEPARENT_B)),
         ]);
 
-        // Each call booted its own server, and each prompt ran against the newest one.
-        expect(spawnOrder).toHaveLength(2);
-        expect(promptOrder).toEqual(['prompt:1', 'prompt:2']);
+        await firstPromptStarted.promise;
+        // The second call is still queued: it has neither booted its server nor prompted.
+        expect(spawnedTraceparents).toEqual([TRACEPARENT_A]);
+        expect(promptCalls).toBe(1);
+
+        releaseFirstPrompt.resolve();
+        await calls;
+
+        expect(spawnedTraceparents).toEqual([TRACEPARENT_A, TRACEPARENT_B]);
+        expect(mockServerClose).toHaveBeenCalledTimes(1);
       });
 
       it('bypasses the response cache so every call produces spans', async () => {

--- a/test/providers/opencode-sdk.test.ts
+++ b/test/providers/opencode-sdk.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import fsPromises from 'fs/promises';
+import os from 'os';
 import path from 'path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -10,7 +11,7 @@ import {
   FS_READONLY_TOOLS,
   OpenCodeSDKProvider,
 } from '../../src/providers/opencode-sdk';
-import { createDeferred } from '../util/utils';
+import { createDeferred, mockProcessEnv } from '../util/utils';
 import type { MockInstance } from 'vitest';
 
 import type { CallApiContextParams } from '../../src/types/index';
@@ -57,6 +58,19 @@ const mockServerClose = vi.fn();
 // Mock createOpencode function that returns { client, server }
 const mockCreateOpencode = vi.fn();
 const mockCreateOpencodeClient = vi.fn();
+
+// Mock client with session.prompt(). Defined at module scope so tests that install their own
+// createOpencode implementation can hand back the same client the default setup uses.
+const mockClient = {
+  session: {
+    create: mockSessionCreate,
+    prompt: mockSessionPrompt,
+    messages: mockSessionMessages,
+    delete: mockSessionDelete,
+    list: mockSessionList,
+    abort: mockSessionAbort,
+  },
+};
 
 // Helper to create mock session create response
 // SDK returns: { id, title, version, time }
@@ -136,18 +150,6 @@ describe('OpenCodeSDKProvider', () => {
     mockSessionPrompt.mockReset();
     mockSessionDelete.mockReset();
     mockSessionAbort.mockReset();
-
-    // Setup mock client with session.prompt()
-    const mockClient = {
-      session: {
-        create: mockSessionCreate,
-        prompt: mockSessionPrompt,
-        messages: mockSessionMessages,
-        delete: mockSessionDelete,
-        list: mockSessionList,
-        abort: mockSessionAbort,
-      },
-    };
 
     // Setup mock server
     const mockServer = {
@@ -2679,6 +2681,248 @@ describe('OpenCodeSDKProvider', () => {
       expect(result.error).toBe('OpenCode SDK call aborted before it started');
       expect(mockSessionPrompt).not.toHaveBeenCalled();
       expect(mockSessionAbort).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('traceparent propagation', () => {
+    const TRACEPARENT_A = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+    const TRACEPARENT_B = '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+    const TRACEPARENT_ZERO = '00-00000000000000000000000000000000-0000000000000000-00';
+
+    const contextWith = (traceparent?: string): CallApiContextParams => ({
+      prompt: { raw: 'Test prompt', label: 'test' },
+      vars: {},
+      ...(traceparent === undefined ? {} : { traceparent }),
+    });
+
+    /**
+     * The SDK ignores its own `env` option and spawns with `process.env`, so what matters is
+     * what `process.env` holds at the instant `createOpencode()` is invoked. Capture it there.
+     */
+    const captureSpawnEnv = () => {
+      const seen: Array<Record<string, string | undefined>> = [];
+      mockCreateOpencode.mockImplementation(async () => {
+        seen.push({
+          OPENCODE_TRACEPARENT: process.env.OPENCODE_TRACEPARENT,
+          PATH: process.env.PATH,
+        });
+        return {
+          client: mockClient,
+          server: { url: 'http://127.0.0.1:4096', close: mockServerClose },
+        };
+      });
+      return seen;
+    };
+
+    let restoreEnv: (() => void) | undefined;
+
+    beforeEach(() => {
+      restoreEnv = mockProcessEnv({ OPENCODE_TRACEPARENT: undefined });
+    });
+
+    afterEach(() => {
+      restoreEnv?.();
+      restoreEnv = undefined;
+    });
+
+    it('exposes the call traceparent to the spawned server', async () => {
+      const seen = captureSpawnEnv();
+      const provider = new OpenCodeSDKProvider({ env: { ANTHROPIC_API_KEY: 'test-api-key' } });
+
+      await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+
+      expect(seen).toHaveLength(1);
+      expect(seen[0].OPENCODE_TRACEPARENT).toBe(TRACEPARENT_A);
+    });
+
+    it('restores process.env after the spawn so the value never leaks', async () => {
+      captureSpawnEnv();
+      const provider = new OpenCodeSDKProvider({ env: { ANTHROPIC_API_KEY: 'test-api-key' } });
+
+      await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+
+      expect(process.env.OPENCODE_TRACEPARENT).toBeUndefined();
+    });
+
+    it('restores a pre-existing OPENCODE_TRACEPARENT rather than deleting it', async () => {
+      mockProcessEnv({ OPENCODE_TRACEPARENT: 'ambient-value' });
+      captureSpawnEnv();
+      const provider = new OpenCodeSDKProvider({
+        config: { restart_server_per_call: true },
+        env: { ANTHROPIC_API_KEY: 'test-api-key' },
+      });
+
+      await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+
+      expect(process.env.OPENCODE_TRACEPARENT).toBe('ambient-value');
+    });
+
+    it('does not override an ambient traceparent when not restarting per call', async () => {
+      mockProcessEnv({ OPENCODE_TRACEPARENT: 'ambient-value' });
+      const seen = captureSpawnEnv();
+      const provider = new OpenCodeSDKProvider({ env: { ANTHROPIC_API_KEY: 'test-api-key' } });
+
+      await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+
+      expect(seen[0].OPENCODE_TRACEPARENT).toBe('ambient-value');
+    });
+
+    it('clears an ambient traceparent when restarting per call without one', async () => {
+      mockProcessEnv({ OPENCODE_TRACEPARENT: 'ambient-value' });
+      const seen = captureSpawnEnv();
+      const provider = new OpenCodeSDKProvider({
+        config: { restart_server_per_call: true },
+        env: { ANTHROPIC_API_KEY: 'test-api-key' },
+      });
+
+      await provider.callApi('Test prompt', contextWith(undefined));
+
+      expect(seen[0].OPENCODE_TRACEPARENT).toBeUndefined();
+      expect(process.env.OPENCODE_TRACEPARENT).toBe('ambient-value');
+    });
+
+    it('treats an all-zero traceparent as absent', async () => {
+      const seen = captureSpawnEnv();
+      const provider = new OpenCodeSDKProvider({ env: { ANTHROPIC_API_KEY: 'test-api-key' } });
+
+      await provider.callApi('Test prompt', contextWith(TRACEPARENT_ZERO));
+
+      expect(seen[0].OPENCODE_TRACEPARENT).toBeUndefined();
+    });
+
+    it('applies the rest of buildServerEnv to the spawn, not just the traceparent', async () => {
+      const seen = captureSpawnEnv();
+      const provider = new OpenCodeSDKProvider({ env: { ANTHROPIC_API_KEY: 'test-api-key' } });
+
+      await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+
+      // Regression: the SDK never read the `env` option, so the ~/.opencode/bin PATH entry
+      // (and every other computed variable) used to be dropped on the floor.
+      expect(seen[0].PATH).toContain(path.join(os.homedir(), '.opencode', 'bin'));
+    });
+
+    describe('restart_server_per_call', () => {
+      it('restarts the server when the traceparent changes', async () => {
+        const seen = captureSpawnEnv();
+        const provider = new OpenCodeSDKProvider({
+          config: { restart_server_per_call: true },
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+        await provider.callApi('Test prompt', contextWith(TRACEPARENT_B));
+
+        expect(mockCreateOpencode).toHaveBeenCalledTimes(2);
+        expect(mockServerClose).toHaveBeenCalledTimes(1);
+        expect(seen.map((entry) => entry.OPENCODE_TRACEPARENT)).toEqual([
+          TRACEPARENT_A,
+          TRACEPARENT_B,
+        ]);
+      });
+
+      it('reuses the server when the traceparent is unchanged', async () => {
+        captureSpawnEnv();
+        const provider = new OpenCodeSDKProvider({
+          config: { restart_server_per_call: true },
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+        await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+
+        expect(mockCreateOpencode).toHaveBeenCalledTimes(1);
+        expect(mockServerClose).not.toHaveBeenCalled();
+      });
+
+      it('does not restart when the flag is unset, leaving the boot traceparent in place', async () => {
+        const seen = captureSpawnEnv();
+        const provider = new OpenCodeSDKProvider({ env: { ANTHROPIC_API_KEY: 'test-api-key' } });
+
+        await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+        await provider.callApi('Test prompt', contextWith(TRACEPARENT_B));
+
+        expect(mockCreateOpencode).toHaveBeenCalledTimes(1);
+        expect(mockServerClose).not.toHaveBeenCalled();
+        expect(seen.map((entry) => entry.OPENCODE_TRACEPARENT)).toEqual([TRACEPARENT_A]);
+      });
+
+      it('serializes concurrent calls so server swaps never interleave', async () => {
+        const spawnOrder: string[] = [];
+        const promptOrder: string[] = [];
+        mockCreateOpencode.mockImplementation(async () => {
+          spawnOrder.push(`spawn:${process.env.OPENCODE_TRACEPARENT}`);
+          return {
+            client: mockClient,
+            server: { url: 'http://127.0.0.1:4096', close: mockServerClose },
+          };
+        });
+        mockSessionPrompt.mockImplementation(async () => {
+          // Whatever server this prompt lands on must still be the one booted for it, so
+          // record the boundary and yield to give an interleaving a chance to show up.
+          promptOrder.push(`prompt:${spawnOrder.length}`);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return createMockPromptResponse([{ type: 'text', text: 'Test response' }]);
+        });
+
+        const provider = new OpenCodeSDKProvider({
+          config: { restart_server_per_call: true },
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await Promise.all([
+          provider.callApi('Test prompt', contextWith(TRACEPARENT_A)),
+          provider.callApi('Test prompt', contextWith(TRACEPARENT_B)),
+        ]);
+
+        // Each call booted its own server, and each prompt ran against the newest one.
+        expect(spawnOrder).toHaveLength(2);
+        expect(promptOrder).toEqual(['prompt:1', 'prompt:2']);
+      });
+
+      it('bypasses the response cache so every call produces spans', async () => {
+        enableCache();
+        try {
+          captureSpawnEnv();
+          const provider = new OpenCodeSDKProvider({
+            config: { restart_server_per_call: true },
+            env: { ANTHROPIC_API_KEY: 'test-api-key' },
+          });
+
+          await provider.callApi('Test prompt', contextWith(TRACEPARENT_A));
+          await provider.callApi('Test prompt', contextWith(TRACEPARENT_B));
+
+          expect(mockSessionPrompt).toHaveBeenCalledTimes(2);
+        } finally {
+          disableCache();
+        }
+      });
+
+      it('rejects baseUrl, which promptfoo cannot restart', async () => {
+        const provider = new OpenCodeSDKProvider({
+          config: { restart_server_per_call: true, baseUrl: 'http://127.0.0.1:4096' },
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await expect(provider.callApi('Test prompt', contextWith(TRACEPARENT_A))).rejects.toThrow(
+          'cannot be combined with baseUrl',
+        );
+        expect(mockCreateOpencode).not.toHaveBeenCalled();
+      });
+
+      it.each([
+        ['persist_sessions', { persist_sessions: true }],
+        ['session_id', { session_id: 'session-abc' }],
+      ])('rejects %s, whose state a restart would discard', async (name, extra) => {
+        const provider = new OpenCodeSDKProvider({
+          config: { restart_server_per_call: true, ...extra },
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await expect(provider.callApi('Test prompt', contextWith(TRACEPARENT_A))).rejects.toThrow(
+          name,
+        );
+        expect(mockCreateOpencode).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -97,6 +97,12 @@ const allowedSkippedTests: AllowedSkip[] = [
     reason: 'E2E coverage requires an API key and optional Codex SDK dependency',
   },
   {
+    file: 'providers/opencode-sdk.spawn-env.test.ts',
+    kind: 'skip',
+    linePattern: /hasSdk && canSpawnStub \? describe : describe\.skip/,
+    reason: 'Real-SDK spawn contract needs the optional OpenCode SDK and a POSIX stub CLI on PATH',
+  },
+  {
     file: 'commands/mcp/lib/security.test.ts',
     kind: 'skipIf',
     linePattern:


### PR DESCRIPTION
## Summary

Fixes #10518. The `opencode:sdk` provider never forwarded `context.traceparent` to the OpenCode server it spawns, so spans emitted by `opencode serve` carried no usable trace context and `trajectory:*` assertions (`tool-used`, `tool-args-match`, `step-count`) were silently unusable against it. Every other agentic provider already threads it — `claude-agent-sdk.ts:1872`, `codex-sdk.ts:850`.

Fixing it surfaced a second, larger bug underneath.

## `buildServerEnv()` was dead code

`OpenCodeSDKModule` (this repo's local interface for the SDK) declared an `env` option that **`@opencode-ai/sdk` has never had**. Its `ServerOptions` type has no `env` field, and `createOpencodeServer()` always spawns with a hard-coded environment:

```js
// node_modules/@opencode-ai/sdk/dist/v2/server.js
const proc = launch(`opencode`, args, {
  env: { ...process.env, OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config ?? {}) },
});
```

So everything `buildServerEnv()` computed was discarded in full — not just the traceparent, but the `~/.opencode/bin` PATH entry that lets `cross-spawn` resolve the CLI, the `DEBUG` log-level sync, and provider-level `env` overrides.

I verified this against **1.18.26** (latest; this repo is on `^1.18.21`) — still unfixed, and `grep -c env dist/v2/server.d.ts` is `0`. So the upstream-first path raised in the issue thread isn't available in any released version, which is why this lands as a provider-side fix.

Verified both directions against the real SDK with a stub `opencode` binary:

| what the child process saw | `OPENCODE_TRACEPARENT` | custom env var |
| --- | --- | --- |
| before (only the `env` option) | `<unset>` | `<unset>` |
| after (env applied around the spawn) | `00-4bf92f35…-00f067aa0ba902b7-01` | `from-buildServerEnv` |

The env is applied to `process.env` across the synchronous window in which `createOpencode()` reaches `cross-spawn` — it `await`s `createOpencodeServer()`, whose body runs straight through to `launch()` before its own first `await` — and restored in a `finally` that therefore runs before any suspension point. The mutation window spans no `await`, so concurrently spawning providers can neither observe the values nor inherit them. The same script confirmed `process.env` was already restored in the parent before `createOpencode()` resolved. The `env` option is still passed through so this becomes a no-op if upstream ever honors it.

## `restart_server_per_call`

`ensureClient()` started one server for the whole run and short-circuited on `if (this.client) return;`. It now takes the call's traceparent, and the new opt-in flag restarts the server when that traceparent changes — OpenCode's OTel plugin reads `OPENCODE_TRACEPARENT` only once, at process boot, so restarting is the only way to hand it a fresh one.

It's opt-in because it costs a server start per test case. When enabled:

- **The whole `ensureClient` → session → prompt lifecycle is serialized** on the provider instance. The existing `runSerializedSessionCall()` begins *after* `ensureClient()`, so it cannot protect a traceparent-driven server swap; the call now runs under a provider-wide queue key.
- **Response caching is disabled.** A cache hit returns without running the agent, so it emits no spans and the `trajectory:*` assertion the flag exists to serve would have nothing to read.
- **`baseUrl`, `persist_sessions` and `session_id` are rejected.** promptfoo can't restart a server it doesn't own, and a restart discards the session state the other two exist to preserve. Failing beats silently emitting uncorrelated traces.

If the flag is set while tracing is off there is no traceparent to tag the server with, so the provider warns once rather than silently charging you serialized, uncached calls for nothing.

With the flag off, behavior is unchanged except that `OPENCODE_TRACEPARENT` is now seeded at server boot when the ambient environment hasn't already set it — matching `claude-agent-sdk`'s precedence, and giving one correct root trace instead of none.

## Drive-by: `ensureOpenCodeModule()` race

The new concurrency test caught a pre-existing bug. Concurrent calls each ran `loadOpenCodeSDK()` and assigned `this.opencodeModule` after the await — last writer wins. `loadOpenCodeSDK()` walks several import strategies in turn, and a partially-resolved namespace could win the race, producing `createOpencode is not a function`. The in-flight load is now memoized (dropped on failure so a later call can retry).

## Testing

17 new tests in `test/providers/opencode-sdk.test.ts` (151 pass), plus a real-SDK contract test described below. Coverage: traceparent reaches the spawn; `process.env` restored afterwards; a pre-existing ambient value is restored rather than deleted, and is not overridden unless the flag owns it; all-zero traceparent treated as absent; the rest of `buildServerEnv` reaches the spawn (regression for the dead-code bug); restart on change; no restart when unchanged or when the flag is off; concurrent calls don't interleave server swaps; caching bypassed; all three incompatible-config rejections; the no-trace-context warning fires once and not at all when a usable traceparent is present.

Verified end-to-end against a real `opencode serve` with `npm run local -- eval` (tracing enabled, two test cases), A/B'd against the same config on `main`:

| | `main` | this branch |
| --- | --- | --- |
| OpenCode servers started | 1 | 2 |

with the provider logging the swap between the two test cases' actual trace IDs:

```
[OpenCode SDK] Restarting server to re-parent spans
  (traceparent 00-d0692e09e959421016b7aa5f9abf92ca-… -> 00-8de782b9ccc1548a0dd77e9925cc55c9-…)
```

(Both runs returned empty model output in my sandbox — identical on `main`, an unrelated local opencode auth issue.)

Mutation-checked rather than assumed — neutering the env application fails 4 tests, neutering the restart logic fails 2.

### Guarding against an SDK upgrade

The unit tests mock `createOpencode`, so they cannot see the synchronous-spawn assumption break — and it can break with no change to our code, if an upstream release awaits anything before spawning.

`test/providers/opencode-sdk.spawn-env.test.ts` covers that gap. It runs against the **real** SDK with a stub `opencode` CLI on `PATH` and asserts the outcome rather than the mechanism: the child process must observe the environment we asked for, and `process.env` must already be restored in the parent before the returned promise resolves. If upstream ever starts honoring the `env` option, it still passes — nothing would actually be broken.

Verified it catches the regression by simulating the upgrade — inserting `await Promise.resolve()` before the `launch()` call in `node_modules` fails both cases (the spawn no longer even sees our `PATH`, so it resolves the real CLI instead of the stub). Runs in ~0.6s; skipped when the optional SDK is absent or on Windows, where the POSIX stub would need its own shim.

`spawnWithServerEnv` moved from a private method to an exported module function so the test can drive it against the real SDK; it never used `this`.

Also verified: `tsc`, `npm run l`, `npm run f`, `npm run knip` (clean), `npm run architecture:check` (passed), and `SKIP_OG_GENERATION=true npm run build` in `site/`.
