### PR TITLE
feat(webui): add failure summary filters

### DIFF
--- a/src/app/src/pages/eval/components/FailureSummary.test.tsx
+++ b/src/app/src/pages/eval/components/FailureSummary.test.tsx
@@ -1,15 +1,16 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
+import { mockCallApiResponse, resetCallApiMock } from '@app/tests/apiMocks';
 import { callApi } from '@app/utils/api';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FailureSummary } from './FailureSummary';
 
 const addFilter = vi.fn();
 const removeFilter = vi.fn();
 let filterValues: Record<string, unknown> = {};
 
-vi.mock('@app/utils/api');
+vi.mock('@app/utils/api', () => ({ callApi: vi.fn() }));
 vi.mock('./store', () => ({
   useTableStore: () => ({
     addFilter,
@@ -23,20 +24,11 @@ describe('FailureSummary', () => {
     addFilter.mockReset();
     removeFilter.mockReset();
     filterValues = {};
-    vi.mocked(callApi).mockReset();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
+    resetCallApiMock();
   });
 
   it('groups failures and adds an exact error filter when selected', async () => {
-    vi.mocked(callApi).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        failures: [{ error: 'Request timed out', count: 2 }],
-      }),
-    } as unknown as Response);
+    mockCallApiResponse({ failures: [{ error: 'Request timed out', count: 2 }] });
 
     render(
       <TooltipProvider>
@@ -66,12 +58,7 @@ describe('FailureSummary', () => {
         value: 'Request timed out',
       },
     };
-    vi.mocked(callApi).mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        failures: [{ error: 'Request timed out', count: 1 }],
-      }),
-    } as unknown as Response);
+    mockCallApiResponse({ failures: [{ error: 'Request timed out', count: 1 }] });
 
     render(
       <TooltipProvider>

--- a/src/app/src/pages/eval/components/FailureSummary.test.tsx
+++ b/src/app/src/pages/eval/components/FailureSummary.test.tsx
@@ -1,0 +1,86 @@
+import { TooltipProvider } from '@app/components/ui/tooltip';
+import { callApi } from '@app/utils/api';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FailureSummary } from './FailureSummary';
+
+const addFilter = vi.fn();
+const removeFilter = vi.fn();
+let filterValues: Record<string, unknown> = {};
+
+vi.mock('@app/utils/api');
+vi.mock('./store', () => ({
+  useTableStore: () => ({
+    addFilter,
+    filters: { values: filterValues },
+    removeFilter,
+  }),
+}));
+
+describe('FailureSummary', () => {
+  beforeEach(() => {
+    addFilter.mockReset();
+    removeFilter.mockReset();
+    filterValues = {};
+    vi.mocked(callApi).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('groups failures and adds an exact error filter when selected', async () => {
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        failures: [{ error: 'Request timed out', count: 2 }],
+      }),
+    } as unknown as Response);
+
+    render(
+      <TooltipProvider>
+        <FailureSummary evalId="eval-123" />
+      </TooltipProvider>,
+    );
+
+    const failureGroup = await screen.findByRole('button', { name: '2 failures' });
+    await userEvent.click(failureGroup);
+
+    expect(callApi).toHaveBeenCalledWith(
+      '/eval/eval-123/failure-summary',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(addFilter).toHaveBeenCalledWith({
+      type: 'error',
+      operator: 'equals',
+      value: 'Request timed out',
+    });
+  });
+
+  it('removes the filter when the selected error group is already active', async () => {
+    filterValues = {
+      existing: {
+        type: 'error',
+        operator: 'equals',
+        value: 'Request timed out',
+      },
+    };
+    vi.mocked(callApi).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        failures: [{ error: 'Request timed out', count: 1 }],
+      }),
+    } as unknown as Response);
+
+    render(
+      <TooltipProvider>
+        <FailureSummary evalId="eval-123" />
+      </TooltipProvider>,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: '1 failure' }));
+
+    expect(removeFilter).toHaveBeenCalledWith('existing');
+  });
+});

--- a/src/app/src/pages/eval/components/FailureSummary.test.tsx
+++ b/src/app/src/pages/eval/components/FailureSummary.test.tsx
@@ -1,7 +1,7 @@
 import { TooltipProvider } from '@app/components/ui/tooltip';
 import { mockCallApiResponse, resetCallApiMock } from '@app/tests/apiMocks';
 import { callApi } from '@app/utils/api';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FailureSummary } from './FailureSummary';
