### PR TITLE
refactor(providers): simplify setup and token caps

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.test.tsx
@@ -197,6 +197,32 @@ describe('ProviderTypeSelector', () => {
     expect(httpProvider).toBeNull();
   });
 
+  it('updates available providers after the parent changes the allowed IDs', () => {
+    const provider: ProviderOptions = { id: '', config: {} };
+    const setProvider = vi.fn();
+    const { rerender } = renderWithTooltipProvider(
+      <ProviderTypeSelector
+        provider={provider}
+        setProvider={setProvider}
+        availableProviderIds={['http']}
+      />,
+    );
+    expect(screen.getByText('HTTP/HTTPS Endpoint')).toBeVisible();
+    expect(screen.queryByText('Python')).not.toBeInTheDocument();
+
+    rerender(
+      <TooltipProvider>
+        <ProviderTypeSelector
+          provider={provider}
+          setProvider={setProvider}
+          availableProviderIds={['python']}
+        />
+      </TooltipProvider>,
+    );
+    expect(screen.getByText('Python')).toBeVisible();
+    expect(screen.queryByText('HTTP/HTTPS Endpoint')).not.toBeInTheDocument();
+  });
+
   it('should only display provider options included in availableProviderIds when availableProviderIds prop is provided', () => {
     const mockSetProvider = vi.fn();
     // Start with no provider to get expanded view initially

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@app/components/ui/button';
 import { Input } from '@app/components/ui/input';
@@ -1081,21 +1081,19 @@ export default function ProviderTypeSelector({
   };
 
   // Filter available options if availableProviderIds is provided, by search term, and by tag
-  const filteredProviderOptions = allProviderOptions.filter((option) => {
-    // Filter by availableProviderIds if provided
-    const isAvailable = !availableProviderIds || availableProviderIds.includes(option.value);
+  const filteredProviderOptions = useMemo(() => {
+    const normalizedSearch = searchTerm.toLowerCase();
+    return allProviderOptions.filter((option) => {
+      const isAvailable = !availableProviderIds || availableProviderIds.includes(option.value);
+      const matchesSearch =
+        !normalizedSearch ||
+        option.label.toLowerCase().includes(normalizedSearch) ||
+        option.description.toLowerCase().includes(normalizedSearch);
+      const matchesTag = !selectedTag || option.tag === selectedTag;
 
-    // Filter by search term if provided
-    const matchesSearch =
-      !searchTerm ||
-      option.label.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      option.description.toLowerCase().includes(searchTerm.toLowerCase());
-
-    // Filter by selected tag if provided
-    const matchesTag = !selectedTag || option.tag === selectedTag;
-
-    return isAvailable && matchesSearch && matchesTag;
-  });
+      return isAvailable && matchesSearch && matchesTag;
+    });
+  }, [searchTerm, selectedTag, availableProviderIds]);
 
   // Get the selected provider option for collapsed view
   const selectedOption = selectedProviderType

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -619,21 +619,15 @@ export async function createDummyFiles(
         providers.push(...providerChoices);
       }
 
-      if (
-        providerChoices.some(
-          (choice) =>
-            typeof choice === 'string' && choice.startsWith('file://') && choice.endsWith('.js'),
-        )
-      ) {
+      const providerIds = providerChoices.filter((choice) => typeof choice === 'string');
+      if (providerIds.some((id) => id.startsWith('file://') && id.endsWith('.js'))) {
         await writeFile({
           file: 'provider.js',
           contents: JAVASCRIPT_PROVIDER,
           required: true,
         });
       }
-      if (
-        providerChoices.some((choice) => typeof choice === 'string' && choice.startsWith('exec:'))
-      ) {
+      if (providerIds.some((id) => id.startsWith('exec:'))) {
         // Generate platform-appropriate executable provider script
         const isWindows = process.platform === 'win32';
         await writeFile({
@@ -643,11 +637,8 @@ export async function createDummyFiles(
         });
       }
       if (
-        providerChoices.some(
-          (choice) =>
-            typeof choice === 'string' &&
-            (choice.startsWith('python:') ||
-              (choice.startsWith('file://') && choice.endsWith('.py'))),
+        providerIds.some(
+          (id) => id.startsWith('python:') || (id.startsWith('file://') && id.endsWith('.py')),
         )
       ) {
         await writeFile({

--- a/src/providers/meta.ts
+++ b/src/providers/meta.ts
@@ -171,29 +171,36 @@ function assertSupportedReasoningEffort(effort: unknown): void {
 // configured — strip a leaked OPENAI_MAX_COMPLETION_TOKENS / OPENAI_MAX_TOKENS
 // env default so reasoning keeps the full output budget. A passthrough
 // max_tokens alias is mapped to the canonical field.
-function applyMetaOutputCap(
+function applyMetaChatOutputCap(
   body: Record<string, unknown>,
   passthrough: Record<string, unknown>,
-  field: 'max_completion_tokens' | 'max_output_tokens',
   value: number | undefined,
 ): void {
-  if (field in passthrough) {
-    if (field === 'max_output_tokens') {
-      delete body.max_completion_tokens;
-    }
+  if ('max_completion_tokens' in passthrough) {
     return;
   }
-  const outputCap =
-    (field === 'max_output_tokens' ? passthrough.max_completion_tokens : undefined) ??
-    passthrough.max_tokens ??
-    value;
-  if (field === 'max_output_tokens') {
-    delete body.max_completion_tokens;
-  }
+  const outputCap = passthrough.max_tokens ?? value;
   if (outputCap === undefined) {
-    delete body[field];
+    delete body.max_completion_tokens;
   } else {
-    body[field] = outputCap;
+    body.max_completion_tokens = outputCap;
+  }
+}
+
+function applyMetaResponsesOutputCap(
+  body: Record<string, unknown>,
+  passthrough: Record<string, unknown>,
+  value: number | undefined,
+): void {
+  delete body.max_completion_tokens;
+  if ('max_output_tokens' in passthrough) {
+    return;
+  }
+  const outputCap = passthrough.max_completion_tokens ?? passthrough.max_tokens ?? value;
+  if (outputCap === undefined) {
+    delete body.max_output_tokens;
+  } else {
+    body.max_output_tokens = outputCap;
   }
 }
 
@@ -417,12 +424,7 @@ class MetaProvider extends OpenAiChatCompletionProvider {
     // The Meta API caps generation with max_completion_tokens (max_tokens is
     // only a deprecated alias); honor an explicit max_tokens as the canonical
     // field rather than silently dropping it.
-    applyMetaOutputCap(
-      body,
-      passthrough,
-      'max_completion_tokens',
-      config.max_completion_tokens ?? config.max_tokens,
-    );
+    applyMetaChatOutputCap(body, passthrough, config.max_completion_tokens ?? config.max_tokens);
     applyMetaSamplingHygiene(body, config, passthrough, [
       'top_p',
       'presence_penalty',
@@ -517,10 +519,9 @@ export class MetaResponsesProvider extends OpenAiResponsesProvider {
 
     // The Responses API caps generation with max_output_tokens; map the
     // chat-style caps across so a config shared with meta:<model> keeps its cap.
-    applyMetaOutputCap(
+    applyMetaResponsesOutputCap(
       body,
       passthrough,
-      'max_output_tokens',
       config.max_output_tokens ?? config.max_completion_tokens ?? config.max_tokens,
     );
     applyMetaSamplingHygiene(body, config, passthrough, ['top_p']);

--- a/test/providers/meta.test.ts
+++ b/test/providers/meta.test.ts
@@ -303,6 +303,22 @@ describe('MetaProvider request body shaping', () => {
     expect(body.reasoning_effort).toBe('high');
   });
 
+  it.each([0, null, undefined, 512])(
+    'preserves canonical chat passthrough cap %s over aliases',
+    async (cap) => {
+      const provider = asChat(
+        createMetaProvider('meta:chat:muse-spark-1.1', {
+          config: {
+            max_completion_tokens: 4096,
+            passthrough: { max_completion_tokens: cap, max_tokens: 2048 },
+          },
+        }),
+      );
+      const { body } = await provider.getOpenAiBody('Hello');
+      expect(body).toHaveProperty('max_completion_tokens', cap);
+    },
+  );
+
   it('forwards max_completion_tokens', async () => {
     const provider = asChat(
       createMetaProvider('meta:chat:muse-spark-1.1', {
@@ -624,6 +640,21 @@ describe('MetaResponsesProvider', () => {
 });
 
 describe('MetaResponsesProvider request body shaping', () => {
+  it.each([0, null, undefined, 512])(
+    'preserves canonical Responses passthrough cap %s and removes chat aliases',
+    async (cap) => {
+      const provider = createMetaProvider('meta:responses:muse-spark-1.1', {
+        config: {
+          max_output_tokens: 4096,
+          passthrough: { max_output_tokens: cap, max_completion_tokens: 2048, max_tokens: 1024 },
+        },
+      });
+      const { body } = await (provider as MetaResponsesProvider).getOpenAiBody('Hello');
+      expect(body).toHaveProperty('max_output_tokens', cap);
+      expect(body).not.toHaveProperty('max_completion_tokens');
+    },
+  );
+
   it('maps chat-style max_completion_tokens onto max_output_tokens', async () => {
     const provider = createMetaProvider('meta:responses:muse-spark-1.1', {
       config: { max_completion_tokens: 4096 },

--- a/test/providers/openai/responses/request.test.ts
+++ b/test/providers/openai/responses/request.test.ts
@@ -11,6 +11,57 @@ import { fetchWithRetries } from '../../../../src/util/fetch/index';
 import { createDeferred } from '../../../util/utils';
 import { setOpenAiEnv } from './setup';
 
+function mockBackgroundCreateAndPoll(
+  responseId: string,
+  outputText: string,
+  usage: { input_tokens: number; output_tokens: number; total_tokens: number },
+) {
+  const counts = { creates: 0, polls: 0 };
+  const responseIds = new Set<string>();
+  vi.mocked(cache.fetchWithCache).mockImplementation(async (url, options) => {
+    if (String(url).endsWith('/responses') && options?.method === 'POST') {
+      const id = `${responseId}_${++counts.creates}`;
+      responseIds.add(id);
+      // Keep creation in flight until concurrent subscribers have registered.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      return {
+        data: { id, status: 'queued', output: [], usage: null },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      };
+    }
+    const id = String(url).split('/').at(-1)!;
+    if (
+      responseIds.has(id) &&
+      String(url).endsWith(`/responses/${id}`) &&
+      options?.method === 'GET'
+    ) {
+      counts.polls++;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      return {
+        data: {
+          id,
+          status: 'completed',
+          output: [
+            {
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: outputText }],
+            },
+          ],
+          usage,
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      };
+    }
+    throw new Error(`Unexpected request: ${options?.method} ${String(url)}`);
+  });
+  return counts;
+}
+
 describe('OpenAiResponsesProvider request building', () => {
   it('should format and call the responses API correctly', async () => {
     const mockApiResponse = {
@@ -459,50 +510,10 @@ describe('OpenAiResponsesProvider request building', () => {
   });
 
   it('should coalesce background polling for case-equivalent routing headers', async () => {
-    let creates = 0;
-    let polls = 0;
-    let creation: Promise<any> | undefined;
-    vi.mocked(cache.fetchWithCache).mockImplementation(async (url, options) => {
-      if (String(url).endsWith('/responses') && options?.method === 'POST') {
-        creates++;
-        if (!creation) {
-          // Resolve on a macrotask so the in-flight creation stays coalescable
-          // until both concurrent subscribers have registered.
-          creation = new Promise((resolve) =>
-            setImmediate(() =>
-              resolve({
-                data: { id: 'resp_header_case', status: 'queued', output: [], usage: null },
-                cached: false,
-                status: 200,
-                statusText: 'OK',
-              }),
-            ),
-          );
-        }
-        return creation;
-      }
-      if (String(url).endsWith('/responses/resp_header_case') && options?.method === 'GET') {
-        polls++;
-        await new Promise<void>((resolve) => setImmediate(resolve));
-        return {
-          data: {
-            id: 'resp_header_case',
-            status: 'completed',
-            output: [
-              {
-                type: 'message',
-                role: 'assistant',
-                content: [{ type: 'output_text', text: 'Case-normalized result' }],
-              },
-            ],
-            usage: { input_tokens: 1000, output_tokens: 1000, total_tokens: 2000 },
-          },
-          cached: false,
-          status: 200,
-          statusText: 'OK',
-        };
-      }
-      throw new Error(`Unexpected request: ${options?.method} ${String(url)}`);
+    const counts = mockBackgroundCreateAndPoll('resp_header_case', 'Case-normalized result', {
+      input_tokens: 1000,
+      output_tokens: 1000,
+      total_tokens: 2000,
     });
     const upper = new OpenAiResponsesProvider('gpt-4.1', {
       config: {
@@ -528,45 +539,17 @@ describe('OpenAiResponsesProvider request building', () => {
       }),
     ]);
 
-    expect(creates).toBe(1);
-    expect(polls).toBe(1);
+    expect(counts.creates).toBe(1);
+    expect(counts.polls).toBe(1);
     expect(results.filter((result) => (result.cost ?? 0) > 0)).toHaveLength(1);
     expect(results.filter((result) => result.cost === 0)).toHaveLength(1);
   });
 
   it('should coalesce semantically identical background request bodies with reordered keys', async () => {
-    let creates = 0;
-    vi.mocked(cache.fetchWithCache).mockImplementation(async (url, options) => {
-      if (String(url).endsWith('/responses') && options?.method === 'POST') {
-        const id = `resp_canonical_${++creates}`;
-        await new Promise<void>((resolve) => setImmediate(resolve));
-        return {
-          data: { id, status: 'queued', output: [], usage: null },
-          cached: false,
-          status: 200,
-          statusText: 'OK',
-        };
-      }
-      if (String(url).includes('/responses/resp_canonical_') && options?.method === 'GET') {
-        return {
-          data: {
-            id: String(url).split('/').at(-1),
-            status: 'completed',
-            output: [
-              {
-                type: 'message',
-                role: 'assistant',
-                content: [{ type: 'output_text', text: 'Canonical background result' }],
-              },
-            ],
-            usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
-          },
-          cached: false,
-          status: 200,
-          statusText: 'OK',
-        };
-      }
-      throw new Error(`Unexpected request: ${options?.method} ${String(url)}`);
+    const counts = mockBackgroundCreateAndPoll('resp_canonical', 'Canonical background result', {
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
     });
     const first = new OpenAiResponsesProvider('gpt-4.1', {
       config: {
@@ -590,7 +573,7 @@ describe('OpenAiResponsesProvider request building', () => {
       second.callApi('Canonical task'),
     ]);
 
-    expect(creates).toBe(1);
+    expect(counts.creates).toBe(1);
     expect(results.map((result) => result.output)).toEqual([
       'Canonical background result',
       'Canonical background result',

--- a/test/test-hygiene.test.ts
+++ b/test/test-hygiene.test.ts
@@ -347,7 +347,7 @@ function isPersistentMockSetter(node: Node): boolean {
 
 // A vi.mock factory runs at module load; other function bodies are deferred.
 function findPersistentMockSetter(
-  node: Node,
+  nodes: readonly Node[],
   opts: { enterRootFunction?: boolean } = {},
 ): Node | undefined {
   let found: Node | undefined;
@@ -361,7 +361,12 @@ function findPersistentMockSetter(
     }
     forEachChild(current, (child) => visit(child, false));
   }
-  visit(node, true);
+  for (const node of nodes) {
+    visit(node, true);
+    if (found) {
+      break;
+    }
+  }
   return found;
 }
 
@@ -447,7 +452,7 @@ function findModuleScopePersistentSetter(
         ? statement.expression.expression
         : statement.expression;
     if (expression.type !== 'CallExpression' || !isViCall(expression, 'mock')) {
-      return findPersistentMockSetter(expression);
+      return findPersistentMockSetter([expression]);
     }
     const factory = expression.arguments[1];
     if (!factory) {
@@ -455,25 +460,19 @@ function findModuleScopePersistentSetter(
     }
     const resolvedFactory =
       factory.type === 'Identifier' ? (factories.get(factory.name) ?? factory) : factory;
-    return findPersistentMockSetter(resolvedFactory, { enterRootFunction: true });
+    return findPersistentMockSetter([resolvedFactory], { enterRootFunction: true });
   }
 
   if (statement.type === 'VariableDeclaration') {
-    for (const declaration of statement.declarations) {
-      const found = declaration.init ? findPersistentMockSetter(declaration.init) : undefined;
-      if (found) {
-        return found;
-      }
-    }
+    return findPersistentMockSetter(
+      statement.declarations.flatMap((declaration) => (declaration.init ? [declaration.init] : [])),
+    );
   }
 
   if (statement.type === 'ClassDeclaration') {
-    for (const member of statement.body.body) {
-      const found = member.type === 'StaticBlock' ? findPersistentMockSetter(member) : undefined;
-      if (found) {
-        return found;
-      }
-    }
+    return findPersistentMockSetter(
+      statement.body.body.filter((member) => member.type === 'StaticBlock'),
+    );
   }
   return undefined;
 }
@@ -737,7 +736,7 @@ function scanSyntaxPolicies(file: HygieneFile): SyntaxPolicyResults {
     if (executesAtCollection && node.type === 'CallExpression') {
       collectionCallback = findCollectionCallback(node, factories);
       if (collectionCallback && isViCall(node, 'hoisted')) {
-        results.hoistedMockSetter ??= findPersistentMockSetter(collectionCallback, {
+        results.hoistedMockSetter ??= findPersistentMockSetter([collectionCallback], {
           enterRootFunction: true,
         });
       }


### PR DESCRIPTION
## Summary

Simplify provider setup and request shaping while preserving the existing selection and token-cap rules. Addresses all six AI findings shown across five files on September 3.

- Memoize provider filtering by search, category, and availability. The provider sort already runs once at module load.
- Filter string provider choices once before onboarding generates script templates.
- Split Meta chat and Responses token-cap handling into endpoint-specific helpers, preserving passthrough precedence and Responses alias cleanup.
- Share background create/poll mocks between both flagged Responses tests, retaining asynchronous overlap and request/billing assertions.
- Share early-exit traversal across mock initializer and static-block roots while retaining function-scope boundaries.

## Validation

- Full backend suite: 23,821 tests passed (10 existing skips), 829 files passed.
- Focused backend suites: 450 tests passed across 17 files.
- Provider selector: 41 tests passed, including availability changes after a render.
- TypeScript, production build, Knip, lint, and formatting passed; existing complexity/configuration warnings remain.
- Local CLI evaluation against a mock HTTP server: four Meta chat/Responses cases passed with score 1, no errors, and the expected canonical token cap in every request. No external model calls.
- Regression coverage checks canonical passthrough caps of 0, null, undefined, and a positive number against competing aliases.
