### PR TITLE
fix(matchers): fail closed when llm-rubric grader response omits its verdict

### DIFF
--- a/src/matchers/rubric.ts
+++ b/src/matchers/rubric.ts
@@ -828,9 +828,10 @@ function deriveVerdictFromGrader(
     pass = /^(true|yes|pass|y)$/i.test(String(parsed.pass));
   }
 
-  let score = parsed.score;
-  if (typeof score !== 'number') {
-    score = Number.isFinite(Number(score)) ? Number(score) : Number(pass);
+  let score: number = typeof parsed.score === 'number' ? parsed.score : 0;
+  if (typeof parsed.score !== 'number') {
+    const asNum = Number(parsed.score);
+    score = Number.isFinite(asNum) ? asNum : Number(pass);
   }
 
   if (hasThreshold) {

--- a/src/matchers/rubric.ts
+++ b/src/matchers/rubric.ts
@@ -860,9 +860,22 @@ export async function runJsonGradingPrompt({
     return failure as Omit<GradingResult, 'assertion'>;
   }
 
-  let pass = parsed.pass ?? true;
-  if (typeof pass !== 'boolean') {
-    pass = /^(true|yes|pass|y)$/i.test(String(pass));
+  // A grader response that omits the verdict must not default to passing.
+  // Derive from score when present (the pre-#2999 behavior), and fail
+  // closed when the response carries neither a verdict nor a score.
+  let pass: boolean;
+  if (parsed.pass === undefined || parsed.pass === null) {
+    if (parsed.score === undefined || parsed.score === null) {
+      return graderFailureFromResponse(
+        'Grader response contained neither a pass verdict nor a score',
+        resp,
+      );
+    }
+    pass = Number(parsed.score) > 0;
+  } else if (typeof parsed.pass === 'boolean') {
+    pass = parsed.pass;
+  } else {
+    pass = /^(true|yes|pass|y)$/i.test(String(parsed.pass));
   }
 
   let score = parsed.score;

--- a/src/matchers/rubric.ts
+++ b/src/matchers/rubric.ts
@@ -860,9 +860,16 @@ export async function runJsonGradingPrompt({
     return failure as Omit<GradingResult, 'assertion'>;
   }
 
+  const threshold =
+    typeof assertion?.threshold === 'string' ? Number(assertion.threshold) : assertion?.threshold;
+  const hasThreshold = typeof threshold === 'number' && Number.isFinite(threshold);
+
   // A grader response that omits the verdict must not default to passing.
-  // Derive from score when present (the pre-#2999 behavior), and fail
-  // closed when the response carries neither a verdict nor a score.
+  // With a configured threshold, derive the verdict from score >= threshold
+  // (so a score-only result exactly at its threshold passes, matching the
+  // threshold semantics asserted elsewhere). Without one, fall back to the
+  // pre-#2999 score > 0 derivation, and fail closed when the response
+  // carries neither a verdict nor a score.
   let pass: boolean;
   if (parsed.pass === undefined || parsed.pass === null) {
     if (parsed.score === undefined || parsed.score === null) {
@@ -871,7 +878,7 @@ export async function runJsonGradingPrompt({
         resp,
       );
     }
-    pass = Number(parsed.score) > 0;
+    pass = hasThreshold ? Number(parsed.score) >= threshold : Number(parsed.score) > 0;
   } else if (typeof parsed.pass === 'boolean') {
     pass = parsed.pass;
   } else {
@@ -883,9 +890,7 @@ export async function runJsonGradingPrompt({
     score = Number.isFinite(Number(score)) ? Number(score) : Number(pass);
   }
 
-  const threshold =
-    typeof assertion?.threshold === 'string' ? Number(assertion.threshold) : assertion?.threshold;
-  if (typeof threshold === 'number' && Number.isFinite(threshold)) {
+  if (hasThreshold) {
     pass = pass && score >= threshold;
   }
 

--- a/src/matchers/rubric.ts
+++ b/src/matchers/rubric.ts
@@ -804,6 +804,41 @@ function graderFailureFromResponse(
   return failure;
 }
 
+function deriveVerdictFromGrader(
+  parsed: { pass?: unknown; score?: unknown },
+  threshold: number | undefined,
+): { pass: boolean | null; score: number } {
+  const hasThreshold = typeof threshold === 'number' && Number.isFinite(threshold);
+
+  // A grader response that omits the verdict must not default to passing.
+  // With a configured threshold, derive the verdict from score >= threshold
+  // (so a score-only result exactly at its threshold passes, matching the
+  // threshold semantics asserted elsewhere). Without one, fall back to the
+  // pre-#2999 score > 0 derivation, and fail closed (null) when the
+  // response carries neither a verdict nor a score.
+  let pass: boolean | null;
+  if (parsed.pass === undefined || parsed.pass === null) {
+    if (parsed.score === undefined || parsed.score === null) {
+      return { pass: null, score: 0 };
+    }
+    pass = hasThreshold ? Number(parsed.score) >= threshold : Number(parsed.score) > 0;
+  } else if (typeof parsed.pass === 'boolean') {
+    pass = parsed.pass;
+  } else {
+    pass = /^(true|yes|pass|y)$/i.test(String(parsed.pass));
+  }
+
+  let score = parsed.score;
+  if (typeof score !== 'number') {
+    score = Number.isFinite(Number(score)) ? Number(score) : Number(pass);
+  }
+
+  if (hasThreshold) {
+    pass = pass && score >= threshold;
+  }
+  return { pass, score };
+}
+
 export async function runJsonGradingPrompt({
   assertion,
   checkName,
@@ -862,36 +897,13 @@ export async function runJsonGradingPrompt({
 
   const threshold =
     typeof assertion?.threshold === 'string' ? Number(assertion.threshold) : assertion?.threshold;
-  const hasThreshold = typeof threshold === 'number' && Number.isFinite(threshold);
 
-  // A grader response that omits the verdict must not default to passing.
-  // With a configured threshold, derive the verdict from score >= threshold
-  // (so a score-only result exactly at its threshold passes, matching the
-  // threshold semantics asserted elsewhere). Without one, fall back to the
-  // pre-#2999 score > 0 derivation, and fail closed when the response
-  // carries neither a verdict nor a score.
-  let pass: boolean;
-  if (parsed.pass === undefined || parsed.pass === null) {
-    if (parsed.score === undefined || parsed.score === null) {
-      return graderFailureFromResponse(
-        'Grader response contained neither a pass verdict nor a score',
-        resp,
-      );
-    }
-    pass = hasThreshold ? Number(parsed.score) >= threshold : Number(parsed.score) > 0;
-  } else if (typeof parsed.pass === 'boolean') {
-    pass = parsed.pass;
-  } else {
-    pass = /^(true|yes|pass|y)$/i.test(String(parsed.pass));
-  }
-
-  let score = parsed.score;
-  if (typeof score !== 'number') {
-    score = Number.isFinite(Number(score)) ? Number(score) : Number(pass);
-  }
-
-  if (hasThreshold) {
-    pass = pass && score >= threshold;
+  const { pass, score } = deriveVerdictFromGrader(parsed, threshold);
+  if (pass === null) {
+    return graderFailureFromResponse(
+      'Grader response contained neither a pass verdict nor a score',
+      resp,
+    );
   }
 
   const reason =

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -2906,6 +2906,10 @@ describe('tryParse and renderLlmRubricPrompt', () => {
 });
 
 describe('matchesLlmRubric missing-verdict fail-closed semantics', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('fails when the grader response omits both pass and score', async () => {
     vi.spyOn(Grader, 'callApi').mockResolvedValue({
       output: JSON.stringify({ reason: 'Looked fine to me' }),
@@ -2949,6 +2953,32 @@ describe('matchesLlmRubric missing-verdict fail-closed semantics', () => {
 
     expect(result.pass).toBe(false);
     expect(result.score).toBe(0);
+  });
+
+  it('passes a score-only zero verdict when threshold is exactly 0', async () => {
+    const rubricPrompt = 'Grading prompt';
+    const llmOutput = 'Sample output';
+    const assertion: Assertion = {
+      type: 'llm-rubric',
+      value: rubricPrompt,
+      threshold: 0,
+    };
+
+    const atFloorProvider = createMockProvider({
+      response: createProviderResponse({
+        output: JSON.stringify({ score: 0, reason: 'At the floor' }),
+      }),
+    });
+
+    await expect(
+      matchesLlmRubric(
+        rubricPrompt,
+        llmOutput,
+        { rubricPrompt, provider: atFloorProvider },
+        {},
+        assertion,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ assertion, pass: true }));
   });
 
   it('still honors an explicit pass alongside score 0', async () => {

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -2904,3 +2904,64 @@ describe('tryParse and renderLlmRubricPrompt', () => {
     expect(result).toContain('string item');
   });
 });
+
+describe('matchesLlmRubric missing-verdict fail-closed semantics', () => {
+  it('fails when the grader response omits both pass and score', async () => {
+    vi.spyOn(Grader, 'callApi').mockResolvedValue({
+      output: JSON.stringify({ reason: 'Looked fine to me' }),
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    const result = await matchesLlmRubric('Expected output', 'Sample output', {
+      rubricPrompt: 'Grading prompt',
+      provider: Grader,
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain('neither a pass verdict nor a score');
+  });
+
+  it('derives pass from a positive score when pass is omitted', async () => {
+    vi.spyOn(Grader, 'callApi').mockResolvedValue({
+      output: JSON.stringify({ score: 1, reason: 'Strong match' }),
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    const result = await matchesLlmRubric('Expected output', 'Sample output', {
+      rubricPrompt: 'Grading prompt',
+      provider: Grader,
+    });
+
+    expect(result.pass).toBe(true);
+    expect(result.score).toBe(1);
+  });
+
+  it('fails a zero score when pass is omitted', async () => {
+    vi.spyOn(Grader, 'callApi').mockResolvedValue({
+      output: JSON.stringify({ score: 0, reason: 'Did not meet the rubric' }),
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    const result = await matchesLlmRubric('Expected output', 'Sample output', {
+      rubricPrompt: 'Grading prompt',
+      provider: Grader,
+    });
+
+    expect(result.pass).toBe(false);
+    expect(result.score).toBe(0);
+  });
+
+  it('still honors an explicit pass alongside score 0', async () => {
+    vi.spyOn(Grader, 'callApi').mockResolvedValue({
+      output: JSON.stringify({ pass: true, score: 0, reason: 'Passing per rubric override' }),
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    const result = await matchesLlmRubric('Expected output', 'Sample output', {
+      rubricPrompt: 'Grading prompt',
+      provider: Grader,
+    });
+
+    expect(result.pass).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug

In `runJsonGradingPrompt` (src/matchers/rubric.ts), a grader JSON response missing the `pass` field defaulted to passing:

```ts
let pass = parsed.pass ?? true;
```

So a grader response like `{"score": 0, "reason": ...}` recorded a **pass** with score 0, and a reason-only response (`{"reason": ...}`) passed with score 1. The grader failing to emit a verdict was indistinguishable from the grader approving the output.

This regressed in #2999, which replaced the previous score-based derivation with the unconditional default.

## The fix

- When `pass` is omitted and `score` is present: derive `pass` from `score > 0` (restores the pre-#2999 behavior).
- When the response carries **neither** a verdict nor a score: return a grader failure (`Grader response contained neither a pass verdict nor a score`) instead of a silent pass.
- Explicit boolean `pass`, string coercion (`true/yes/pass/y`), and threshold semantics are unchanged.

## Testing

Four regression tests added to `test/matchers/llm-rubric.test.ts`:

1. neither-field response fails with the explanatory reason
2. omitted pass with positive score derives pass
3. omitted pass with zero score fails
4. explicit `pass: true` alongside `score: 0` still passes

Full file suite: 104 tests passing. Found during an external integrity audit of grader-response handling across eval tooling.