### PR TITLE
fix(providers): drop Claude model ids that resolve nowhere

### DIFF
--- a/src/providers/anthropic/completion.ts
+++ b/src/providers/anthropic/completion.ts
@@ -40,8 +40,8 @@ export class AnthropicCompletionProvider extends AnthropicGenericProvider {
   // NOTE: As of March 15, 2025, all legacy completion models are retired
   // and should not be used for new applications.
   // Recommended alternatives:
-  // - For claude-1.x and claude-instant-1.x: use claude-3-5-haiku-20241022
-  // - For claude-2.x: use claude-3-5-sonnet-20241022
+  // - For claude-1.x and claude-instant-1.x: use claude-haiku-4-5
+  // - For claude-2.x: use claude-sonnet-4-6
   static ANTHROPIC_COMPLETION_MODELS = [
     // All models below are deprecated and will be retired soon
     // Only kept for reference - migrate to newer models in new code

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -79,34 +79,30 @@ export const ANTHROPIC_MODELS = [
     },
   })),
   // Claude 4.6 models
-  ...['claude-sonnet-4-6', 'claude-sonnet-4-6-latest'].map((model) => ({
+  ...['claude-sonnet-4-6'].map((model) => ({
     id: model,
     cost: {
       input: 3 / 1e6, // $3 / MTok
       output: 15 / 1e6, // $15 / MTok
     },
   })),
-  ...['claude-opus-4-6', 'claude-opus-4-6-latest'].map((model) => ({
+  ...['claude-opus-4-6'].map((model) => ({
     id: model,
     cost: {
       input: 5 / 1e6, // $5 / MTok
       output: 25 / 1e6, // $25 / MTok
     },
   })),
-  ...['claude-opus-4-5', 'claude-opus-4-5-20251101', 'claude-opus-4-5-latest'].map((model) => ({
+  ...['claude-opus-4-5', 'claude-opus-4-5-20251101'].map((model) => ({
     id: model,
     cost: {
       input: 5 / 1e6, // $5 / MTok
       output: 25 / 1e6, // $25 / MTok
     },
   })),
-  ...[
-    'claude-opus-4-1',
-    'claude-opus-4-1-20250805',
-    'claude-opus-4-20250514',
-    'claude-opus-4-0',
-    'claude-opus-4-latest',
-  ].map((model) => ({
+  // Both are retired on the Anthropic API. The rates stay because Bedrock still serves
+  // Opus 4.1, and cost attribution on historical evals needs them.
+  ...['claude-opus-4-1-20250805', 'claude-opus-4-20250514'].map((model) => ({
     id: model,
     cost: {
       input: 15 / 1e6, // $15 / MTok
@@ -116,10 +112,8 @@ export const ANTHROPIC_MODELS = [
   ...[
     'claude-sonnet-4-5',
     'claude-sonnet-4-5-20250929',
-    'claude-sonnet-4-5-latest',
+    // Retired on the Anthropic API; still served by Bedrock in every region.
     'claude-sonnet-4-20250514',
-    'claude-sonnet-4-0',
-    'claude-sonnet-4-latest',
   ].map((model) => ({
     id: model,
     cost: {
@@ -127,7 +121,7 @@ export const ANTHROPIC_MODELS = [
       output: 15 / 1e6, // $15 / MTok
     },
   })),
-  ...['claude-haiku-4-5', 'claude-haiku-4-5-20251001', 'claude-haiku-4-5-latest'].map((model) => ({
+  ...['claude-haiku-4-5', 'claude-haiku-4-5-20251001'].map((model) => ({
     id: model,
     cost: {
       input: 1 / 1e6, // $1 / MTok
@@ -150,40 +144,38 @@ export const ANTHROPIC_MODELS = [
       output: 0.024 / 1000,
     },
   })),
-  ...['claude-3-haiku-20240307', 'claude-3-haiku-latest'].map((model) => ({
+  ...['claude-3-haiku-20240307'].map((model) => ({
     id: model,
     cost: {
       input: 0.00025 / 1000,
       output: 0.00125 / 1000,
     },
   })),
-  ...['claude-3-opus-20240229', 'claude-3-opus-latest'].map((model) => ({
+  ...['claude-3-opus-20240229'].map((model) => ({
     id: model,
     cost: {
       input: 0.015 / 1000,
       output: 0.075 / 1000,
     },
   })),
-  ...['claude-3-5-haiku-20241022', 'claude-3-5-haiku-latest'].map((model) => ({
+  ...['claude-3-5-haiku-20241022'].map((model) => ({
     id: model,
     cost: {
       input: 0.8 / 1e6,
       output: 4 / 1e6,
     },
   })),
-  ...[
-    'claude-3-5-sonnet-20240620',
-    'claude-3-5-sonnet-20241022',
-    'claude-3-5-sonnet-latest',
-    'claude-3-7-sonnet-20250219',
-    'claude-3-7-sonnet-latest',
-  ].map((model) => ({
-    id: model,
-    cost: {
-      input: 3 / 1e6,
-      output: 15 / 1e6,
-    },
-  })),
+  // Retired on the Anthropic API; still served by Bedrock (3.5 Sonnet in APAC, 3.7 Sonnet in
+  // eu-west-2 and ap-south-1), so the rates stay for cost attribution there.
+  ...['claude-3-5-sonnet-20240620', 'claude-3-5-sonnet-20241022', 'claude-3-7-sonnet-20250219'].map(
+    (model) => ({
+      id: model,
+      cost: {
+        input: 3 / 1e6,
+        output: 15 / 1e6,
+      },
+    }),
+  ),
 ];
 
 // Model-ID matchers for each Claude family, across Anthropic, Bedrock (incl. the

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -2339,7 +2339,6 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   // Nova 2 models with extended thinking support
   'amazon.nova-2-lite-v1:0': BEDROCK_MODEL.AMAZON_NOVA_2,
   'amazon.nova-2-sonic-v1:0': BEDROCK_MODEL.AMAZON_NOVA, // Sonic uses bidirectional streaming API
-  'anthropic.claude-3-5-haiku-20241022-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-3-5-sonnet-20240620-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-3-5-sonnet-20241022-v2:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'anthropic.claude-3-7-sonnet-20250219-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
@@ -2443,7 +2442,6 @@ export const AWS_BEDROCK_MODELS: Record<string, IBedrockModel> = {
   'us.amazon.nova-premier-v1:0': BEDROCK_MODEL.AMAZON_NOVA,
   'us.amazon.nova-2-lite-v1:0': BEDROCK_MODEL.AMAZON_NOVA_2,
   'us.amazon.nova-2-sonic-v1:0': BEDROCK_MODEL.AMAZON_NOVA,
-  'us.anthropic.claude-3-5-haiku-20241022-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-3-5-sonnet-20240620-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-3-5-sonnet-20241022-v2:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
   'us.anthropic.claude-3-7-sonnet-20250219-v1:0': BEDROCK_MODEL.CLAUDE_MESSAGES,
@@ -2660,6 +2658,11 @@ export function getHandlerForModel(
       'us.anthropic.claude-3-opus-20240229-v1:0',
       'anthropic.claude-opus-4-20250514-v1:0',
       'us.anthropic.claude-opus-4-20250514-v1:0',
+      // Withdrawn from Bedrock: absent from list-foundation-models in all 17 commercial
+      // regions on 2026-09-04. Listed here so it fails with a clear message instead of
+      // falling through to the `anthropic.claude` catch-all and failing at request time.
+      'anthropic.claude-3-5-haiku-20241022-v1:0',
+      'us.anthropic.claude-3-5-haiku-20241022-v1:0',
       'anthropic.claude-instant-v1',
       'anthropic.claude-v1',
       'anthropic.claude-v2',

--- a/src/providers/cloudflare-gateway.ts
+++ b/src/providers/cloudflare-gateway.ts
@@ -8,7 +8,7 @@
  *
  * Usage:
  *   cloudflare-gateway:openai:gpt-4o
- *   cloudflare-gateway:anthropic:claude-sonnet-4-20250514
+ *   cloudflare-gateway:anthropic:claude-sonnet-4-6
  *   cloudflare-gateway:groq:llama-3.3-70b-versatile
  *
  * @see https://developers.cloudflare.com/ai-gateway/

--- a/src/providers/opencode-sdk.ts
+++ b/src/providers/opencode-sdk.ts
@@ -263,7 +263,7 @@ export interface OpenCodeSDKConfig {
   provider_id?: string;
 
   /**
-   * Model ID to use (e.g., 'claude-sonnet-4-20250514', 'gpt-4o')
+   * Model ID to use (e.g., 'claude-sonnet-4-6', 'gpt-4o')
    * Combined with provider_id to specify the exact model
    */
   model?: string;

--- a/test/providers/anthropic/messages.test.ts
+++ b/test/providers/anthropic/messages.test.ts
@@ -1610,7 +1610,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('executes MCP tool_use blocks and continues the Anthropic conversation with tool_result', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: {
             enabled: true,
@@ -1687,7 +1687,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('sums thinking tokens across MCP continuation rounds', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: {
             enabled: true,
@@ -1745,7 +1745,7 @@ describe('AnthropicMessagesProvider', () => {
 
     it('does not cache MCP continuation results by default', async () => {
       enableCache();
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: {
             enabled: true,
@@ -1813,7 +1813,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('leaves mixed MCP and non-MCP tool_use blocks on the existing output path', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: {
             enabled: true,
@@ -1854,7 +1854,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('drops forced tool_choice on MCP continuation requests', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           tool_choice: 'required' as any,
           mcp: {
@@ -1920,7 +1920,7 @@ describe('AnthropicMessagesProvider', () => {
     ])(
       'marks MCP tool_result blocks as errors before continuing the Anthropic conversation ($label)',
       async ({ mcpResult, expectedContent }) => {
-        provider = createProvider('claude-3-5-sonnet-latest', {
+        provider = createProvider('claude-sonnet-4-6', {
           config: {
             mcp: {
               enabled: true,
@@ -1975,7 +1975,7 @@ describe('AnthropicMessagesProvider', () => {
     );
 
     it('leaves non-MCP Anthropic tool_use blocks on the existing output path', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: {
             enabled: true,
@@ -2009,7 +2009,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('publishes executed MCP tool calls as metadata.toolCalls across rounds', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: { enabled: true, server: { command: 'npm', args: ['start'] } },
         },
@@ -2073,7 +2073,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('marks a failed MCP tool call as is_error in metadata.toolCalls', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: { enabled: true, server: { command: 'npm', args: ['start'] } },
         },
@@ -2109,7 +2109,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('omits metadata.toolCalls entirely when no MCP tool ran', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: { enabled: true, server: { command: 'npm', args: ['start'] } },
         },
@@ -2129,7 +2129,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('keeps tool calls made before the max_tool_calls bail-out', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           max_tool_calls: 1,
           mcp: { enabled: true, server: { command: 'npm', args: ['start'] } },
@@ -2175,7 +2175,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('returns an error when MCP tool execution exceeds max_tool_calls', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           max_tool_calls: 1,
           mcp: {
@@ -2235,7 +2235,7 @@ describe('AnthropicMessagesProvider', () => {
       // Regression: max_tool_calls: 0 is an explicit "do not auto-execute MCP
       // tools" guard, but 0 was treated as invalid and silently widened to the
       // default of 8, so tools ran anyway.
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           max_tool_calls: 0,
           mcp: {
@@ -2272,7 +2272,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('blocks parallel MCP tool execution when it would exceed max_tool_calls', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           max_tool_calls: 1,
           mcp: {
@@ -2312,7 +2312,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('continues MCP tool execution through the streaming path', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           stream: true,
           mcp: {
@@ -2373,7 +2373,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('returns a streaming error once further MCP execution exceeds max_tool_calls', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           max_tool_calls: 1,
           stream: true,
@@ -2436,7 +2436,7 @@ describe('AnthropicMessagesProvider', () => {
 
   describe('cleanup', () => {
     it('should await initialization before cleanup', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: {
             enabled: true,
@@ -2462,7 +2462,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('should handle cleanup when MCP is not enabled', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: {
             enabled: false,
@@ -2476,7 +2476,7 @@ describe('AnthropicMessagesProvider', () => {
     });
 
     it('should handle cleanup errors gracefully', async () => {
-      provider = createProvider('claude-3-5-sonnet-latest', {
+      provider = createProvider('claude-sonnet-4-6', {
         config: {
           mcp: {
             enabled: true,

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -51,9 +51,11 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(6); // (0.004 * 100) + (0.02 * 200)
     });
 
-    it('should calculate cost for Claude 3.7 latest model', () => {
-      const cost = calculateAnthropicCost('claude-3-7-sonnet-latest', { cost: 0.02 }, 100, 200);
-      expect(cost).toBe(6); // (0.004 * 100) + (0.02 * 200)
+    it('should return undefined for claude-3-7-sonnet-latest (alias does not exist)', () => {
+      // No Claude model publishes a `-latest` alias; the Models API 404s on every one.
+      // A config.cost override still applies, so pass none here.
+      const cost = calculateAnthropicCost('claude-3-7-sonnet-latest', {}, 100, 200);
+      expect(cost).toBeUndefined();
     });
 
     it('should calculate cost for Claude Opus 4 model', () => {
@@ -66,9 +68,9 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(6); // (0.02 * 100) + (0.02 * 200) - when config.cost is provided, it's used for both
     });
 
-    it('should calculate cost for Claude Sonnet 4 latest model', () => {
-      const cost = calculateAnthropicCost('claude-sonnet-4-latest', { cost: 0.02 }, 100, 200);
-      expect(cost).toBe(6); // (0.02 * 100) + (0.02 * 200) - when config.cost is provided, it's used for both
+    it('should return undefined for claude-sonnet-4-latest (alias does not exist)', () => {
+      const cost = calculateAnthropicCost('claude-sonnet-4-latest', {}, 100, 200);
+      expect(cost).toBeUndefined();
     });
 
     it('should calculate default cost for Claude Opus 4.1 model', () => {
@@ -96,9 +98,9 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(0.0011); // (0.000001 * 100) + (0.000005 * 200) - $1/MTok input, $5/MTok output
     });
 
-    it('should calculate default cost for Claude Haiku 4.5 latest model', () => {
+    it('should return undefined for claude-haiku-4-5-latest (alias does not exist)', () => {
       const cost = calculateAnthropicCost('claude-haiku-4-5-latest', {}, 100, 200);
-      expect(cost).toBe(0.0011); // (0.000001 * 100) + (0.000005 * 200) - $1/MTok input, $5/MTok output
+      expect(cost).toBeUndefined();
     });
 
     it('should calculate default cost for Claude Opus 4.8 model', () => {
@@ -165,9 +167,9 @@ describe('Anthropic utilities', () => {
       expect(cost).toBeUndefined();
     });
 
-    it('should calculate default cost for Claude Opus 4.6 latest model', () => {
+    it('should return undefined for claude-opus-4-6-latest (alias does not exist)', () => {
       const cost = calculateAnthropicCost('claude-opus-4-6-latest', {}, 100, 200);
-      expect(cost).toBe(0.0055); // (0.000005 * 100) + (0.000025 * 200) - $5/MTok input, $25/MTok output
+      expect(cost).toBeUndefined();
     });
 
     it('should calculate default cost for Claude Sonnet 4.6 model', () => {
@@ -175,9 +177,9 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(0.0033); // (0.000003 * 100) + (0.000015 * 200) - $3/MTok input, $15/MTok output
     });
 
-    it('should calculate default cost for Claude Sonnet 4.6 latest model', () => {
+    it('should return undefined for claude-sonnet-4-6-latest (alias does not exist)', () => {
       const cost = calculateAnthropicCost('claude-sonnet-4-6-latest', {}, 100, 200);
-      expect(cost).toBe(0.0033); // (0.000003 * 100) + (0.000015 * 200) - $3/MTok input, $15/MTok output
+      expect(cost).toBeUndefined();
     });
 
     it('should calculate default cost for Claude Opus 4.5 model', () => {
@@ -185,9 +187,9 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(0.0055); // (0.000005 * 100) + (0.000025 * 200) - $5/MTok input, $25/MTok output
     });
 
-    it('should calculate default cost for Claude Opus 4.5 latest model', () => {
+    it('should return undefined for claude-opus-4-5-latest (alias does not exist)', () => {
       const cost = calculateAnthropicCost('claude-opus-4-5-latest', {}, 100, 200);
-      expect(cost).toBe(0.0055); // (0.000005 * 100) + (0.000025 * 200) - $5/MTok input, $25/MTok output
+      expect(cost).toBeUndefined();
     });
 
     it('bills Claude Sonnet 4.5 at the standard rate below 200k tokens', () => {
@@ -202,8 +204,9 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(0.9); // (3/1e6 * 250,000) + (15/1e6 * 10,000) = 0.75 + 0.15 = 0.9
     });
 
-    it('bills the Claude Sonnet 4.5 latest alias at the standard rate above 200k tokens', () => {
-      const cost = calculateAnthropicCost('claude-sonnet-4-5-latest', {}, 300_000, 20_000);
+    it('bills the bare Claude Sonnet 4.5 alias at the standard rate above 200k tokens', () => {
+      // `claude-sonnet-4-5` resolves; `claude-sonnet-4-5-latest` does not.
+      const cost = calculateAnthropicCost('claude-sonnet-4-5', {}, 300_000, 20_000);
       expect(cost).toBe(1.2); // (3/1e6 * 300,000) + (15/1e6 * 20,000) = 0.9 + 0.3 = 1.2
     });
 
@@ -219,9 +222,9 @@ describe('Anthropic utilities', () => {
       expect(cost).toBe(1.2); // (3/1e6 * 300,000) + (15/1e6 * 20,000) = 0.9 + 0.3 = 1.2
     });
 
-    it('bills the Claude Sonnet 4.6 latest alias at the standard rate above 200k tokens', () => {
+    it('returns undefined for the Claude Sonnet 4.6 latest alias (it does not exist)', () => {
       const cost = calculateAnthropicCost('claude-sonnet-4-6-latest', {}, 250_000, 10_000);
-      expect(cost).toBe(0.9); // (3/1e6 * 250,000) + (15/1e6 * 10,000) = 0.75 + 0.15 = 0.9
+      expect(cost).toBeUndefined();
     });
 
     it('should calculate default cost for Claude Opus 5 model', () => {
@@ -256,7 +259,8 @@ describe('Anthropic utilities', () => {
 
     it('should use base pricing for other Claude Sonnet 4 models', () => {
       // Other Sonnet 4 models bill at the same standard rate
-      const models = ['claude-sonnet-4-20250514', 'claude-sonnet-4-0', 'claude-sonnet-4-latest'];
+      // Only the dated id resolves — `claude-sonnet-4-0` and `-latest` 404 on the Models API.
+      const models = ['claude-sonnet-4-20250514'];
 
       models.forEach((model) => {
         const cost = calculateAnthropicCost(model, {}, 300_000, 20_000);

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -3712,9 +3712,9 @@ describe('AWS_BEDROCK_MODELS mapping', () => {
     expect(AWS_BEDROCK_MODELS['us.amazon.nova-micro-v1:0']).toBe(BEDROCK_MODEL.AMAZON_NOVA);
     expect(AWS_BEDROCK_MODELS['us.amazon.nova-pro-v1:0']).toBe(BEDROCK_MODEL.AMAZON_NOVA);
     expect(AWS_BEDROCK_MODELS['us.amazon.nova-premier-v1:0']).toBe(BEDROCK_MODEL.AMAZON_NOVA);
-    expect(AWS_BEDROCK_MODELS['us.anthropic.claude-3-5-haiku-20241022-v1:0']).toBe(
-      BEDROCK_MODEL.CLAUDE_MESSAGES,
-    );
+    // Withdrawn from Bedrock in every commercial region; deregistered so it raises
+    // "Unknown Amazon Bedrock model" instead of silently hitting the Claude catch-all.
+    expect(AWS_BEDROCK_MODELS['us.anthropic.claude-3-5-haiku-20241022-v1:0']).toBeUndefined();
     expect(AWS_BEDROCK_MODELS['us.anthropic.claude-3-5-sonnet-20240620-v1:0']).toBe(
       BEDROCK_MODEL.CLAUDE_MESSAGES,
     );


### PR DESCRIPTION
Follow-up to #10632, which documented nine Claude ids as retired on the Anthropic API. This removes the ones that are dead on *every* platform promptfoo can reach, and keeps the ones a platform still serves.

## What I probed

`GET /v1/models/{id}` on the Anthropic API, and `aws bedrock list-foundation-models` across all 17 commercial regions:

| Model ID | Anthropic API | Bedrock |
| --- | --- | --- |
| `claude-opus-4-1-20250805` | 404 | **live** |
| `claude-sonnet-4-20250514` | 404 | **live** (all regions) |
| `claude-3-haiku-20240307` | 404 | **live** (all regions) |
| `claude-3-5-sonnet-20240620` | 404 | **live** (ap-south-1, ap-southeast-1, ap-northeast-2) |
| `claude-3-5-sonnet-20241022` | 404 | **live** (ap-south-1, ap-southeast-1, ap-northeast-2) |
| `claude-3-7-sonnet-20250219` | 404 | **live** (eu-west-2, ap-south-1) |
| `claude-opus-4-20250514` | 404 | gone |
| `claude-3-5-haiku-20241022` | 404 | gone |
| `claude-3-opus-20240229` | 404 | gone |

**Six of the nine are still served by Bedrock**, so their rates stay in `ANTHROPIC_MODELS` — Bedrock and Vertex normalize into that table for cost, and historical evals need it. `test/providers/bedrock/index.test.ts` already had a case named *"keeps Claude 3.5/3.7 Sonnet (still offered in APAC regions)"*, which is exactly right and caught an earlier, broader cut of this change before it did any damage.

## Removed

- **Every `-latest` alias** — 14 of them across the 3.x, 4.x, 4.5 and 4.6 families — plus the bare `claude-opus-4-0`, `claude-sonnet-4-0` and `claude-opus-4-1` forms. All 404 on the Models API, and nothing normalizes into them: Bedrock and Vertex address these models by dated id. The test file already asserted this for `claude-opus-4-8-latest` and `claude-opus-4-7-latest`; this extends the same truth to the rest, so those tests now read consistently.
- **`claude-3-5-haiku-20241022` from `AWS_BEDROCK_MODELS`**, since it is absent from every Bedrock region. It moves into the "Unknown Amazon Bedrock model" list so it fails with a clear message rather than falling through to the `anthropic.claude` catch-all and failing at request time — the same treatment `claude-3-opus` and `claude-opus-4` already had.
- Three doc comments that recommended retired models as migration targets or usage examples (`completion.ts`, `cloudflare-gateway.ts`, `opencode-sdk.ts`).

## Deliberately unchanged

`legacyPredefinedTargets` in the redteam UI still carries `claude-opus-4-1-20250805`. That list exists precisely so saved configurations keep resolving, and the picker list already excludes it — the repo had this right.

Partner-platform lifecycles beyond Bedrock are **not** verified here: I had no Vertex ADC token, so Azure and Vertex tables are untouched.

## Verification

- `npx vitest run test/providers/ test/app` — 8844 passed.
- Frontend suite — 5434 passed.
- `npm run tsc` clean, `biome ci .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7jDD7WZBVV2GUpknv9Aff