### PR TITLE
feat(webui): add rating feedback links

### DIFF
--- a/site/docs/configuration/test-cases.md
+++ b/site/docs/configuration/test-cases.md
@@ -79,6 +79,28 @@ The per-test value overrides `--repeat`, `commandLineOptions.repeat`, or
 `evaluateOptions.repeat` for that test. Other tests continue to use the global repeat count.
 Repeat indexes use separate cache entries; add `--no-cache` when every run must call the provider.
 
+### Rating Feedback Links
+
+Set `feedback.pass` or `feedback.fail` to open an HTTPS link when a reviewer marks a result passed or failed in the web UI. Links open in a new tab when the rating is set. Use `defaultTest` to apply them to every test.
+
+```yaml title="promptfooconfig.yaml"
+providers:
+  - echo
+prompts:
+  - '{{question}}'
+defaultTest:
+  feedback:
+    pass: 'https://reviews.example.com/results/{{resultId}}?rating={{rating}}'
+    fail: 'https://reviews.example.com/results/{{resultId}}?rating={{rating}}'
+tests:
+  - vars:
+      question: 'What is the capital of France?'
+    metadata:
+      testCaseId: geography-001
+```
+
+Supported placeholders are `{{evalId}}`, `{{resultId}}`, `{{testCaseId}}`, and `{{rating}}`; values are URL-encoded before the link opens. Feedback links are HTTPS-only and cannot contain URL credentials. This link-only integration does not send requests or store authentication tokens.
+
 ### Filtering Tests by Provider
 
 Control which providers run specific tests using the `providers` field. This allows you to run different test suites against different models in a single evaluation:

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -23,49 +23,49 @@
           "$ref": "#/definitions/__schema14"
         },
         "scenarios": {
-          "$ref": "#/definitions/__schema29"
-        },
-        "defaultTest": {
-          "$ref": "#/definitions/__schema30"
-        },
-        "outputPath": {
-          "$ref": "#/definitions/__schema31"
-        },
-        "sharing": {
-          "$ref": "#/definitions/__schema32"
-        },
-        "nunjucksFilters": {
           "$ref": "#/definitions/__schema33"
         },
-        "env": {
+        "defaultTest": {
           "$ref": "#/definitions/__schema34"
         },
-        "derivedMetrics": {
+        "outputPath": {
           "$ref": "#/definitions/__schema35"
         },
-        "extensions": {
+        "sharing": {
           "$ref": "#/definitions/__schema36"
         },
-        "metadata": {
+        "nunjucksFilters": {
           "$ref": "#/definitions/__schema37"
         },
-        "redteam": {
+        "env": {
           "$ref": "#/definitions/__schema38"
         },
-        "writeLatestResults": {
+        "derivedMetrics": {
           "$ref": "#/definitions/__schema39"
         },
-        "tracing": {
+        "extensions": {
           "$ref": "#/definitions/__schema40"
         },
+        "metadata": {
+          "$ref": "#/definitions/__schema41"
+        },
+        "redteam": {
+          "$ref": "#/definitions/__schema42"
+        },
+        "writeLatestResults": {
+          "$ref": "#/definitions/__schema43"
+        },
+        "tracing": {
+          "$ref": "#/definitions/__schema44"
+        },
         "evaluateOptions": {
-          "$ref": "#/definitions/__schema45"
+          "$ref": "#/definitions/__schema49"
         },
         "commandLineOptions": {
-          "$ref": "#/definitions/__schema47"
+          "$ref": "#/definitions/__schema51"
         },
         "targets": {
-          "$ref": "#/definitions/__schema48"
+          "$ref": "#/definitions/__schema52"
         }
       },
       "required": ["prompts"],
@@ -738,13 +738,13 @@
                 "$ref": "#/definitions/__schema15"
               },
               {
-                "$ref": "#/definitions/__schema28"
+                "$ref": "#/definitions/__schema32"
               }
             ]
           }
         },
         {
-          "$ref": "#/definitions/__schema28"
+          "$ref": "#/definitions/__schema32"
         }
       ]
     },
@@ -781,8 +781,11 @@
         "threshold": {
           "$ref": "#/definitions/__schema26"
         },
-        "metadata": {
+        "feedback": {
           "$ref": "#/definitions/__schema27"
+        },
+        "metadata": {
+          "$ref": "#/definitions/__schema31"
         }
       },
       "additionalProperties": false
