### PR TITLE
docs(providers): separate retired Claude model IDs from live ones

### DIFF
--- a/site/docs/configuration/tools.md
+++ b/site/docs/configuration/tools.md
@@ -67,7 +67,7 @@ providers:
                 location: { type: string }
               required: [location]
 
-  - id: anthropic:claude-sonnet-4-20250514
+  - id: anthropic:claude-sonnet-4-6
     config:
       tools: *tools # Alias: reuse the same tools
 
@@ -250,7 +250,7 @@ You can also use provider-native formats directly. They pass through unchanged w
 ```yaml
 # Anthropic native format - passes through as-is
 providers:
-  - id: anthropic:claude-sonnet-4-20250514
+  - id: anthropic:claude-sonnet-4-6
     config:
       tools:
         - name: get_weather
@@ -338,7 +338,7 @@ providers:
         anthropic-version: '2023-06-01'
       transformToolsFormat: anthropic # Transforms OpenAI → Anthropic format
       body:
-        model: claude-sonnet-4-20250514
+        model: claude-sonnet-4-6
         max_tokens: 1024
         messages: '{{ prompt }}'
         tools: '{{ tools }}'
@@ -374,7 +374,7 @@ providers:
         Content-Type: application/json
       # No transformToolsFormat - tools pass through as-is
       body:
-        model: claude-sonnet-4-20250514
+        model: claude-sonnet-4-6
         messages: '{{ prompt }}'
         tools: '{{ tools }}'
       tools:

--- a/site/docs/integrations/google-sheets.md
+++ b/site/docs/integrations/google-sheets.md
@@ -19,7 +19,7 @@ description: 'Public Google Sheet Example'
 prompts:
   - 'Please translate the following text to {{language}}: {{input}}'
 providers:
-  - anthropic:messages:claude-3-5-sonnet-20241022
+  - anthropic:messages:claude-sonnet-4-6
   - openai:chat:gpt-5
 // highlight-start
 tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsKB3zKg9H18c/edit?usp=sharing
@@ -122,7 +122,7 @@ prompts:
   - file://prompt1.txt
   - file://prompt2.txt
 providers:
-  - anthropic:messages:claude-3-5-sonnet-20241022
+  - anthropic:messages:claude-sonnet-4-6
   - openai:chat:gpt-5-mini
 tests: https://docs.google.com/spreadsheets/d/1eqFnv1vzkPvS7zG-mYsqNDwOzvSaiIAsKB3zKg9H18c/edit?usp=sharing
 defaultTest:

--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -51,31 +51,45 @@ This also enables [model-graded assertions](#model-graded-tests) such as `llm-ru
 
 ## Models
 
-The `anthropic` provider supports the following models via the messages API:
+These models currently resolve on the Anthropic Messages API:
 
