### PR TITLE
fix(assertions): render file-loaded model rubrics

### DIFF
--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -311,6 +311,8 @@ The `value` of an assertion can be loaded directly from a file using the `file:/
       value: file://gettysburg_address.txt
 ```
 
+For deterministic assertions such as `equals` and `contains`, loaded file contents are compared as literal text. For model-graded assertions such as `llm-rubric`, `factuality`, and `model-graded-closedqa`, loaded string values support the same Nunjucks variables as inline values.
+
 #### Javascript
 
 If the file ends in `.js`, the Javascript is executed:

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -86,6 +86,22 @@ tests:
       question: How many planets are in our solar system?
 ```
 
+Rubrics loaded from text files are also rendered with test variables:
+
+```yaml
+tests:
+  - vars:
+      topic: capybaras
+    assert:
+      - type: llm-rubric
+        value: file://rubric.txt
+```
+
+```txt title="rubric.txt"
+Fail unless the output mentions "{{topic}}".
+Start your reason with: GOT=[{{topic}}]
+```
+
 ## Overriding the LLM grader
 
 By default, `llm-rubric` uses `gpt-5` for grading. You can override this in several ways:

--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -477,6 +477,7 @@ async function runAssertionInternal({
   type ValueFromScriptType = string | boolean | number | GradingResult | object | undefined;
   let renderedValue = assertion.value;
   let valueFromScript: ValueFromScriptType;
+  const baseType = getAssertionBaseType(assertion);
   if (typeof renderedValue === 'string') {
     if (renderedValue.startsWith('file://')) {
       const basePath = cliState.basePath || '';
@@ -532,6 +533,9 @@ async function runAssertionInternal({
         }
       } else {
         renderedValue = processFileReference(renderedValue);
+        if (typeof renderedValue === 'string' && MODEL_GRADED_ASSERTION_TYPES.has(baseType)) {
+          renderedValue = nunjucks.renderString(renderedValue, resolvedVars);
+        }
       }
     } else if (isPackagePath(renderedValue)) {
       const basePath = cliState.basePath || '';
@@ -552,7 +556,11 @@ async function runAssertionInternal({
     renderedValue = renderedValue.map((v) => {
       if (typeof v === 'string') {
         if (v.startsWith('file://')) {
-          return processFileReference(v);
+          const fileValue = processFileReference(v);
+          if (typeof fileValue === 'string' && MODEL_GRADED_ASSERTION_TYPES.has(baseType)) {
+            return nunjucks.renderString(fileValue, resolvedVars);
+          }
+          return fileValue;
         }
         return nunjucks.renderString(v, resolvedVars);
       }
@@ -564,7 +572,6 @@ async function runAssertionInternal({
   // Script assertion types (javascript, python, ruby) interpret renderedValue as code to execute
   // All other types should use the script output as the comparison value
   const SCRIPT_RESULT_ASSERTIONS = new Set(['javascript', 'python', 'ruby']);
-  const baseType = getAssertionBaseType(assertion);
 
   if (valueFromScript !== undefined && !SCRIPT_RESULT_ASSERTIONS.has(baseType)) {
     // Validate the script result type - only javascript/python/ruby can return functions

--- a/test/assertions/runAssertion.test.ts
+++ b/test/assertions/runAssertion.test.ts
@@ -3732,6 +3732,28 @@ describe('runAssertion', () => {
       expect(result.pass).toBe(true);
     });
 
+    it('should preserve template text in non-model-graded file references', async () => {
+      const assertion: Assertion = {
+        type: 'equals',
+        value: 'file://expected_output.txt',
+      };
+
+      vi.mocked(fs.readFileSync).mockReturnValue('Expected {{topic}}');
+      vi.mocked(path.resolve).mockReturnValue('/base/path/expected_output.txt');
+      vi.mocked(path.extname).mockReturnValue('.txt');
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Some prompt',
+        provider: new OpenAiChatCompletionProvider('gpt-4o-mini'),
+        assertion,
+        test: { vars: { topic: 'capybaras' } } as AtomicTestCase,
+        providerResponse: { output: 'Expected {{topic}}' },
+      });
+
+      expect(result.pass).toBe(true);
+      expect(result.metadata?.renderedAssertionValue).toBe('Expected {{topic}}');
+    });
+
     it('should handle file references in array values', async () => {
       const assertion: Assertion = {
         type: 'contains-any',
@@ -3799,6 +3821,44 @@ describe('runAssertion', () => {
 
       expect(fs.readFileSync).toHaveBeenCalledWith('/base/path/schema.json', 'utf8');
       expect(result.pass).toBe(true);
+    });
+
+    it('should render llm-rubric file references before calling the grader', async () => {
+      const capturedPrompt = vi.fn<ApiProvider['callApi']>(async () => ({
+        output: JSON.stringify({ pass: true, score: 1, reason: 'graded' }),
+      }));
+      const capturingGrader = createMockProvider({
+        id: 'capturing-grader',
+        callApi: capturedPrompt,
+      });
+
+      const assertion: Assertion = {
+        type: 'llm-rubric',
+        value: 'file://rubric.txt',
+        provider: capturingGrader,
+      };
+
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        'Fail unless the output mentions "{{topic}}". Start your reason with: GOT=[{{topic}}]',
+      );
+      vi.mocked(path.resolve).mockReturnValue('/base/path/rubric.txt');
+      vi.mocked(path.extname).mockReturnValue('.txt');
+
+      const result: GradingResult = await runAssertion({
+        prompt: 'Some prompt',
+        assertion,
+        test: { vars: { topic: 'capybaras' } } as AtomicTestCase,
+        providerResponse: { output: 'static model output' },
+        provider: new OpenAiChatCompletionProvider('gpt-4o-mini'),
+      });
+
+      const gradingPrompt = capturedPrompt.mock.calls[0]?.[0] as string;
+      expect(gradingPrompt).toContain('GOT=[capybaras]');
+      expect(gradingPrompt).not.toContain('{{topic}}');
+
+      expect(result.metadata?.renderedAssertionValue).toBe(
+        'Fail unless the output mentions "capybaras". Start your reason with: GOT=[capybaras]',
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #10447

## Summary
- render `file://` string assertion values with Nunjucks for model-graded assertion types before calling the grader
- preserve literal `file://` behavior for deterministic assertions like `equals` / `contains`
- document the file-loaded rubric behavior in the expected outputs docs and `llm-rubric` page

This is the behavior fix for #10447. It is intentionally scoped differently from #10448, which is warning-only diagnostic coverage for still-unrendered file-loaded templates.

## Tests
- RED first: `npx vitest run test/assertions/runAssertion.test.ts -t "render llm-rubric file references"` showed the grader prompt still contained `{{topic}}`
- `npx vitest run test/assertions/runAssertion.test.ts -t "file references"`
- `npx vitest run test/assertions/runAssertion.test.ts`
- `npx @biomejs/biome check src/assertions/index.ts test/assertions/runAssertion.test.ts` (passes with the existing `runAssertionInternal` complexity warning)
- `npx prettier --check site/docs/configuration/expected-outputs/index.md site/docs/configuration/expected-outputs/model-graded/llm-rubric.md`
- `git diff --check`
- E2E: `npm run local -- eval -c /tmp/promptfoo-file-rubric-rendering/promptfooconfig.yaml --no-cache -o /tmp/promptfoo-file-rubric-rendering/result.json` with an `echo` target and local `exec` grader; captured grader prompt contained `GOT=[capybaras]` and did not contain `{{topic}}`

`npm run tsc` still fails on existing optional `@openai/codex-security` import/type errors in `src/providers/openai/codex-security.ts`, unrelated to this assertion diff.