@@ -1211,12 +1214,42 @@
     "__schema27": {
       "type": "object",
       "properties": {
+        "pass": {
+          "$ref": "#/definitions/__schema28"
+        },
+        "fail": {
+          "$ref": "#/definitions/__schema30"
+        }
+      },
+      "additionalProperties": false
+    },
+    "__schema28": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema29"
+        }
+      ]
+    },
+    "__schema29": {
+      "type": "string",
+      "minLength": 1
+    },
+    "__schema30": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/__schema29"
+        }
+      ]
+    },
+    "__schema31": {
+      "type": "object",
+      "properties": {
         "pluginConfig": {},
         "strategyConfig": {}
       },
       "additionalProperties": {}
     },
-    "__schema28": {
+    "__schema32": {
       "type": "object",
       "properties": {
         "path": {
@@ -1269,7 +1302,7 @@
       "required": ["path"],
       "additionalProperties": false
     },
-    "__schema29": {
+    "__schema33": {
       "type": "array",
       "items": {
         "anyOf": [
@@ -1357,10 +1390,17 @@
                         }
                       ]
                     },
-                    "metadata": {
+                    "feedback": {
                       "allOf": [
                         {
                           "$ref": "#/definitions/__schema27"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/__schema31"
                         }
                       ]
                     }
@@ -1381,7 +1421,7 @@
         ]
       }
     },
-    "__schema30": {
+    "__schema34": {
       "anyOf": [
         {
           "type": "string"
@@ -1416,15 +1456,18 @@
             "threshold": {
               "$ref": "#/definitions/__schema26"
             },
-            "metadata": {
+            "feedback": {
               "$ref": "#/definitions/__schema27"
+            },
+            "metadata": {
+              "$ref": "#/definitions/__schema31"
             }
           },
           "additionalProperties": false
         }
       ]
     },
-    "__schema31": {
+    "__schema35": {
       "anyOf": [
         {
           "type": "string"
@@ -1437,7 +1480,7 @@
         }
       ]
     },
-    "__schema32": {
+    "__schema36": {
       "anyOf": [
         {
           "type": "boolean"
@@ -1456,7 +1499,7 @@
         }
       ]
     },
-    "__schema33": {
+    "__schema37": {
       "type": "object",
       "propertyNames": {
         "type": "string"
@@ -1465,7 +1508,7 @@
         "type": "string"
       }
     },
-    "__schema34": {
+    "__schema38": {
       "anyOf": [
         {
           "$ref": "#/definitions/__schema7"
@@ -1491,7 +1534,7 @@
         }
       ]
     },
-    "__schema35": {
+    "__schema39": {
       "type": "array",
       "items": {
         "type": "object",
@@ -1512,7 +1555,7 @@
         "additionalProperties": false
       }
     },
-    "__schema36": {
+    "__schema40": {
       "anyOf": [
         {
           "type": "array",
@@ -1525,14 +1568,14 @@
         }
       ]
     },
-    "__schema37": {
+    "__schema41": {
       "type": "object",
       "propertyNames": {
         "type": "string"
       },
       "additionalProperties": {}
     },
-    "__schema38": {
+    "__schema42": {
       "type": "object",
       "properties": {
         "injectVar": {
@@ -3090,10 +3133,10 @@
         }
       }
     },
-    "__schema39": {
+    "__schema43": {
       "type": "boolean"
     },
-    "__schema40": {
+    "__schema44": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -3202,19 +3245,19 @@
                   "const": "tempo"
                 },
                 "endpoint": {
-                  "$ref": "#/definitions/__schema41"
+                  "$ref": "#/definitions/__schema45"
                 },
                 "auth": {
                   "type": "object",
                   "properties": {
                     "token": {
-                      "$ref": "#/definitions/__schema42"
+                      "$ref": "#/definitions/__schema46"
                     },
                     "username": {
-                      "$ref": "#/definitions/__schema43"
+                      "$ref": "#/definitions/__schema47"
                     },
                     "password": {
-                      "$ref": "#/definitions/__schema44"
+                      "$ref": "#/definitions/__schema48"
                     }
                   },
                   "additionalProperties": false
@@ -3245,7 +3288,7 @@
                   "const": "braintrust"
                 },
                 "endpoint": {
-                  "$ref": "#/definitions/__schema41"
+                  "$ref": "#/definitions/__schema45"
                 },
                 "projectId": {
                   "type": "string",
@@ -3289,7 +3332,7 @@
                   "const": "langfuse"
                 },
                 "endpoint": {
-                  "$ref": "#/definitions/__schema41"
+                  "$ref": "#/definitions/__schema45"
                 },
                 "auth": {
                   "type": "object",
@@ -3338,23 +3381,23 @@
       "required": ["enabled"],
       "additionalProperties": false
     },
-    "__schema41": {
+    "__schema45": {
       "type": "string",
       "format": "uri"
     },
-    "__schema42": {
+    "__schema46": {
       "type": "string",
       "minLength": 1
     },
-    "__schema43": {
+    "__schema47": {
       "type": "string",
       "minLength": 1
     },
-    "__schema44": {
+    "__schema48": {
       "type": "string",
       "minLength": 1
     },
-    "__schema45": {
+    "__schema49": {
       "type": "object",
       "properties": {
         "cache": {
@@ -3397,15 +3440,15 @@
           "type": "boolean"
         },
         "filterRange": {
-          "$ref": "#/definitions/__schema46"
+          "$ref": "#/definitions/__schema50"
         }
       },
       "additionalProperties": false
     },
-    "__schema46": {
+    "__schema50": {
       "type": "string"
     },
-    "__schema47": {
+    "__schema51": {
       "type": "object",
       "properties": {
         "description": {
@@ -3533,7 +3576,7 @@
         "filterRange": {
           "allOf": [
             {
-              "$ref": "#/definitions/__schema46"
+              "$ref": "#/definitions/__schema50"
             }
           ]
         },
@@ -3607,7 +3650,7 @@
       },
       "additionalProperties": false
     },
-    "__schema48": {
+    "__schema52": {
       "allOf": [
         {
           "$ref": "#/definitions/__schema3"

--- a/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.test.tsx
@@ -10,7 +10,11 @@ import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ShiftKeyProvider } from '../../../contexts/ShiftKeyContext';
-import EvalOutputCell, { isImageProvider, isVideoProvider } from './EvalOutputCell';
+import EvalOutputCell, {
+  buildRatingFeedbackUrl,
+  isImageProvider,
+  isVideoProvider,
+} from './EvalOutputCell';
 
 import type { EvalOutputCellProps } from './EvalOutputCell';
 
@@ -2806,6 +2810,79 @@ describe('EvalOutputCell thumbs up/down toggle functionality', () => {
 
     // Verify comment is passed to onRating
     expect(mockOnRating).toHaveBeenCalledWith(true, undefined, 'Important comment');
+  });
+
+  it('opens the configured feedback link when setting a pass rating', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+    const props = createPropsForToggleTest();
+    props.evaluationId = 'eval-123';
+    props.testCaseId = 'case/123';
+    props.output.testCase = {
+      feedback: {
+        pass: 'https://reviews.example.com/results/{{resultId}}?eval={{evalId}}&test={{testCaseId}}&rating={{rating}}',
+      },
+    };
+    renderWithProviders(<EvalOutputCell {...props} />);
+
+    await userEvent.click(screen.getByLabelText('Mark test passed'));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://reviews.example.com/results/test-id?eval=eval-123&test=case%2F123&rating=pass',
+      '_blank',
+      'noopener,noreferrer',
+    );
+    openSpy.mockRestore();
+  });
+
+  it('does not open feedback when clearing an existing rating', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+    const props = createPropsForToggleTest();
+    props.output.testCase = {
+      feedback: { pass: 'https://reviews.example.com/results/{{resultId}}' },
+    };
+    renderWithProviders(<EvalOutputCell {...props} />);
+
+    const thumbsUpButton = screen.getByLabelText('Mark test passed');
+    await userEvent.click(thumbsUpButton);
+    openSpy.mockClear();
+    await userEvent.click(thumbsUpButton);
+
+    expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+});
+
+describe('buildRatingFeedbackUrl', () => {
+  it('URL-encodes placeholder values', () => {
+    expect(
+      buildRatingFeedbackUrl(
+        'https://reviews.example.com/{{evalId}}/{{resultId}}/{{testCaseId}}?rating={{rating}}',
+        {
+          evalId: 'eval 1',
+          resultId: 'result/1',
+          testCaseId: 'case&1',
+          rating: 'pass',
+        },
+      ),
+    ).toBe('https://reviews.example.com/eval%201/result%2F1/case%261?rating=pass');
+  });
+
+  it('rejects unsafe feedback URLs at runtime', () => {
+    expect(
+      buildRatingFeedbackUrl('http://reviews.example.com/results/{{resultId}}', {
+        resultId: 'result-1',
+        rating: 'fail',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('rejects unsupported placeholders at runtime', () => {
+    expect(
+      buildRatingFeedbackUrl('https://reviews.example.com/results/{{unknown}}', {
+        resultId: 'result-1',
+        rating: 'fail',
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/src/app/src/pages/eval/components/EvalOutputCell.tsx
+++ b/src/app/src/pages/eval/components/EvalOutputCell.tsx
@@ -78,6 +78,43 @@ function stringifyOutputText(text: unknown): string {
   return JSON.stringify(text) ?? String(text);
 }
 
+const RATING_FEEDBACK_PLACEHOLDER_PATTERN = /\{\{(evalId|resultId|testCaseId|rating)\}\}/g;
+const RATING_FEEDBACK_ANY_PLACEHOLDER_PATTERN = /\{\{([^{}]+)\}\}/g;
+const RATING_FEEDBACK_PLACEHOLDER_NAMES = new Set(['evalId', 'resultId', 'testCaseId', 'rating']);
+
+export function buildRatingFeedbackUrl(
+  template: string | undefined,
+  values: {
+    evalId?: string;
+    resultId: string;
+    testCaseId?: string;
+    rating: 'pass' | 'fail';
+  },
+): string | undefined {
+  if (!template) {
+    return undefined;
+  }
+  if (
+    Array.from(template.matchAll(RATING_FEEDBACK_ANY_PLACEHOLDER_PATTERN)).some(
+      (placeholder) => !placeholder[1] || !RATING_FEEDBACK_PLACEHOLDER_NAMES.has(placeholder[1]),
+    )
+  ) {
+    return undefined;
+  }
+
+  const urlString = template.replace(
+    RATING_FEEDBACK_PLACEHOLDER_PATTERN,
+    (_, name: keyof typeof values) => encodeURIComponent(values[name] ?? ''),
+  );
+
+  try {
+    const url = new URL(urlString);
+    return url.protocol === 'https:' && !url.username && !url.password ? url.href : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Detects if the provider is an image generation provider.
  * Image providers follow patterns like:
@@ -1460,6 +1497,18 @@ function EvalOutputCell({
   const handleRating = (isPass: boolean) => {
     const newRating = activeRating === isPass ? null : isPass;
     setActiveRating(newRating);
+    const feedbackUrl =
+      newRating === null
+        ? undefined
+        : buildRatingFeedbackUrl(output.testCase.feedback?.[isPass ? 'pass' : 'fail'], {
+            evalId: evaluationId,
+            resultId: output.id,
+            testCaseId,
+            rating: isPass ? 'pass' : 'fail',
+          });
+    if (feedbackUrl) {
+      window.open(feedbackUrl, '_blank', 'noopener,noreferrer');
+    }
     // Defer the API call to allow the UI to update first
     queueMicrotask(() => {
       onRating(newRating, undefined, commentText);

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -2595,6 +2595,7 @@ async function prepareTestCaseForEval(
   testCase.assertScoringFunction =
     testCase.assertScoringFunction || defaultTest?.assertScoringFunction;
   testCase.providers = testCase.providers ?? defaultTest?.providers;
+  testCase.feedback = testCase.feedback ?? defaultTest?.feedback;
 
   if (typeof testCase.assertScoringFunction === 'string') {
     const { filePath: resolvedPath, functionName } = parseFileUrl(testCase.assertScoringFunction);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -869,6 +869,48 @@ export type ScoringFunction = (
 
 // Each test case is graded pass/fail with a score.  A test case represents a unique input to the LLM after substituting `vars` in the prompt.
 // HEADS UP: When you add a property here, you probably need to load it from `defaultTest` in evaluator.ts.
+const RATING_FEEDBACK_PLACEHOLDER_PATTERN = /\{\{([^{}]+)\}\}/g;
+const RATING_FEEDBACK_PLACEHOLDER_NAMES = new Set(['evalId', 'resultId', 'testCaseId', 'rating']);
+
+const RatingFeedbackUrlSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (template) => {
+      const placeholders = Array.from(template.matchAll(RATING_FEEDBACK_PLACEHOLDER_PATTERN));
+      if (
+        placeholders.some(
+          (placeholder) =>
+            !placeholder[1] || !RATING_FEEDBACK_PLACEHOLDER_NAMES.has(placeholder[1]),
+        )
+      ) {
+        return false;
+      }
+
+      try {
+        const url = new URL(template.replace(RATING_FEEDBACK_PLACEHOLDER_PATTERN, 'placeholder'));
+        return url.protocol === 'https:' && !url.username && !url.password;
+      } catch {
+        return false;
+      }
+    },
+    {
+      error:
+        'Feedback URLs must use HTTPS without credentials and may use only {{evalId}}, {{resultId}}, {{testCaseId}}, or {{rating}} placeholders',
+    },
+  );
+
+export const RatingFeedbackSchema = z
+  .object({
+    pass: RatingFeedbackUrlSchema.optional(),
+    fail: RatingFeedbackUrlSchema.optional(),
+  })
+  .refine(({ pass, fail }) => Boolean(pass || fail), {
+    error: 'Feedback requires a pass or fail URL',
+  });
+
+export type RatingFeedback = z.infer<typeof RatingFeedbackSchema>;
+
 export const TestCaseSchema = z.object({
   // Optional description of what you're testing
   description: z.string().optional(),
@@ -929,6 +971,9 @@ export const TestCaseSchema = z.object({
 
   // The required score for this test case.  If not provided, the test case is graded pass/fail.
   threshold: z.number().optional(),
+
+  // Optional HTTPS links opened when a result is manually marked passed or failed in the web UI.
+  feedback: RatingFeedbackSchema.optional(),
 
   // Use catchall(z.any()) to allow arbitrary metadata keys while still typing known internal properties.
   // Don't use z.intersection() here as it generates allOf with additionalProperties:false

--- a/test/evaluator/defaultTest.test.ts
+++ b/test/evaluator/defaultTest.test.ts
@@ -184,6 +184,7 @@ describe('Evaluator with external defaultTest', () => {
       options: { provider: 'test-provider' },
       metadata: { suite: 'test-suite' },
       threshold: 0.8,
+      feedback: { pass: 'https://reviews.example.com/results/{{resultId}}' },
     };
 
     const testSuite: TestSuite = {
@@ -195,6 +196,7 @@ describe('Evaluator with external defaultTest', () => {
           vars: { testVar: 'override' },
           assert: [{ type: 'contains' as const, value: 'exp' }],
           threshold: 0.9,
+          feedback: { fail: 'https://reviews.example.com/results/{{resultId}}' },
         },
       ],
       defaultTest,
@@ -213,6 +215,7 @@ describe('Evaluator with external defaultTest', () => {
     });
     expect(firstResult.testCase.threshold).toBe(0.8);
     expect(firstResult.testCase.metadata).toEqual({ suite: 'test-suite' });
+    expect(firstResult.testCase.feedback).toEqual(defaultTest.feedback);
 
     // Second test should merge/override appropriately
     const secondResult = summary.results[1] as any;
@@ -221,6 +224,9 @@ describe('Evaluator with external defaultTest', () => {
       { type: 'contains' as const, value: 'exp' },
     ]);
     expect(secondResult.testCase.threshold).toBe(0.9); // Override
+    expect(secondResult.testCase.feedback).toEqual({
+      fail: 'https://reviews.example.com/results/{{resultId}}',
+    });
   });
 
   it('should allow a test case to opt out of defaultTest assertions', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -156,6 +156,7 @@ describe('index.ts exports', () => {
     'PluginConfigSchema',
     'PolicyObjectSchema',
     'ProvidersSchema',
+    'RatingFeedbackSchema',
     'ResultFailureReason',
     'ScenarioSchema',
     'SpecialAssertionTypesSchema',

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -339,6 +339,28 @@ describe('TestCaseSchema assertScoringFunction', () => {
   });
 });
 
+describe('TestCaseSchema feedback', () => {
+  it('accepts HTTPS links with supported placeholders', () => {
+    const result = TestCaseSchema.safeParse({
+      feedback: {
+        pass: 'https://reviews.example.com/results/{{resultId}}?rating={{rating}}',
+        fail: 'https://reviews.example.com/evals/{{evalId}}/{{testCaseId}}',
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    { feedback: {} },
+    { feedback: { pass: 'http://reviews.example.com/results/{{resultId}}' } },
+    { feedback: { pass: 'https://user:password@reviews.example.com/results' } },
+    { feedback: { pass: 'https://reviews.example.com/results/{{unknown}}' } },
+  ])('rejects unsafe or incomplete feedback configuration: %o', (testCase) => {
+    expect(TestCaseSchema.safeParse(testCase).success).toBe(false);
+  });
+});
+
 // Tests for #7096: Ensure TestCaseSchema.options accepts properties from all merged schemas
 // This was broken when z.intersection() generated allOf with additionalProperties:false
 describe('TestCaseSchema options (merged schema properties)', () => {


### PR DESCRIPTION
Fixes #2047

## Summary
- add validated HTTPS feedback links for manual pass/fail ratings
- support URL-encoded evaluation, result, test-case, and rating placeholders
- inherit links from `defaultTest` and document the configuration

## Testing
- `npx vitest run test/types/index.test.ts test/evaluator/defaultTest.test.ts --sequence.shuffle=false`
- `npm run test:app -- src/pages/eval/components/EvalOutputCell.test.tsx --run`
- `npm run build`
- `npm run tsc`
- `SKIP_OG_GENERATION=true npm run build` (from `site/`)