### PR TITLE
fix(providers): apply normalized Envoy base URL after user config spread

### DIFF
--- a/src/providers/envoy.ts
+++ b/src/providers/envoy.ts
@@ -60,10 +60,10 @@ export function createEnvoyProvider(
   const envoyConfig = {
     ...options,
     config: {
-      apiBaseUrl: normalizedBaseUrl,
-      // Authentication is optional and depends on gateway configuration
-      // Users can specify apiKey, headers, or other auth in their config
       ...configWithoutBasePath,
+      // Keep the normalized URL last so a raw apiBaseUrl from the user's
+      // config cannot overwrite it (it may lack the /v1 suffix).
+      apiBaseUrl: normalizedBaseUrl,
     },
   };
 


### PR DESCRIPTION
## Description

In `createEnvoyProvider`, the user's inner config (minus `basePath`) was spread **after** the normalized base URL:

```ts
config: {
  apiBaseUrl: normalizedBaseUrl,
  ...configWithoutBasePath,   // re-overwrites apiBaseUrl when set via config
}
```

`configWithoutBasePath` still carries a raw `apiBaseUrl` when one was supplied via `config`, so the `/v1` normalization only ever applied to the `ENVOY_API_BASE_URL` env path. With `envoy:<model>` + `config: { apiBaseUrl: "https://gw.example.com" }`, `OpenAiChatCompletionProvider.getApiUrl()` returned the raw URL and requests went to `/chat/completions` instead of `/v1/chat/completions`.

The fix spreads the user config first and applies `apiBaseUrl: normalizedBaseUrl` last, matching the key ordering used by the Cerebras provider (`src/providers/cerebras.ts`).

## Before/after semantics (verified with a standalone node script)

```js
// before: { apiBaseUrl: normalized, ...userCfg }  -> 'https://gw.example.com'      (raw, no /v1)
// after:  { ...userCfg, apiBaseUrl: normalized }  -> 'https://gw.example.com/v1'
```

No test file exists for the envoy provider (`test/` has none); the diff is a two-line spread reorder.

## Notes

- No existing test pins the old ordering (`grep -r envoy test/` is empty).