@@ -69,5 +69,20 @@ describe('FailureSummary', () => {
     await userEvent.click(await screen.findByRole('button', { name: '1 failure' }));
 
     expect(removeFilter).toHaveBeenCalledWith('existing');
+  });
+
+  it('does not render a group for an invalid summary response', async () => {
+    mockCallApiResponse({});
+
+    render(
+      <TooltipProvider>
+        <FailureSummary evalId="eval-123" />
+      </TooltipProvider>,
+    );
+
+    await waitFor(() => {
+      expect(callApi).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText('Failure groups:')).not.toBeInTheDocument();
   });
 });

--- a/src/app/src/pages/eval/components/FailureSummary.tsx
+++ b/src/app/src/pages/eval/components/FailureSummary.tsx
@@ -30,8 +30,8 @@ export function FailureSummary({ evalId }: FailureSummaryProps) {
           setFailures([]);
           return;
         }
-        const data = (await response.json()) as FailureSummaryResponse;
-        setFailures(data.failures);
+        const data = (await response.json()) as Partial<FailureSummaryResponse> | null;
+        setFailures(Array.isArray(data?.failures) ? data.failures : []);
       } catch (error) {
         if (!(error instanceof DOMException && error.name === 'AbortError')) {
           setFailures([]);

--- a/src/app/src/pages/eval/components/FailureSummary.tsx
+++ b/src/app/src/pages/eval/components/FailureSummary.tsx
@@ -5,15 +5,18 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@app/components/ui/tool
 import { callApi } from '@app/utils/api';
 import { AlertCircle } from 'lucide-react';
 import { useTableStore } from './store';
-import type { GetFailureSummaryResponse } from '@promptfoo/types/api/eval';
 
 interface FailureSummaryProps {
   evalId: string;
 }
 
+type FailureSummaryResponse = {
+  failures: Array<{ error: string; count: number }>;
+};
+
 export function FailureSummary({ evalId }: FailureSummaryProps) {
   const { addFilter, filters, removeFilter } = useTableStore();
-  const [failures, setFailures] = useState<GetFailureSummaryResponse['failures']>([]);
+  const [failures, setFailures] = useState<FailureSummaryResponse['failures']>([]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -27,7 +30,7 @@ export function FailureSummary({ evalId }: FailureSummaryProps) {
           setFailures([]);
           return;
         }
-        const data = (await response.json()) as GetFailureSummaryResponse;
+        const data = (await response.json()) as FailureSummaryResponse;
         setFailures(data.failures);
       } catch (error) {
         if (!(error instanceof DOMException && error.name === 'AbortError')) {

--- a/src/app/src/pages/eval/components/FailureSummary.tsx
+++ b/src/app/src/pages/eval/components/FailureSummary.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { Badge } from '@app/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@app/components/ui/tooltip';
+import { callApi } from '@app/utils/api';
+import { AlertCircle } from 'lucide-react';
+import { useTableStore } from './store';
+import type { GetFailureSummaryResponse } from '@promptfoo/types/api/eval';
+
+interface FailureSummaryProps {
+  evalId: string;
+}
+
+export function FailureSummary({ evalId }: FailureSummaryProps) {
+  const { addFilter, filters, removeFilter } = useTableStore();
+  const [failures, setFailures] = useState<GetFailureSummaryResponse['failures']>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadFailureSummary() {
+      try {
+        const response = await callApi(`/eval/${encodeURIComponent(evalId)}/failure-summary`, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          setFailures([]);
+          return;
+        }
+        const data = (await response.json()) as GetFailureSummaryResponse;
+        setFailures(data.failures);
+      } catch (error) {
+        if (!(error instanceof DOMException && error.name === 'AbortError')) {
+          setFailures([]);
+        }
+      }
+    }
+
+    void loadFailureSummary();
+    return () => controller.abort();
+  }, [evalId]);
+
+  const activeFilterIds = useMemo(
+    () =>
+      new Map(
+        Object.entries(filters.values)
+          .filter(([, filter]) => filter.type === 'error' && filter.operator === 'equals')
+          .map(([id, filter]) => [filter.value, id]),
+      ),
+    [filters.values],
+  );
+
+  if (failures.length === 0) {
+    return null;
+  }
+
+  const toggleFailureFilter = (error: string) => {
+    const activeFilterId = activeFilterIds.get(error);
+    if (activeFilterId) {
+      removeFilter(activeFilterId);
+      return;
+    }
+    addFilter({
+      type: 'error',
+      operator: 'equals',
+      value: error,
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-xs font-medium text-muted-foreground">Failure groups:</span>
+      {failures.map(({ error, count }) => {
+        const isActive = activeFilterIds.has(error);
+        return (
+          <Tooltip key={error}>
+            <TooltipTrigger asChild>
+              <button type="button" onClick={() => toggleFailureFilter(error)}>
+                <Badge
+                  variant="secondary"
+                  className={
+                    isActive
+                      ? 'cursor-pointer bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-300'
+                      : 'cursor-pointer hover:bg-muted'
+                  }
+                >
+                  <AlertCircle className="mr-1 size-3 text-red-500" />
+                  {count} {count === 1 ? 'failure' : 'failures'}
+                </Badge>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-md break-words">
+              {error}
+              <br />
+              {isActive ? 'Click to remove filter' : 'Click to filter'}
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/src/pages/eval/components/ResultsFilters/FiltersForm.tsx
+++ b/src/app/src/pages/eval/components/ResultsFilters/FiltersForm.tsx
@@ -22,6 +22,7 @@ import { type ResultsFilter, useTableStore } from '../store';
 const TYPE_LABELS: Record<ResultsFilter['type'], string> = {
   metric: 'Metric',
   metadata: 'Metadata',
+  error: 'Error',
   plugin: 'Plugin',
   strategy: 'Strategy',
   severity: 'Severity',

--- a/src/app/src/pages/eval/components/ResultsView.test.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.test.tsx
@@ -79,6 +79,10 @@ vi.mock('./FilterModeSelector', () => ({
   ),
 }));
 
+vi.mock('./FailureSummary', () => ({
+  FailureSummary: () => null,
+}));
+
 const mockUseFilterMode = vi.fn();
 vi.mock('./FilterModeProvider', () => ({
   useFilterMode: () => mockUseFilterMode(),

--- a/src/app/src/pages/eval/components/ResultsView.tsx
+++ b/src/app/src/pages/eval/components/ResultsView.tsx
@@ -33,6 +33,7 @@ import { ConfirmEvalNameDialog } from './ConfirmEvalNameDialog';
 import { DownloadDialog, DownloadMenuItem } from './DownloadMenu';
 import EvalHeader from './EvalHeader';
 import EvalSelectorDialog from './EvalSelectorDialog';
+import { FailureSummary } from './FailureSummary';
 import { FilterChips } from './FilterChips';
 import { useFilterMode } from './FilterModeProvider';
 import { FilterModeSelector } from './FilterModeSelector';
@@ -119,6 +120,10 @@ function getAppliedFilterLabel(
     };
     const operatorDisplay = operatorSymbols[filter.operator] || filter.operator;
     return `${filter.field} ${operatorDisplay} ${truncatedValue}`;
+  }
+
+  if (filter.type === 'error') {
+    return `Error: ${truncatedValue}`;
   }
 
   if (filter.type === 'plugin') {
@@ -913,6 +918,7 @@ export default function ResultsView({
                         </button>
                       </Badge>
                     )}
+                    <FailureSummary evalId={currentEvalId} />
                     {filters.appliedCount > 0 && (
                       <AppliedFilterBadges
                         filters={appliedFilters}

--- a/src/app/src/pages/eval/components/store.test.ts
+++ b/src/app/src/pages/eval/components/store.test.ts
@@ -1996,6 +1996,7 @@ describe('useTableStore', () => {
             options: {
               metric: computeAvailableMetrics(mockTable),
               metadata: [],
+              error: [],
               plugin: [],
               strategy: [],
               severity: [],
@@ -2045,6 +2046,7 @@ describe('useTableStore', () => {
             options: {
               metric: computeAvailableMetrics(mockTable),
               metadata: [],
+              error: [],
               plugin: [],
               strategy: [],
               severity: [],
@@ -2108,6 +2110,7 @@ describe('useTableStore', () => {
             options: {
               metric: computeAvailableMetrics(mockTable),
               metadata: [],
+              error: [],
               plugin: [],
               strategy: [],
               severity: [],
@@ -2152,6 +2155,7 @@ describe('useTableStore', () => {
             options: {
               metric: computeAvailableMetrics(mockTable),
               metadata: [],
+              error: [],
               plugin: [],
               strategy: [],
               severity: [],
@@ -2192,6 +2196,7 @@ describe('useTableStore', () => {
             options: {
               metric: computeAvailableMetrics(mockTable),
               metadata: [],
+              error: [],
               plugin: [],
               strategy: [],
               severity: [],

--- a/src/app/src/pages/eval/components/store.ts
+++ b/src/app/src/pages/eval/components/store.ts
@@ -220,6 +220,7 @@ interface ColumnState {
 }
 
 export type ResultsFilterType =
+  | 'error'
   | 'metric'
   | 'metadata'
   | 'plugin'
@@ -364,6 +365,7 @@ interface TableState {
     options: {
       metric: string[];
       metadata: string[];
+      error: string[];
       // Redteam-specific filter options are only available for redteam evaluations.
       plugin?: string[];
       strategy?: string[];
@@ -577,6 +579,7 @@ export const useTableStore = create<TableState>()(
             options: {
               metric: computeAvailableMetrics(table),
               metadata: [],
+              error: [],
               ...redteamOptions,
             },
             policyIdToNameMap,
@@ -601,6 +604,7 @@ export const useTableStore = create<TableState>()(
             options: {
               metric: computeAvailableMetrics(results.table),
               metadata: [],
+              error: [],
               ...redteamOptions,
             },
             policyIdToNameMap,
@@ -732,6 +736,7 @@ export const useTableStore = create<TableState>()(
               options: {
                 metric: computeAvailableMetrics(data.table),
                 metadata: [],
+                error: [],
                 ...redteamOptions,
               },
               policyIdToNameMap,
@@ -765,6 +770,7 @@ export const useTableStore = create<TableState>()(
       options: {
         metric: [],
         metadata: [],
+        error: [],
       },
     },
 

--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -894,6 +894,23 @@ export default class Eval {
     return await EvalResult.findManyByEvalId(this.id, { testIdx });
   }
 
+  async getFailureSummary(): Promise<Array<{ error: string; count: number }>> {
+    const db = await getDb();
+    const rows = await db.all<{ error: string; count: number }>(sql`
+      SELECT error, COUNT(*) AS count
+      FROM eval_results
+      WHERE eval_id = ${this.id}
+        AND success = 0
+        AND error IS NOT NULL
+        AND TRIM(error) != ''
+      GROUP BY error
+      ORDER BY count DESC, error ASC
+      LIMIT 100
+    `);
+
+    return rows.map(({ error, count }) => ({ error, count: Number(count) }));
+  }
+
   /**
    * CRITICAL: Builds the WHERE SQL clause for filtering results.
    * This is the single source of truth for all filtering logic.
@@ -1053,6 +1070,8 @@ export default class Eval {
                 AND LENGTH(TRIM(COALESCE(json_each.value, ''))) > 0
             )`;
           }
+        } else if (type === 'error' && operator === 'equals') {
+          condition = sql`error = ${value}`;
         } else if (type === 'plugin') {
           const isCategory = Object.keys(PLUGIN_CATEGORIES).includes(value);
 

--- a/src/openapi/server.ts
+++ b/src/openapi/server.ts
@@ -84,7 +84,7 @@ const OpenApiEvalTableJsonResponseSchema = z.union([
   EvalSchemas.Table.JsonExportResponse,
 ]);
 
-export const SERVER_OPENAPI_ROUTE_COUNT = 67;
+export const SERVER_OPENAPI_ROUTE_COUNT = 68;
 
 type OpenApiSchema = NonNullable<ZodMediaTypeObject['schema']>;
 type OpenApiResponse = ResponseConfig & { description: string };
@@ -535,6 +535,22 @@ export function createServerOpenApiRegistry() {
       404: notFound('Evaluation not found'),
       500: serverError(),
       413: errorResponse('Evaluation table is too large'),
+    },
+  });
+
+  register({
+    method: 'get',
+    path: '/api/eval/{id}/failure-summary',
+    operationId: 'getEvalFailureSummary',
+    tags: ['Eval'],
+    summary: 'Group failed evaluation results by error',
+    request: {
+      params: params('GetFailureSummaryParams', EvalSchemas.FailureSummary.Params),
+    },
+    responses: {
+      200: jsonResponse('GetFailureSummaryResponse', EvalSchemas.FailureSummary.Response),
+      400: validationError(),
+      404: notFound('Evaluation not found'),
     },
   });
 

--- a/src/server/routes/eval.ts
+++ b/src/server/routes/eval.ts
@@ -480,6 +480,25 @@ evalRouter.get('/:id/table', async (req: Request, res: Response): Promise<void> 
   sendEvalTableResponse(res, id, responsePayload);
 });
 
+evalRouter.get('/:id/failure-summary', async (req: Request, res: Response): Promise<void> => {
+  const paramsResult = EvalSchemas.FailureSummary.Params.safeParse(req.params);
+  if (!paramsResult.success) {
+    res.status(400).json({ error: z.prettifyError(paramsResult.error) });
+    return;
+  }
+
+  const eval_ = await Eval.findById(paramsResult.data.id);
+  if (!eval_) {
+    res.status(404).json({ error: 'Eval not found' });
+    return;
+  }
+
+  const response = EvalSchemas.FailureSummary.Response.parse({
+    failures: await eval_.getFailureSummary(),
+  });
+  res.json(response);
+});
+
 evalRouter.get('/:id/metadata-keys', async (req: Request, res: Response): Promise<void> => {
   const paramsResult = EvalSchemas.MetadataKeys.Params.safeParse(req.params);
   if (!paramsResult.success) {

--- a/src/types/api/eval.ts
+++ b/src/types/api/eval.ts
@@ -135,6 +135,22 @@ export const EvalTableResponseSchema = z
 export const EvalTableJsonExportResponseSchema = z.lazy(() => EvaluateTableSchema);
 export type EvalTableResponse = z.infer<typeof EvalTableResponseSchema>;
 
+// GET /api/eval/:id/failure-summary
+
+export const GetFailureSummaryParamsSchema = EvalIdParamSchema;
+
+export const GetFailureSummaryResponseSchema = z.object({
+  failures: z.array(
+    z.object({
+      error: z.string().min(1),
+      count: z.number().int().positive(),
+    }),
+  ),
+});
+
+export type GetFailureSummaryParams = z.infer<typeof GetFailureSummaryParamsSchema>;
+export type GetFailureSummaryResponse = z.infer<typeof GetFailureSummaryResponseSchema>;
+
 // POST /api/eval/job
 
 /**
@@ -371,6 +387,10 @@ export const EvalSchemas = {
     Query: EvalTableQuerySchema,
     Response: EvalTableResponseSchema,
     JsonExportResponse: EvalTableJsonExportResponseSchema,
+  },
+  FailureSummary: {
+    Params: GetFailureSummaryParamsSchema,
+    Response: GetFailureSummaryResponseSchema,
   },
   AddResults: {
     Params: AddResultsParamsSchema,

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, gte, sql } from 'drizzle-orm';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDb } from '../../src/database/index';
 import { updateSignalFile, updateSignalFileForDeletedEvals } from '../../src/database/signal';
@@ -1738,6 +1738,50 @@ describe('evaluator', () => {
       expect(result.body).toEqual([]);
       expect(result.totalCount).toBe(0);
       expect(result.filteredCount).toBe(0);
+    });
+  });
+
+  describe('getFailureSummary', () => {
+    it('groups failed results by error and supports filtering by a selected group', async () => {
+      const eval_ = await EvalFactory.create({
+        numResults: 5,
+        resultTypes: ['error'],
+      });
+      const db = await getDb();
+
+      await db
+        .update(evalResultsTable)
+        .set({ error: 'Request timed out' })
+        .where(eq(evalResultsTable.evalId, eval_.id))
+        .run();
+      await db
+        .update(evalResultsTable)
+        .set({ error: 'Invalid provider response' })
+        .where(and(eq(evalResultsTable.evalId, eval_.id), gte(evalResultsTable.testIdx, 3)))
+        .run();
+
+      await expect(eval_.getFailureSummary()).resolves.toEqual([
+        { error: 'Request timed out', count: 3 },
+        { error: 'Invalid provider response', count: 2 },
+      ]);
+
+      const table = await eval_.getTablePage({
+        filters: [
+          JSON.stringify({
+            logicOperator: 'and',
+            type: 'error',
+            operator: 'equals',
+            value: 'Request timed out',
+          }),
+        ],
+      });
+
+      expect(table.filteredCount).toBe(3);
+      expect(
+        table.body
+          .flatMap((row) => row.outputs)
+          .every((output) => output.error === 'Request timed out'),
+      ).toBe(true);
     });
   });
 

--- a/test/server/routes/serverRouteSmoke.test.ts
+++ b/test/server/routes/serverRouteSmoke.test.ts
@@ -475,6 +475,12 @@ const smokeCases: SmokeCase[] = [
   },
   {
     method: 'get',
+    openApiPath: '/api/eval/{id}/failure-summary',
+    path: '/api/eval/eval-1/failure-summary',
+    expectedStatus: 404,
+  },
+  {
+    method: 'get',
     openApiPath: '/api/eval/{id}/metadata-keys',
     path: '/api/eval/ab/metadata-keys',
     expectedStatus: 400,


### PR DESCRIPTION
Fixes #3885

## Summary
- add a failure-summary endpoint that groups failed eval results by exact error message
- show clickable failure-group badges in the results toolbar
- apply the selected group as an exact server-side table filter

## Testing
- `npx vitest run test/models/eval.test.ts --sequence.shuffle=false`
- `npm run test:app -- src/pages/eval/components/FailureSummary.test.tsx --run`
- `npm run build`