### PR TITLE
test(providers): cover env omission and singular server merge in MCP transform

### DIFF
--- a/test/providers/mcp/transform.test.ts
+++ b/test/providers/mcp/transform.test.ts
@@ -383,6 +383,33 @@ describe('transformMCPConfigToClaudeCode', () => {
     });
   });
 
+  it('omits the env key entirely when the server has no env map', async () => {
+    const servers = await transformMCPConfigToClaudeCode({
+      enabled: true,
+      server: { name: 'plain', command: 'npx', args: ['-y', 'plain-server'] },
+    });
+
+    expect(servers.plain).toEqual({ type: 'stdio', command: 'npx', args: ['-y', 'plain-server'] });
+    // A phantom `env: undefined` must never reach the SDK either.
+    expect(Object.hasOwn(servers.plain, 'env')).toBe(false);
+  });
+
+  it('merges a single `server` entry into the same map as `servers`', async () => {
+    const servers = await transformMCPConfigToClaudeCode({
+      enabled: true,
+      server: { name: 'solo', command: 'node', args: ['srv.js'], env: { KEY: 'v' } },
+      servers: [{ name: 'grouped', command: 'npx', args: ['other.js'] }],
+    });
+
+    expect(servers.solo).toEqual({
+      type: 'stdio',
+      command: 'node',
+      args: ['srv.js'],
+      env: { KEY: 'v' },
+    });
+    expect(servers.grouped).toEqual({ type: 'stdio', command: 'npx', args: ['other.js'] });
+  });
+
   it.each([
     null,
     [],


### PR DESCRIPTION
## Summary

Follow-up to #10510 (superseded by #10557). Two of the four transform tests from that PR still add coverage that current `main` does not have, so here they are on their own:

1. **`env` stays absent when a stdio server declares none.** `transformMCPServerConfigToClaudeCode` spreads `config.env` conditionally; this pins that the key is omitted entirely (not emitted as `env: undefined`) so the SDK never sees a phantom empty env.
2. **A singular `server` entry lands in the same map as `servers`.** The two shapes are merged before transformation; this pins parity for the singular form, including env forwarding, alongside a `servers` entry in one call.

Both pass against `main` as of today and fail when the corresponding line is removed (checked locally by deleting the conditional spread and the `config.server` merge).

## To verify

- `npx vitest run test/providers/mcp/transform.test.ts`