-| Model ID                                                            | Description            |
-| ------------------------------------------------------------------- | ---------------------- |
-| `anthropic:messages:claude-fable-5-1`                               | Claude Fable 5.1       |
-| `anthropic:messages:claude-mythos-5-1`                              | Claude Mythos 5.1      |
-| `anthropic:messages:claude-fable-5`                                 | Claude Fable 5         |
-| `anthropic:messages:claude-mythos-5`                                | Claude Mythos 5        |
-| `anthropic:messages:claude-opus-5`                                  | Claude Opus 5          |
-| `anthropic:messages:claude-opus-4-8`                                | Claude 4.8 Opus        |
-| `anthropic:messages:claude-opus-4-7`                                | Claude 4.7 Opus        |
-| `anthropic:messages:claude-sonnet-5`                                | Claude Sonnet 5        |
-| `anthropic:messages:claude-sonnet-4-6`                              | Claude 4.6 Sonnet      |
-| `anthropic:messages:claude-opus-4-6`                                | Claude 4.6 Opus        |
-| `anthropic:messages:claude-opus-4-5-20251101` (claude-opus-4-5)     | Claude 4.5 Opus        |
-| `anthropic:messages:claude-opus-4-20250514`                         | Claude 4 Opus          |
-| `anthropic:messages:claude-sonnet-4-5-20250929` (claude-sonnet-4-5) | Claude 4.5 Sonnet      |
-| `anthropic:messages:claude-sonnet-4-20250514`                       | Claude 4 Sonnet        |
-| `anthropic:messages:claude-haiku-4-5-20251001` (claude-haiku-4-5)   | Claude 4.5 Haiku       |
-| `anthropic:messages:claude-3-7-sonnet-20250219`                     | Claude 3.7 Sonnet      |
-| `anthropic:messages:claude-3-5-sonnet-20241022`                     | Claude 3.5 Sonnet (v2) |
-| `anthropic:messages:claude-3-5-sonnet-20240620`                     | Claude 3.5 Sonnet (v1) |
-| `anthropic:messages:claude-3-5-haiku-20241022`                      | Claude 3.5 Haiku       |
-| `anthropic:messages:claude-3-opus-20240229`                         | Claude 3 Opus          |
-| `anthropic:messages:claude-3-haiku-20240307`                        | Claude 3 Haiku         |
+| Model ID                                                            | Description       |
+| ------------------------------------------------------------------- | ----------------- |
+| `anthropic:messages:claude-fable-5-1`                               | Claude Fable 5.1  |
+| `anthropic:messages:claude-mythos-5-1`                              | Claude Mythos 5.1 |
+| `anthropic:messages:claude-fable-5`                                 | Claude Fable 5    |
+| `anthropic:messages:claude-mythos-5`                                | Claude Mythos 5   |
+| `anthropic:messages:claude-opus-5`                                  | Claude Opus 5     |
+| `anthropic:messages:claude-opus-4-8`                                | Claude 4.8 Opus   |
+| `anthropic:messages:claude-opus-4-7`                                | Claude 4.7 Opus   |
+| `anthropic:messages:claude-sonnet-5`                                | Claude Sonnet 5   |
+| `anthropic:messages:claude-sonnet-4-6`                              | Claude 4.6 Sonnet |
+| `anthropic:messages:claude-opus-4-6`                                | Claude 4.6 Opus   |
+| `anthropic:messages:claude-opus-4-5-20251101` (claude-opus-4-5)     | Claude 4.5 Opus   |
+| `anthropic:messages:claude-sonnet-4-5-20250929` (claude-sonnet-4-5) | Claude 4.5 Sonnet |
+| `anthropic:messages:claude-haiku-4-5-20251001` (claude-haiku-4-5)   | Claude 4.5 Haiku  |
+
+The Mythos rows are limited-access models: the ID is correct, but an org without access gets
+the same `not_found_error` a retired model returns.
+
+### Retired on the Anthropic API
+
+These IDs return `404 not_found_error` from Anthropic. Promptfoo still accepts them — they
+remain valid on AWS Bedrock, GCP Vertex, and OpenAI-compatible gateways, which set their own
+lifecycle dates, and cost attribution for historical evals needs the rates — but a direct
+`anthropic:messages:` call will fail.
+
+| Model ID                     | Description            | Suggested replacement |
+| ---------------------------- | ---------------------- | --------------------- |
+| `claude-opus-4-1-20250805`   | Claude 4.1 Opus        | `claude-opus-4-8`     |
+| `claude-opus-4-20250514`     | Claude 4 Opus          | `claude-opus-4-8`     |
+| `claude-sonnet-4-20250514`   | Claude 4 Sonnet        | `claude-sonnet-4-6`   |
+| `claude-3-7-sonnet-20250219` | Claude 3.7 Sonnet      | `claude-sonnet-4-6`   |
+| `claude-3-5-sonnet-20241022` | Claude 3.5 Sonnet (v2) | `claude-sonnet-4-6`   |
+| `claude-3-5-sonnet-20240620` | Claude 3.5 Sonnet (v1) | `claude-sonnet-4-6`   |
+| `claude-3-5-haiku-20241022`  | Claude 3.5 Haiku       | `claude-haiku-4-5`    |
+| `claude-3-opus-20240229`     | Claude 3 Opus          | `claude-opus-4-8`     |
+| `claude-3-haiku-20240307`    | Claude 3 Haiku         | `claude-haiku-4-5`    |
 
 :::note Model aliases
 
