### PR TITLE
fix(providers): allow zero-argument MCP commands

### DIFF
--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -147,14 +147,14 @@ export class MCPClient {
 
     // Initialize servers
     const servers = this.config.servers || (this.config.server ? [this.config.server] : []);
-    for (const [index, server] of servers.entries()) {
-      // Unnamed command servers may run the same executable with different env/args.
-      // Give each one a distinct map key so both connections can be used and closed.
-      const serverKey =
-        server.name ||
-        server.url ||
-        server.path ||
-        (server.command ? `${server.command}:${index}` : 'default');
+    const usedKeys = new Set(this.clients.keys());
+    for (const server of servers) {
+      const baseKey = server.name || server.url || server.path || server.command || 'default';
+      let serverKey = baseKey;
+      for (let suffix = 1; usedKeys.has(serverKey); suffix++) {
+        serverKey = `${baseKey}:${suffix}`;
+      }
+      usedKeys.add(serverKey);
       logger.info(`connecting to server ${serverKey}`);
       await this.connectToServer(server, serverKey);
     }
@@ -434,7 +434,7 @@ export class MCPClient {
     this.transports.delete(serverKey);
 
     // Reconnect with fresh token
-    await this.connectToServer(oauthConfig.serverConfig);
+    await this.connectToServer(oauthConfig.serverConfig, serverKey);
     logger.debug(`[MCP] Successfully refreshed OAuth token for server ${serverKey}`);
   }
 

--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -166,12 +166,12 @@ export class MCPClient {
     try {
       const requestOptions = getEffectiveRequestOptions(this.config);
 
-      if (server.command && server.args) {
+      if (server.command) {
         const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
         // NPM package or other command execution
         transport = new StdioClientTransport({
           command: server.command,
-          args: server.args,
+          args: server.args ?? [],
           env: getStdioEnv(server),
         });
         await client.connect(transport, requestOptions);
@@ -273,7 +273,7 @@ export class MCPClient {
           logger.debug('Connected using SSE transport');
         }
       } else {
-        throw new Error('Either command+args or path or url must be specified for MCP server');
+        throw new Error('Either command or path or url must be specified for MCP server');
       }
 
       // Ping server to verify connection if configured

--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -147,14 +147,23 @@ export class MCPClient {
 
     // Initialize servers
     const servers = this.config.servers || (this.config.server ? [this.config.server] : []);
-    for (const server of servers) {
-      logger.info(`connecting to server ${server.name || server.url || server.path || 'default'}`);
-      await this.connectToServer(server);
+    for (const [index, server] of servers.entries()) {
+      // Unnamed command servers may run the same executable with different env/args.
+      // Give each one a distinct map key so both connections can be used and closed.
+      const serverKey =
+        server.name ||
+        server.url ||
+        server.path ||
+        (server.command ? `${server.command}:${index}` : 'default');
+      logger.info(`connecting to server ${serverKey}`);
+      await this.connectToServer(server, serverKey);
     }
   }
 
-  private async connectToServer(server: MCPServerConfig): Promise<void> {
-    const serverKey = server.name || server.url || server.path || 'default';
+  private async connectToServer(
+    server: MCPServerConfig,
+    serverKey = server.name || server.url || server.path || 'default',
+  ): Promise<void> {
     const { Client } = await loadMcpClientSdk();
     const client = new Client({
       name: 'promptfoo-MCP',

--- a/test/providers/mcp/client.test.ts
+++ b/test/providers/mcp/client.test.ts
@@ -213,6 +213,23 @@ describe('MCPClient', () => {
       expect(mcpClient.hasInitialized).toBe(false);
     });
 
+    it('should initialize a zero-argument command server with its configured env', async () => {
+      mcpClient = new MCPClient({
+        enabled: true,
+        server: { command: 'mcp-server', env: { MCP_MODE: 'test' } },
+      });
+
+      await mcpClient.initialize();
+
+      expect(StdioClientTransport).toHaveBeenCalledWith({
+        command: 'mcp-server',
+        args: [],
+        env: { ...process.env, MCP_MODE: 'test' },
+      });
+      expect(mcpClient.hasInitialized).toBe(true);
+      await mcpClient.cleanup();
+    });
+
     it('should initialize with per-server env merged into process.env', async () => {
       mockClient.connect.mockResolvedValueOnce(undefined);
       mockClient.listTools.mockResolvedValueOnce({

--- a/test/providers/mcp/client.test.ts
+++ b/test/providers/mcp/client.test.ts
@@ -230,6 +230,34 @@ describe('MCPClient', () => {
       await mcpClient.cleanup();
     });
 
+    it('keeps unnamed zero-argument command servers distinct', async () => {
+      mockClient.listTools
+        .mockResolvedValueOnce({
+          tools: [{ name: 'first_tool', description: '', inputSchema: {} }],
+        })
+        .mockResolvedValueOnce({
+          tools: [{ name: 'second_tool', description: '', inputSchema: {} }],
+        });
+
+      mcpClient = new MCPClient({
+        enabled: true,
+        servers: [
+          { command: 'mcp-server', env: { MCP_MODE: 'first' } },
+          { command: 'mcp-server', env: { MCP_MODE: 'second' } },
+        ],
+      });
+
+      await mcpClient.initialize();
+
+      expect(mcpClient.connectedServers).toHaveLength(2);
+      expect(mcpClient.getAllTools().map((tool) => tool.name)).toEqual([
+        'first_tool',
+        'second_tool',
+      ]);
+      await mcpClient.cleanup();
+      expect(mockClient.close).toHaveBeenCalledTimes(2);
+    });
+
     it('should initialize with per-server env merged into process.env', async () => {
       mockClient.connect.mockResolvedValueOnce(undefined);
       mockClient.listTools.mockResolvedValueOnce({

--- a/test/providers/mcp/client.test.ts
+++ b/test/providers/mcp/client.test.ts
@@ -258,6 +258,19 @@ describe('MCPClient', () => {
       expect(mockClient.close).toHaveBeenCalledTimes(2);
     });
 
+    it('does not overwrite an explicitly named server with a generated command key', async () => {
+      mcpClient = new MCPClient({
+        enabled: true,
+        servers: [{ name: 'mcp-server:1', command: 'mcp-server' }, { command: 'mcp-server' }],
+      });
+
+      await mcpClient.initialize();
+
+      expect(mcpClient.connectedServers).toHaveLength(2);
+      await mcpClient.cleanup();
+      expect(mockClient.close).toHaveBeenCalledTimes(2);
+    });
+
     it('should initialize with per-server env merged into process.env', async () => {
       mockClient.connect.mockResolvedValueOnce(undefined);
       mockClient.listTools.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

- Connect stdio MCP servers with `command` and no `args`, passing an empty argument list and preserving the server's environment overrides.
- Keep distinct keys for unnamed commands and resolve collisions with explicitly named, URL-based, or path-based servers. Preserve the resolved key during OAuth reconnects so tools and cleanup continue to target the right connection.

## Reproduction and validation

Three focused regressions failed before their respective fixes: zero-argument commands failed initialization; two unnamed commands sharing an executable overwrote the first connection; and a generated command key collided with an explicit server name.

- `npx vitest run test/providers/mcp/client.test.ts test/providers/mcp/transform.test.ts --sequence.shuffle=false`: 102 passed.
- `npm run tsc`, `npm run l`, `npm run f`, `git diff --check`: passed. The full `npm run build` passed after the initial command fix; subsequent connection-key changes passed type checking and focused tests.
- `npm run local -- eval -c /private/tmp/promptfoo-mcp-zeroargs-config.yaml --no-cache -o /private/tmp/promptfoo-mcp-zeroargs-output.json`: passed on the final code against a real zero-argument executable MCP server. The exported result had `success: true`, `score: 1`, no error, and the configured `MCP_MODE` value. Temporary fixture paths are local and are not part of the PR.
