### PR TITLE
fix(providers): thread opencode traceparent per call

### DIFF
--- a/site/docs/providers/opencode-sdk.md
+++ b/site/docs/providers/opencode-sdk.md
@@ -188,29 +188,30 @@ When enabling write/edit/bash tools, consider how you will reset files after eac
 
 ## Supported Parameters
 
-| Parameter           | Type    | Description                                                                | Default                                |
-| ------------------- | ------- | -------------------------------------------------------------------------- | -------------------------------------- |
-| `apiKey`            | string  | Inject API key into a spawned OpenCode server for `provider_id`            | Environment variable                   |
-| `baseUrl`           | string  | URL for an existing OpenCode server                                        | Auto-start server                      |
-| `hostname`          | string  | Server hostname when starting a new server                                 | `127.0.0.1`                            |
-| `port`              | number  | Server port when starting a new server                                     | Auto-select                            |
-| `timeout`           | number  | Server startup timeout in milliseconds                                     | `30000`                                |
-| `log_level`         | string  | OpenCode server log level (`debug`, `info`, `warn`, `error`, `off`)        | Provider default                       |
-| `working_dir`       | string  | Directory for file operations and read-only default tools                  | Temporary directory                    |
-| `workspace`         | string  | Workspace identifier for workspace-aware OpenCode requests                 | None                                   |
-| `provider_id`       | string  | LLM provider (`anthropic`, `openai`, `google`, `ollama`, etc.)             | OpenCode default                       |
-| `model`             | string  | Model to use for this request                                              | OpenCode default                       |
-| `format`            | object  | Output format, including JSON Schema structured output                     | Text                                   |
-| `variant`           | string  | Provider/model variant defined in OpenCode config                          | Default variant                        |
-| `tools`             | object  | Tool configuration                                                         | None; read-only with `working_dir`     |
-| `permission`        | object  | Permission configuration for tools                                         | No extra rules; wildcard-deny baseline |
-| `agent`             | string  | Built-in or preconfigured agent to use                                     | Default agent                          |
-| `custom_agent`      | object  | Custom agent configuration when promptfoo starts the OpenCode server       | None                                   |
-| `session_id`        | string  | Resume an existing session                                                 | Create new session                     |
-| `parent_session_id` | string  | Fork from an existing session (v2 server only); inherits compacted history | None                                   |
-| `persist_sessions`  | boolean | Reuse the same session for repeated calls with the same provider config    | `false`                                |
-| `mcp`               | object  | MCP server configuration when promptfoo starts the OpenCode server         | None                                   |
-| `cache_mcp`         | boolean | Enable caching when MCP is configured                                      | `false`                                |
+| Parameter                 | Type    | Description                                                                   | Default                                |
+| ------------------------- | ------- | ----------------------------------------------------------------------------- | -------------------------------------- |
+| `apiKey`                  | string  | Inject API key into a spawned OpenCode server for `provider_id`               | Environment variable                   |
+| `baseUrl`                 | string  | URL for an existing OpenCode server                                           | Auto-start server                      |
+| `hostname`                | string  | Server hostname when starting a new server                                    | `127.0.0.1`                            |
+| `port`                    | number  | Server port when starting a new server                                        | Auto-select                            |
+| `timeout`                 | number  | Server startup timeout in milliseconds                                        | `30000`                                |
+| `log_level`               | string  | OpenCode server log level (`debug`, `info`, `warn`, `error`, `off`)           | Provider default                       |
+| `working_dir`             | string  | Directory for file operations and read-only default tools                     | Temporary directory                    |
+| `workspace`               | string  | Workspace identifier for workspace-aware OpenCode requests                    | None                                   |
+| `provider_id`             | string  | LLM provider (`anthropic`, `openai`, `google`, `ollama`, etc.)                | OpenCode default                       |
+| `model`                   | string  | Model to use for this request                                                 | OpenCode default                       |
+| `format`                  | object  | Output format, including JSON Schema structured output                        | Text                                   |
+| `variant`                 | string  | Provider/model variant defined in OpenCode config                             | Default variant                        |
+| `tools`                   | object  | Tool configuration                                                            | None; read-only with `working_dir`     |
+| `permission`              | object  | Permission configuration for tools                                            | No extra rules; wildcard-deny baseline |
+| `agent`                   | string  | Built-in or preconfigured agent to use                                        | Default agent                          |
+| `custom_agent`            | object  | Custom agent configuration when promptfoo starts the OpenCode server          | None                                   |
+| `session_id`              | string  | Resume an existing session                                                    | Create new session                     |
+| `parent_session_id`       | string  | Fork from an existing session (v2 server only); inherits compacted history    | None                                   |
+| `persist_sessions`        | boolean | Reuse the same session for repeated calls with the same provider config       | `false`                                |
+| `restart_server_per_call` | boolean | Restart promptfoo's owned OpenCode server when the eval trace context changes | `false`                                |
+| `mcp`                     | object  | MCP server configuration when promptfoo starts the OpenCode server            | None                                   |
+| `cache_mcp`               | boolean | Enable caching when MCP is configured                                         | `false`                                |
 
 ## Supported Providers
 