@@ -84,10 +98,9 @@ Anthropic does not publish `-latest` aliases — `claude-sonnet-4-5-latest` retu
 parentheses above: `claude-sonnet-4-5` resolves to `claude-sonnet-4-5-20250929`.
 Claude 4.6 and newer are already unversioned IDs, so there is nothing to shorten.
 
-Rows without a parenthetical have no alias. Availability also differs by platform:
-Claude 4, 4.1, 3.7, and 3.5 no longer resolve on the direct Anthropic API, while several
-of them are still served by Bedrock, Vertex, and OpenRouter. The rows stay listed both
-for those platforms and for cost attribution on historical evals.
+Rows without a parenthetical have no alias. Availability differs by platform — see
+[Retired on the Anthropic API](#retired-on-the-anthropic-api) for the IDs that only work
+through Bedrock, Vertex, and gateways.
 
 :::
 
@@ -111,41 +124,41 @@ Claude models are available across multiple platforms. Here's how the model name
 | Claude 4.5 Sonnet | claude-sonnet-4-5-20250929 (claude-sonnet-4-5) | claude-sonnet-4-5-20250929                                            | anthropic.claude-sonnet-4-5-20250929-v1:0         | claude-sonnet-4-5@20250929                     |
 | Claude 4.5 Haiku  | claude-haiku-4-5-20251001 (claude-haiku-4-5)   | claude-haiku-4-5-20251001                                             | anthropic.claude-haiku-4-5-20251001-v1:0          | claude-haiku-4-5@20251001                      |
 | Claude 4.1 Opus   | Retired on the direct API                      | claude-opus-4-1-20250805                                              | anthropic.claude-opus-4-1-20250805-v1:0           | claude-opus-4-1@20250805                       |
-| Claude 4 Opus     | claude-opus-4-20250514                         | claude-opus-4-20250514                                                | anthropic.claude-opus-4-20250514-v1:0             | claude-opus-4@20250514                         |
-| Claude 4 Sonnet   | claude-sonnet-4-20250514                       | claude-sonnet-4-20250514                                              | anthropic.claude-sonnet-4-20250514-v1:0           | claude-sonnet-4@20250514                       |
-| Claude 3.7 Sonnet | claude-3-7-sonnet-20250219                     | claude-3-7-sonnet-20250219                                            | anthropic.claude-3-7-sonnet-20250219-v1:0         | claude-3-7-sonnet@20250219                     |
-| Claude 3.5 Sonnet | claude-3-5-sonnet-20241022                     | claude-3-5-sonnet-20241022                                            | anthropic.claude-3-5-sonnet-20241022-v2:0         | claude-3-5-sonnet-v2@20241022                  |
-| Claude 3.5 Haiku  | claude-3-5-haiku-20241022                      | claude-3-5-haiku-20241022                                             | anthropic.claude-3-5-haiku-20241022-v1:0          | claude-3-5-haiku@20241022                      |
-| Claude 3 Opus     | claude-3-opus-20240229                         | claude-3-opus-20240229                                                | anthropic.claude-3-opus-20240229-v1:0             | claude-3-opus@20240229                         |
-| Claude 3 Haiku    | claude-3-haiku-20240307                        | claude-3-haiku-20240307                                               | anthropic.claude-3-haiku-20240307-v1:0            | claude-3-haiku@20240307                        |
+| Claude 4 Opus     | Retired on the direct API                      | claude-opus-4-20250514                                                | anthropic.claude-opus-4-20250514-v1:0             | claude-opus-4@20250514                         |
+| Claude 4 Sonnet   | Retired on the direct API                      | claude-sonnet-4-20250514                                              | anthropic.claude-sonnet-4-20250514-v1:0           | claude-sonnet-4@20250514                       |
+| Claude 3.7 Sonnet | Retired on the direct API                      | claude-3-7-sonnet-20250219                                            | anthropic.claude-3-7-sonnet-20250219-v1:0         | claude-3-7-sonnet@20250219                     |
+| Claude 3.5 Sonnet | Retired on the direct API                      | claude-3-5-sonnet-20241022                                            | anthropic.claude-3-5-sonnet-20241022-v2:0         | claude-3-5-sonnet-v2@20241022                  |
+| Claude 3.5 Haiku  | Retired on the direct API                      | claude-3-5-haiku-20241022                                             | anthropic.claude-3-5-haiku-20241022-v1:0          | claude-3-5-haiku@20241022                      |
+| Claude 3 Opus     | Retired on the direct API                      | claude-3-opus-20240229                                                | anthropic.claude-3-opus-20240229-v1:0             | claude-3-opus@20240229                         |
+| Claude 3 Haiku    | Retired on the direct API                      | claude-3-haiku-20240307                                               | anthropic.claude-3-haiku-20240307-v1:0            | claude-3-haiku@20240307                        |
 
 ### Supported Parameters
 
-| Config Property | Environment Variable  | Description                                                                         |
-| --------------- | --------------------- | ----------------------------------------------------------------------------------- |
-| apiKey          | ANTHROPIC_API_KEY     | Your API key from Anthropic                                                         |
-| apiKeyRequired  | -                     | Skip the API key preflight and authenticate via a local Claude Code session         |
-| apiBaseUrl      | ANTHROPIC_BASE_URL    | The base URL for requests to the Anthropic API                                      |
-| temperature     | ANTHROPIC_TEMPERATURE | Controls the randomness of the output (default: 0). Omitted when `top_p` is set.    |
-| max_tokens      | ANTHROPIC_MAX_TOKENS  | The maximum length of the generated text (default: 1024)                            |
-| cost            | -                     | Legacy per-token override applied to both input and output pricing                  |
-| inputCost       | -                     | Override input token pricing in promptfoo cost estimates                            |
-| outputCost      | -                     | Override output token pricing in promptfoo cost estimates                           |
-| top_p           | -                     | Controls nucleus sampling. Mutually exclusive with `temperature`.                   |
-| top_k           | -                     | Only sample from the top K options for each subsequent token                        |
-| stop_sequences  | -                     | Array of strings that will stop generation when encountered                         |
-| stream          | -                     | Enable streaming (required when `max_tokens` > 21,333)                              |
-| tools           | -                     | An array of tool or function definitions for the model to call                      |
-| tool_choice     | -                     | An object specifying the tool to call                                               |
-| effort          | -                     | Output effort level: `low`, `medium`, `high`, `xhigh`, or `max`                     |
-| output_format   | -                     | JSON schema configuration for structured outputs                                    |
-| thinking        | -                     | Configuration for Claude's extended thinking (`enabled`, `adaptive`, or `disabled`) |
-| showThinking    | -                     | Whether to include thinking content in the output (default: true)                   |
-| cache_control   | -                     | Auto-apply cache_control to the last cacheable block in the request                 |
-| metadata        | -                     | Request metadata such as `user_id` for tracking purposes                            |
-| service_tier    | -                     | Priority tier: `auto` (default) or `standard_only`                                  |
-| headers         | -                     | Additional headers to be sent with the API request                                  |
-| extra_body      | -                     | Additional parameters to be included in the API request body                        |
+| Config Property | Environment Variable  | Description                                                                                       |
+| --------------- | --------------------- | ------------------------------------------------------------------------------------------------- |
+| apiKey          | ANTHROPIC_API_KEY     | Your API key from Anthropic                                                                       |
+| apiKeyRequired  | -                     | Skip the API key preflight and authenticate via a local Claude Code session                       |
+| apiBaseUrl      | ANTHROPIC_BASE_URL    | The base URL for requests to the Anthropic API                                                    |
+| temperature     | ANTHROPIC_TEMPERATURE | Controls the randomness of the output (default: 0). Omitted when `top_p` is set.                  |
+| max_tokens      | ANTHROPIC_MAX_TOKENS  | The maximum length of the generated text (default: 1024, or 2048 on models that think by default) |
+| cost            | -                     | Legacy per-token override applied to both input and output pricing                                |
+| inputCost       | -                     | Override input token pricing in promptfoo cost estimates                                          |
+| outputCost      | -                     | Override output token pricing in promptfoo cost estimates                                         |
+| top_p           | -                     | Controls nucleus sampling. Mutually exclusive with `temperature`.                                 |
+| top_k           | -                     | Only sample from the top K options for each subsequent token                                      |
+| stop_sequences  | -                     | Array of strings that will stop generation when encountered                                       |
+| stream          | -                     | Enable streaming (required when `max_tokens` > 21,333)                                            |
+| tools           | -                     | An array of tool or function definitions for the model to call                                    |
+| tool_choice     | -                     | An object specifying the tool to call                                                             |
+| effort          | -                     | Output effort level: `low`, `medium`, `high`, `xhigh`, or `max`                                   |
+| output_format   | -                     | JSON schema configuration for structured outputs                                                  |
+| thinking        | -                     | Configuration for Claude's extended thinking (`enabled`, `adaptive`, or `disabled`)               |
+| showThinking    | -                     | Whether to include thinking content in the output (default: true)                                 |
+| cache_control   | -                     | Auto-apply cache_control to the last cacheable block in the request                               |
+| metadata        | -                     | Request metadata such as `user_id` for tracking purposes                                          |
+| service_tier    | -                     | Priority tier: `auto` (default) or `standard_only`                                                |
+| headers         | -                     | Additional headers to be sent with the API request                                                |
+| extra_body      | -                     | Additional parameters to be included in the API request body                                      |
 
 ### Prompt Template
 

--- a/site/docs/red-team/llm-supply-chain.md
+++ b/site/docs/red-team/llm-supply-chain.md
@@ -286,7 +286,7 @@ Run acceptance tests before deployment:
 
 ```bash
 promptfoo redteam run -c vendor-acceptance.yaml \
-  --var CANDIDATE_MODEL=anthropic:claude-sonnet-4-20250514
+  --var CANDIDATE_MODEL=anthropic:claude-sonnet-4-6
 ```
 
 ### Comparing Models Side-by-Side
@@ -299,7 +299,7 @@ description: Security comparison - current vs candidate
 targets:
   - id: openai:gpt-4o
     label: current-production
-  - id: anthropic:claude-sonnet-4-20250514
+  - id: anthropic:claude-sonnet-4-6
     label: candidate
 
 redteam:

--- a/site/docs/red-team/model-drift.md
+++ b/site/docs/red-team/model-drift.md
@@ -355,7 +355,7 @@ targets:
     label: gpt-4.1-baseline
   - id: openai:gpt-4.1-mini
     label: gpt-4.1-mini-comparison
-  - id: anthropic:claude-sonnet-4-20250514
+  - id: anthropic:claude-sonnet-4-6
     label: claude-sonnet-comparison
 
 redteam:

--- a/site/docs/red-team/plugins/mcp.md
+++ b/site/docs/red-team/plugins/mcp.md
@@ -89,7 +89,7 @@ Here's an example configuration for testing an MCP-enabled customer support agen
 description: Red Teaming MCP with tool use
 
 providers:
-  - id: anthropic:messages:claude-3-haiku-20240307
+  - id: anthropic:messages:claude-haiku-4-5
     config:
       mcp:
         enabled: true

--- a/site/docs/red-team/troubleshooting/data-handling.md
+++ b/site/docs/red-team/troubleshooting/data-handling.md
@@ -58,7 +58,7 @@ Or configure a different provider for grading:
 
 ```yaml
 redteam:
-  provider: anthropic:messages:claude-sonnet-4-20250514
+  provider: anthropic:messages:claude-sonnet-4-6
 ```
 
 With this configuration, Promptfoo servers usually receive only [telemetry](#telemetry) unless you use red team target/provider setup helpers, red team target/provider test requests, sharing, Cloud sync, hosted reports, or other Cloud-backed features.


### PR DESCRIPTION
## Summary

I probed every Claude ID the Anthropic provider docs name against the live API (`GET /v1/models/{id}`, falling back to a 1-token Messages call). **Nine IDs listed under "supports the following models via the messages API" return `404 not_found_error`.**

| Model ID | Anthropic API | | Model ID | Anthropic API |
| --- | --- | --- | --- | --- |
| `claude-opus-4-1-20250805` | **404** | | `claude-3-5-sonnet-20241022` | **404** |
| `claude-opus-4-20250514` | **404** | | `claude-3-5-sonnet-20240620` | **404** |
| `claude-sonnet-4-20250514` | **404** | | `claude-3-5-haiku-20241022` | **404** |
| `claude-3-7-sonnet-20250219` | **404** | | `claude-3-opus-20240229` | **404** |
| | | | `claude-3-haiku-20240307` | **404** |

The page already said this further down, in the alias note — the tables above it just hadn't caught up. The cross-platform table had the same split brain: its Claude 4.1 Opus row correctly read "Retired on the direct API" while the seven rows beneath it still advertised a working Anthropic ID.

`GET /v1/models` returns 11 models, and none of the above are among them.

## Changes

- **Split the model table** into what resolves today and a "Retired on the Anthropic API" table, each row carrying a suggested replacement. The retired IDs stay documented — promptfoo still accepts them for Bedrock, Vertex and gateways, and cost attribution on historical evals needs the rates.
- **Cross-platform table**: set the Anthropic API column to "Retired on the direct API" for the seven rows that 404, matching the 4.1 Opus row. **Partner-platform columns are untouched** — those lifecycles are independent and I did not probe them.
- **Six docs pages** shipped copy-pasteable configs pinned to retired IDs (`anthropic:claude-sonnet-4-20250514` and friends) — anyone copying them got a 404. Repointed to `claude-sonnet-4-6` / `claude-haiku-4-5`, both verified live. Blog posts are left alone: they're dated records, not instructions.
- Noted the **Mythos rows are limited-access**, so a 404 there means the org lacks access rather than the model being gone — worth stating so nobody "fixes" them into the retired table.
- `max_tokens` default is 1024 **or 2048** depending on whether the model thinks by default, per #10631.

## Also confirmed live

No `-latest` alias resolves — `claude-sonnet-4-5-latest`, `claude-opus-4-5-latest`, `claude-haiku-4-5-latest`, `claude-opus-4-1-latest`, `claude-opus-4-latest`, `claude-sonnet-4-latest`, `claude-3-7-sonnet-latest`, `claude-3-5-sonnet-latest`, `claude-3-5-haiku-latest` and `claude-3-opus-latest` all 404 — while the bare family IDs `claude-opus-4-5`, `claude-sonnet-4-5` and `claude-haiku-4-5` do resolve. That matches what the page already claims, so the alias note needed only a pointer to the new table.

## Verification

- `cd site && SKIP_OG_GENERATION=true npm run build` — clean, no broken links or anchors.
- `biome ci .` clean.

Related: this is the Anthropic slice of #9792, verified and landed on its own. The rest of that PR's catalog claims still need the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7jDD7WZBVV2GUpknv9Aff