### PR TITLE
feat(assertions): filter trace spans by attributes

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -72,7 +72,7 @@ These metrics are created by logical tests that are run on LLM output.
 | [select-best](#select-best)                                     | Output is selected as best among multiple outputs                  |
 | [similar](#similar)                                             | Embedding similarity is above threshold                            |
 | [starts-with](#starts-with)                                     | output starts with string                                          |
-| [trace-span-count](#trace-span-count)                           | Count spans matching patterns with min/max thresholds              |
+| [trace-span-count](#trace-span-count)                           | Count spans matching names and attributes with min/max thresholds  |
 | [trace-span-duration](#trace-span-duration)                     | Check span durations with percentile support                       |
 | [trace-error-spans](#trace-error-spans)                         | Detect errors in traces by status codes, attributes, and messages  |
 | [webhook](#webhook)                                             | provided webhook returns \{pass: true\}                            |
@@ -1106,6 +1106,26 @@ Common patterns:
 - `api.*` - Matches spans starting with "api."
 - `*.error` - Matches spans ending with ".error"
 
+All three trace assertions also accept an optional `attributes` object. Use it when different tools or agents emit the same span name:
+
+```yaml
+assert:
+  - type: trace-span-count
+    value:
+      pattern: '*'
+      attributes:
+        gen_ai.tool.name: search
+      min: 1
+      max: 3
+  - type: trace-span-duration
+    value:
+      attributes:
+        gen_ai.tool.name: search
+      max: 2000
+```
+
+A span must match both `pattern` and every attribute. Attribute keys are literal, including dots; values use case-sensitive exact equality without glob matching or type conversion. Values must be strings, booleans, or finite numbers. Missing attributes do not match, while an empty object adds no restriction. Duration percentiles and error percentages use only the selected spans. If matching spans must exist, include a `trace-span-count` assertion with `min: 1`; duration and error assertions retain their existing behavior when no spans match.
+
 ### Trace-Span-Duration
 
 The `trace-span-duration` assertion checks if span durations in a trace are within acceptable limits. It can check individual spans or percentiles across all matching spans.
@@ -1140,6 +1160,7 @@ assert:
 Key features:
 
 - `pattern` (optional): Filter spans by name pattern. Defaults to `*` (all spans)
+- `attributes` (optional): Filter by exact span attributes, as described under [Trace-Span-Count](#trace-span-count)
 - `max`: Maximum allowed duration in milliseconds
 - `percentile` (optional): Check percentile instead of all spans (e.g., 50 for median, 95 for 95th percentile). Must be a number from 0 to 100 inclusive; out-of-range values cause an assertion error. Use the 0-100 scale, not 0-1 — `0.95` is accepted as the 0.95th percentile (effectively the fastest span), not p95
 
@@ -1190,6 +1211,7 @@ Configuration options:
 - `max_count`: Maximum number of error spans allowed
 - `max_percentage`: Maximum error rate as a percentage (0-100)
 - `pattern`: Filter spans by name pattern
+- `attributes`: Filter by exact span attributes; `max_percentage` uses only the matching spans
 
 The assertion provides detailed error information including span names and error messages to help with debugging.
 

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -113,51 +113,51 @@ tests:
 
 These metrics are programmatic tests that are run on LLM output. [See all details](/docs/configuration/expected-outputs/deterministic)
 
-| Assertion Type                                                                                                     | Returns true if...                                                 |
-| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
-| [equals](/docs/configuration/expected-outputs/deterministic/#equality)                                             | output matches exactly                                             |
-| [contains](/docs/configuration/expected-outputs/deterministic/#contains)                                           | output contains a string or number as text                         |
-| [icontains](/docs/configuration/expected-outputs/deterministic/#contains)                                          | output contains a string or number as text, case insensitive       |
-| [regex](/docs/configuration/expected-outputs/deterministic/#regex)                                                 | output matches regex                                               |
-| [starts-with](/docs/configuration/expected-outputs/deterministic/#starts-with)                                     | output starts with string                                          |
-| [contains-any](/docs/configuration/expected-outputs/deterministic/#contains-any)                                   | output contains any of the listed substrings                       |
-| [contains-all](/docs/configuration/expected-outputs/deterministic/#contains-all)                                   | output contains all list of substrings                             |
-| [icontains-any](/docs/configuration/expected-outputs/deterministic/#contains-any)                                  | output contains any of the listed substrings, case insensitive     |
-| [icontains-all](/docs/configuration/expected-outputs/deterministic/#contains-all)                                  | output contains all list of substrings, case insensitive           |
-| [is-json](/docs/configuration/expected-outputs/deterministic/#is-json)                                             | output is valid json (optional json schema validation)             |
-| [contains-json](/docs/configuration/expected-outputs/deterministic/#contains-json)                                 | output contains valid json (optional json schema validation)       |
-| [contains-html](/docs/configuration/expected-outputs/deterministic/#contains-html)                                 | output contains HTML content                                       |
-| [is-html](/docs/configuration/expected-outputs/deterministic/#is-html)                                             | output is valid HTML                                               |
-| [is-sql](/docs/configuration/expected-outputs/deterministic/#is-sql)                                               | output is a non-empty valid SQL statement                          |
-| [contains-sql](/docs/configuration/expected-outputs/deterministic/#contains-sql)                                   | output is valid SQL or contains a valid SQL code block             |
-| [is-xml](/docs/configuration/expected-outputs/deterministic/#is-xml)                                               | output is a supported well-formed XML document                     |
-| [contains-xml](/docs/configuration/expected-outputs/deterministic/#contains-xml)                                   | output contains valid xml fragment(s)                              |
-| [is-refusal](/docs/configuration/expected-outputs/deterministic/#is-refusal)                                       | output indicates the model refused to perform the task             |
-| [javascript](/docs/configuration/expected-outputs/javascript)                                                      | provided Javascript function validates the output                  |
-| [python](/docs/configuration/expected-outputs/python)                                                              | provided Python function validates the output                      |
-| [ruby](/docs/configuration/expected-outputs/ruby)                                                                  | provided Ruby function validates the output                        |
-| [webhook](/docs/configuration/expected-outputs/deterministic/#webhook)                                             | provided webhook returns \{pass: true\}                            |
-| [rouge-n](/docs/configuration/expected-outputs/deterministic/#rouge-n)                                             | Rouge-N score is above a given threshold (default 0.75)            |
-| [bleu](/docs/configuration/expected-outputs/deterministic/#bleu)                                                   | BLEU score is above a given threshold (default 0.5)                |
-| [gleu](/docs/configuration/expected-outputs/deterministic/#gleu)                                                   | GLEU >= threshold (default 0.5); empty output scores 0             |
-| [levenshtein](/docs/configuration/expected-outputs/deterministic/#levenshtein-distance)                            | Levenshtein distance is below a threshold                          |
-| [latency](/docs/configuration/expected-outputs/deterministic/#latency)                                             | Latency is below a threshold (milliseconds)                        |
-| [meteor](/docs/configuration/expected-outputs/deterministic/#meteor)                                               | METEOR score is above a given threshold (default 0.5)              |
-| [perplexity](/docs/configuration/expected-outputs/deterministic/#perplexity)                                       | Perplexity is below a threshold                                    |
-| [perplexity-score](/docs/configuration/expected-outputs/deterministic/#perplexity-score)                           | Normalized perplexity                                              |
-| [cost](/docs/configuration/expected-outputs/deterministic/#cost)                                                   | Cost is below a threshold (for models with cost info such as GPT)  |
-| [is-valid-function-call](/docs/configuration/expected-outputs/deterministic/#is-valid-function-call)               | Ensure that the function call matches the function's JSON schema   |
-| [is-valid-openai-function-call](/docs/configuration/expected-outputs/deterministic/#is-valid-openai-function-call) | Ensure that the function call matches the function's JSON schema   |
-| [is-valid-openai-tools-call](/docs/configuration/expected-outputs/deterministic/#is-valid-openai-tools-call)       | Ensure all tool calls match the tools JSON schema                  |
-| [trace-span-count](/docs/configuration/expected-outputs/deterministic/#trace-span-count)                           | Count spans matching patterns with min/max thresholds              |
-| [trace-span-duration](/docs/configuration/expected-outputs/deterministic/#trace-span-duration)                     | Check span durations with percentile support                       |
-| [trace-error-spans](/docs/configuration/expected-outputs/deterministic/#trace-error-spans)                         | Detect errors in traces by status codes, attributes, and messages  |
-| [skill-used](/docs/configuration/expected-outputs/deterministic/#skill-used)                                       | Ensure normalized provider skill metadata includes expected skills |
-| [trajectory:tool-used](/docs/configuration/expected-outputs/deterministic/#trajectorytool-used)                    | Ensure a traced agent trajectory used specific tools               |
-| [trajectory:tool-args-match](/docs/configuration/expected-outputs/deterministic/#trajectorytool-args-match)        | Ensure traced tool calls used the expected arguments               |
-| [trajectory:tool-sequence](/docs/configuration/expected-outputs/deterministic/#trajectorytool-sequence)            | Ensure traced tool usage happened in the expected order            |
-| [trajectory:step-count](/docs/configuration/expected-outputs/deterministic/#trajectorystep-count)                  | Count normalized trajectory steps by type or name pattern          |
-| [guardrails](/docs/configuration/expected-outputs/guardrails)                                                      | Evaluate the target's normalized input or output guardrail signal  |
+| Assertion Type                                                                                                     | Returns true if...                                                              |
+| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| [equals](/docs/configuration/expected-outputs/deterministic/#equality)                                             | output matches exactly                                                          |
+| [contains](/docs/configuration/expected-outputs/deterministic/#contains)                                           | output contains a string or number as text                                      |
+| [icontains](/docs/configuration/expected-outputs/deterministic/#contains)                                          | output contains a string or number as text, case insensitive                    |
+| [regex](/docs/configuration/expected-outputs/deterministic/#regex)                                                 | output matches regex                                                            |
+| [starts-with](/docs/configuration/expected-outputs/deterministic/#starts-with)                                     | output starts with string                                                       |
+| [contains-any](/docs/configuration/expected-outputs/deterministic/#contains-any)                                   | output contains any of the listed substrings                                    |
+| [contains-all](/docs/configuration/expected-outputs/deterministic/#contains-all)                                   | output contains all list of substrings                                          |
+| [icontains-any](/docs/configuration/expected-outputs/deterministic/#contains-any)                                  | output contains any of the listed substrings, case insensitive                  |
+| [icontains-all](/docs/configuration/expected-outputs/deterministic/#contains-all)                                  | output contains all list of substrings, case insensitive                        |
+| [is-json](/docs/configuration/expected-outputs/deterministic/#is-json)                                             | output is valid json (optional json schema validation)                          |
+| [contains-json](/docs/configuration/expected-outputs/deterministic/#contains-json)                                 | output contains valid json (optional json schema validation)                    |
+| [contains-html](/docs/configuration/expected-outputs/deterministic/#contains-html)                                 | output contains HTML content                                                    |
+| [is-html](/docs/configuration/expected-outputs/deterministic/#is-html)                                             | output is valid HTML                                                            |
+| [is-sql](/docs/configuration/expected-outputs/deterministic/#is-sql)                                               | output is a non-empty valid SQL statement                                       |
+| [contains-sql](/docs/configuration/expected-outputs/deterministic/#contains-sql)                                   | output is valid SQL or contains a valid SQL code block                          |
+| [is-xml](/docs/configuration/expected-outputs/deterministic/#is-xml)                                               | output is a supported well-formed XML document                                  |
+| [contains-xml](/docs/configuration/expected-outputs/deterministic/#contains-xml)                                   | output contains valid xml fragment(s)                                           |
+| [is-refusal](/docs/configuration/expected-outputs/deterministic/#is-refusal)                                       | output indicates the model refused to perform the task                          |
+| [javascript](/docs/configuration/expected-outputs/javascript)                                                      | provided Javascript function validates the output                               |
+| [python](/docs/configuration/expected-outputs/python)                                                              | provided Python function validates the output                                   |
+| [ruby](/docs/configuration/expected-outputs/ruby)                                                                  | provided Ruby function validates the output                                     |
+| [webhook](/docs/configuration/expected-outputs/deterministic/#webhook)                                             | provided webhook returns \{pass: true\}                                         |
+| [rouge-n](/docs/configuration/expected-outputs/deterministic/#rouge-n)                                             | Rouge-N score is above a given threshold (default 0.75)                         |
+| [bleu](/docs/configuration/expected-outputs/deterministic/#bleu)                                                   | BLEU score is above a given threshold (default 0.5)                             |
+| [gleu](/docs/configuration/expected-outputs/deterministic/#gleu)                                                   | GLEU >= threshold (default 0.5); empty output scores 0                          |
+| [levenshtein](/docs/configuration/expected-outputs/deterministic/#levenshtein-distance)                            | Levenshtein distance is below a threshold                                       |
+| [latency](/docs/configuration/expected-outputs/deterministic/#latency)                                             | Latency is below a threshold (milliseconds)                                     |
+| [meteor](/docs/configuration/expected-outputs/deterministic/#meteor)                                               | METEOR score is above a given threshold (default 0.5)                           |
+| [perplexity](/docs/configuration/expected-outputs/deterministic/#perplexity)                                       | Perplexity is below a threshold                                                 |
+| [perplexity-score](/docs/configuration/expected-outputs/deterministic/#perplexity-score)                           | Normalized perplexity                                                           |
+| [cost](/docs/configuration/expected-outputs/deterministic/#cost)                                                   | Cost is below a threshold (for models with cost info such as GPT)               |
+| [is-valid-function-call](/docs/configuration/expected-outputs/deterministic/#is-valid-function-call)               | Ensure that the function call matches the function's JSON schema                |
+| [is-valid-openai-function-call](/docs/configuration/expected-outputs/deterministic/#is-valid-openai-function-call) | Ensure that the function call matches the function's JSON schema                |
+| [is-valid-openai-tools-call](/docs/configuration/expected-outputs/deterministic/#is-valid-openai-tools-call)       | Ensure all tool calls match the tools JSON schema                               |
+| [trace-span-count](/docs/configuration/expected-outputs/deterministic/#trace-span-count)                           | Count spans matching names and attributes with min/max thresholds               |
+| [trace-span-duration](/docs/configuration/expected-outputs/deterministic/#trace-span-duration)                     | Check durations of spans selected by name and attributes, including percentiles |
+| [trace-error-spans](/docs/configuration/expected-outputs/deterministic/#trace-error-spans)                         | Check error counts and rates in spans selected by name and attributes           |
+| [skill-used](/docs/configuration/expected-outputs/deterministic/#skill-used)                                       | Ensure normalized provider skill metadata includes expected skills              |
+| [trajectory:tool-used](/docs/configuration/expected-outputs/deterministic/#trajectorytool-used)                    | Ensure a traced agent trajectory used specific tools                            |
+| [trajectory:tool-args-match](/docs/configuration/expected-outputs/deterministic/#trajectorytool-args-match)        | Ensure traced tool calls used the expected arguments                            |
+| [trajectory:tool-sequence](/docs/configuration/expected-outputs/deterministic/#trajectorytool-sequence)            | Ensure traced tool usage happened in the expected order                         |
+| [trajectory:step-count](/docs/configuration/expected-outputs/deterministic/#trajectorystep-count)                  | Count normalized trajectory steps by type or name pattern                       |
+| [guardrails](/docs/configuration/expected-outputs/guardrails)                                                      | Evaluate the target's normalized input or output guardrail signal               |
 
 :::tip
 Every test type can be negated by prepending `not-`. For example, `not-equals` or `not-regex`.

--- a/site/docs/tracing.md
+++ b/site/docs/tracing.md
@@ -255,6 +255,8 @@ tests:
 
 Use trajectory assertions when your spans identify tools, commands, searches, reasoning steps, or messages. Promptfoo also normalizes common command-like tool spans, including OpenAI Agents SDK `exec_command` calls with `cmd` arguments and `shell` calls with `commands` arrays, into command trajectory steps. For traced tool calls, Promptfoo recognizes both generic attributes such as `tool.name` and `tool.arguments` and framework-specific ones such as Vercel AI SDK's `ai.toolCall.name`, `ai.toolCall.args`, `ai.toolCall.arguments`, and `ai.toolCall.input`. If you only need raw span counts, durations, or error detection, use [`trace-span-count`](/docs/configuration/expected-outputs/deterministic/#trace-span-count), [`trace-span-duration`](/docs/configuration/expected-outputs/deterministic/#trace-span-duration), or [`trace-error-spans`](/docs/configuration/expected-outputs/deterministic/#trace-error-spans).
 
+The three raw-span assertions accept `value.attributes` to select spans by exact attributes in addition to their name pattern. For example, `attributes: { 'gen_ai.tool.name': 'search' }` limits a count, duration, or error-rate check to the search tool even when every tool emits a span named `execute_tool`. All supplied attributes must match; missing attributes are excluded. See the [attribute-filter examples](/docs/configuration/expected-outputs/deterministic/#trace-span-count) for supported values and presence checks.
+
 ### Turn marker spans {#per-llm-turn-spans}
 
 Several first-party providers expose turn marker spans to trace assertions. Some markers correspond to internal model generations; Codex SDK and app-server markers correspond to the protocol turn exposed by those APIs. The span name and convention depend on the provider:

--- a/src/app/src/pages/eval-creator/components/assertionValueValidation.test.ts
+++ b/src/app/src/pages/eval-creator/components/assertionValueValidation.test.ts
@@ -267,6 +267,51 @@ describe('structured value assertions', () => {
       ),
     ).toBeUndefined();
   });
+
+  it.each([
+    'trace-span-count',
+    'not-trace-span-count',
+    'trace-span-duration',
+    'not-trace-span-duration',
+    'trace-error-spans',
+    'not-trace-error-spans',
+  ] as const)('validates attribute filters before running %s', (type) => {
+    const value = { pattern: '*', max: 250 };
+    for (const attributes of [
+      [],
+      null,
+      'search',
+      new Date(),
+      new Map(),
+      { tool: [] },
+      { tool: {} },
+      { tool: undefined },
+      { count: Infinity },
+      { count: NaN },
+    ]) {
+      expect(
+        getRunnableAssertionValueError(make({ type, value: { ...value, attributes } })),
+      ).toMatch(/attribute filters/);
+    }
+    for (const attributes of [
+      undefined,
+      {},
+      Object.create(null),
+      { 'gen_ai.tool.name': 'search', cached: false, count: 0 },
+    ]) {
+      expect(
+        getRunnableAssertionValueError(make({ type, value: { ...value, attributes } })),
+      ).toBeUndefined();
+    }
+  });
+
+  it('preserves optional and numeric trace error limits', () => {
+    for (const value of [undefined, 0, 2]) {
+      expect(
+        getRunnableAssertionValueError(make({ type: 'trace-error-spans', value })),
+      ).toBeUndefined();
+    }
+  });
 });
 
 describe('required string assertions', () => {

--- a/src/app/src/pages/eval-creator/components/assertionValueValidation.ts
+++ b/src/app/src/pages/eval-creator/components/assertionValueValidation.ts
@@ -368,6 +368,26 @@ function getWordCountError(assertion: Assertion): string | undefined {
   return undefined;
 }
 
+function getTraceAttributeFiltersError(value: unknown): string | undefined {
+  if (!isRecord(value) || value.attributes === undefined) {
+    return undefined;
+  }
+  const attributes = value.attributes;
+  if (
+    !isRecord(attributes) ||
+    ![Object.prototype, null].includes(Object.getPrototypeOf(attributes)) ||
+    Object.values(attributes).some(
+      (attribute) =>
+        typeof attribute !== 'string' &&
+        typeof attribute !== 'boolean' &&
+        !(typeof attribute === 'number' && Number.isFinite(attribute)),
+    )
+  ) {
+    return 'Enter trace attribute filters as a JSON object with string, boolean, or finite number values.';
+  }
+  return undefined;
+}
+
 function getTraceSpanCountValueError(value: unknown): string | undefined {
   if (!isRecord(value) || !hasNonBlankString(value.pattern)) {
     return 'Enter JSON with a span name pattern.';
@@ -378,7 +398,7 @@ function getTraceSpanCountValueError(value: unknown): string | undefined {
   ) {
     return 'Enter numeric trace span count limits.';
   }
-  return undefined;
+  return getTraceAttributeFiltersError(value);
 }
 
 function getTraceSpanDurationValueError(value: unknown): string | undefined {
@@ -394,7 +414,7 @@ function getTraceSpanDurationValueError(value: unknown): string | undefined {
   ) {
     return 'Enter a trace span percentile from 0 to 100.';
   }
-  return undefined;
+  return getTraceAttributeFiltersError(value);
 }
 
 function getTrajectoryToolArgsMatchValueError(value: unknown): string | undefined {
@@ -442,6 +462,9 @@ function getStructuredValueError(assertion: Assertion): string | undefined {
   }
   if (assertion.type === 'trace-span-duration' || assertion.type === 'not-trace-span-duration') {
     return getTraceSpanDurationValueError(assertion.value);
+  }
+  if (assertion.type === 'trace-error-spans' || assertion.type === 'not-trace-error-spans') {
+    return getTraceAttributeFiltersError(assertion.value);
   }
   if (
     assertion.type === 'trajectory:tool-args-match' ||

--- a/src/app/src/pages/eval-creator/components/setupReadiness.test.ts
+++ b/src/app/src/pages/eval-creator/components/setupReadiness.test.ts
@@ -597,6 +597,27 @@ describe('setupReadiness', () => {
       ).toBe(true);
     });
 
+    it('blocks trace attribute filters that the runtime would reject', () => {
+      for (const [attributes, expected] of [
+        [[], false],
+        [{}, true],
+      ] as const) {
+        expect(
+          getSetupReadiness({
+            providers: ['openai:gpt-4.1'],
+            prompts: ['Use tracing'],
+            tests: [
+              {
+                assert: [
+                  { type: 'trace-span-count' as const, value: { pattern: '*', attributes } },
+                ],
+              },
+            ],
+          }).isReadyToRun,
+        ).toBe(expected);
+      }
+    });
+
     it('validates trajectory goal content and normalized score thresholds', () => {
       const baseConfig = {
         providers: ['openai:gpt-4.1'],

--- a/src/assertions/traceErrorSpans.ts
+++ b/src/assertions/traceErrorSpans.ts
@@ -1,4 +1,4 @@
-import { filterTraceSpans } from './traceUtils';
+import { filterTraceSpans, withTraceAttributeFilterContext } from './traceUtils';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 import type { TraceSpan } from '../types/tracing';
@@ -107,7 +107,10 @@ export const handleTraceErrorSpans = ({
     return {
       pass: true,
       score: 1,
-      reason: `No spans found matching pattern "${pattern}"`,
+      reason: withTraceAttributeFilterContext(
+        `No spans found matching pattern "${pattern}"`,
+        attributes,
+      ),
       assertion,
     };
   }
@@ -158,7 +161,7 @@ export const handleTraceErrorSpans = ({
   return {
     pass,
     score: pass ? 1 : 0,
-    reason,
+    reason: withTraceAttributeFilterContext(reason, attributes),
     assertion,
   };
 };

--- a/src/assertions/traceErrorSpans.ts
+++ b/src/assertions/traceErrorSpans.ts
@@ -1,12 +1,14 @@
-import { matchesPattern } from './traceUtils';
+import { filterTraceSpans } from './traceUtils';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 import type { TraceSpan } from '../types/tracing';
+import type { TraceSpanAttributeFilter } from './traceUtils';
 
 interface TraceErrorSpansValue {
   max_count?: number;
   max_percentage?: number;
   pattern?: string;
+  attributes?: TraceSpanAttributeFilter;
 }
 
 function isErrorSpan(span: TraceSpan): boolean {
@@ -74,6 +76,7 @@ export const handleTraceErrorSpans = ({
   let maxCount: number | undefined;
   let maxPercentage: number | undefined;
   let pattern = '*';
+  let attributes: TraceSpanAttributeFilter | undefined;
 
   // Handle simple number value for backwards compatibility
   if (typeof value === 'number') {
@@ -88,6 +91,7 @@ export const handleTraceErrorSpans = ({
     maxCount = objValue.max_count;
     maxPercentage = objValue.max_percentage;
     pattern = objValue.pattern || '*';
+    attributes = objValue.attributes;
   }
 
   if (maxCount === undefined && maxPercentage === undefined) {
@@ -97,7 +101,7 @@ export const handleTraceErrorSpans = ({
   const spans = assertionValueContext.trace.spans as TraceSpan[];
 
   // Filter spans by pattern
-  const matchingSpans = spans.filter((span) => matchesPattern(span.name, pattern));
+  const matchingSpans = filterTraceSpans(spans, pattern, attributes);
 
   if (matchingSpans.length === 0) {
     return {

--- a/src/assertions/traceSpanCount.ts
+++ b/src/assertions/traceSpanCount.ts
@@ -1,12 +1,14 @@
-import { matchesPattern } from './traceUtils';
+import { filterTraceSpans } from './traceUtils';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 import type { TraceSpan } from '../types/tracing';
+import type { TraceSpanAttributeFilter } from './traceUtils';
 
 interface TraceSpanCountValue {
   pattern: string;
   min?: number;
   max?: number;
+  attributes?: TraceSpanAttributeFilter;
 }
 
 export const handleTraceSpanCount = ({
@@ -22,11 +24,11 @@ export const handleTraceSpanCount = ({
     throw new Error('trace-span-count assertion must have a value object with pattern property');
   }
 
-  const { pattern, min, max } = value;
+  const { pattern, min, max, attributes } = value;
   const spans = assertionValueContext.trace.spans as TraceSpan[];
 
   // Count spans matching the pattern
-  const matchingSpans = spans.filter((span) => matchesPattern(span.name, pattern));
+  const matchingSpans = filterTraceSpans(spans, pattern, attributes);
   const count = matchingSpans.length;
 
   // Check against constraints

--- a/src/assertions/traceSpanCount.ts
+++ b/src/assertions/traceSpanCount.ts
@@ -1,4 +1,4 @@
-import { filterTraceSpans } from './traceUtils';
+import { filterTraceSpans, withTraceAttributeFilterContext } from './traceUtils';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 import type { TraceSpan } from '../types/tracing';
@@ -61,7 +61,7 @@ export const handleTraceSpanCount = ({
   return {
     pass,
     score: pass ? 1 : 0,
-    reason,
+    reason: withTraceAttributeFilterContext(reason, attributes),
     assertion,
   };
 };

--- a/src/assertions/traceSpanDuration.ts
+++ b/src/assertions/traceSpanDuration.ts
@@ -1,12 +1,14 @@
-import { matchesPattern } from './traceUtils';
+import { filterTraceSpans } from './traceUtils';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 import type { TraceSpan } from '../types/tracing';
+import type { TraceSpanAttributeFilter } from './traceUtils';
 
 interface TraceSpanDurationValue {
   pattern?: string;
   max: number;
   percentile?: number;
+  attributes?: TraceSpanAttributeFilter;
 }
 
 function calculatePercentile(durations: number[], percentile: number): number {
@@ -32,7 +34,7 @@ export const handleTraceSpanDuration = ({
     throw new Error('trace-span-duration assertion must have a value object with max property');
   }
 
-  const { pattern = '*', max, percentile } = value;
+  const { pattern = '*', max, percentile, attributes } = value;
 
   if (
     percentile !== undefined &&
@@ -44,13 +46,9 @@ export const handleTraceSpanDuration = ({
   const spans = assertionValueContext.trace.spans as TraceSpan[];
 
   // Filter spans by pattern and calculate durations
-  const matchingSpans = spans.filter((span) => {
-    return (
-      matchesPattern(span.name, pattern) &&
-      span.startTime !== undefined &&
-      span.endTime !== undefined
-    );
-  });
+  const matchingSpans = filterTraceSpans(spans, pattern, attributes).filter(
+    (span) => span.startTime !== undefined && span.endTime !== undefined,
+  );
 
   if (matchingSpans.length === 0) {
     return {

--- a/src/assertions/traceSpanDuration.ts
+++ b/src/assertions/traceSpanDuration.ts
@@ -1,4 +1,4 @@
-import { filterTraceSpans } from './traceUtils';
+import { filterTraceSpans, withTraceAttributeFilterContext } from './traceUtils';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 import type { TraceSpan } from '../types/tracing';
@@ -54,7 +54,10 @@ export const handleTraceSpanDuration = ({
     return {
       pass: true,
       score: 1,
-      reason: `No spans found matching pattern "${pattern}" with complete timing data`,
+      reason: withTraceAttributeFilterContext(
+        `No spans found matching pattern "${pattern}" with complete timing data`,
+        attributes,
+      ),
       assertion,
     };
   }
@@ -105,7 +108,7 @@ export const handleTraceSpanDuration = ({
   return {
     pass,
     score: pass ? 1 : 0,
-    reason,
+    reason: withTraceAttributeFilterContext(reason, attributes),
     assertion,
   };
 };

--- a/src/assertions/traceUtils.ts
+++ b/src/assertions/traceUtils.ts
@@ -2,6 +2,45 @@
  * Shared utilities for trace assertions
  */
 
+export type TraceSpanAttributeFilter = Record<string, string | number | boolean>;
+
+export function filterTraceSpans<T extends { name: string; attributes?: Record<string, unknown> }>(
+  spans: T[],
+  pattern: string,
+  attributes?: unknown,
+): T[] {
+  if (attributes !== undefined) {
+    if (
+      attributes === null ||
+      typeof attributes !== 'object' ||
+      ![Object.prototype, null].includes(Object.getPrototypeOf(attributes)) ||
+      Object.values(attributes).some(
+        (value) =>
+          typeof value !== 'string' &&
+          typeof value !== 'boolean' &&
+          !(typeof value === 'number' && Number.isFinite(value)),
+      )
+    ) {
+      throw new Error(
+        'Trace assertion attributes must be an object with string, boolean, or finite number values',
+      );
+    }
+  }
+
+  const entries = Object.entries(attributes ?? {});
+  return spans.filter(
+    (span) =>
+      matchesPattern(span.name, pattern) &&
+      entries.every(
+        ([key, value]) =>
+          span.attributes !== undefined &&
+          span.attributes !== null &&
+          Object.prototype.hasOwnProperty.call(span.attributes, key) &&
+          span.attributes[key] === value,
+      ),
+  );
+}
+
 /**
  * Match a span name against a glob-like pattern.
  * Supports * (any characters) and ? (single character) wildcards.

--- a/src/assertions/traceUtils.ts
+++ b/src/assertions/traceUtils.ts
@@ -4,6 +4,16 @@
 
 export type TraceSpanAttributeFilter = Record<string, string | number | boolean>;
 
+export function withTraceAttributeFilterContext(
+  reason: string,
+  attributes?: TraceSpanAttributeFilter,
+): string {
+  const keys = Object.keys(attributes ?? {});
+  return keys.length > 0
+    ? `${reason}. Attribute filters applied to keys: ${JSON.stringify(keys)}.`
+    : reason;
+}
+
 export function filterTraceSpans<T extends { name: string; attributes?: Record<string, unknown> }>(
   spans: T[],
   pattern: string,

--- a/test/assertions/trace.test.ts
+++ b/test/assertions/trace.test.ts
@@ -185,6 +185,33 @@ describe('trace assertions', () => {
 
       expect(result.pass).toBe(pass);
       expect(result.score).toBe(pass ? 1 : 0);
+      expect(result.reason).toContain('Attribute filters applied to keys: ["gen_ai.tool.name"]');
+      expect(result.reason).not.toContain('search');
+    });
+
+    it.each<{ assertion: Assertion; pass: boolean }>([
+      { assertion: { type: 'trace-span-count', value: { min: 1 } }, pass: false },
+      { assertion: { type: 'trace-span-duration', value: { max: 500 } }, pass: true },
+      { assertion: { type: 'trace-error-spans', value: { max_count: 0 } }, pass: true },
+    ])('explains an empty attribute selection for $assertion', async ({ assertion, pass }) => {
+      mockTraceStore.getTrace.mockResolvedValue(mockTraceData);
+      const result = await runAssertion({
+        assertion: {
+          ...assertion,
+          value: {
+            ...(assertion.value as object),
+            pattern: '*',
+            attributes: { 'gen_ai.tool.name': 'private-tool-value' },
+          },
+        },
+        test: mockTest,
+        providerResponse: mockProviderResponse,
+        traceId: 'test-trace-id',
+      });
+
+      expect(result.pass).toBe(pass);
+      expect(result.reason).toContain('Attribute filters applied to keys: ["gen_ai.tool.name"]');
+      expect(result.reason).not.toContain('private-tool-value');
     });
   });
 

--- a/test/assertions/trace.test.ts
+++ b/test/assertions/trace.test.ts
@@ -131,6 +131,63 @@ describe('trace assertions', () => {
     ],
   };
 
+  describe('deterministic assertions with span attribute filters', () => {
+    it.each<{ assertion: Assertion; pass: boolean }>([
+      { assertion: { type: 'trace-span-count', value: { max: 2 } }, pass: true },
+      { assertion: { type: 'trace-span-count', value: { min: 3 } }, pass: false },
+      { assertion: { type: 'trace-span-duration', value: { max: 500 } }, pass: true },
+      {
+        assertion: { type: 'trace-span-duration', value: { max: 200, percentile: 50 } },
+        pass: true,
+      },
+      {
+        assertion: { type: 'trace-span-duration', value: { max: 200, percentile: 95 } },
+        pass: false,
+      },
+      { assertion: { type: 'trace-error-spans', value: { max_count: 1 } }, pass: true },
+      {
+        assertion: { type: 'trace-error-spans', value: { max_percentage: 49 } },
+        pass: false,
+      },
+      {
+        assertion: { type: 'trace-error-spans', value: { max_percentage: 50 } },
+        pass: true,
+      },
+    ])('applies filters before grading $assertion', async ({ assertion, pass }) => {
+      const spans = [
+        { spanId: 'search-ok', duration: 100, tool: 'search', statusCode: 0 },
+        { spanId: 'search-error', duration: 300, tool: 'search', statusCode: 2 },
+        { spanId: 'fetch-error', duration: 5000, tool: 'fetch', statusCode: 2 },
+        { spanId: 'unknown-error', duration: 9000, tool: undefined, statusCode: 2 },
+      ].map(({ spanId, duration, tool, statusCode }) => ({
+        spanId,
+        name: 'execute_tool',
+        startTime: 1000,
+        endTime: 1000 + duration,
+        attributes: tool ? { 'gen_ai.tool.name': tool } : {},
+        statusCode,
+      }));
+      mockTraceStore.getTrace.mockResolvedValue({ ...mockTraceData, spans });
+
+      const result = await runAssertion({
+        assertion: {
+          ...assertion,
+          value: {
+            ...(assertion.value as object),
+            pattern: 'execute_*',
+            attributes: { 'gen_ai.tool.name': 'search' },
+          },
+        },
+        test: mockTest,
+        providerResponse: mockProviderResponse,
+        traceId: 'test-trace-id',
+      });
+
+      expect(result.pass).toBe(pass);
+      expect(result.score).toBe(pass ? 1 : 0);
+    });
+  });
+
   describe('javascript assertions with trace', () => {
     it('uses the evaluation tracing context for the grader test index', async () => {
       const graderSpan = vi.fn();

--- a/test/assertions/traceUtils.test.ts
+++ b/test/assertions/traceUtils.test.ts
@@ -1,5 +1,98 @@
 import { describe, expect, it } from 'vitest';
-import { matchesPattern } from '../../src/assertions/traceUtils';
+import { filterTraceSpans, matchesPattern } from '../../src/assertions/traceUtils';
+
+import type { TraceSpan } from '../../src/types/tracing';
+
+describe('filterTraceSpans', () => {
+  const spans: TraceSpan[] = [
+    {
+      spanId: 'search',
+      name: 'execute_tool',
+      startTime: 0,
+      attributes: { 'gen_ai.tool.name': 'search', cached: false, retries: 0 },
+    },
+    {
+      spanId: 'fetch',
+      name: 'execute_tool',
+      startTime: 0,
+      attributes: { 'gen_ai.tool.name': 'fetch', cached: false, retries: 0 },
+    },
+    {
+      spanId: 'other-operation',
+      name: 'invoke_agent',
+      startTime: 0,
+      attributes: { 'gen_ai.tool.name': 'search', cached: false, retries: 0 },
+    },
+    { spanId: 'missing', name: 'execute_tool', startTime: 0 },
+  ];
+
+  it('combines the span pattern with all exact attribute conditions', () => {
+    const matching = filterTraceSpans(spans, 'execute_*', {
+      'gen_ai.tool.name': 'search',
+      cached: false,
+      retries: 0,
+    });
+    expect(matching.map((span) => span.spanId)).toEqual(['search']);
+    expect(matching[0]).toBe(spans[0]);
+  });
+
+  it.each([
+    { 'gen_ai.tool.name': 'SEARCH' },
+    { 'gen_ai.tool.name': 'search*' },
+    { 'gen_ai.tool.name': 'search', retries: 1 },
+    { cached: 'false' },
+    { retries: '0' },
+    { missing: false },
+  ])('does not coerce, glob-match, or ignore missing attributes: %j', (attributes) => {
+    expect(filterTraceSpans(spans, 'execute_*', attributes)).toEqual([]);
+  });
+
+  it('preserves name-only matching with omitted or empty filters', () => {
+    const expected = [spans[0], spans[1], spans[3]];
+    expect(filterTraceSpans(spans, 'EXECUTE_*')).toEqual(expected);
+    expect(filterTraceSpans(spans, 'EXECUTE_*', {})).toEqual(expected);
+  });
+
+  it('only reads own literal attribute keys', () => {
+    const inherited = Object.create({ 'gen_ai.tool.name': 'search' });
+    const own = JSON.parse('{"__proto__":"literal","gen_ai.tool.name":"search"}');
+    const candidates = [
+      { ...spans[0], spanId: 'inherited', attributes: inherited },
+      { ...spans[0], spanId: 'nested', attributes: { gen_ai: { tool: { name: 'search' } } } },
+      { ...spans[0], spanId: 'own', attributes: own },
+    ];
+    expect(
+      filterTraceSpans(candidates, '*', { 'gen_ai.tool.name': 'search' }).map(
+        (span) => span.spanId,
+      ),
+    ).toEqual(['own']);
+    expect(
+      filterTraceSpans(candidates, '*', JSON.parse('{"__proto__":"literal"}')).map(
+        (span) => span.spanId,
+      ),
+    ).toEqual(['own']);
+  });
+
+  it.each([
+    null,
+    [],
+    'search',
+    false,
+    0,
+    new Map(),
+    new Date(0),
+    { tool: null },
+    { tool: [] },
+    { tool: {} },
+    { tool: undefined },
+    { retries: Number.NaN },
+    { retries: Number.POSITIVE_INFINITY },
+  ])('rejects malformed filters even with no spans: %j', (attributes) => {
+    expect(() => filterTraceSpans([], '*', attributes)).toThrow(
+      'Trace assertion attributes must be an object with string, boolean, or finite number values',
+    );
+  });
+});
 
 describe('tracing utilities', () => {
   describe('matchesPattern', () => {


### PR DESCRIPTION
## Summary

Agent frameworks often emit the same span name for different tools or agents. Name patterns alone cannot apply a latency budget or error-rate threshold to one operation. This adds an optional `value.attributes` filter to `trace-span-count`, `trace-span-duration`, and `trace-error-spans`.

```yaml
assert:
  - type: trace-span-count
    value:
      pattern: '*'
      attributes:
        gen_ai.tool.name: search
      min: 1
      max: 3
  - type: trace-span-duration
    value:
      attributes:
        gen_ai.tool.name: search
      max: 2000
```

Each selected span must match the existing name pattern and every supplied attribute. Attribute keys are literal, including dots; values use exact equality and must be strings, booleans, or finite numbers. Missing attributes do not match. Omitting the option, or passing an empty object, preserves existing selection behavior.

Duration percentiles and error percentages use only the selected spans. The existing no-match behavior is preserved; the documentation recommends pairing duration/error assertions with a count assertion when a matching span must exist. The existing configuration schema already preserves assertion values, so no schema or migration change is needed.

Assertion reasons identify the active attribute keys without including their values. The eval creator validates the same filter shapes before allowing a run, including the three negated assertion types, while preserving optional and numeric trace-error-spans values.

## Validation

- 181 tests passed across the three trace handlers, shared trace utilities, the `runAssertion` trace pipeline, assertion aggregation, and evaluator assertions (8 files, single worker).
- 187 frontend validation/readiness tests passed. Regression tests first demonstrated that invalid filters were accepted by all six trace assertion types and by setup readiness, then passed after the fix.
- `npm run l && npm run f` passed.
- `npm run tsc` passed.
- Build passed with its components run serially: `tsc`, `tsdown`, `npm run build:app`, and `npm run postbuild` (Node 24.20.0, npm 11.19.0).
- `npm run architecture:check` passed without changing its dependency baseline.
- Ran `npm run local -- eval` with a deterministic local provider that sent real OTLP HTTP spans to the local receiver. Inspected exported JSON: one positive case passed, two deliberate boundary cases failed, and the CLI reported zero runtime errors. The positive case isolated two `search` spans from same-named `fetch` and unattributed spans, enforced their count and latency, and calculated an error rate of 1/2 = 50%. The 49% threshold failed, and a required absent tool failed its minimum count. Exported assertion configuration retained `attributes` intact.
- Repeated the real local CLI workflow after adding reason context: all six component reasons identify `gen_ai.tool.name` without revealing filter values; scores and expected failure behavior are unchanged.
