### PR TITLE
refactor(providers): deduplicate Cloudflare config

### DIFF
--- a/src/providers/cloudflare-ai.ts
+++ b/src/providers/cloudflare-ai.ts
@@ -83,20 +83,24 @@ function getPassthroughConfig(config?: CloudflareAiConfig) {
   return passthrough;
 }
 
+function getOpenAiConfig(providerOptions: CloudflareAiProviderOptions): OpenAiCompletionOptions {
+  const apiBaseUrl = getApiBaseUrl(providerOptions.config, providerOptions.env);
+  const passthrough = getPassthroughConfig(providerOptions.config);
+
+  return {
+    ...providerOptions.config,
+    apiKeyEnvar: 'CLOUDFLARE_API_KEY',
+    apiBaseUrl,
+    passthrough,
+  };
+}
+
 export class CloudflareAiChatCompletionProvider extends OpenAiChatCompletionProvider {
   private cloudflareConfig: CloudflareAiConfig;
   private modelType = 'chat';
 
   constructor(modelName: string, providerOptions: CloudflareAiProviderOptions) {
-    const apiBaseUrl = getApiBaseUrl(providerOptions.config, providerOptions.env);
-    const passthrough = getPassthroughConfig(providerOptions.config);
-
-    const config: OpenAiCompletionOptions = {
-      ...providerOptions.config,
-      apiKeyEnvar: 'CLOUDFLARE_API_KEY',
-      apiBaseUrl,
-      passthrough,
-    };
+    const config = getOpenAiConfig(providerOptions);
 
     super(modelName, {
       ...providerOptions,
@@ -137,15 +141,7 @@ export class CloudflareAiCompletionProvider extends OpenAiCompletionProvider {
   private modelType = 'completion';
 
   constructor(modelName: string, providerOptions: CloudflareAiProviderOptions) {
-    const apiBaseUrl = getApiBaseUrl(providerOptions.config, providerOptions.env);
-    const passthrough = getPassthroughConfig(providerOptions.config);
-
-    const config: OpenAiCompletionOptions = {
-      ...providerOptions.config,
-      apiKeyEnvar: 'CLOUDFLARE_API_KEY',
-      apiBaseUrl,
-      passthrough,
-    };
+    const config = getOpenAiConfig(providerOptions);
 
     super(modelName, {
       ...providerOptions,
@@ -186,15 +182,7 @@ export class CloudflareAiEmbeddingProvider extends OpenAiEmbeddingProvider {
   private modelType = 'embedding';
 
   constructor(modelName: string, providerOptions: CloudflareAiProviderOptions) {
-    const apiBaseUrl = getApiBaseUrl(providerOptions.config, providerOptions.env);
-    const passthrough = getPassthroughConfig(providerOptions.config);
-
-    const config: OpenAiCompletionOptions = {
-      ...providerOptions.config,
-      apiKeyEnvar: 'CLOUDFLARE_API_KEY',
-      apiBaseUrl,
-      passthrough,
-    };
+    const config = getOpenAiConfig(providerOptions);
 
     super(modelName, {
       ...providerOptions,


### PR DESCRIPTION
## Summary

- extract the repeated Cloudflare OpenAI configuration assembly into one file-local helper
- preserve URL and environment precedence, credential validation, passthrough filtering, and each provider's distinct superclass options
- keep chat, completion, and embedding constructors behaviorally unchanged while removing 12 net lines

## Test plan

- `npx vitest run test/providers/cloudflare-ai.test.ts --sequence.shuffle=false` (35 passed)
- `npx vitest run test/providers/cloudflare-ai.test.ts --sequence.shuffle=true --sequence.seed=20260906` (35 passed)
- `npm run tsc`
- `npx @biomejs/biome check src/providers/cloudflare-ai.ts`
- `npm run l`
- `npm run knip -- --no-progress --reporter github-actions`
- `git diff --check`
- guarded changed-file formatter equivalent with `xargs -r`

`npm run f` itself reaches the same successful Biome check, then exits 123 because this TypeScript-only diff gives Prettier an empty file list. The guarded equivalent passes without changing the file.
