### PR TITLE
refactor(code-scan): reuse raw diff parser

### DIFF
--- a/src/codeScan/git/diffProcessor.ts
+++ b/src/codeScan/git/diffProcessor.ts
@@ -20,17 +20,10 @@ import logger from '../../logger';
 import { DiffProcessorError } from '../../types/codeScan';
 import { isInDenylist, MAX_BLOB_SIZE_BYTES, MAX_PATCH_SIZE_BYTES } from '../constants/filtering';
 import { annotateDiffWithLineRanges } from './diffAnnotator';
+import { parseRawDiff } from './rawDiffParser';
 
 import type { FileRecord } from '../../types/codeScan';
 import type { LineRange } from '../util/diffLineRanges';
-
-interface RawDiffEntry {
-  path: string;
-  oldPath?: string;
-  status: string;
-  shaA: string | null;
-  shaB: string | null;
-}
 
 interface NumstatEntry {
   linesAdded: number;
@@ -44,75 +37,6 @@ type PatchResult =
 
 const PATCH_CONCURRENCY = 8;
 const TEXT_DETECTION_CONCURRENCY = 16;
-
-/**
- * Parse git diff --raw -z output
- *
- * Format for normal operations (M, A, D):
- *   :oldmode newmode oldsha newsha status\0path\0
- *
- * Format for renames/copies (R, C):
- *   :oldmode newmode oldsha newsha status\0oldpath\0newpath\0
- *
- * Note: Rename/Copy status includes similarity (e.g., R100, R90, C100)
- */
-function parseRawDiff(rawOutput: string): RawDiffEntry[] {
-  const entries = rawOutput.split('\0').filter(Boolean);
-  const results: RawDiffEntry[] = [];
-
-  let i = 0;
-  while (i < entries.length) {
-    const metaLine = entries[i];
-    i++;
-
-    if (!metaLine || i >= entries.length) {
-      break;
-    }
-
-    // Parse: :100644 100644 abc123... def456... M (or R100, C100, etc)
-    const parts = metaLine.trim().split(/\s+/);
-    if (parts.length < 5) {
-      continue;
-    }
-
-    const shaA = parts[2] === '0000000000000000000000000000000000000000' ? null : parts[2];
-    const shaB = parts[3] === '0000000000000000000000000000000000000000' ? null : parts[3];
-    const status = parts[4];
-
-    // Check if this is a rename or copy operation
-    // Status will be like: R100, R90, C100, C95, etc.
-    const isRenameOrCopy = status.startsWith('R') || status.startsWith('C');
-
-    if (isRenameOrCopy) {
-      // Renames and copies have TWO paths: oldpath and newpath
-      // Format: metadata\0oldpath\0newpath\0
-      const oldPath = entries[i];
-      i++;
-      const newPath = entries[i];
-      i++;
-
-      if (!oldPath || !newPath) {
-        continue;
-      }
-
-      // Use the new/destination path as the main path
-      results.push({ path: newPath, oldPath, status, shaA, shaB });
-    } else {
-      // Normal operations (M, A, D) have ONE path
-      // Format: metadata\0path\0
-      const filePath = entries[i];
-      i++;
-
-      if (!filePath) {
-        continue;
-      }
-
-      results.push({ path: filePath, status, shaA, shaB });
-    }
-  }
-
-  return results;
-}
 
 /**
  * Parse git diff --numstat output


### PR DESCRIPTION
## Summary

- route production code-scan diff processing through the existing raw diff parser
- remove the byte-identical private parser and type so parser tests cover the implementation used at runtime

This is a behavior-preserving cleanup. Git invocation, NUL-safe path parsing, rename/copy handling, SHA normalization, filtering, and patch generation are unchanged.

## Validation

- `npx vitest run test/codeScans --sequence.shuffle=false` (156 tests passed)
- `npx vitest run test/types/codeScan.test.ts --sequence.shuffle=false` (11 tests passed)
- `npm run tsc`
- `npm run l`
- `npx @biomejs/biome check src/codeScan/git/diffProcessor.ts`
