### PR TITLE
fix(matchers): mark grader failures in factuality checks

### DIFF
--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -27,7 +27,7 @@ import {
   renderLlmRubricPrompt,
   runJsonGradingPrompt,
 } from './rubric';
-import { fail, graderFail, normalizeMatcherTokenUsage, tryParse } from './shared';
+import { graderFail, normalizeMatcherTokenUsage, tryParse } from './shared';
 
 import type {
   Assertion,
@@ -337,7 +337,7 @@ export async function matchesFactuality(
     providerCallContext,
   );
   if (resp.error || !resp.output) {
-    return fail(resp.error || 'No output', resp.tokenUsage);
+    return graderFail(resp.error || 'No output', resp.tokenUsage);
   }
 
   invariant(typeof resp.output === 'string', 'factuality produced malformed response');
@@ -348,7 +348,7 @@ export async function matchesFactuality(
       return buildFactualityResult(parsedJson.option, parsedJson.reason, grading, resp);
     }
   } catch (err) {
-    return fail((err as Error).message, resp.tokenUsage);
+    return graderFail((err as Error).message, resp.tokenUsage);
   }
 
   // Fallback to old pattern matching format
@@ -357,7 +357,7 @@ export async function matchesFactuality(
     const parsedLegacy = parseLegacyFactualityResponse(resp.output);
     return buildFactualityResult(parsedLegacy.option, parsedLegacy.reason, grading, resp);
   } catch (err) {
-    return fail((err as Error).message, resp.tokenUsage);
+    return graderFail((err as Error).message, resp.tokenUsage);
   }
 }
 
@@ -395,7 +395,7 @@ export async function matchesClosedQa(
     providerCallContext,
   );
   if (resp.error || !resp.output) {
-    return fail(resp.error || 'No output', resp.tokenUsage);
+    return graderFail(resp.error || 'No output', resp.tokenUsage);
   }
 
   invariant(typeof resp.output === 'string', 'model-graded-closedqa produced malformed response');
@@ -407,7 +407,10 @@ export async function matchesClosedQa(
     } else if (resp.output.trimEnd().endsWith('N')) {
       reason = `The submission does not meet the criterion:\n${resp.output}`;
     } else {
-      reason = `Model grader produced a malformed response:\n${resp.output}`;
+      return graderFail(
+        `Model grader produced a malformed response:\n${resp.output}`,
+        resp.tokenUsage,
+      );
     }
     return {
       pass,
@@ -416,7 +419,7 @@ export async function matchesClosedQa(
       tokensUsed: normalizeMatcherTokenUsage(resp.tokenUsage),
     };
   } catch (err) {
-    return fail(`Error parsing output: ${(err as Error).message}`, resp.tokenUsage);
+    return graderFail(`Error parsing output: ${(err as Error).message}`, resp.tokenUsage);
   }
 }
 

--- a/test/matchers/closed-qa.test.ts
+++ b/test/matchers/closed-qa.test.ts
@@ -74,6 +74,64 @@ describe('matchesClosedQa', () => {
     });
   });
 
+  it('should mark provider errors as grader failures', async () => {
+    const input = 'Input text';
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const grading = {};
+
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
+      error: 'grader provider unavailable',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    await expect(matchesClosedQa(input, expected, output, grading)).resolves.toMatchObject({
+      pass: false,
+      score: 0,
+      reason: 'grader provider unavailable',
+      metadata: { graderError: true },
+    });
+  });
+
+  it('should mark missing grader output as a grader failure', async () => {
+    const input = 'Input text';
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const grading = {};
+
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
+      output: '',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    await expect(matchesClosedQa(input, expected, output, grading)).resolves.toMatchObject({
+      pass: false,
+      score: 0,
+      reason: 'No output',
+      metadata: { graderError: true },
+    });
+  });
+
+  it('should mark malformed grader output as a grader failure', async () => {
+    const input = 'Input text';
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const grading = {};
+
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValueOnce({
+      output: 'the grader did not answer with yes or no',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    await expect(matchesClosedQa(input, expected, output, grading)).resolves.toMatchObject({
+      pass: false,
+      score: 0,
+      reason:
+        'Model grader produced a malformed response:\nthe grader did not answer with yes or no',
+      metadata: { graderError: true },
+    });
+  });
+
   it('should throw an error when an error occurs', async () => {
     const input = 'Input text';
     const expected = 'Expected output';

--- a/test/matchers/factuality.test.ts
+++ b/test/matchers/factuality.test.ts
@@ -153,6 +153,44 @@ describe('matchesFactuality', () => {
     });
   });
 
+  it('should mark provider errors as grader failures', async () => {
+    const input = 'Input text';
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const grading = {};
+
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValue({
+      error: 'grader provider unavailable',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    await expect(matchesFactuality(input, expected, output, grading)).resolves.toMatchObject({
+      pass: false,
+      score: 0,
+      reason: 'grader provider unavailable',
+      metadata: { graderError: true },
+    });
+  });
+
+  it('should mark missing grader output as a grader failure', async () => {
+    const input = 'Input text';
+    const expected = 'Expected output';
+    const output = 'Sample output';
+    const grading = {};
+
+    vi.spyOn(DefaultGradingProvider, 'callApi').mockResolvedValue({
+      output: '',
+      tokenUsage: { total: 10, prompt: 5, completion: 5 },
+    });
+
+    await expect(matchesFactuality(input, expected, output, grading)).resolves.toMatchObject({
+      pass: false,
+      score: 0,
+      reason: 'No output',
+      metadata: { graderError: true },
+    });
+  });
+
   it('should use the overridden factuality grading config', async () => {
     const input = 'Input text';
     const expected = 'Expected output';
@@ -214,7 +252,7 @@ describe('matchesFactuality', () => {
     });
   });
 
-  it('should fail when JSON has invalid category', async () => {
+  it('should mark JSON with an invalid category as a grader failure', async () => {
     const input = 'Input text';
     const expected = 'Expected output';
     const output = 'Sample output';
@@ -231,6 +269,7 @@ describe('matchesFactuality', () => {
       pass: false,
       score: 0,
       reason: 'Invalid category value: Z',
+      metadata: { graderError: true },
       tokensUsed: expect.objectContaining({
         total: expect.any(Number),
         prompt: expect.any(Number),


### PR DESCRIPTION
Fixes #10481

## Summary
- use existing `graderFail` semantics when factuality and closed-QA grading providers return errors or no output
- mark malformed factuality / closed-QA grader responses with `metadata.graderError=true`
- keep valid semantic failures (`D` / `N`) as ordinary assertion failures

## Tests
- RED first: `npx vitest run test/matchers/factuality.test.ts test/matchers/closed-qa.test.ts` failed on the new `metadata.graderError` expectations
- `npx vitest run test/matchers/factuality.test.ts test/matchers/closed-qa.test.ts`
- `npx vitest run test/matchers/factuality.test.ts test/matchers/closed-qa.test.ts test/matchers/utils.test.ts test/assertions/modelGradedClosedQa.test.ts test/assertions/contextPropagation.test.ts`
- `npx @biomejs/biome check src/matchers/llmGrading.ts test/matchers/factuality.test.ts test/matchers/closed-qa.test.ts`
- `git diff --check`
- E2E: ran `npm run local -- eval ... --no-cache -o /tmp/promptfoo-grader-failure-metadata.json` against a temporary local config with a malformed `exec` grader; exported JSON showed both `factuality` and `model-graded-closedqa` component results include `metadata.graderError=true`

`npm run tsc` still fails on existing optional `@openai/codex-security` import/type errors in `src/providers/openai/codex-security.ts`, unrelated to this matcher diff.