### PR TITLE
fix(providers): price auto-quality xai image edits

### DIFF
--- a/src/providers/xai/image.ts
+++ b/src/providers/xai/image.ts
@@ -127,6 +127,7 @@ export class XAIImageProvider extends OpenAiImageProvider {
     resolution: XaiImageOptions['resolution'] = '1k',
     sourceImageCount: number = 0,
     quality?: XaiImageOptions['quality'],
+    isEdit: boolean = false,
   ): number {
     // grok-imagine-image-pro is redirected to the quality model after
     // 2026-05-15; any other unrecognized grok-imagine-* slug (e.g. a future
@@ -144,12 +145,11 @@ export class XAIImageProvider extends OpenAiImageProvider {
       return 0.02 * n + 0.002 * sourceImageCount;
     }
     if (pricingModel === 'grok-imagine-image-2.0') {
-      // `auto` and an unset quality both bill at the `low` tier, matching the $0.04
-      // xAI charged for a default 1k request. Anything else (e.g. `high`, which the
-      // API rejects) falls back to the most expensive tier so an estimate never
-      // undercharges. xAI publishes no separate source-image surcharge for this
-      // model, so it mirrors the quality tier's rate.
-      const tier = !quality || quality === 'auto' || quality === 'low' ? 'low' : 'medium';
+      // `auto` (and an unset quality) currently serves low for generations but medium
+      // for edits. Anything else (e.g. `high`, which the API rejects) falls back to
+      // the most expensive tier so an estimate never undercharges.
+      const autoTier = isEdit ? 'medium' : 'low';
+      const tier = !quality || quality === 'auto' ? autoTier : quality === 'low' ? 'low' : 'medium';
       const perImage =
         IMAGINE_IMAGE_2_0_COSTS[`${tier}_${resolution}`] ?? IMAGINE_IMAGE_2_0_COSTS.medium_2k;
       return perImage * n + 0.01 * sourceImageCount;
@@ -268,6 +268,7 @@ export class XAIImageProvider extends OpenAiImageProvider {
             config.resolution,
             this.countSourceImages(config),
             config.quality,
+            isEdit,
           ));
       const images = buildStructuredImageOutputs(data);
 

--- a/test/providers/xai/image.test.ts
+++ b/test/providers/xai/image.test.ts
@@ -248,6 +248,22 @@ describe('XAI Image Provider', () => {
       expect(result.cost).toBeCloseTo(0.04, 10);
     });
 
+    it('prices auto-quality grok-imagine-image-2.0 edits at the medium output tier', async () => {
+      const provider = new XAIImageProvider('grok-imagine-image-2.0', {
+        config: {
+          apiKey: mockApiKey,
+          quality: 'auto',
+          resolution: '1k',
+          image: { url: 'https://example.com/source.png' },
+        },
+      });
+
+      const result = await provider.callApi('Edit the cat');
+
+      // Auto currently serves medium for edits: $0.06 output + $0.01 input image.
+      expect(result.cost).toBeCloseTo(0.07, 10);
+    });
+
     it('routes Grok Imagine quality aliases to the canonical model slug', async () => {
       const provider = new XAIImageProvider('grok-imagine-image-quality-latest', {
         config: { apiKey: mockApiKey },


### PR DESCRIPTION
## Summary

- price `grok-imagine-image-2.0` auto-quality edits at the medium output tier
- preserve the low-tier fallback for auto-quality image generations
- add regression coverage for a 1K auto-quality edit with one source image

## Verification

- `node node_modules/typescript/bin/tsc --noEmit --pretty false`
- `git diff --check`
- focused Vitest attempted locally, but the temporary install remained incomplete (`keyv/index.js` missing); GitHub CI will run it in a clean environment

## Evidence

xAI's August 28 release note says auto quality currently uses low for image generation and medium for image editing. For a 1K edit with one source image, fallback cost should be $0.06 output + $0.01 input = $0.07; the previous code returned $0.05.
