### PR TITLE
fix(providers): preserve claude mcp stdio env

### DIFF
--- a/site/docs/providers/claude-agent-sdk.md
+++ b/site/docs/providers/claude-agent-sdk.md
@@ -376,6 +376,8 @@ providers:
           - command: node
             args: ['mcp-server.js']
             name: local-server
+            env:
+              MY_SERVER_ENABLE_TOOLSET_A: 'true'
 
       strict_mcp_config: true # Only use configured servers (true by default)
 ```
@@ -383,6 +385,10 @@ providers:
 This direct SDK integration cannot enforce the shared MCP `tools` allowlist or non-empty
 `exclude_tools` filters, so those configurations fail closed instead of silently exposing a broader
 tool set. An empty `exclude_tools` list is a no-op.
+
+For stdio MCP servers configured with `command`/`args` or `path`, use per-server `env` to pass
+environment variables to the MCP process, including variables that restrict which tools the server
+registers.
 
 For detailed MCP configuration, see [Claude Code MCP documentation](https://docs.claude.com/en/docs/claude-code/mcp).
 

--- a/src/providers/mcp/transform.ts
+++ b/src/providers/mcp/transform.ts
@@ -165,6 +165,11 @@ export function validateMCPConfigForClaudeCode(config: MCPConfig): void {
           typeof candidate.headers !== 'object' ||
           Array.isArray(candidate.headers) ||
           Object.values(candidate.headers).some((value) => typeof value !== 'string'))) ||
+      (candidate.env !== undefined &&
+        (!candidate.env ||
+          typeof candidate.env !== 'object' ||
+          Array.isArray(candidate.env) ||
+          Object.values(candidate.env).some((value) => typeof value !== 'string'))) ||
       (candidate.auth !== undefined &&
         (!candidate.auth || typeof candidate.auth !== 'object' || Array.isArray(candidate.auth)))
     ) {
@@ -218,11 +223,21 @@ async function transformMCPServerConfigToClaudeCode(
       headers: { ...(config.headers ?? {}), ...getAuthHeaders(renderedConfig, oauthToken) },
     };
   } else if (config.command) {
-    out = { type: 'stdio', command: config.command, args: config.args ?? [] };
+    out = {
+      type: 'stdio',
+      command: config.command,
+      args: config.args ?? [],
+      ...(config.env ? { env: config.env } : {}),
+    };
   } else if (config.path) {
     const isPy = config.path.endsWith('.py');
     const command = isPy ? (process.platform === 'win32' ? 'python' : 'python3') : process.execPath;
-    out = { type: 'stdio', command, args: [config.path] };
+    out = {
+      type: 'stdio',
+      command,
+      args: [config.path],
+      ...(config.env ? { env: config.env } : {}),
+    };
   } else {
     throw new Error('MCP configuration cannot be converted to Claude Agent SDK MCP server config');
   }

--- a/src/providers/mcp/types.ts
+++ b/src/providers/mcp/types.ts
@@ -10,6 +10,7 @@ export interface MCPServerConfig {
   url?: string; // URL for remote server (not currently supported)
   auth?: MCPServerAuth; // Authentication configuration
   headers?: Record<string, string>; // Additional HTTP headers for URL-based servers
+  env?: Record<string, string>; // Environment variables for stdio servers
 }
 
 // Bearer token authentication

--- a/test/providers/mcp/transform.test.ts
+++ b/test/providers/mcp/transform.test.ts
@@ -323,6 +323,47 @@ describe('transformMCPConfigToClaudeCode', () => {
     });
   });
 
+  it('preserves env for command-based stdio servers', async () => {
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        server: {
+          name: 'restricted-tools',
+          command: 'uvx',
+          args: ['my-mcp-server'],
+          env: { MY_SERVER_ENABLE_TOOLSET_A: 'true' },
+        },
+      }),
+    ).resolves.toEqual({
+      'restricted-tools': {
+        type: 'stdio',
+        command: 'uvx',
+        args: ['my-mcp-server'],
+        env: { MY_SERVER_ENABLE_TOOLSET_A: 'true' },
+      },
+    });
+  });
+
+  it('preserves env for path-based stdio servers', async () => {
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        server: {
+          name: 'path-server',
+          path: '/tmp/restricted-mcp-server.js',
+          env: { MCP_MODE: 'discovery' },
+        },
+      }),
+    ).resolves.toEqual({
+      'path-server': {
+        type: 'stdio',
+        command: process.execPath,
+        args: ['/tmp/restricted-mcp-server.js'],
+        env: { MCP_MODE: 'discovery' },
+      },
+    });
+  });
+
   it('preserves prototype-shaped server names as own entries', async () => {
     const servers = await transformMCPConfigToClaudeCode({
       enabled: true,
@@ -347,6 +388,8 @@ describe('transformMCPConfigToClaudeCode', () => {
     { enabled: true, server: { url: 123 } },
     { enabled: true, server: { path: 42 } },
     { enabled: true, server: { command: 'mcp-server', args: 'not-an-array' } },
+    { enabled: true, server: { command: 'mcp-server', env: 'not-an-object' } },
+    { enabled: true, server: { command: 'mcp-server', env: { MODE: 1 } } },
     { enabled: true, server: { url: 'https://example.test', headers: 'not-an-object' } },
     { enabled: true, server: { url: 'https://example.test', auth: [] } },
   ])('rejects malformed MCP config %#', async (config) => {


### PR DESCRIPTION
## Summary
- Preserve per-server `env` when converting command/args and path-based stdio MCP servers for the Claude Agent SDK provider.
- Validate stdio server `env` maps so malformed non-string values fail closed instead of being forwarded ambiguously.
- Document per-server MCP env usage for Claude Agent SDK process-based servers.

## Why
Stdio MCP servers commonly use environment variables to decide which tools they register. Dropping the configured `env` silently broadens or changes the tool surface exposed to an agent, which makes least-privilege agent evals look stricter than they actually are.

Fixes #10509

## Validation
- `npx vitest run test/providers/mcp/transform.test.ts` initially failed on the new env preservation and malformed-env tests before the implementation change.
- `npx vitest run test/providers/claude-agent-sdk.test.ts test/providers/mcp/transform.test.ts`
- `node --import tsx - <<SCRIPT` local smoke: verified real `transformMCPConfigToClaudeCode` preserves env for command/path stdio servers and rejects non-string env values.
- `npx @biomejs/biome check src/providers/mcp/transform.ts src/providers/mcp/types.ts test/providers/mcp/transform.test.ts`
- `npx prettier --check site/docs/providers/claude-agent-sdk.md`
- `git diff --check`

## Notes
- `npm run tsc` still fails locally on the existing optional `@openai/codex-security` import/type errors in `src/providers/openai/codex-security.ts`; this branch does not touch that provider.
