### PR TITLE
docs(examples): remove nonexistent embeddings example from xAI README

### DIFF
--- a/examples/xai/README.md
+++ b/examples/xai/README.md
@@ -5,6 +5,5 @@ Examples for using promptfoo with [xAI's Grok](https://x.ai/) models.
 ## Examples
 
 - [chat](./chat/) - Text generation and reasoning with Grok models
-- [embeddings](./embeddings/) - Semantic similarity with xAI embeddings
 - [video](./video/) - Video generation with Grok Imagine
 - [voice](./voice/) - Real-time voice conversations with Grok Voice Agent


### PR DESCRIPTION
The xAI examples README listed a `./embeddings/` example directory that does not exist in the repo (only `chat/`, `video/`, `voice/` — xAI's API has no embeddings endpoint), so the link 404'd on GitHub. Removed the bullet.

Note for the record: this PR originally also changed the HLE guide's model-grading link, but the Build Docs check proved that link was already correct — Docusaurus resolves non-`.md` relative links against the page's route directory (`/docs/guides/hle-benchmark/`), so the original `../../` base was right. Reverted that part; the check now covers only this one-line README fix.