### PR TITLE
fix(deps): update js-yaml to 5.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "http-z": "^8.1.1",
         "istextorbinary": "^9.5.0",
         "js-rouge": "^3.2.0",
-        "js-yaml": "5.4.0",
+        "js-yaml": "5.4.1",
         "json5": "^2.2.3",
         "keyv": "^5.6.0",
         "keyv-file": "^5.3.3",
@@ -29446,9 +29446,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.0.tgz",
-      "integrity": "sha512-jE7vUJIebKzYQI5xu4co5CRBDlDEYnHrdzsxs4O2giCz4v2SbVMYKpmt1D9L38OKQAeCWmrOTRiCV93u0UkaJA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",
@@ -46173,7 +46173,7 @@
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "dompurify": "^3.4.8",
-        "js-yaml": "5.4.0",
+        "js-yaml": "5.4.1",
         "react-countup": "^6.5.3",
         "swiper": "^14.0.0"
       },
@@ -46277,7 +46277,7 @@
         "csv-stringify": "^6.7.0",
         "diff": "^9.0.0",
         "idb-keyval": "^6.2.2",
-        "js-yaml": "5.4.0",
+        "js-yaml": "5.4.1",
         "jsdom": "^29.0.0",
         "lucide-react": "^1.0.0",
         "postcss": "^8.5.26",

--- a/package.json
+++ b/package.json
@@ -373,7 +373,7 @@
     "http-z": "^8.1.1",
     "istextorbinary": "^9.5.0",
     "js-rouge": "^3.2.0",
-    "js-yaml": "5.4.0",
+    "js-yaml": "5.4.1",
     "json5": "^2.2.3",
     "keyv": "^5.6.0",
     "keyv-file": "^5.3.3",

--- a/site/package.json
+++ b/site/package.json
@@ -90,7 +90,7 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "dompurify": "^3.4.8",
-    "js-yaml": "5.4.0",
+    "js-yaml": "5.4.1",
     "react-countup": "^6.5.3",
     "swiper": "^14.0.0"
   }

--- a/site/src/utils/yaml.test.ts
+++ b/site/src/utils/yaml.test.ts
@@ -27,6 +27,17 @@ describe('loadYaml', () => {
     });
   });
 
+  it('limits empty merge sources and oversized merge sequences', () => {
+    const small = 'merged:\n  <<: [{}, {}, {}]';
+    const large = `merged:\n  <<: [${Array(101).fill('{}').join(', ')}]`;
+
+    expect(() => loadYaml(small, { maxTotalMergeKeys: 2 })).toThrow(/maxTotalMergeKeys/);
+    expect(loadYaml(small, { maxTotalMergeKeys: 3 })).toEqual({ merged: {} });
+    expect(() => loadYaml(large, { maxTotalMergeKeys: -1 })).toThrow(
+      /abnormal merge sequence size/,
+    );
+  });
+
   it('preserves js-yaml v4 legacy standard tags', () => {
     expect(loadYaml('!!binary SGVsbG8=')).toEqual(new Uint8Array([72, 101, 108, 108, 111]));
     expect(loadYaml('2024-01-02')).toEqual(new Date('2024-01-02T00:00:00.000Z'));

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -51,7 +51,7 @@
     "csv-stringify": "^6.7.0",
     "diff": "^9.0.0",
     "idb-keyval": "^6.2.2",
-    "js-yaml": "5.4.0",
+    "js-yaml": "5.4.1",
     "jsdom": "^29.0.0",
     "lucide-react": "^1.0.0",
     "postcss": "^8.5.26",

--- a/test/util/yamlLoad.test.ts
+++ b/test/util/yamlLoad.test.ts
@@ -35,6 +35,21 @@ describe('loadYaml', () => {
     expect(() => loadYaml(content)).toThrow(/cannot merge mappings/);
   });
 
+  it('counts empty merge sources toward the total merge work limit', () => {
+    const content = 'merged:\n  <<: [{}, {}, {}]';
+
+    expect(() => loadYaml(content, { maxTotalMergeKeys: 2 })).toThrow(/maxTotalMergeKeys/);
+    expect(loadYaml(content, { maxTotalMergeKeys: 3 })).toEqual({ merged: {} });
+  });
+
+  it('rejects oversized merge sequences even when the work limit is disabled', () => {
+    const content = `merged:\n  <<: [${Array(101).fill('{}').join(', ')}]`;
+
+    expect(() => loadYaml(content, { maxTotalMergeKeys: -1 })).toThrow(
+      /abnormal merge sequence size/,
+    );
+  });
+
   it('keeps merge tokens outside mapping keys as plain strings', () => {
     expect(loadYaml('values: [<<]\ntext: <<')).toEqual({
       values: ['<<'],


### PR DESCRIPTION
## Summary

- Update `js-yaml` from 5.4.0 to 5.4.1 after #10629 landed, keeping the root, app, site, and lockfile versions aligned.
- Adopt upstream's merge-work accounting and bounded merge-sequence behavior for user-authored YAML.
- Add core and site regression tests for empty merge sources and oversized merge sequences.

## Validation

- Exact current-main branch: 279 focused core/manifest/config tests, 38 app YAML tests, and 8 site YAML tests passed.
- Root/app build, TypeScript, docs site build (`SKIP_OG_GENERATION=true`), lint, format check, and dependency consistency passed.
- No-cache CLI eval passed (1/1, score 1, zero errors); `npm audit` reported zero critical advisories (7 moderate, 28 high).
- The full local test suite was intentionally skipped; current-head CI is the full-matrix gate before merge.
