### PR TITLE
refactor(code-scan): remove unused diff extraction

### DIFF
--- a/src/codeScan/git/diff.ts
+++ b/src/codeScan/git/diff.ts
@@ -1,55 +1,9 @@
 /**
- * Git Diff Extraction
- *
- * Extracts git diffs between the current branch and the base branch.
+ * Git Branch Validation
  */
 
-import simpleGit, { type SimpleGit } from 'simple-git';
 import { GitError } from '../../types/codeScan';
-
-/**
- * Get the base branch name by detecting the remote's default branch
- * Falls back to local branch detection (main or master)
- * @param git Simple git instance
- * @returns Base branch name
- */
-async function getBaseBranch(git: SimpleGit): Promise<string> {
-  try {
-    // First, try to detect the remote's default branch
-    try {
-      const remoteHead = await git.raw(['symbolic-ref', 'refs/remotes/origin/HEAD']);
-      if (remoteHead) {
-        // Parse branch name from "refs/remotes/origin/main" -> "main"
-        const match = remoteHead.trim().match(/refs\/remotes\/origin\/(.+)/);
-        if (match && match[1]) {
-          return match[1];
-        }
-      }
-    } catch {
-      // Remote HEAD not set or no remote, fall back to local detection
-    }
-
-    // Fallback: Check local branches for main or master
-    const branches = await git.branch();
-    if (branches.all.includes('main')) {
-      return 'main';
-    }
-    if (branches.all.includes('master')) {
-      return 'master';
-    }
-
-    throw new GitError(
-      'Could not find a default base branch (main or master). Please specify a base branch or commit to compare against with --base',
-    );
-  } catch (error) {
-    if (error instanceof GitError) {
-      throw error;
-    }
-    throw new GitError(
-      `Failed to determine base branch: ${error instanceof Error ? error.message : String(error)}. Please specify a base branch or commit to compare against with --base`,
-    );
-  }
-}
+import type { SimpleGit } from 'simple-git';
 
 /**
  * Validate that we're on a branch (not detached HEAD)
@@ -72,43 +26,6 @@ export async function validateOnBranch(git: SimpleGit): Promise<string> {
     }
     throw new GitError(
       `Failed to validate branch: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-}
-
-/**
- * Extract git diff between current branch and base branch
- * @param repoPath Path to the git repository
- * @returns Git diff string
- * @throws GitError if diff extraction fails or if there are no diffs
- */
-export async function extractDiff(repoPath: string): Promise<{ diff: string; baseBranch: string }> {
-  const git = simpleGit(repoPath);
-
-  // Validate we're on a branch
-  await validateOnBranch(git);
-
-  // Get base branch
-  const baseBranch = await getBaseBranch(git);
-
-  try {
-    // Get diff using three-dot syntax (merge base)
-    const diff = await git.diff([`${baseBranch}...HEAD`]);
-
-    if (!diff || diff.trim().length === 0) {
-      throw new GitError(
-        `No changes detected between current branch and ${baseBranch}. ` +
-          'Please commit your changes or ensure your branch has diverged from the base branch.',
-      );
-    }
-
-    return { diff, baseBranch };
-  } catch (error) {
-    if (error instanceof GitError) {
-      throw error;
-    }
-    throw new GitError(
-      `Failed to extract diff: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
 }

--- a/test/codeScans/git/diff.test.ts
+++ b/test/codeScans/git/diff.test.ts
@@ -3,33 +3,21 @@
  */
 
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
-import { extractDiff, validateOnBranch } from '../../../src/codeScan/git/diff';
+import { validateOnBranch } from '../../../src/codeScan/git/diff';
 import { GitError } from '../../../src/types/codeScan';
 import type { SimpleGit, StatusResult } from 'simple-git';
 
-// Define a partial mock type for the SimpleGit methods we use
-type MockSimpleGit = Pick<SimpleGit, 'status' | 'branch' | 'diff' | 'log'> & {
+type MockSimpleGit = Pick<SimpleGit, 'status'> & {
   status: Mock;
-  branch: Mock;
-  diff: Mock;
-  log: Mock;
 };
 
-// Mock simple-git with a factory that returns a mock instance
 const mockGit: MockSimpleGit = {
   status: vi.fn(),
-  branch: vi.fn(),
-  diff: vi.fn(),
-  log: vi.fn(),
 };
-
-vi.mock('simple-git', () => ({
-  default: vi.fn(() => mockGit),
-}));
 
 describe('Git Diff', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockGit.status.mockReset();
   });
 
   describe('validateOnBranch', () => {
@@ -54,127 +42,6 @@ describe('Git Diff', () => {
       await expect(validateOnBranch(mockGit as unknown as SimpleGit)).rejects.toThrow(
         'Not on a branch',
       );
-    });
-  });
-
-  describe('extractDiff', () => {
-    it('should extract diff comparing against main branch', async () => {
-      const mockDiff = `diff --git a/file.ts b/file.ts
-index 123..456 100644
---- a/file.ts
-+++ b/file.ts
-@@ -1,3 +1,4 @@
-+const newLine = 'test';
- const existingLine = 'existing';`;
-
-      // Mock status (for validateOnBranch)
-      mockGit.status.mockResolvedValue({
-        current: 'feature/test',
-        detached: false,
-      } as StatusResult);
-
-      // Mock main branch exists
-      mockGit.branch.mockResolvedValue({
-        all: ['main', 'feature/test'],
-        branches: {},
-        current: 'feature/test',
-        detached: false,
-      } as any);
-      mockGit.diff.mockResolvedValue(mockDiff);
-
-      const result = await extractDiff('/fake/repo');
-
-      expect(result).toEqual({
-        diff: mockDiff,
-        baseBranch: 'main',
-      });
-      expect(mockGit.diff).toHaveBeenCalledWith(['main...HEAD']);
-    });
-
-    it('should fall back to master branch if main does not exist', async () => {
-      const mockDiff = 'diff content';
-
-      // Mock status (for validateOnBranch)
-      mockGit.status.mockResolvedValue({
-        current: 'feature/test',
-        detached: false,
-      } as StatusResult);
-
-      // Mock main branch does not exist, master does
-      mockGit.branch.mockResolvedValue({
-        all: ['master', 'feature/test'],
-        branches: {},
-        current: 'feature/test',
-        detached: false,
-      } as any);
-      mockGit.diff.mockResolvedValue(mockDiff);
-
-      const result = await extractDiff('/fake/repo');
-
-      expect(result).toEqual({
-        diff: mockDiff,
-        baseBranch: 'master',
-      });
-      expect(mockGit.diff).toHaveBeenCalledWith(['master...HEAD']);
-    });
-
-    it('should throw GitError when neither main nor master exists', async () => {
-      // Mock status (for validateOnBranch)
-      mockGit.status.mockResolvedValue({
-        current: 'feature/test',
-        detached: false,
-      } as StatusResult);
-
-      // Mock neither branch exists - should throw error
-      mockGit.branch.mockResolvedValue({
-        all: ['feature/test'],
-        branches: {},
-        current: 'feature/test',
-        detached: false,
-      } as any);
-
-      await expect(extractDiff('/fake/repo')).rejects.toThrow(GitError);
-    });
-
-    it('should throw GitError if no changes detected', async () => {
-      // Mock status (for validateOnBranch)
-      mockGit.status.mockResolvedValue({
-        current: 'feature/test',
-        detached: false,
-      } as StatusResult);
-
-      mockGit.branch.mockResolvedValue({
-        all: ['main', 'feature/test'],
-        branches: {},
-        current: 'feature/test',
-        detached: false,
-      } as any);
-
-      // Mock empty diff
-      mockGit.diff.mockResolvedValue('');
-
-      await expect(extractDiff('/fake/repo')).rejects.toThrow(GitError);
-      await expect(extractDiff('/fake/repo')).rejects.toThrow('No changes detected');
-    });
-
-    it('should throw GitError if diff extraction fails', async () => {
-      // Mock status (for validateOnBranch)
-      mockGit.status.mockResolvedValue({
-        current: 'feature/test',
-        detached: false,
-      } as StatusResult);
-
-      mockGit.branch.mockResolvedValue({
-        all: ['main', 'feature/test'],
-        branches: {},
-        current: 'feature/test',
-        detached: false,
-      } as any);
-
-      mockGit.diff.mockRejectedValue(new Error('git diff failed'));
-
-      await expect(extractDiff('/fake/repo')).rejects.toThrow(GitError);
-      await expect(extractDiff('/fake/repo')).rejects.toThrow('Failed to extract diff');
     });
   });
 });


### PR DESCRIPTION
## Summary

- remove the unused extractDiff pipeline and its private base-branch detection
- remove obsolete extraction mocks and tests while preserving validateOnBranch behavior and coverage
- leave the scanner’s active validateOnBranch and processDiff path unchanged

## Validation

- npx vitest run test/codeScans/git/diff.test.ts test/codeScans/scanner-no-files.test.ts test/codeScans/scanner/fork-pr-auth.test.ts --sequence.shuffle=false (13 tests)
- npx vitest run test/codeScans --sequence.shuffle=false (151 tests)
- npx vitest run test/types/codeScan.test.ts --sequence.shuffle=false (11 tests)
- npm run tsc
- npm run knip -- --no-progress --reporter github-actions
- npm run l
- npx @biomejs/biome check src/codeScan/git/diff.ts test/codeScans/git/diff.test.ts
- git diff --check origin/main...HEAD
- independent reviewer, two native prepublish reviews, and a fresh verifier: no findings
