### PR TITLE
ci: give npm-install jobs a 10-minute timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,7 +216,7 @@ jobs:
 
   style-check:
     name: Style Check
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -281,7 +281,7 @@ jobs:
 
   assets:
     name: Generate Assets
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -357,7 +357,7 @@ jobs:
 
   docs:
     name: Build Docs
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -390,7 +390,7 @@ jobs:
 
   code-scan-action:
     name: Code Scan Action
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -426,7 +426,7 @@ jobs:
 
   site-tests:
     name: Site tests
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -530,7 +530,7 @@ jobs:
   integration-tests:
     name: Run Integration Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6


### PR DESCRIPTION
## Problem

Six CI jobs run a full `npm ci` under `timeout-minutes: 5`. On a green `main` run they finish in 1.5–3.8 minutes, so the slowest clear the cap by about a minute — and when the npm cache misses, they do not clear it at all.

Step timings from a cancelled Style Check:

```
4. Upgrade npm            success     07:08:42 -> 07:08:44
5. Install Dependencies   cancelled   07:08:44 -> 07:13:40   <- 4m56s, hit the 5m cap
6. Run Biome CI           skipped
7. Run Prettier Check     skipped
```

Biome never ran. GitHub records a timeout as `cancelled`, which `gh pr checks` renders as a plain `fail`, so it reads as a real lint failure on the PR.

Measured durations on two green `main` runs:

| Job | Run A | Run B | Cap |
| --- | --- | --- | --- |
| Style Check | 3.33m | 3.56m | 5m |
| Build Docs | 3.75m | 3.68m | 5m |
| Run Integration Tests | 2.01m | 2.03m | 5m |
| Site tests | 1.76m | 1.86m | 5m |
| Generate Assets | 1.63m | 1.85m | 5m |
| Code Scan Action | 1.45m | 1.65m | 5m |

Three PRs today were blocked by this, each needing a manual re-run — and re-running is not a reliable fix either, because `gh run rerun --failed` does not re-run *cancelled* jobs. Clearing a timeout means re-running the whole workflow.

## Fix

Raise the six `npm ci` jobs to the 10 minutes the repo's other `npm ci` jobs already use (`webui`, `smoke-tests`, `share-test`, `redteam`, `redteam-staging`). Jobs that do not install the full lockfile — `ci-config`, `shell-format`, `python`, `actionlint`, `ruby`, `golang` — keep the 5-minute cap.

The split is exactly the observed failure set: every `npm ci` job capped at 5 minutes is one that has been cancelled; no `npm ci` job already at 10 minutes has been.

This weakens no signal — a genuinely stuck job still fails, just after a budget that install-time variance cannot trip on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7jDD7WZBVV2GUpknv9Aff