### PR TITLE
fix(security): redact credential-named variables in persisted env maps

### DIFF
--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -203,6 +203,58 @@ export function isSecretField(fieldName: string): boolean {
 }
 
 /**
+ * Credential words that make an environment variable name secret-bearing.
+ *
+ * Singular only, on purpose: each `_`-delimited word is matched by suffix, so `MAX_TOKENS`
+ * (word `TOKENS`) and `RETRY_KEYS` stay out of the match while `GITHUB_TOKEN`,
+ * `STRIPE_SECRET_KEY` and `PGPASSWORD` are caught.
+ */
+const ENV_SECRET_WORDS = new Set([
+  'TOKEN',
+  'SECRET',
+  'PASSWORD',
+  'PASSWD',
+  'PWD',
+  'KEY',
+  'APIKEY',
+  'CREDENTIAL',
+  'CREDENTIALS',
+  'PASSPHRASE',
+  'AUTH',
+  'DSN',
+]);
+
+/** SCREAMING_SNAKE_CASE (underscores optional): `GITHUB_TOKEN`, `PGPASSWORD` — not `apiKey`. */
+const ENV_VAR_NAME_RE = /^[A-Z][A-Z0-9_]*$/;
+
+/**
+ * Check whether an environment-variable name looks credential-bearing.
+ *
+ * `SECRET_FIELD_NAMES` matches exact names, which can never cover the project-specific
+ * names real environments use — `GITHUB_TOKEN`, `STRIPE_SECRET_KEY`, `PGPASSWORD` all
+ * slip through it. An `env` map is passed straight to a subprocess, so it is the one
+ * place a config is *expected* to hold credentials; treat a credential-worded key there
+ * as secret.
+ *
+ * Restricted to SCREAMING_SNAKE_CASE so it never fires on ordinary config fields
+ * (`maxTokens`, `tokenCount`, `keyName`), which keep the exact-name behavior.
+ */
+export function isSecretEnvVarName(name: string): boolean {
+  if (isSecretField(name)) {
+    return true;
+  }
+  if (!ENV_VAR_NAME_RE.test(name)) {
+    return false;
+  }
+  // A word matches when it *ends with* a credential word, so the vendor-prefixed spellings
+  // that have no separator (`PGPASSWORD`, `AWS_SECRETKEY`) match too. Suffix rather than
+  // substring keeps the plurals out: `TOKENS` does not end with `TOKEN`.
+  return name
+    .split('_')
+    .some((word) => [...ENV_SECRET_WORDS].some((secret) => word.endsWith(secret)));
+}
+
+/**
  * Sanitizes runtime options to ensure only JSON-serializable data is persisted or exported.
  * Removes non-serializable fields like AbortSignal, functions, and symbols.
  */
