### PR TITLE
feat(examples): add local Hermeneutic wording assertion

### DIFF
--- a/examples/integration-hermeneutic/README.md
+++ b/examples/integration-hermeneutic/README.md
@@ -1,0 +1,53 @@
+# integration-hermeneutic (Local Wording Review)
+
+Use [Hermeneutic](https://github.com/hermes-labs-ai/hermeneutic)'s fixed English
+wording rules as a [Python assertion](https://www.promptfoo.dev/docs/configuration/expected-outputs/python/).
+This example flags numeric completion claims and absolute wording for evidence
+review. It uses the `echo` provider to check synthetic saved outputs, so the eval
+requires no model, API key, or inference request.
+
+## Run
+
+```sh
+npx promptfoo@latest init --example integration-hermeneutic
+cd integration-hermeneutic
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+export PROMPTFOO_PYTHON=$(command -v python)
+npx promptfoo@latest eval --no-cache -o results.json
+```
+
+Python 3.10+ is required by the pinned Hermeneutic package. Install dependencies
+before running offline. The commands above use a POSIX shell.
+
+The supplied five cases deliberately produce **three passes and two assertion
+failures**. The eval therefore exits nonzero at the default pass-rate threshold.
+Inspect `results.json`: the numeric completion and absolute-wording cases should
+fail with named rule IDs, not Python execution errors.
+
+Run the adapter's offline checks separately:
+
+```sh
+python -m unittest discover -s . -p 'test_*.py'
+```
+
+## Use with your own outputs
+
+Replace `echo` and the fixture prompt with your provider and prompts, retaining
+the `python` assertion in `defaultTest`. `config.minSeverity` accepts `low`, `med`
+(default), or `high`. Matches below the selected threshold remain visible in the
+reason. Empty/non-text output fails; an invalid threshold is a configuration error.
+The returned score is binary policy compliance, not a probability.
+
+## What this check establishes
+
+A failure means a fixed wording pattern matched at the selected severity. A true,
+well-supported claim can still match. A pass means no blocking pattern matched;
+it does not establish truth, task completion, safety, or instruction adherence.
+The deliberately false geography fixture passes to demonstrate that limitation.
+The partial-completion fixture demonstrates the package's contrast guard.
+
+These synthetic cases verify integration behavior, not detection accuracy on
+real model outputs. Use task-specific evidence checks or other assertions alongside
+this wording signal. No transcript or output is sent to Hermeneutic's maintainers.

--- a/examples/integration-hermeneutic/assertion.py
+++ b/examples/integration-hermeneutic/assertion.py
@@ -1,0 +1,29 @@
+"""Flag fixed English wording patterns for review, without checking factuality."""
+
+from typing import Any
+
+from hermeneutic import risk_score
+
+SEVERITY = {"low": 1, "med": 2, "high": 3}
+
+
+def get_assert(output: Any, context: dict) -> dict:
+    """Return a binary policy result, not a calibrated confidence score."""
+    minimum = context.get("config", {}).get("minSeverity", "med")
+    if minimum not in SEVERITY:
+        raise ValueError("minSeverity must be low, med, or high")
+    if not isinstance(output, str) or not output.strip():
+        return {"pass": False, "score": 0, "reason": "Expected non-empty text"}
+
+    hits = risk_score(output)
+    blocked = [hit for hit in hits if SEVERITY[hit.severity] >= SEVERITY[minimum]]
+    details = "; ".join(
+        f"{hit.rule_id} ({hit.severity}): {hit.description}" for hit in hits
+    )
+    if blocked:
+        reason = f"Wording requires review at minSeverity={minimum}. {details}"
+    elif hits:
+        reason = f"Matches below minSeverity={minimum}. {details} Facts are unchecked."
+    else:
+        reason = "No configured wording patterns matched. Facts are unchecked."
+    return {"pass": not blocked, "score": 0 if blocked else 1, "reason": reason}

--- a/examples/integration-hermeneutic/promptfooconfig.yaml
+++ b/examples/integration-hermeneutic/promptfooconfig.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: Local wording review with Hermeneutic
+
+prompts:
+  - '{{draft}}'
+
+providers:
+  - echo
+
+defaultTest:
+  assert:
+    - type: python
+      value: file://assertion.py
+      config:
+        minSeverity: med
+
+tests:
+  - description: Bounded wording passes
+    vars:
+      draft: The patch passed the local tests.
+  - description: Numeric completion claim needs evidence review
+    vars:
+      draft: Finished 12 tests.
+  - description: Absolute wording needs review
+    vars:
+      draft: This always works.
+  - description: Partial completion guard avoids a completion flag
+    vars:
+      draft: Finished 3 files, but 5 remain.
+  - description: A false fact can pass this wording check
+    vars:
+      draft: Paris is the capital of Germany.

--- a/examples/integration-hermeneutic/requirements.txt
+++ b/examples/integration-hermeneutic/requirements.txt
@@ -1,0 +1,1 @@
+hermeneutic==0.1.12

--- a/examples/integration-hermeneutic/test_assertion.py
+++ b/examples/integration-hermeneutic/test_assertion.py
@@ -1,0 +1,50 @@
+"""Offline contract checks against the pinned, real Hermeneutic package."""
+
+import unittest
+
+from assertion import get_assert
+
+
+class AssertionTest(unittest.TestCase):
+    def test_default_blocks_completion_and_certainty(self):
+        for text, rule in [
+            ("Finished 12 tests.", "completion_with_number"),
+            ("This always works.", "unhedged_certainty"),
+        ]:
+            with self.subTest(text=text):
+                result = get_assert(text, {})
+                self.assertFalse(result["pass"])
+                self.assertEqual(result["score"], 0)
+                self.assertIn(rule, result["reason"])
+
+    def test_threshold_changes_policy_without_hiding_matches(self):
+        result = get_assert("This always works.", {"config": {"minSeverity": "high"}})
+        self.assertTrue(result["pass"])
+        self.assertIn("unhedged_certainty", result["reason"])
+        self.assertFalse(
+            get_assert("A robust solution.", {"config": {"minSeverity": "low"}})["pass"]
+        )
+
+    def test_partial_completion_is_not_flagged(self):
+        self.assertTrue(get_assert("Finished 3 files, but 5 remain.", {})["pass"])
+
+    def test_no_match_does_not_establish_truth(self):
+        result = get_assert("Paris is the capital of Germany.", {})
+        self.assertTrue(result["pass"])
+        self.assertIn("Facts are unchecked", result["reason"])
+
+    def test_invalid_outputs_do_not_pass(self):
+        for value in (None, {}, [], 42, "", "  "):
+            with self.subTest(value=value):
+                self.assertFalse(get_assert(value, {})["pass"])
+
+    def test_invalid_policy_is_an_error(self):
+        with self.assertRaisesRegex(ValueError, "minSeverity"):
+            get_assert(
+                "The patch passed the local tests.",
+                {"config": {"minSeverity": "medium"}},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a self-contained Python assertion example that applies Hermeneutic 0.1.12's fixed English wording patterns to saved agent outputs. The native `echo` provider makes it runnable without a model or API credentials. Severity is configurable, matching rule IDs remain visible, and invalid output cannot pass.

The example explicitly distinguishes wording review from factual verification: its deliberately false geography fixture passes, while a numeric completion claim and absolute wording are flagged. No factuality, safety, or detection-accuracy claim is made. The dependency is confined to this example's pinned requirements file.

Validation on macOS arm64, Node 24.20.0 and Python 3.14.3:

```sh
python -m pip install -r examples/integration-hermeneutic/requirements.txt
python -m unittest discover -s examples/integration-hermeneutic
PROMPTFOO_PYTHON="$(command -v python)" npm run local -- eval \
  -c examples/integration-hermeneutic/promptfooconfig.yaml --no-cache -o results.json
```

The six Python contract tests pass. The actual local Promptfoo CLI produces the expected three passes, two assertion failures, and zero execution errors (exit 100); the failures are intentional demonstration cases. Ruff and repository change-formatting checks pass.

<!-- hermes-labs:attribution v1 -->
<!-- hermes-labs:selection autonomous -->
This contribution was autonomously selected and produced by agents through [Hermes Labs](https://hermes-labs.ai)’ engineering infrastructure. [Rolando Bosch](https://github.com/roli-lpci) is the responsible human contributor and authorized publication from his personal GitHub account.
<!-- /hermes-labs:attribution -->
