### PR TITLE
fix: guard empty drift stats and clarify provider options

### DIFF
--- a/site/docs/red-team/model-drift.md
+++ b/site/docs/red-team/model-drift.md
@@ -100,7 +100,7 @@ jobs:
       - name: Check for regressions
         run: |
           # Extract attack success rate
-          ASR=$(jq '.results.stats.failures / (.results.stats.successes + .results.stats.failures) * 100' results.json)
+          ASR=$(jq 'if (.results.stats.successes + .results.stats.failures) == 0 then 0 else .results.stats.failures / (.results.stats.successes + .results.stats.failures) * 100 end' results.json)
           echo "Attack Success Rate: ${ASR}%"
 
           # Fail if ASR exceeds threshold
@@ -210,7 +210,7 @@ Custom tests provide deterministic pass/fail results that are easy to track:
 
 ```bash
 # Extract pass rate
-PASS_RATE=$(jq '.results.stats.successes / (.results.stats.successes + .results.stats.failures) * 100' results.json)
+PASS_RATE=$(jq 'if (.results.stats.successes + .results.stats.failures) == 0 then 0 else .results.stats.successes / (.results.stats.successes + .results.stats.failures) * 100 end' results.json)
 echo "Pass rate: ${PASS_RATE}%"
 
 # Fail CI if pass rate drops below threshold
@@ -252,7 +252,7 @@ jobs:
 
 ```bash
 # Extract ASR from results
-jq '.results.stats.failures / (.results.stats.successes + .results.stats.failures) * 100' results.json
+jq 'if (.results.stats.successes + .results.stats.failures) == 0 then 0 else .results.stats.failures / (.results.stats.successes + .results.stats.failures) * 100 end' results.json
 ```
 
 **Category-level changes**: Track ASR per vulnerability category to identify which defenses are drifting:
@@ -279,7 +279,7 @@ Define acceptable drift thresholds in your CI scripts:
 
 ```bash
 # Example threshold check in CI
-ASR=$(jq '.results.stats.failures / (.results.stats.successes + .results.stats.failures) * 100' results.json)
+ASR=$(jq 'if (.results.stats.successes + .results.stats.failures) == 0 then 0 else .results.stats.failures / (.results.stats.successes + .results.stats.failures) * 100 end' results.json)
 
 # Block deployment if ASR exceeds 15%
 if (( $(echo "$ASR > 15" | bc -l) )); then

--- a/src/providers/abliteration.ts
+++ b/src/providers/abliteration.ts
@@ -92,6 +92,8 @@ export class AbliterationProvider extends OpenAiChatCompletionProvider {
 export function createAbliterationProvider(
   providerPath: string,
   options: {
+    providerOptions?: ProviderOptions;
+    /** @deprecated Use `providerOptions` instead. */
     config?: ProviderOptions;
     id?: string;
     env?: EnvOverrides;
@@ -106,7 +108,7 @@ export function createAbliterationProvider(
     );
   }
 
-  const providerOptions = options.config || {};
+  const providerOptions = options.providerOptions ?? options.config ?? {};
 
   return new AbliterationProvider(modelName, {
     ...providerOptions,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -159,7 +159,7 @@ export const providerMap: ProviderFactory[] = [
       context: LoadApiProviderContext,
     ) => {
       return createAbliterationProvider(providerPath, {
-        config: providerOptions,
+        providerOptions,
         env: context.env,
       });
     },

--- a/test/providers/abliteration.test.ts
+++ b/test/providers/abliteration.test.ts
@@ -481,6 +481,20 @@ describe('AbliterationProvider', () => {
 });
 
 describe('createAbliterationProvider', () => {
+  it('accepts providerOptions while preserving the legacy config argument', () => {
+    const options = { config: { apiKey: 'preferred-key' } };
+    const preferred = createAbliterationProvider('abliteration:model', {
+      providerOptions: options,
+      config: { config: { apiKey: 'legacy-key' } },
+    }) as AbliterationProvider;
+    const legacy = createAbliterationProvider('abliteration:model', {
+      config: options,
+    }) as AbliterationProvider;
+
+    expect(preferred.getApiKey()).toBe('preferred-key');
+    expect(legacy.getApiKey()).toBe('preferred-key');
+  });
+
   it('creates a provider from the default syntax', () => {
     const provider = createAbliterationProvider('abliteration:abliterated-model');
 

--- a/test/providers/mcp/transform.test.ts
+++ b/test/providers/mcp/transform.test.ts
@@ -261,6 +261,22 @@ describe('transformMCPConfigToClaudeCode', () => {
     ).resolves.toEqual({});
   });
 
+  it('uses the singular server when it shares a key with a plural server', async () => {
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        server: { name: 'shared', command: 'single-server' },
+        servers: [{ name: 'shared', command: 'plural-server' }],
+      }),
+    ).resolves.toEqual({ shared: { type: 'stdio', command: 'single-server', args: [] } });
+  });
+
+  it('rejects a server without a URL, command, or path', async () => {
+    await expect(transformMCPConfigToClaudeCode({ enabled: true, server: {} })).rejects.toThrow(
+      'MCP configuration cannot be converted to Claude Agent SDK MCP server config',
+    );
+  });
+
   it('rejects unsupported tool filters instead of silently dropping them', async () => {
     await expect(
       transformMCPConfigToClaudeCode({


### PR DESCRIPTION
## Summary

- Guard four ASR/pass-rate examples against empty result sets so the sample CI comparisons receive numeric values.
- Introduce the clearer `providerOptions` argument for Abliteration factory calls, update registry usage, and retain the legacy `config` alias for callers.
- Cover last-wins MCP server-key collisions and the empty-server conversion error.

This addresses all 4 AI findings visible in 3 files on the GitHub Security AI findings page on September 4. The separate open MCP transform PR #10634 covers different cases (env omission and non-colliding singular/plural merge).

## Validation

- `npx vitest run test/providers/abliteration.test.ts test/providers/mcp/transform.test.ts test/providers/index.test.ts` — 268 passed
- `npm run tsc` — passed with clean lockfile dependencies
- `npm run f && npm run l` — passed; existing registry complexity warning
- `SKIP_OG_GENERATION=true npm run build` in `site/` — passed
- Checked jq expressions against empty and 1-in-4 result counts (0 and 25)