@@ -937,18 +989,21 @@ export function sanitizeUrlEncodedString(value: string): string {
 /**
  * Sanitize plain object fields
  */
-function sanitizePlainObject(obj: any, depth: number, maxDepth: number): any {
+function sanitizePlainObject(obj: any, depth: number, maxDepth: number, isEnvMap = false): any {
   const sanitized: any = {};
+  const isSecretKey = isEnvMap ? isSecretEnvVarName : isSecretField;
   for (const [key, value] of Object.entries(obj)) {
     if (key === 'url' && typeof value === 'string') {
       sanitized[key] = sanitizeUrl(value);
-    } else if (isSecretField(key)) {
+    } else if (isSecretKey(key)) {
       sanitized[key] = REDACTED;
     } else if (typeof value === 'string' && looksLikeSecret(value)) {
       // Redact values that look like secrets (API keys, tokens, etc.)
       sanitized[key] = REDACTED;
     } else {
-      sanitized[key] = recursiveSanitize(value, depth + 1, maxDepth);
+      // An `env` map is handed verbatim to a subprocess, so its keys are environment
+      // variable names and get the broader credential-word match one level down.
+      sanitized[key] = recursiveSanitize(value, depth + 1, maxDepth, key === 'env');
     }
   }
   return sanitized;
@@ -957,7 +1012,7 @@ function sanitizePlainObject(obj: any, depth: number, maxDepth: number): any {
 /**
  * Recursively sanitize an object, redacting secret fields at any depth
  */
-function recursiveSanitize(obj: any, depth = 0, maxDepth = MAX_DEPTH): any {
+function recursiveSanitize(obj: any, depth = 0, maxDepth = MAX_DEPTH, isEnvMap = false): any {
   if (typeof obj === 'function') {
     return `[Function] ${obj.name}`;
   }
@@ -989,7 +1044,7 @@ function recursiveSanitize(obj: any, depth = 0, maxDepth = MAX_DEPTH): any {
   }
 
   // Handle plain objects
-  return sanitizePlainObject(obj, depth, maxDepth);
+  return sanitizePlainObject(obj, depth, maxDepth, isEnvMap);
 }
 
 /**

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  isSecretEnvVarName,
   preserveTracingCredentialReferences,
   redactAzureBlobSasTokens,
   restoreAzureBlobSasTokens,
@@ -170,7 +171,103 @@ describe('sanitizeTracingConfigForPersistence', () => {
   });
 });
 
+describe('isSecretEnvVarName', () => {
+  it.each([
+    'GITHUB_TOKEN',
+    'STRIPE_SECRET_KEY',
+    'PGPASSWORD',
+    'MY_SERVICE_SECRET',
+    'DB_PASSWD',
+    'OPENAI_API_KEY',
+    'AWS_SECRETKEY',
+    'SIGNING_PASSPHRASE',
+  ])('treats %s as credential-bearing', (name) => {
+    expect(isSecretEnvVarName(name)).toBe(true);
+  });
+
+  it.each([
+    // Plurals: words are matched by suffix, and TOKENS does not end with TOKEN.
+    'MAX_TOKENS',
+    'RETRY_KEYS',
+    'LOG_LEVEL',
+    'AWS_REGION',
+    'SERVICE_URL',
+    'NODE_ENV',
+    // Ordinary config fields keep the exact-name behavior; the env-var rule is
+    // SCREAMING_SNAKE_CASE only, so it can never widen them.
+    'maxTokens',
+    'tokenCount',
+    'keyName',
+    'max_tokens',
+  ])('leaves %s alone', (name) => {
+    expect(isSecretEnvVarName(name)).toBe(false);
+  });
+});
+
 describe('sanitizeObject', () => {
+  describe('environment variable maps', () => {
+    it('redacts credential-named variables inside an env map', () => {
+      // Regression: `env` is handed verbatim to a subprocess, so it is where a config
+      // legitimately carries credentials. Exact-name matching against SECRET_FIELD_NAMES
+      // caught only `API_KEY`, leaving project-specific names in cleartext in the
+      // provider config persisted with every eval result.
+      const result = sanitizeObject({
+        env: {
+          API_KEY: 'sk-value',
+          GITHUB_TOKEN: 'ghp_value',
+          MY_SERVICE_SECRET: 'plainvalue123',
+          PGPASSWORD: 'hunter2',
+          LOG_LEVEL: 'debug',
+          MAX_TOKENS: '4096',
+          AWS_REGION: 'us-east-1',
+        },
+      });
+
+      expect(result.env).toEqual({
+        API_KEY: '[REDACTED]',
+        GITHUB_TOKEN: '[REDACTED]',
+        MY_SERVICE_SECRET: '[REDACTED]',
+        PGPASSWORD: '[REDACTED]',
+        // Non-credential variables stay readable - they are what makes a failed run
+        // debuggable from the persisted config.
+        LOG_LEVEL: 'debug',
+        MAX_TOKENS: '4096',
+        AWS_REGION: 'us-east-1',
+      });
+    });
+
+    it('reaches an env map nested in a provider config', () => {
+      const result = sanitizeObject(
+        {
+          config: {
+            mcp: { servers: [{ command: 'node', env: { GITHUB_TOKEN: 'ghp_value' } }] },
+          },
+        },
+        // Match the persistence boundary, which lifts the default depth cap so nested
+        // provider configs are walked in full.
+        { maxDepth: Number.POSITIVE_INFINITY },
+      );
+
+      expect(result.config.mcp.servers[0].env.GITHUB_TOKEN).toBe('[REDACTED]');
+    });
+
+    it('does not widen redaction outside env maps', () => {
+      const result = sanitizeObject({
+        maxTokens: 4096,
+        tokenCount: 12,
+        keyName: 'X-Api-Key',
+        MAX_TOKENS: '2048',
+      });
+
+      expect(result).toEqual({
+        maxTokens: 4096,
+        tokenCount: 12,
+        keyName: 'X-Api-Key',
+        MAX_TOKENS: '2048',
+      });
+    });
+  });
+
   describe('primitives and basic types', () => {
     it('should handle null', () => {
       expect(sanitizeObject(null)).toBeNull();


### PR DESCRIPTION
## Summary

`sanitizeProvider` persists a provider's `config` with every eval result, and `sanitizeObject` decides what to redact by matching field names **exactly** against `SECRET_FIELD_NAMES`. That set can never cover the project-specific names real environments use, so an `env` map inside a provider config leaked most of its values in cleartext to the SQLite database and JSONL artifacts.

Reproduced against `sanitizeObject` on `main`:

| Variable | Before | After |
| --- | --- | --- |
| `API_KEY` | `[REDACTED]` | `[REDACTED]` |
| `GITHUB_TOKEN` | **leaked** | `[REDACTED]` |
| `MY_SERVICE_SECRET` | **leaked** | `[REDACTED]` |
| `PGPASSWORD` | **leaked** | `[REDACTED]` |
| `LOG_LEVEL` | `debug` | `debug` |
| `MAX_TOKENS` | `4096` | `4096` |
| `AWS_REGION` | `us-east-1` | `us-east-1` |

## Approach

An `env` map is handed verbatim to a subprocess, which makes it the one place a config is *expected* to carry credentials. `isSecretEnvVarName` matches credential words there instead of only exact names, with three guards that keep it from over-reaching:

- **Scoped to `env` maps.** The check is only applied to a map reached under an `env` key; everywhere else keeps the existing `isSecretField` behavior.
- **SCREAMING_SNAKE_CASE only.** `maxTokens`, `tokenCount`, `keyName` and `max_tokens` can never match.
- **Suffix, not substring.** `PGPASSWORD` and `AWS_SECRETKEY` match; `MAX_TOKENS` and `RETRY_KEYS` do not, because `TOKENS` does not end with `TOKEN`.

Non-credential variables stay readable on purpose — they are what makes a failed run debuggable from its persisted config.

## Scope

Pre-existing for any provider config carrying an `env` map. It gets wider with per-server MCP `env` support (#10509 / #10557), which adds `mcp.servers[].env` — a credential-shaped map inside `config`.

Note that `ProviderOptions.env` is *not* affected: `sanitizeProvider` persists only `id`, `label` and `config`.

## Verification

- New coverage in `test/util/sanitizer.test.ts`: the positive/negative name tables, an env map nested in a provider config at full persistence depth, and a guard that redaction does not widen outside `env` maps.
- `npx vitest run test/util/ test/models/ test/providers/mcp/` — 2943 passed.
- `npm run tsc`, `biome ci .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7jDD7WZBVV2GUpknv9Aff