### PR TITLE
fix(providers): treat Claude Sonnet 5 as thinking-on-by-default

### DIFF
--- a/examples/anthropic/sonnet-5/README.md
+++ b/examples/anthropic/sonnet-5/README.md
@@ -18,7 +18,7 @@ Claude Sonnet 5 is the Claude 5-generation Sonnet — built to be Anthropic's mo
 
 ## Working with Sonnet 5
 
-- **Adaptive thinking is opt-in.** Set `thinking: { type: adaptive }` (as this example does) to let the model decide when and how much to reason per request. Without an explicit `thinking` block the model runs **without** extended thinking, even at high effort. Unlike Fable 5 / Mythos 5, Sonnet 5 also accepts `thinking: { type: disabled }`.
+- **Adaptive thinking is on by default.** Omitting `thinking` already lets the model decide when and how much to reason per request; this example sets `thinking: { type: adaptive }` explicitly to make the mode visible in the config. Unlike Fable 5 / Mythos 5, Sonnet 5 also accepts `thinking: { type: disabled }` when you need reasoning off. (Opus 4.7 and 4.8 are the models where an omitted block means _no_ thinking.)
 - **`effort` tunes the cost/performance tradeoff.** Sonnet 5 supports `low`, `medium`, `high`, `xhigh`, and `max`. `high` is a good cost-efficient default; step up to `xhigh`/`max` for the hardest work and pair high effort with a large `max_tokens`.
 - **Sampling controls are managed for you.** Sonnet 5 rejects `temperature`, `top_p`, and `top_k` at the model level; promptfoo omits them automatically (don't set them in config).
 - **Pricing.** $3/$15 per million input/output tokens standard, with introductory pricing of $2/$10 through August 31, 2026 (to track that, set `inputCost`/`outputCost` — a single `cost` is applied as both rates). The full 1M-token context bills at the standard rate (no long-context surcharge).

--- a/examples/anthropic/sonnet-5/promptfooconfig.yaml
+++ b/examples/anthropic/sonnet-5/promptfooconfig.yaml
@@ -14,9 +14,9 @@ providers:
       # Sonnet 5 deprecates manual sampling controls (temperature/top_p/top_k) at the
       # model level — promptfoo omits them automatically, so don't set them here.
       #
-      # Adaptive thinking is opt-in: without an explicit `thinking` block the model
-      # runs WITHOUT extended thinking even at high effort. Set it to let the model
-      # decide when and how much to reason per request.
+      # Adaptive thinking is on by default on Sonnet 5 — omitting this block still
+      # lets the model decide when and how much to reason. Set explicitly here so the
+      # mode is visible; use `type: disabled` to turn reasoning off.
       thinking:
         type: adaptive
       effort: high # Sonnet 5's cost-efficient sweet spot; xhigh/max are available for harder work

--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -677,7 +677,7 @@ The same suppression applies when you reach Opus 4.8 through AWS Bedrock, GCP Ve
 Opus 4.7 is designed around adaptive thinking and runs with the reasoning stack always on. Promptfoo handles the key differences from earlier Opus models automatically:
 
 - **Temperature is managed for you.** Opus 4.7 samples adaptively and does not accept `temperature`; promptfoo omits the field from every request. Passing `temperature` in config or `ANTHROPIC_TEMPERATURE` logs a one-time heads-up so you can clean the value out of your eval.
-- **Adaptive thinking is the default.** Use `thinking: { type: 'adaptive' }` (or leave `thinking` unset) to let the model choose how much to reason per request. Budget-based modes from older models aren't used on 4.7.
+- **Adaptive thinking is opt-in.** Set `thinking: { type: 'adaptive' }` to let the model choose how much to reason per request; leaving `thinking` unset runs Opus 4.7 **without** extended thinking, even at high effort. (Opus 5 is the model where an omitted block means adaptive.) Budget-based modes from older models aren't used on 4.7.
 - **`xhigh` effort level is available.** It sits between `high` and `max` and is a good starting point for coding and agentic tasks. See the [Effort Level](#effort-level) section.
 - **Updated tokenizer.** The same input can map to 1.0–1.35× more tokens than Opus 4.6, so measure real traffic if you're comparing costs.
 

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -224,8 +224,8 @@ interface ClaudeModelFamily {
   /** Rejects forced tool use even with adaptive thinking (Fable/Mythos 5.1). */
   forcedToolChoiceUnsupported?: boolean;
   /**
-   * Omitting `thinking` runs adaptive thinking rather than no thinking (Opus 5), so requests
-   * that never set `thinking` still spend thinking tokens against `max_tokens`.
+   * Omitting `thinking` runs adaptive thinking rather than no thinking (Opus 5, Sonnet 5), so
+   * requests that never set `thinking` still spend thinking tokens against `max_tokens`.
    */
   thinkingOnByDefault?: boolean;
   /**
@@ -271,10 +271,15 @@ const CLAUDE_MODEL_FAMILIES: readonly ClaudeModelFamily[] = [
     disabledThinkingEffortCapped: true,
     regionalPremium: true,
   },
+  // Sonnet 5, like Opus 5, thinks by default: a request that omits `thinking` still returns
+  // thinking blocks and bills thinking tokens against `max_tokens` (verified live — an
+  // omitted block returned `['thinking', 'text']` with `thinking_tokens: 59`). Opus 4.7/4.8
+  // are the models where omitting it means no thinking at all.
   {
     match: CLAUDE_SONNET_5_PATTERN,
     warningName: 'Claude Sonnet 5',
     samplingParamsDeprecated: true,
+    thinkingOnByDefault: true,
     regionalPremium: true,
   },
   // Opus 4.7 and 4.8 share behavior and warning wording.

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -3694,6 +3694,31 @@ describe('AnthropicMessagesProvider', () => {
       expect(params.thinking?.budget_tokens).toBeUndefined();
     });
 
+    it.each([
+      { model: 'claude-sonnet-5', expected: 2048 },
+      { model: 'claude-opus-5', expected: 2048 },
+      { model: 'claude-opus-4-8', expected: 1024 },
+      { model: 'claude-opus-4-7', expected: 1024 },
+    ])(
+      'sizes the default max_tokens for $model by whether it thinks by default',
+      async ({ model, expected }) => {
+        // Sonnet 5 and Opus 5 return thinking blocks for a request that never sets
+        // `thinking`, and those tokens come out of max_tokens — so the default needs
+        // headroom or answers truncate mid-sentence. Opus 4.7/4.8 do not think unless
+        // asked, and keep the smaller default.
+        const provider = createProvider(model, { config: {} });
+        const createSpy = vi
+          .spyOn(provider.anthropic.messages, 'create')
+          .mockResolvedValue({ ...mockResp, model });
+
+        await provider.callApi('Hello');
+
+        expect((createSpy.mock.calls[0][0] as unknown as Record<string, unknown>).max_tokens).toBe(
+          expected,
+        );
+      },
+    );
+
     it('omits the built-in temperature default for Opus 5 (no explicit config)', async () => {
       // Opus 5 inherits the Opus 4.7+ sampling-param deprecation: temperature would 400.
       const provider = createProvider('claude-opus-5', { config: {} });

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -2209,7 +2209,10 @@ describe('Anthropic utilities', () => {
       }
       // Opus 4.7/4.8 keep their own warning name and are not thinking-on-by-default.
       expect(isThinkingOnByDefaultClaudeModel('claude-opus-4-8')).toBe(false);
-      expect(isThinkingOnByDefaultClaudeModel('claude-sonnet-5')).toBe(false);
+      expect(isThinkingOnByDefaultClaudeModel('claude-opus-4-7')).toBe(false);
+      // Sonnet 5 is not Opus 5, but it does think by default.
+      expect(isClaudeOpus5Model('claude-sonnet-5')).toBe(false);
+      expect(isThinkingOnByDefaultClaudeModel('claude-sonnet-5')).toBe(true);
     });
 
     it('rejects disabled thinking on Opus 5 only above effort "high"', () => {
@@ -2287,8 +2290,14 @@ describe('Anthropic utilities', () => {
       // case that sizes the default max_tokens and truncates answers when it is wrong.
       expect(claudeThinkingConsumesTokens('claude-opus-5', undefined)).toBe(true);
       expect(claudeThinkingConsumesTokens('claude-opus-5', null)).toBe(true);
+      // Sonnet 5 thinks by default too. Verified against the live API: a request that omits
+      // `thinking` came back with content blocks ['thinking', 'text'] and
+      // usage.output_tokens_details.thinking_tokens = 59.
+      expect(claudeThinkingConsumesTokens('claude-sonnet-5', undefined)).toBe(true);
+      expect(claudeThinkingConsumesTokens('claude-sonnet-5', null)).toBe(true);
+      // Opus 4.7/4.8 do not — same probe returned ['text'] and thinking_tokens = 0.
       expect(claudeThinkingConsumesTokens('claude-opus-4-8', undefined)).toBe(false);
-      expect(claudeThinkingConsumesTokens('claude-sonnet-5', undefined)).toBe(false);
+      expect(claudeThinkingConsumesTokens('claude-opus-4-7', undefined)).toBe(false);
       // Explicitly disabled never consumes tokens (except on always-on models, where the
       // API rejects `disabled` and normalization strips it before this is called).
       expect(claudeThinkingConsumesTokens('claude-opus-5', { type: 'disabled' })).toBe(false);


### PR DESCRIPTION
## Summary

Sonnet 5 runs adaptive thinking when a request omits `thinking`, the same as Opus 5. Promptfoo's capability table only marked Opus 5, so a Sonnet 5 request that never sets `thinking` got the no-thinking default of `max_tokens: 1024` while the model spent part of that budget reasoning — exactly the truncation `thinkingOnByDefault`'s own docstring warns about:

> providers size their default `max_tokens` off this — get it wrong and responses truncate mid-answer.

## Live verification

`thinking` omitted, `max_tokens: 1024`, same prompt:

| Model | Content blocks | `thinking_tokens` |
| --- | --- | --- |
| `claude-sonnet-5` | `['thinking', 'text']` | **59** |
| `claude-opus-5` | `['thinking', 'text']` | **49** |
| `claude-opus-4-7` | `['text']` | 0 |
| `claude-opus-4-8` | `['text']` | 0 |

## Changes

- `CLAUDE_SONNET_5_PATTERN` gains `thinkingOnByDefault: true`, so Sonnet 5 gets the same 2048 default as Opus 5.
- Two existing assertions pinned the wrong behavior — `claudeThinkingConsumesTokens('claude-sonnet-5', undefined)` and `isThinkingOnByDefaultClaudeModel('claude-sonnet-5')` both expected the no-thinking answer. Corrected against the probe, with the measured numbers in the comment.
- A matrix test now covers the resulting default `max_tokens` for all four models, which is the behavior that actually breaks when this is wrong.

## Docs

The same confusion was in the docs, in both directions:

- **Opus 4.7 section** claimed adaptive thinking "is the default" and that `thinking` may be left unset. That contradicts the Opus 4.8 section directly above it *and* the Opus 5 section above that, both of which state that omitting the block means no thinking on 4.7/4.8. The probe agrees with the latter two.
- **Sonnet 5 example** (README + config comment) claimed adaptive thinking is opt-in and that omitting the block runs the model without extended thinking. That is Opus 4.7/4.8 behavior, not Sonnet 5's.

## Verification

- `npx vitest run test/providers/anthropic/ test/providers/bedrock/index.test.ts test/providers/google/vertex.test.ts` — 902 passed.
- `biome ci .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7jDD7WZBVV2GUpknv9Aff