### PR TITLE
refactor(providers): remove dead Hyperbolic response parsing

### DIFF
--- a/src/providers/hyperbolic/chat.ts
+++ b/src/providers/hyperbolic/chat.ts
@@ -290,64 +290,6 @@ export class HyperbolicProvider extends OpenAiChatCompletionProvider {
     }
 
     try {
-      if (typeof response.raw === 'string') {
-        try {
-          const rawData = JSON.parse(response.raw);
-
-          if (
-            this.isReasoningModel() &&
-            rawData?.usage?.completion_tokens_details?.reasoning_tokens
-          ) {
-            const reasoningTokens = rawData.usage.completion_tokens_details.reasoning_tokens;
-            const acceptedPredictions =
-              rawData.usage.completion_tokens_details.accepted_prediction_tokens || 0;
-            const rejectedPredictions =
-              rawData.usage.completion_tokens_details.rejected_prediction_tokens || 0;
-
-            if (response.tokenUsage) {
-              response.tokenUsage.completionDetails = {
-                reasoning: reasoningTokens,
-                acceptedPrediction: acceptedPredictions,
-                rejectedPrediction: rejectedPredictions,
-              };
-
-              logger.debug(
-                `Hyperbolic reasoning token details for ${this.modelName}: ` +
-                  `reasoning=${reasoningTokens}, accepted=${acceptedPredictions}, rejected=${rejectedPredictions}`,
-              );
-            }
-          }
-        } catch (err) {
-          logger.error(`Failed to parse raw response JSON: ${err}`);
-        }
-      } else if (typeof response.raw === 'object' && response.raw !== null) {
-        const rawData = response.raw;
-
-        if (
-          this.isReasoningModel() &&
-          rawData?.usage?.completion_tokens_details?.reasoning_tokens
-        ) {
-          const reasoningTokens = rawData.usage.completion_tokens_details.reasoning_tokens;
-          const acceptedPredictions =
-            rawData.usage.completion_tokens_details.accepted_prediction_tokens || 0;
-          const rejectedPredictions =
-            rawData.usage.completion_tokens_details.rejected_prediction_tokens || 0;
-
-          if (response.tokenUsage) {
-            response.tokenUsage.completionDetails = {
-              reasoning: reasoningTokens,
-              acceptedPrediction: acceptedPredictions,
-              rejectedPrediction: rejectedPredictions,
-            };
-
-            logger.debug(
-              `Hyperbolic reasoning token details for ${this.modelName}: ` +
-                `reasoning=${reasoningTokens}, accepted=${acceptedPredictions}, rejected=${rejectedPredictions}`,
-            );
-          }
-        }
-      }
-
       if (response.tokenUsage && !response.cached) {
         const reasoningTokens = response.tokenUsage.completionDetails?.reasoning || 0;
 

--- a/test/providers/hyperbolic.test.ts
+++ b/test/providers/hyperbolic.test.ts
@@ -56,39 +56,6 @@ describe('HyperbolicProvider', () => {
   });
 
   describe('callApi', () => {
-    it('should handle successful API response', async () => {
-      provider = new HyperbolicProvider('deepseek-ai/DeepSeek-R1', {});
-
-      const mockResponse = {
-        output: 'Test response',
-        tokenUsage: { prompt: 100, completion: 50 },
-        cached: false,
-        raw: JSON.stringify({
-          usage: {
-            prompt_tokens: 100,
-            completion_tokens: 50,
-            completion_tokens_details: {
-              reasoning_tokens: 30,
-              accepted_prediction_tokens: 10,
-              rejected_prediction_tokens: 5,
-            },
-          },
-        }),
-      };
-
-      vi.spyOn(OpenAiChatCompletionProvider.prototype, 'callApi').mockResolvedValue(mockResponse);
-
-      const result = await provider.callApi('Test prompt');
-
-      expect(result.output).toBe('Test response');
-      expect(result.tokenUsage.completionDetails).toEqual({
-        reasoning: 30,
-        acceptedPrediction: 10,
-        rejectedPrediction: 5,
-      });
-      expect(result.cost).toBeDefined();
-    });
-
     it('should handle API errors', async () => {
       provider = new HyperbolicProvider('deepseek-ai/DeepSeek-R1', {});
 

--- a/test/providers/hyperbolic/chat.test.ts
+++ b/test/providers/hyperbolic/chat.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../../src/cache';
 import {
   calculateHyperbolicCost,
   createHyperbolicProvider,
@@ -7,6 +8,13 @@ import {
   HyperbolicProvider,
 } from '../../../src/providers/hyperbolic/chat';
 import { OpenAiChatCompletionProvider } from '../../../src/providers/openai/chat';
+
+vi.mock('../../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/cache')>()),
+  fetchWithCache: vi.fn(),
+}));
+
+const mockFetchWithCache = vi.mocked(fetchWithCache);
 
 describe('HyperbolicProvider', () => {
   let provider: HyperbolicProvider;
@@ -17,9 +25,11 @@ describe('HyperbolicProvider', () => {
         apiKey: 'test-key',
       },
     },
+    env: { HYPERBOLIC_API_KEY: 'test-key' },
   };
 
   beforeEach(() => {
+    mockFetchWithCache.mockReset();
     provider = new HyperbolicProvider(modelName, options);
   });
 
@@ -45,60 +55,49 @@ describe('HyperbolicProvider', () => {
     });
   });
 
-  it('should process API response correctly for reasoning model', async () => {
-    const mockResponse = {
-      raw: {
+  it.each([
+    {
+      label: 'populated',
+      details: {
+        reasoning_tokens: 100,
+        accepted_prediction_tokens: 50,
+        rejected_prediction_tokens: 25,
+      },
+      expected: { reasoning: 100, acceptedPrediction: 50, rejectedPrediction: 25 },
+    },
+    {
+      label: 'zero-valued',
+      details: {
+        reasoning_tokens: 0,
+        accepted_prediction_tokens: 0,
+        rejected_prediction_tokens: 0,
+      },
+      expected: { reasoning: 0, acceptedPrediction: 0, rejectedPrediction: 0 },
+    },
+    { label: 'absent', details: undefined, expected: undefined },
+  ])('should normalize $label reasoning details from API usage', async ({ details, expected }) => {
+    mockFetchWithCache.mockResolvedValue({
+      data: {
+        choices: [{ message: { content: 'answer' }, finish_reason: 'stop' }],
         usage: {
-          completion_tokens_details: {
-            reasoning_tokens: 100,
-            accepted_prediction_tokens: 50,
-            rejected_prediction_tokens: 25,
-          },
+          total_tokens: 350,
+          prompt_tokens: 200,
+          completion_tokens: 150,
+          ...(details ? { completion_tokens_details: details } : {}),
         },
       },
-      tokenUsage: {
-        prompt: 200,
-        completion: 150,
-      },
-    };
-
-    vi.spyOn(OpenAiChatCompletionProvider.prototype, 'callApi').mockResolvedValue(mockResponse);
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+    });
 
     const result = await provider.callApi('test prompt');
 
-    expect(result.tokenUsage.completionDetails).toEqual({
-      reasoning: 100,
-      acceptedPrediction: 50,
-      rejectedPrediction: 25,
-    });
-  });
-
-  it('should handle raw response as string', async () => {
-    const mockResponse = {
-      raw: JSON.stringify({
-        usage: {
-          completion_tokens_details: {
-            reasoning_tokens: 100,
-            accepted_prediction_tokens: 50,
-            rejected_prediction_tokens: 25,
-          },
-        },
-      }),
-      tokenUsage: {
-        prompt: 200,
-        completion: 150,
-      },
-    };
-
-    vi.spyOn(OpenAiChatCompletionProvider.prototype, 'callApi').mockResolvedValue(mockResponse);
-
-    const result = await provider.callApi('test prompt');
-
-    expect(result.tokenUsage.completionDetails).toEqual({
-      reasoning: 100,
-      acceptedPrediction: 50,
-      rejectedPrediction: 25,
-    });
+    expect(result.output).toBe('answer');
+    expect(result.tokenUsage?.completionDetails).toEqual(expected);
+    expect(result).not.toHaveProperty('raw');
+    expect(result.cost).toBe((0.5 / 1e6) * 200 + (2.18 / 1e6) * 150);
   });
 
   it('should handle error response', async () => {
@@ -109,24 +108,8 @@ describe('HyperbolicProvider', () => {
     expect(result.error).toBe('API error');
   });
 
-  it('should handle invalid JSON in raw response', async () => {
-    const mockResponse = {
-      raw: 'invalid json',
-      tokenUsage: {
-        prompt: 200,
-        completion: 150,
-      },
-    };
-
-    vi.spyOn(OpenAiChatCompletionProvider.prototype, 'callApi').mockResolvedValue(mockResponse);
-
-    const result = await provider.callApi('test prompt');
-    expect(result.tokenUsage.completionDetails).toBeUndefined();
-  });
-
   it('should calculate cost for non-cached response', async () => {
     const mockResponse = {
-      raw: 'test response',
       tokenUsage: {
         prompt: 1000,
         completion: 500,


### PR DESCRIPTION
## Summary

- remove unreachable Hyperbolic `response.raw` reparsing
- rely on inherited OpenAI usage normalization for completion-token details
- replace impossible raw-response mocks with transport-level usage fixtures and remove duplicate stale coverage

## Validation

- `npx vitest run test/providers/hyperbolic.test.ts test/providers/hyperbolic --sequence.shuffle=false` (68 passed)
- `npx vitest run test/providers/hyperbolic.test.ts test/providers/hyperbolic --sequence.seed=20260906` (68 passed)
- `npx vitest run test/providers/hyperbolic/chat.test.ts test/providers/openai/util.test.ts --sequence.shuffle=false` (167 passed)
- `npm run tsc`
- `npx @biomejs/biome check src/providers/hyperbolic/chat.ts test/providers/hyperbolic.test.ts test/providers/hyperbolic/chat.test.ts`
- `git diff --check origin/main...HEAD`
