### PR TITLE
fix(matchers): warn on implicit self grading fallback

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -275,6 +275,11 @@ tests:
 
 This works at every level where a grader can be set — per-assertion (`assertion.provider`), per-test (`test.options.provider`), and globally (`defaultTest.options.provider`).
 
+If no explicit grader is configured, promptfoo also falls back to `defaultTest.provider` before the
+built-in grading provider. That keeps single-provider configs backwards compatible, but it means the
+same provider may generate and grade the output. Configure `defaultTest.options.provider`,
+`test.options.provider`, `assertion.provider`, or `--grader` when you want a separate judge.
+
 If you configure a full provider object globally, do not also add a shorthand
 `provider: openai:chat:...` to the assertion. Assertion-level providers take precedence, so the
 global provider object's `config` values such as `apiBaseUrl`, `apiKey`, `temperature`, or

--- a/src/matchers/providers.ts
+++ b/src/matchers/providers.ts
@@ -197,12 +197,18 @@ export async function getGradingProvider(
     const defaultTest = cliState.config?.defaultTest;
     const defaultTestObj = typeof defaultTest === 'object' ? (defaultTest as TestCase) : null;
     const fallbackProviders = [
-      defaultTestObj?.provider || undefined,
-      defaultTestObj?.options?.provider?.text || undefined,
-      defaultTestObj?.options?.provider || undefined,
+      { provider: defaultTestObj?.provider || undefined, source: 'defaultTest.provider' },
+      {
+        provider: defaultTestObj?.options?.provider?.text || undefined,
+        source: 'defaultTest.options.provider.text',
+      },
+      {
+        provider: defaultTestObj?.options?.provider || undefined,
+        source: 'defaultTest.options.provider',
+      },
     ];
 
-    const cfg = fallbackProviders.find((candidateProvider) => {
+    const fallback = fallbackProviders.find(({ provider: candidateProvider }) => {
       if (!candidateProvider) {
         return false;
       }
@@ -215,13 +221,22 @@ export async function getGradingProvider(
       return true;
     });
 
+    const cfg = fallback?.provider;
     if (cfg) {
       // Recursively call getGradingProvider to handle all provider types (string, object, etc.)
       finalProvider = await getGradingProvider(type, cfg, defaultProvider);
       if (finalProvider) {
-        logger.debug('[Grading] Using provider from defaultTest fallback', {
+        const logContext = {
           providerId: finalProvider.id(),
-        });
+        };
+        if (fallback.source === 'defaultTest.provider') {
+          logger.warn(
+            '[Grading] defaultTest.provider is being used as the grader because no explicit grader is configured',
+            logContext,
+          );
+        } else {
+          logger.debug('[Grading] Using provider from defaultTest fallback', logContext);
+        }
       }
     } else {
       finalProvider = defaultProvider;

--- a/test/matchers/getGradingProvider.test.ts
+++ b/test/matchers/getGradingProvider.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import cliState from '../../src/cliState';
+import logger from '../../src/logger';
 import { getGradingProvider } from '../../src/matchers/providers';
 import { loadApiProvider } from '../../src/providers/index';
 import { createMockProvider } from '../factories/provider';
@@ -9,6 +10,7 @@ vi.mock('../../src/providers', () => ({
 }));
 
 vi.mock('../../src/cliState');
+vi.mock('../../src/logger');
 
 describe('getGradingProvider', () => {
   const mockProvider = createMockProvider();
@@ -145,6 +147,45 @@ describe('getGradingProvider', () => {
         basePath: undefined,
       });
       expect(result).toBe(azureProvider);
+    });
+
+    it('should warn when defaultTest.provider implicitly selects the same grading provider', async () => {
+      const targetProvider = createMockProvider({ id: 'openai:gpt-4.1' });
+
+      (cliState as any).config = {
+        defaultTest: {
+          provider: 'openai:gpt-4.1',
+        },
+      };
+
+      vi.mocked(loadApiProvider).mockResolvedValue(targetProvider);
+
+      const result = await getGradingProvider('text', undefined, null);
+
+      expect(result).toBe(targetProvider);
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[Grading] defaultTest.provider is being used as the grader because no explicit grader is configured',
+        {
+          providerId: 'openai:gpt-4.1',
+        },
+      );
+    });
+
+    it('should not warn when an explicit provider selects the grader', async () => {
+      const graderProvider = createMockProvider({ id: 'openai:gpt-5.6' });
+
+      (cliState as any).config = {
+        defaultTest: {
+          provider: 'openai:gpt-4.1',
+        },
+      };
+
+      vi.mocked(loadApiProvider).mockResolvedValue(graderProvider);
+
+      const result = await getGradingProvider('text', 'openai:gpt-5.6', null);
+
+      expect(result).toBe(graderProvider);
+      expect(logger.warn).not.toHaveBeenCalled();
     });
 
     it('should skip defaultTest.provider when it is promptfoo:simulated-user', async () => {


### PR DESCRIPTION
## Summary
- Warn when model-graded assertions implicitly use `defaultTest.provider` as the grader because no explicit grader was configured.
- Keep the existing fallback order intact for backwards compatibility.
- Document that `defaultTest.provider` can become the implicit grader and may make the target grade itself.

## Why
`defaultTest.provider` is primarily the test target override, but today it is also used as a grader fallback. That can make the target model generate and grade the same output with only a debug log, so users may miss a self-grading setup in CI or normal eval output.

Fixes #10581

## Validation
- `npx vitest run test/matchers/getGradingProvider.test.ts` initially failed on the new warning assertion before the implementation change.
- `npx vitest run test/matchers/getGradingProvider.test.ts test/matchers/utils.test.ts`
- `npx @biomejs/biome check src/matchers/providers.ts test/matchers/getGradingProvider.test.ts`
- `npx prettier --check site/docs/configuration/expected-outputs/model-graded/index.md`
- `git diff --check`

## Notes
- `npm run tsc` still fails locally on the existing optional `@openai/codex-security` import/type errors in `src/providers/openai/codex-security.ts`; this branch does not touch that provider.
