### PR TITLE
fix(redteam): stop attack on target error

### DIFF
--- a/src/redteam/providers/hydra/index.ts
+++ b/src/redteam/providers/hydra/index.ts
@@ -731,8 +731,16 @@ export class HydraProvider implements ApiProvider {
       }
 
       if (targetResponse.error) {
-        logger.info(`${this.logPrefix} Target error`, { turn, error: targetResponse.error });
-        continue;
+        logger.info(`${this.logPrefix} Target error, stopping attack`, {
+          turn,
+          error: targetResponse.error,
+        });
+        // Remove the unanswered user message we added before calling the target,
+        // mirroring the transform-failure cleanup above, so conversation state
+        // (and roundsCompleted below) stays consistent when we stop here.
+        this.conversationHistory.pop();
+        stopReason = 'Target error';
+        break;
       }
 
       if (!Object.prototype.hasOwnProperty.call(targetResponse, 'output')) {

--- a/src/redteam/providers/iterative.ts
+++ b/src/redteam/providers/iterative.ts
@@ -96,7 +96,7 @@ const getIterativeGoalRubric = (goal: string | undefined): string => {
   `;
 };
 
-type StopReason = 'Grader failed' | 'Max iterations reached';
+type StopReason = 'Grader failed' | 'Max iterations reached' | 'Target error';
 
 interface IterativeMetadata {
   finalIteration: number;
@@ -460,11 +460,13 @@ export async function runRedteamConversation({
     accumulateResponseTokenUsage(totalTokenUsage, targetResponse);
     logger.debug('[Iterative] Raw target response', { response: targetResponse });
     if (targetResponse.error) {
-      logger.info(`[Iterative] ${i + 1}/${numIterations} - Target error`, {
+      logger.info(`[Iterative] ${i + 1}/${numIterations} - Target error, stopping attack`, {
         error: targetResponse.error,
         response: targetResponse,
       });
-      continue;
+      stopReason = 'Target error';
+      finalIteration = i + 1;
+      break;
     }
     if (!Object.prototype.hasOwnProperty.call(targetResponse, 'output')) {
       logger.info(

--- a/src/redteam/providers/iterativeMeta.ts
+++ b/src/redteam/providers/iterativeMeta.ts
@@ -75,7 +75,7 @@ interface IterativeMetaMetadata {
   vulnerabilityAchieved: boolean;
   redteamFinalPrompt?: string;
   storedGraderResult?: GradingResult;
-  stopReason: 'Grader failed' | 'Agent abandoned' | 'Max iterations reached';
+  stopReason: 'Grader failed' | 'Agent abandoned' | 'Max iterations reached' | 'Target error';
   redteamHistory: {
     prompt: string;
     promptAudio?: MediaData;
@@ -176,7 +176,7 @@ export async function runMetaAgentRedteam({
   let bestResponse = '';
   let finalIteration = numIterations;
   let storedGraderResult: GradingResult | undefined = undefined;
-  let stopReason: 'Grader failed' | 'Agent abandoned' | 'Max iterations reached' =
+  let stopReason: 'Grader failed' | 'Agent abandoned' | 'Max iterations reached' | 'Target error' =
     'Max iterations reached';
   let lastResponse: TargetResponse | undefined = undefined;
   let failClosedError: string | undefined;
@@ -492,10 +492,12 @@ export async function runMetaAgentRedteam({
     });
 
     if (targetResponse.error) {
-      logger.info(`[IterativeMeta] ${i + 1}/${numIterations} - Target error`, {
+      logger.info(`[IterativeMeta] ${i + 1}/${numIterations} - Target error, stopping attack`, {
         error: targetResponse.error,
       });
-      continue;
+      stopReason = 'Target error';
+      finalIteration = i + 1;
+      break;
     }
 
     if (!Object.prototype.hasOwnProperty.call(targetResponse, 'output')) {

--- a/src/redteam/providers/shared.ts
+++ b/src/redteam/providers/shared.ts
@@ -894,7 +894,10 @@ type SharedBacktrackingStopReason =
   | 'Target ended conversation';
 
 export type RoundBacktrackingStopReason = SharedBacktrackingStopReason | 'Max rounds reached';
-export type TurnBacktrackingStopReason = SharedBacktrackingStopReason | 'Max turns reached';
+export type TurnBacktrackingStopReason =
+  | SharedBacktrackingStopReason
+  | 'Max turns reached'
+  | 'Target error';
 
 /**
  * Externalize large blob payloads in provider responses before they are copied into

--- a/test/redteam/providers/hydra/index.test.ts
+++ b/test/redteam/providers/hydra/index.test.ts
@@ -948,24 +948,20 @@ describe('HydraProvider', () => {
       expect(mockTargetProvider.callApi).toHaveBeenCalledTimes(1);
     });
 
-    it('should continue when target provider returns error', async () => {
+    it('should stop immediately and surface the error when target provider errors on the first turn', async () => {
       mockAgentProvider.callApi.mockResolvedValue({
         output: 'Attack message',
         tokenUsage: { total: 100, prompt: 50, completion: 50 },
       });
 
-      mockTargetProvider.callApi
-        .mockResolvedValueOnce({
-          error: 'Target error',
-          output: '',
-        })
-        .mockResolvedValueOnce({
-          output: 'Valid response',
-        });
+      mockTargetProvider.callApi.mockResolvedValueOnce({
+        error: 'Target error: 502 Bad Gateway',
+        output: '',
+      });
 
       const provider = new HydraProvider({
         injectVar: 'input',
-        maxTurns: 2,
+        maxTurns: 5,
       });
 
       const context: CallApiContextParams = {
@@ -980,11 +976,59 @@ describe('HydraProvider', () => {
 
       const result = await provider.callApi('', context);
 
-      // First turn has error (doesn't count), second turn succeeds (counts as turn 1)
-      // But since we continue after error, we actually make 2 turns total
-      expect(result.metadata?.hydraRoundsCompleted).toBeGreaterThanOrEqual(1);
-      // Agent is called for each turn + learning update
-      expect(mockAgentProvider.callApi).toHaveBeenCalledTimes(3);
+      // The attack must stop at the errored turn rather than continuing to turn 2.
+      expect(mockTargetProvider.callApi).toHaveBeenCalledTimes(1);
+      expect(result.error).toBe('Target error: 502 Bad Gateway');
+      expect(result.metadata?.stopReason).toBe('Target error');
+      // The unanswered user turn should not be counted as completed.
+      expect(result.metadata?.hydraRoundsCompleted).toBe(0);
+      // Agent is called once for the errored turn (no further turns, no learning update retry).
+      expect(mockAgentProvider.callApi).toHaveBeenCalledTimes(2);
+    });
+
+    it('should stop immediately and surface the error when target provider errors mid-run', async () => {
+      mockAgentProvider.callApi.mockResolvedValue({
+        output: 'Attack message',
+        tokenUsage: { total: 100, prompt: 50, completion: 50 },
+      });
+
+      mockTargetProvider.callApi
+        .mockResolvedValueOnce({
+          output: 'Valid response',
+        })
+        .mockResolvedValueOnce({
+          error: 'Target error: 502 Bad Gateway',
+          output: '',
+        })
+        .mockResolvedValueOnce({
+          output: 'This should never be sent',
+        });
+
+      const provider = new HydraProvider({
+        injectVar: 'input',
+        maxTurns: 5,
+      });
+
+      const context: CallApiContextParams = {
+        originalProvider: mockTargetProvider,
+        vars: { input: 'test goal' },
+        prompt: { raw: 'test prompt', label: 'test' },
+        test: {
+          assert: [{ type: 'harmful:test' }],
+          metadata: { goal: 'test goal', pluginId: 'harmful:test' },
+        } as any,
+      };
+
+      const result = await provider.callApi('', context);
+
+      // Only the successful first turn and the errored second turn should reach the target.
+      expect(mockTargetProvider.callApi).toHaveBeenCalledTimes(2);
+      expect(result.error).toBe('Target error: 502 Bad Gateway');
+      expect(result.metadata?.stopReason).toBe('Target error');
+      // Only the first (answered) turn counts as completed.
+      expect(result.metadata?.hydraRoundsCompleted).toBe(1);
+      // The successful first turn is recorded; the errored second turn is not.
+      expect(result.metadata?.redteamHistory).toHaveLength(1);
     });
 
     it('should stop when target ends conversation', async () => {

--- a/test/redteam/providers/iterative.test.ts
+++ b/test/redteam/providers/iterative.test.ts
@@ -1111,7 +1111,7 @@ describe('RedteamIterativeProvider', () => {
       expect(result.tokenUsage.numRequests).toBe(3); // All calls counted
     });
 
-    it('should handle error responses without affecting token counts', async () => {
+    it('should stop the conversation and count only the calls made before a target error', async () => {
       // Clear the mock to use the target provider directly for this test
       mockGetTargetResponse.mockReset();
       mockGetTargetResponse.mockImplementation(async (_provider, prompt, context, _options) => {
@@ -1148,11 +1148,17 @@ describe('RedteamIterativeProvider', () => {
         excludeTargetOutputFromAgenticAttackGeneration: false,
       });
 
-      // Only successful calls should contribute to token usage
-      expect(result.tokenUsage.total).toBe(250); // 100 + 150
-      expect(result.tokenUsage.prompt).toBe(150); // 60 + 90
-      expect(result.tokenUsage.completion).toBe(100); // 40 + 60
-      expect(result.tokenUsage.numRequests).toBe(3); // All calls are counted, including errors
+      // The attack stops at the second (errored) iteration; the third mocked
+      // response is never consumed.
+      expect(mockTargetProvider.callApi).toHaveBeenCalledTimes(2);
+      expect(result.error).toBe('Target provider failed');
+      expect(result.metadata.stopReason).toBe('Target error');
+
+      // Only the first (successful) and second (errored) calls contribute to token usage.
+      expect(result.tokenUsage.total).toBe(100);
+      expect(result.tokenUsage.prompt).toBe(60);
+      expect(result.tokenUsage.completion).toBe(40);
+      expect(result.tokenUsage.numRequests).toBe(2); // Both calls are counted, including the error
     });
 
     it('should handle zero token counts correctly', async () => {

--- a/test/redteam/providers/iterativeMeta.test.ts
+++ b/test/redteam/providers/iterativeMeta.test.ts
@@ -235,6 +235,42 @@ describe('RedteamIterativeMetaProvider', () => {
       expect(result.metadata.stopReason).toBe('Grader failed');
     });
 
+    it('should stop immediately and surface the error when the target errors mid-run', async () => {
+      mockGetTargetResponse
+        .mockResolvedValueOnce({ output: 'Valid response' })
+        .mockResolvedValueOnce({ output: '', error: 'Target error: 502 Bad Gateway' })
+        .mockResolvedValueOnce({ output: 'This should never be sent' });
+
+      const result = await runMetaAgentRedteam({
+        context: {
+          vars: { query: 'test' },
+          prompt: { raw: 'test', label: 'test' },
+          originalProvider: mockTargetProvider,
+        },
+        filters: undefined,
+        injectVar: 'query',
+        numIterations: 5,
+        options: undefined,
+        prompt: { raw: 'test', label: 'test' },
+        agentProvider: mockAgentProvider,
+        gradingProvider: mockGradingProvider,
+        targetProvider: mockTargetProvider,
+        test: {
+          vars: { query: 'test' },
+          assert: [{ type: 'promptfoo:redteam:harmful', metric: 'Harmful' }],
+        } as AtomicTestCase,
+        vars: { query: 'test' },
+      });
+
+      // Only the first (successful) and second (errored) iterations should call the target.
+      expect(mockGetTargetResponse).toHaveBeenCalledTimes(2);
+      expect(result.error).toBe('Target error: 502 Bad Gateway');
+      expect(result.metadata.stopReason).toBe('Target error');
+      expect(result.metadata.finalIteration).toBe(2);
+      // The successful first iteration is recorded; the errored second iteration is not.
+      expect(result.metadata.redteamHistory).toHaveLength(1);
+    });
+
     it('passes target provider raw response into the grader', async () => {
       const mockGrader = {
         getResult: vi.fn<any>().mockResolvedValue({


### PR DESCRIPTION
## Summary

When a redteam target provider returns an error mid-conversation (e.g. a `502 Bad Gateway`), the Hydra, `jailbreak:meta`, and `jailbreak:iterative` strategies did NOT log it and silently continued to the next turn/iteration. 
Errors on the last conversation are recorded as "errors", but errors on mid-conversation disappear. 
This PR makes them stop the attack immediately instead, so the error reliably surfaces in eval Results regardless of which turn it happened on.

`GoblinProvider` (`src/redteam/providers/goblin/index.ts`) is a thin subclass of `HydraProvider` with no override of the attack loop, so it inherits this fix automatically — no separate change needed there.

## Root cause

In `HydraProvider.runAttack` (`hydra/index.ts`), `runMetaAgentRedteam` (`iterativeMeta.ts`), and `runRedteamConversation` (`iterative.ts`), a target response error was handled as:

```ts
if (targetResponse.error) {
  logger.info('... Target error', { error: targetResponse.error });
  continue; // move on to the next turn/iteration
}
```

`continue` meant that turn was dropped without any trace, and the errored response was never recorded. Each function's return value derives its top-level `error` from the *last* target response it saw (`lastResponse?.error` / `lastTargetResponse?.error`). So:

- If the error happened on the **last** turn attempted, it survived as the final state and correctly surfaced as the test's top-level `error` (shown as a failed/errored result in the eval UI).
- If the error happened on an **earlier** turn and a later turn succeeded, the successful response overwrote `lastResponse`, and the earlier error vanished entirely — no top-level error, and no entry in `redteamHistory` (the array the "Messages" tab in eval Results renders). The 502 was completely invisible in the UI.

## Fix

Target errors now stop the attack immediately (`break` instead of `continue`), regardless of which turn/iteration they occur on, recording the correct `stopReason: 'Target error'` and moving on to the next test case:

- `src/redteam/providers/hydra/index.ts` — also pops the just-added, now-unanswered user turn from the in-memory conversation history (mirroring the existing transform-failure cleanup a few lines above), so `hydraRoundsCompleted` stays accurate.
- `src/redteam/providers/iterativeMeta.ts`
- `src/redteam/providers/iterative.ts`
- `src/redteam/providers/shared.ts` — widens `TurnBacktrackingStopReason` with the new `'Target error'` value.

Because `lastResponse`/`lastTargetResponse` is always set immediately before this check, stopping here guarantees it holds the errored response as the final state — so the existing top-level `error`/`failureReason` mechanism the eval UI already uses to render errored results now fires consistently, with no UI changes required.

Out of scope: the separate `agentResp.error` / `redteamResp.error` branches in these same files (errors from the cloud attack-generation call, not the target) are unchanged — that is a distinct failure mode.

## Test plan

- `test/redteam/providers/hydra/index.test.ts`: replaced the outdated "should continue when target provider returns error" test with two tests covering a target error on the first turn and mid-run, asserting the attack stops after exactly one additional target call, `stopReason: 'Target error'`, the top-level `error` is set, and `hydraRoundsCompleted`/`redteamHistory` reflect only completed turns.
- `test/redteam/providers/iterativeMeta.test.ts`: added a mid-run target-error test with the same assertions (no such coverage existed before).
- `test/redteam/providers/iterative.test.ts`: updated the existing "should handle error responses without affecting token counts" test, which asserted the old continue-past-errors behavior, to assert the attack now stops at the errored iteration and only pre-stop token usage is counted.
- `npx vitest run test/redteam/providers/` — 571 tests passing.
- `npx tsc --noEmit` — no new errors.
- `npm run l` / `npm run f` — clean (only pre-existing, unrelated `noExcessiveCognitiveComplexity` warnings on these already-large functions, unchanged by this PR).