@@ -449,6 +450,21 @@ providers:
 ```
 
 This reuse is independent of the promptfoo response cache. It is scoped to the lifetime of the provider instance. If you need to continue a session later, capture its `sessionId` and pass it back with `session_id`.
+
+### Trace Correlation for Trajectory Assertions
+
+Set `restart_server_per_call: true` when an OpenCode telemetry plugin needs the current test case's W3C `traceparent` at server startup. Promptfoo sets `OPENCODE_TRACEPARENT` while spawning its owned OpenCode server, then restarts that server when the trace context changes so emitted spans can be matched by `trajectory:*` assertions.
+
+```yaml
+providers:
+  - id: opencode:sdk
+    config:
+      provider_id: anthropic
+      model: claude-sonnet-4-20250514
+      restart_server_per_call: true
+```
+
+This has a startup cost, so leave it disabled unless you need per-test trace correlation. It cannot be combined with `baseUrl`, where promptfoo does not control the server process, or `persist_sessions`, where reused conversation state conflicts with per-trace server lifecycles.
 
 ### Session Resumption
 

--- a/src/providers/opencode-sdk.ts
+++ b/src/providers/opencode-sdk.ts
@@ -359,6 +359,14 @@ export interface OpenCodeSDKConfig {
   persist_sessions?: boolean;
 
   /**
+   * Restart Promptfoo's owned OpenCode server for each distinct traceparent.
+   * This lets OpenCode telemetry plugins that read OPENCODE_TRACEPARENT at
+   * process startup correlate spans with the current promptfoo test case.
+   * @default false
+   */
+  restart_server_per_call?: boolean;
+
+  /**
    * MCP server configuration
    */
   mcp?: Record<string, OpenCodeMCPServerConfig>;
@@ -839,9 +847,11 @@ export class OpenCodeSDKProvider implements ApiProvider {
   private client?: OpenCodeClient;
   private clientInitialization?: Promise<void>;
   private server?: OpenCodeServer;
+  private activeTraceparent?: string;
   private sessions: Map<string, OpenCodeSessionHandle> = new Map(); // cacheKey -> session info
   private sessionOrder: string[] = []; // Track insertion order for LRU eviction
   private sessionQueues = new Map<string, Promise<void>>();
+  private serverLifecycleQueue: Promise<void> = Promise.resolve();
   private readonly credentialCacheScope = crypto.randomUUID();
   private streamingWarningEmitted = false;
 
@@ -914,15 +924,21 @@ export class OpenCodeSDKProvider implements ApiProvider {
     this.sessionQueues.clear();
 
     // Close server if we started one
-    if (this.server) {
-      try {
-        this.server.close();
-      } catch (err) {
-        logger.debug(`Failed to close OpenCode server: ${err}`);
-      }
-      this.server = undefined;
-    }
+    this.closeOwnedServer();
     this.client = undefined;
+    this.activeTraceparent = undefined;
+  }
+
+  private closeOwnedServer(): void {
+    if (!this.server) {
+      return;
+    }
+    try {
+      this.server.close();
+    } catch (err) {
+      logger.debug(`Failed to close OpenCode server: ${err}`);
+    }
+    this.server = undefined;
   }
 
   /**
@@ -1296,10 +1312,55 @@ export class OpenCodeSDKProvider implements ApiProvider {
     return this.opencodeModule;
   }
 
-  private async ensureClient(config: OpenCodeSDKConfig): Promise<void> {
+  private withTemporaryOpenCodeTraceparent<T>(traceparent: string | undefined, run: () => T): T {
+    const previousTraceparent = process.env.OPENCODE_TRACEPARENT;
+    try {
+      if (traceparent) {
+        // biome-ignore lint: OpenCode SDK v2 ignores options.env, so the child can only inherit this from process.env at spawn time.
+        process.env.OPENCODE_TRACEPARENT = traceparent;
+      } else {
+        // biome-ignore lint: OpenCode SDK v2 ignores options.env, so the child can only inherit this from process.env at spawn time.
+        delete process.env.OPENCODE_TRACEPARENT;
+      }
+      return run();
+    } finally {
+      if (previousTraceparent === undefined) {
+        // biome-ignore lint: Restore the ambient process environment immediately after spawning OpenCode.
+        delete process.env.OPENCODE_TRACEPARENT;
+      } else {
+        // biome-ignore lint: Restore the ambient process environment immediately after spawning OpenCode.
+        process.env.OPENCODE_TRACEPARENT = previousTraceparent;
+      }
+    }
+  }
+
+  private async ensureClient(
+    config: OpenCodeSDKConfig,
+    traceparent: string | undefined,
+  ): Promise<void> {
     const opencodeModule = await this.ensureOpenCodeModule();
 
     this.validateSessionPolicyConfiguration(config);
+
+    if (config.restart_server_per_call && config.baseUrl) {
+      throw new Error(
+        'OpenCode SDK restart_server_per_call cannot be used with baseUrl because promptfoo cannot restart or retag an external server.',
+      );
+    }
+    if (config.restart_server_per_call && config.persist_sessions) {
+      throw new Error(
+        'OpenCode SDK restart_server_per_call cannot be used with persist_sessions because each traceparent needs an isolated server session lifecycle.',
+      );
+    }
+
+    if (config.restart_server_per_call && this.client && this.activeTraceparent !== traceparent) {
+      this.closeOwnedServer();
+      this.client = undefined;
+      this.sessions.clear();
+      this.sessionOrder = [];
+      this.sessionQueues.clear();
+      this.activeTraceparent = undefined;
+    }
 
     if (this.client) {
       return;
@@ -1336,9 +1397,13 @@ export class OpenCodeSDKProvider implements ApiProvider {
         serverOptions.config = serverConfig;
       }
 
-      const opencode = await createOpencode(serverOptions);
+      const opencodePromise = this.withTemporaryOpenCodeTraceparent(traceparent, () =>
+        createOpencode(serverOptions),
+      );
+      const opencode = await opencodePromise;
       this.client = opencode.client;
       this.server = opencode.server;
+      this.activeTraceparent = traceparent;
       logger.debug(`OpenCode server started at ${opencode.server.url}`);
     })();
     this.clientInitialization = initialization;
@@ -1593,6 +1658,29 @@ export class OpenCodeSDKProvider implements ApiProvider {
     }
   }
 
+  private async runSerializedServerLifecycleCall<T>(
+    enabled: boolean | undefined,
+    abortSignal: AbortSignal | undefined,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    if (!enabled) {
+      return run();
+    }
+
+    const previous = this.serverLifecycleQueue;
+    let release: () => void = () => {};
+    this.serverLifecycleQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    try {
+      await this.waitForPreviousSessionCall(previous, abortSignal);
+      return await run();
+    } finally {
+      release();
+    }
+  }
+
   private async waitForPreviousSessionCall(
     previous: Promise<void>,
     abortSignal: AbortSignal | undefined,
@@ -1779,60 +1867,92 @@ export class OpenCodeSDKProvider implements ApiProvider {
         return { error: 'OpenCode SDK call aborted before it started' };
       }
 
-      await this.ensureClient(config);
-      const sessionQueueKey = this.getSessionQueueKey(config, workingDir);
-      return await this.runSerializedSessionCall(
-        sessionQueueKey,
+      return await this.runSerializedServerLifecycleCall(
+        config.restart_server_per_call,
         callOptions?.abortSignal,
         async () => {
-          const session = await this.getOrCreateSession(config, workingDir);
-          ephemeralSession = session.ephemeralSession;
-          if (callOptions?.abortSignal?.aborted) {
-            return { error: 'OpenCode SDK call aborted before it started' };
-          }
-
-          const promptOptions = this.buildPromptParameters(
+          await this.ensureClient(
             config,
-            prompt,
-            session.sessionId,
-            session.sessionQuery,
+            config.restart_server_per_call ? context?.traceparent : undefined,
           );
-          logger.debug(`OpenCode SDK prompt options:`, promptOptions);
+          const sessionQueueKey = this.getSessionQueueKey(config, workingDir);
+          return await this.runSerializedSessionCall(
+            sessionQueueKey,
+            callOptions?.abortSignal,
+            async () => {
+              const session = await this.getOrCreateSession(config, workingDir);
+              ephemeralSession = session.ephemeralSession;
+              try {
+                if (callOptions?.abortSignal?.aborted) {
+                  return { error: 'OpenCode SDK call aborted before it started' };
+                }
 
-          const client = this.client;
-          if (!client) {
-            throw new Error('OpenCode SDK client is not initialized');
-          }
+                const promptOptions = this.buildPromptParameters(
+                  config,
+                  prompt,
+                  session.sessionId,
+                  session.sessionQuery,
+                );
+                logger.debug(`OpenCode SDK prompt options:`, promptOptions);
 
-          // If the caller's abortSignal fires mid-prompt, ask the server to stop
-          // rather than letting it run to completion while we discard the result.
-          // session.abort is only on v2; v1 has no abort primitive, so we still
-          // honor cancellation locally via the response check below.
-          const abortSignal = callOptions?.abortSignal;
-          if (abortSignal && client.session.abort && this.opencodeModule?.apiVersion === 'v2') {
-            const abortParams = this.buildAbortSessionParameters(
-              session.sessionId,
-              session.sessionQuery,
-            );
-            abortListener = () => {
-              client.session.abort?.(abortParams).catch((err) => {
-                logger.debug(`[OpenCode SDK] Failed to abort session ${session.sessionId}: ${err}`);
-              });
-            };
-            abortSignal.addEventListener('abort', abortListener, { once: true });
-          }
+                const client = this.client;
+                if (!client) {
+                  throw new Error('OpenCode SDK client is not initialized');
+                }
 
-          const response = await client.session.prompt(promptOptions);
-          logger.debug(`OpenCode SDK response received`);
+                // If the caller's abortSignal fires mid-prompt, ask the server to stop
+                // rather than letting it run to completion while we discard the result.
+                // session.abort is only on v2; v1 has no abort primitive, so we still
+                // honor cancellation locally via the response check below.
+                const abortSignal = callOptions?.abortSignal;
+                if (
+                  abortSignal &&
+                  client.session.abort &&
+                  this.opencodeModule?.apiVersion === 'v2'
+                ) {
+                  const abortParams = this.buildAbortSessionParameters(
+                    session.sessionId,
+                    session.sessionQuery,
+                  );
+                  abortListener = () => {
+                    client.session.abort?.(abortParams).catch((err) => {
+                      logger.debug(
+                        `[OpenCode SDK] Failed to abort session ${session.sessionId}: ${err}`,
+                      );
+                    });
+                  };
+                  abortSignal.addEventListener('abort', abortListener, { once: true });
+                }
 
-          if (abortSignal?.aborted) {
-            return { error: 'OpenCode SDK call aborted' };
-          }
+                const response = await client.session.prompt(promptOptions);
+                logger.debug(`OpenCode SDK response received`);
 
-          const providerResponse = this.buildProviderResponse(config, response, session.sessionId);
-          await cacheResponse(cacheResult, providerResponse, 'OpenCode SDK');
-          logger.debug(`OpenCode SDK response: ${providerResponse.output.slice(0, 100)}...`);
-          return providerResponse;
+                if (abortSignal?.aborted) {
+                  return { error: 'OpenCode SDK call aborted' };
+                }
+
+                const providerResponse = this.buildProviderResponse(
+                  config,
+                  response,
+                  session.sessionId,
+                );
+                await cacheResponse(cacheResult, providerResponse, 'OpenCode SDK');
+                logger.debug(`OpenCode SDK response: ${providerResponse.output.slice(0, 100)}...`);
+                return providerResponse;
+              } finally {
+                if (config.restart_server_per_call && ephemeralSession) {
+                  try {
+                    await this.deleteSession(ephemeralSession);
+                  } catch (err) {
+                    logger.debug(
+                      `Failed to delete non-persistent session ${ephemeralSession.id}: ${err}`,
+                    );
+                  }
+                  ephemeralSession = undefined;
+                }
+              }
+            },
+          );
         },
       );
     } catch (error) {

--- a/test/providers/opencode-sdk.test.ts
+++ b/test/providers/opencode-sdk.test.ts
@@ -992,6 +992,125 @@ describe('OpenCodeSDKProvider', () => {
         expect(mockCreateOpencode).toHaveBeenCalledTimes(1);
       });
 
+      it('restarts the owned server when traceparent changes under restart_server_per_call', async () => {
+        const provider = new OpenCodeSDKProvider({
+          config: { restart_server_per_call: true },
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('First', {
+          traceparent: '00-11111111111111111111111111111111-1111111111111111-01',
+        } as CallApiContextParams);
+        await provider.callApi('Second', {
+          traceparent: '00-22222222222222222222222222222222-2222222222222222-01',
+        } as CallApiContextParams);
+
+        expect(mockCreateOpencode).toHaveBeenCalledTimes(2);
+        expect(mockServerClose).toHaveBeenCalledTimes(1);
+      });
+
+      it('sets OPENCODE_TRACEPARENT only while spawning a restarted owned server', async () => {
+        const originalTraceparent = process.env.OPENCODE_TRACEPARENT;
+        const seenTraceparents: Array<string | undefined> = [];
+        mockCreateOpencode.mockImplementation(async () => {
+          seenTraceparents.push(process.env.OPENCODE_TRACEPARENT);
+          return {
+            client: {
+              session: {
+                create: mockSessionCreate,
+                prompt: mockSessionPrompt,
+                messages: mockSessionMessages,
+                delete: mockSessionDelete,
+                list: mockSessionList,
+                abort: mockSessionAbort,
+              },
+            },
+            server: { url: 'http://127.0.0.1:4096', close: mockServerClose },
+          };
+        });
+        const provider = new OpenCodeSDKProvider({
+          config: { restart_server_per_call: true },
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('First', {
+          traceparent: '00-33333333333333333333333333333333-3333333333333333-01',
+        } as CallApiContextParams);
+
+        expect(seenTraceparents).toEqual([
+          '00-33333333333333333333333333333333-3333333333333333-01',
+        ]);
+        expect(process.env.OPENCODE_TRACEPARENT).toBe(originalTraceparent);
+      });
+
+      it('does not restart the owned server for traceparent changes unless restart_server_per_call is enabled', async () => {
+        const provider = new OpenCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('First', {
+          traceparent: '00-44444444444444444444444444444444-4444444444444444-01',
+        } as CallApiContextParams);
+        await provider.callApi('Second', {
+          traceparent: '00-55555555555555555555555555555555-5555555555555555-01',
+        } as CallApiContextParams);
+
+        expect(mockCreateOpencode).toHaveBeenCalledTimes(1);
+        expect(mockServerClose).not.toHaveBeenCalled();
+      });
+
+      it('does not set OPENCODE_TRACEPARENT unless restart_server_per_call is enabled', async () => {
+        const originalTraceparent = process.env.OPENCODE_TRACEPARENT;
+        const seenTraceparents: Array<string | undefined> = [];
+        mockCreateOpencode.mockImplementation(async () => {
+          seenTraceparents.push(process.env.OPENCODE_TRACEPARENT);
+          return {
+            client: {
+              session: {
+                create: mockSessionCreate,
+                prompt: mockSessionPrompt,
+                messages: mockSessionMessages,
+                delete: mockSessionDelete,
+                list: mockSessionList,
+                abort: mockSessionAbort,
+              },
+            },
+            server: { url: 'http://127.0.0.1:4096', close: mockServerClose },
+          };
+        });
+        const provider = new OpenCodeSDKProvider({
+          env: { ANTHROPIC_API_KEY: 'test-api-key' },
+        });
+
+        await provider.callApi('First', {
+          traceparent: '00-66666666666666666666666666666666-6666666666666666-01',
+        } as CallApiContextParams);
+
+        expect(seenTraceparents).toEqual([originalTraceparent]);
+        expect(process.env.OPENCODE_TRACEPARENT).toBe(originalTraceparent);
+      });
+
+      it('rejects restart_server_per_call with external baseUrl or persisted sessions', async () => {
+        const remoteProvider = new OpenCodeSDKProvider({
+          config: {
+            baseUrl: 'https://opencode.example.test',
+            restart_server_per_call: true,
+          },
+        });
+        const persistedProvider = new OpenCodeSDKProvider({
+          config: { persist_sessions: true, restart_server_per_call: true },
+        });
+
+        await expect(remoteProvider.callApi('Test prompt')).resolves.toEqual({
+          error:
+            'Error calling OpenCode SDK: OpenCode SDK restart_server_per_call cannot be used with baseUrl because promptfoo cannot restart or retag an external server.',
+        });
+        await expect(persistedProvider.callApi('Test prompt')).resolves.toEqual({
+          error:
+            'Error calling OpenCode SDK: OpenCode SDK restart_server_per_call cannot be used with persist_sessions because each traceparent needs an isolated server session lifecycle.',
+        });
+      });
+
       it('should resume session when session_id provided', async () => {
         const provider = new OpenCodeSDKProvider({
           config: { session_id: 'existing-session' },


### PR DESCRIPTION
## Summary

- Add an opt-in `restart_server_per_call` mode for `opencode:sdk` so promptfoo-owned OpenCode servers restart when the eval `traceparent` changes.
- Temporarily set `OPENCODE_TRACEPARENT` only while spawning OpenCode, matching the current SDK behavior where the server inherits `process.env` at spawn time.
- Reject incompatible `baseUrl` and `persist_sessions` combinations, and document the trajectory assertion tradeoff.

Fixes #10518.

## Why

OpenCode telemetry plugins that read trace context at process startup cannot correlate per-test spans today because `opencode:sdk` keeps one owned server alive across calls and never forwards `context.traceparent`. That makes `trajectory:*` assertions unreliable for OpenCode runs.

## Validation

- `npx vitest run test/providers/opencode-sdk.test.ts` - 139 passed
- `npx @biomejs/biome check src/providers/opencode-sdk.ts test/providers/opencode-sdk.test.ts`
- `npx prettier --check site/docs/providers/opencode-sdk.md`
- `git diff --check`

Also ran `npm run tsc`; it is currently blocked on unrelated existing `src/providers/openai/codex-security.ts` errors because `@openai/codex-security` is not available in this local checkout.

I could not run a real OpenCode + OTLP e2e locally because this machine does not have the `opencode` CLI on PATH. The provider lifecycle is covered with the existing mocked OpenCode SDK suite, including restart, env injection/restoration, default no-op behavior, and incompatible config rejection.