### PR TITLE
refactor(providers): remove unused Llama model catalog

### DIFF
--- a/src/providers/llamaApi.ts
+++ b/src/providers/llamaApi.ts
@@ -3,71 +3,6 @@ import { OpenAiChatCompletionProvider } from './openai/chat';
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderOptions } from '../types/index';
 
-export const LLAMA_API_MODELS = [
-  // Llama 4 Models (Multimodal)
-  {
-    id: 'Llama-4-Maverick-17B-128E-Instruct-FP8',
-    inputModalities: ['text', 'image'],
-    outputModalities: ['text'],
-    contextWindow: 128000,
-    aliases: ['llama-4-maverick'],
-  },
-  {
-    id: 'Llama-4-Scout-17B-16E-Instruct-FP8',
-    inputModalities: ['text', 'image'],
-    outputModalities: ['text'],
-    contextWindow: 128000,
-    aliases: ['llama-4-scout'],
-  },
-
-  // Llama 3.3 Models (Text-only)
-  {
-    id: 'Llama-3.3-70B-Instruct',
-    inputModalities: ['text'],
-    outputModalities: ['text'],
-    contextWindow: 128000,
-    aliases: ['llama-3.3-70b'],
-  },
-  {
-    id: 'Llama-3.3-8B-Instruct',
-    inputModalities: ['text'],
-    outputModalities: ['text'],
-    contextWindow: 128000,
-    aliases: ['llama-3.3-8b'],
-  },
-
-  // Accelerated Variants (Preview)
-  {
-    id: 'Cerebras-Llama-4-Maverick-17B-128E-Instruct',
-    inputModalities: ['text'],
-    outputModalities: ['text'],
-    contextWindow: 32000,
-    provider: 'Cerebras',
-    aliases: ['cerebras-llama-4-maverick'],
-  },
-  {
-    id: 'Cerebras-Llama-4-Scout-17B-16E-Instruct',
-    inputModalities: ['text'],
-    outputModalities: ['text'],
-    contextWindow: 32000,
-    provider: 'Cerebras',
-    aliases: ['cerebras-llama-4-scout'],
-  },
-  {
-    id: 'Groq-Llama-4-Maverick-17B-128E-Instruct',
-    inputModalities: ['text'],
-    outputModalities: ['text'],
-    contextWindow: 128000,
-    provider: 'Groq',
-    aliases: ['groq-llama-4-maverick'],
-  },
-];
-
-export const LLAMA_API_MULTIMODAL_MODELS = [
-  'Llama-4-Maverick-17B-128E-Instruct-FP8',
-  'Llama-4-Scout-17B-16E-Instruct-FP8',
-];
-
 export class LlamaApiProvider extends OpenAiChatCompletionProvider {
   constructor(modelName: string, options: ProviderOptions = {}) {
     super(modelName, {
@@ -99,23 +34,6 @@ export class LlamaApiProvider extends OpenAiChatCompletionProvider {
       config: restConfig,
     };
   }
-
-  static getModelInfo(modelName: string) {
-    return LLAMA_API_MODELS.find(
-      (m) => m.id === modelName || (m.aliases && m.aliases.includes(modelName)),
-    );
-  }
-
-  static isMultimodalModel(modelName: string): boolean {
-    const modelInfo = LlamaApiProvider.getModelInfo(modelName);
-    return modelInfo ? modelInfo.inputModalities.includes('image') : false;
-  }
-
-  static validateModelName(modelName: string): boolean {
-    return LLAMA_API_MODELS.some(
-      (m) => m.id === modelName || (m.aliases && m.aliases.includes(modelName)),
-    );
-  }
 }
 
 /**
@@ -130,21 +48,11 @@ export function createLlamaApiProvider(
   } = {},
 ): ApiProvider {
   const splits = providerPath.split(':');
+  const modelName = splits.slice(splits[1] === 'chat' ? 2 : 1).join(':');
 
-  if (splits[1] === 'chat') {
-    const modelName = splits.slice(2).join(':');
-    return new LlamaApiProvider(modelName, {
-      ...options.config,
-      id: options.id,
-      env: options.env,
-    });
-  } else {
-    // Default to chat for llamaapi provider
-    const modelName = splits.slice(1).join(':');
-    return new LlamaApiProvider(modelName, {
-      ...options.config,
-      id: options.id,
-      env: options.env,
-    });
-  }
+  return new LlamaApiProvider(modelName, {
+    ...options.config,
+    id: options.id,
+    env: options.env,
+  });
 }

--- a/test/providers/llamaApi.test.ts
+++ b/test/providers/llamaApi.test.ts
@@ -1,324 +1,127 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  createLlamaApiProvider,
-  LLAMA_API_MODELS,
-  LLAMA_API_MULTIMODAL_MODELS,
-  LlamaApiProvider,
-} from '../../src/providers/llamaApi';
-import { OpenAiChatCompletionProvider } from '../../src/providers/openai/chat';
+import { describe, expect, it } from 'vitest';
+import { createLlamaApiProvider, LlamaApiProvider } from '../../src/providers/llamaApi';
 
+import type { EnvOverrides } from '../../src/types/env';
 import type { ProviderOptions } from '../../src/types/index';
 
-const openAiMocks = vi.hoisted(() => ({
-  OpenAiChatCompletionProvider: vi.fn(function (this: unknown, modelName: string, options: any) {
-    return {
-      modelName,
-      config: options?.config || {},
-      id: vi.fn().mockReturnValue(`openai:${modelName}`),
-      toString: vi.fn().mockReturnValue(`[OpenAI Provider ${modelName}]`),
-      toJSON: vi.fn().mockReturnValue({ provider: 'openai', model: modelName }),
-    };
-  }),
-}));
-
-vi.mock('../../src/providers/openai/chat', async (importOriginal) => {
-  return {
-    ...(await importOriginal()),
-    OpenAiChatCompletionProvider: openAiMocks.OpenAiChatCompletionProvider,
-  };
-});
-
 describe('LlamaApiProvider', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    openAiMocks.OpenAiChatCompletionProvider.mockReset().mockImplementation(function (
-      this: unknown,
-      modelName: string,
-      options: any,
-    ) {
-      return {
-        modelName,
-        config: options?.config || {},
-        id: vi.fn().mockReturnValue(`openai:${modelName}`),
-        toString: vi.fn().mockReturnValue(`[OpenAI Provider ${modelName}]`),
-        toJSON: vi.fn().mockReturnValue({ provider: 'openai', model: modelName }),
-      };
-    });
-  });
-
   describe('constructor', () => {
-    it('should initialize with correct default configuration', () => {
-      new LlamaApiProvider('Llama-4-Maverick-17B-128E-Instruct-FP8');
+    it('should initialize with the Llama API defaults', () => {
+      const provider = new LlamaApiProvider('test-model');
 
-      expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith(
-        'Llama-4-Maverick-17B-128E-Instruct-FP8',
-        expect.objectContaining({
-          config: expect.objectContaining({
-            apiBaseUrl: 'https://api.llama.com/compat/v1',
-            apiKeyEnvar: 'LLAMA_API_KEY',
-            passthrough: {},
-          }),
-        }),
-      );
+      expect(provider.modelName).toBe('test-model');
+      expect(provider.config).toEqual({
+        apiBaseUrl: 'https://api.llama.com/compat/v1',
+        apiKeyEnvar: 'LLAMA_API_KEY',
+        passthrough: {},
+      });
     });
 
-    it('should merge custom options correctly', () => {
+    it('should preserve custom options while enforcing Llama API connection settings', () => {
+      const passthrough = { custom_param: 'value' };
+      const env: EnvOverrides = { LLAMA_API_KEY: 'dummy' };
       const options: ProviderOptions = {
+        id: 'custom-id',
+        env,
         config: {
           temperature: 0.7,
           max_tokens: 1000,
-          passthrough: {
-            custom_param: 'value',
-          },
+          apiBaseUrl: 'https://example.com/v1',
+          apiKeyEnvar: 'CUSTOM_API_KEY',
+          passthrough,
         },
       };
 
-      new LlamaApiProvider('Llama-3.3-70B-Instruct', options);
+      const provider = new LlamaApiProvider('test-model', options);
 
-      expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith(
-        'Llama-3.3-70B-Instruct',
-        expect.objectContaining({
-          config: expect.objectContaining({
-            apiBaseUrl: 'https://api.llama.com/compat/v1',
-            apiKeyEnvar: 'LLAMA_API_KEY',
-            temperature: 0.7,
-            max_tokens: 1000,
-            passthrough: {
-              custom_param: 'value',
-            },
-          }),
-        }),
-      );
+      expect(provider.config).toEqual({
+        temperature: 0.7,
+        max_tokens: 1000,
+        apiBaseUrl: 'https://api.llama.com/compat/v1',
+        apiKeyEnvar: 'LLAMA_API_KEY',
+        passthrough,
+      });
+      expect(provider.config.passthrough).not.toBe(passthrough);
+      expect(provider.env).toBe(env);
+      expect(provider.id()).toBe('custom-id');
     });
   });
 
-  describe('static methods', () => {
-    describe('getModelInfo()', () => {
-      it('should return model info for valid model ID', () => {
-        const modelInfo = LlamaApiProvider.getModelInfo('Llama-4-Maverick-17B-128E-Instruct-FP8');
+  it('should retain its class name, provider prefix, and string representation', () => {
+    const provider = new LlamaApiProvider('vendor:model');
 
-        expect(modelInfo).toBeDefined();
-        expect(modelInfo?.id).toBe('Llama-4-Maverick-17B-128E-Instruct-FP8');
-        expect(modelInfo?.inputModalities).toContain('text');
-        expect(modelInfo?.inputModalities).toContain('image');
-        expect(modelInfo?.contextWindow).toBe(128000);
-      });
-
-      it('should return model info for alias', () => {
-        const modelInfo = LlamaApiProvider.getModelInfo('llama-4-maverick');
-
-        expect(modelInfo).toBeDefined();
-        expect(modelInfo?.id).toBe('Llama-4-Maverick-17B-128E-Instruct-FP8');
-      });
-
-      it('should return undefined for invalid model', () => {
-        const modelInfo = LlamaApiProvider.getModelInfo('invalid-model');
-        expect(modelInfo).toBeUndefined();
-      });
-    });
-
-    describe('isMultimodalModel()', () => {
-      it('should return true for multimodal models', () => {
-        expect(LlamaApiProvider.isMultimodalModel('Llama-4-Maverick-17B-128E-Instruct-FP8')).toBe(
-          true,
-        );
-        expect(LlamaApiProvider.isMultimodalModel('Llama-4-Scout-17B-16E-Instruct-FP8')).toBe(true);
-        expect(LlamaApiProvider.isMultimodalModel('llama-4-maverick')).toBe(true);
-      });
-
-      it('should return false for text-only models', () => {
-        expect(LlamaApiProvider.isMultimodalModel('Llama-3.3-70B-Instruct')).toBe(false);
-        expect(LlamaApiProvider.isMultimodalModel('Llama-3.3-8B-Instruct')).toBe(false);
-        expect(
-          LlamaApiProvider.isMultimodalModel('Cerebras-Llama-4-Maverick-17B-128E-Instruct'),
-        ).toBe(false);
-      });
-
-      it('should return false for unknown models', () => {
-        expect(LlamaApiProvider.isMultimodalModel('unknown-model')).toBe(false);
-      });
-    });
-
-    describe('validateModelName()', () => {
-      it('should validate known model IDs', () => {
-        expect(LlamaApiProvider.validateModelName('Llama-4-Maverick-17B-128E-Instruct-FP8')).toBe(
-          true,
-        );
-        expect(LlamaApiProvider.validateModelName('Llama-3.3-70B-Instruct')).toBe(true);
-        expect(LlamaApiProvider.validateModelName('Cerebras-Llama-4-Scout-17B-16E-Instruct')).toBe(
-          true,
-        );
-      });
-
-      it('should validate model aliases', () => {
-        expect(LlamaApiProvider.validateModelName('llama-4-maverick')).toBe(true);
-        expect(LlamaApiProvider.validateModelName('llama-3.3-8b')).toBe(true);
-      });
-
-      it('should reject invalid model names', () => {
-        expect(LlamaApiProvider.validateModelName('invalid-model')).toBe(false);
-        expect(LlamaApiProvider.validateModelName('')).toBe(false);
-      });
-    });
+    expect(LlamaApiProvider.name).toBe('LlamaApiProvider');
+    expect(provider.id()).toBe('llamaapi:vendor:model');
+    expect(provider.toString()).toBe('[Llama API Provider vendor:model]');
   });
 
-  describe('toJSON()', () => {
-    it('should redact apiKey and set provider', () => {
-      const p = new LlamaApiProvider('Llama-3.3-8B-Instruct', {
-        config: { temperature: 0.5 },
-      });
-
-      // Mock the internal config to include an apiKey for testing
-      (p as any).config = { apiKey: 'secret', temperature: 0.5 };
-
-      const originalToJSON = LlamaApiProvider.prototype.toJSON;
-      const json = originalToJSON.call(p);
-
-      expect(json.provider).toBe('llamaapi');
-      expect(json.config).not.toHaveProperty('apiKey');
-      expect(json.config.temperature).toBe(0.5);
+  it('should redact apiKey from JSON without mutating the provider config', () => {
+    const provider = new LlamaApiProvider('test-model', {
+      config: { apiKey: 'secret', temperature: 0.5 },
     });
-  });
 
-  describe('id()', () => {
-    it('should include llamaapi prefix', () => {
-      const p = new LlamaApiProvider('Llama-3.3-8B-Instruct');
-
-      // Test the actual implementation
-      const originalId = LlamaApiProvider.prototype.id;
-      const result = originalId.call(p);
-
-      expect(result).toBe('llamaapi:Llama-3.3-8B-Instruct');
+    expect(provider.toJSON()).toEqual({
+      provider: 'llamaapi',
+      model: 'test-model',
+      config: {
+        temperature: 0.5,
+        apiBaseUrl: 'https://api.llama.com/compat/v1',
+        apiKeyEnvar: 'LLAMA_API_KEY',
+        passthrough: {},
+      },
     });
+    expect(provider.config.apiKey).toBe('secret');
   });
 });
 
 describe('createLlamaApiProvider', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    openAiMocks.OpenAiChatCompletionProvider.mockReset().mockImplementation(function (
-      this: unknown,
-      modelName: string,
-      options: any,
-    ) {
-      return {
-        modelName,
-        config: options?.config || {},
-        id: vi.fn().mockReturnValue(`openai:${modelName}`),
-        toString: vi.fn().mockReturnValue(`[OpenAI Provider ${modelName}]`),
-        toJSON: vi.fn().mockReturnValue({ provider: 'openai', model: modelName }),
-      };
-    });
+  it.each([
+    ['llamaapi:model', 'model'],
+    ['llamaapi:chat:model', 'model'],
+    ['llamaapi:vendor:model:version', 'vendor:model:version'],
+    ['llamaapi:chat:vendor:model:version', 'vendor:model:version'],
+    ['llamaapi:chatty:model', 'chatty:model'],
+    ['llamaapi', ''],
+    ['llamaapi:', ''],
+    ['llamaapi:chat', ''],
+    ['llamaapi:chat:', ''],
+    ['llamaapi::model', ':model'],
+    ['llamaapi:chat::model:', ':model:'],
+    ['', ''],
+  ])('should parse provider path %j as model %j', (providerPath, expectedModelName) => {
+    const provider = createLlamaApiProvider(providerPath);
+
+    expect(provider).toBeInstanceOf(LlamaApiProvider);
+    expect((provider as LlamaApiProvider).modelName).toBe(expectedModelName);
   });
 
-  it('should create provider for chat format', () => {
-    createLlamaApiProvider('llamaapi:chat:Llama-4-Maverick-17B-128E-Instruct-FP8');
-
-    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith(
-      'Llama-4-Maverick-17B-128E-Instruct-FP8',
-      expect.any(Object),
-    );
-  });
-
-  it('should default to chat provider when no type specified', () => {
-    createLlamaApiProvider('llamaapi:Llama-3.3-70B-Instruct');
-
-    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith(
-      'Llama-3.3-70B-Instruct',
-      expect.any(Object),
-    );
-  });
-
-  it('should handle model names with colons', () => {
-    createLlamaApiProvider('llamaapi:chat:Cerebras-Llama-4-Scout-17B-16E-Instruct');
-
-    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith(
-      'Cerebras-Llama-4-Scout-17B-16E-Instruct',
-      expect.any(Object),
-    );
-  });
-
-  it('should pass options correctly', () => {
-    const options = {
+  it('should give factory-level id and env options precedence over nested provider options', () => {
+    const nestedEnv: EnvOverrides = { LLAMA_API_KEY: 'nested' };
+    const env: EnvOverrides = { LLAMA_API_KEY: 'outer' };
+    const options: ProviderOptions = {
+      id: 'nested-id',
+      env: nestedEnv,
       config: {
-        config: {
-          temperature: 0.8,
-          max_tokens: 2048,
-        },
+        temperature: 0.8,
+        max_tokens: 2048,
+        passthrough: { custom_param: 'value' },
       },
-      id: 'custom-id',
-      env: { LLAMA_API_KEY: 'dummy' } as any,
     };
 
-    createLlamaApiProvider('llamaapi:Llama-4-Scout-17B-16E-Instruct-FP8', options);
+    const provider = createLlamaApiProvider('llamaapi:vendor:model', {
+      config: options,
+      id: 'outer-id',
+      env,
+    }) as LlamaApiProvider;
 
-    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith(
-      'Llama-4-Scout-17B-16E-Instruct-FP8',
-      expect.objectContaining({
-        config: expect.objectContaining({
-          temperature: 0.8,
-          max_tokens: 2048,
-          apiBaseUrl: 'https://api.llama.com/compat/v1',
-          apiKeyEnvar: 'LLAMA_API_KEY',
-        }),
-        id: 'custom-id',
-        env: expect.objectContaining({ LLAMA_API_KEY: 'dummy' }),
-      }),
-    );
-  });
-});
-
-describe('LLAMA_API_MODELS', () => {
-  it('should contain expected models', () => {
-    const modelIds = LLAMA_API_MODELS.map((m) => m.id);
-
-    expect(modelIds).toContain('Llama-4-Maverick-17B-128E-Instruct-FP8');
-    expect(modelIds).toContain('Llama-4-Scout-17B-16E-Instruct-FP8');
-    expect(modelIds).toContain('Llama-3.3-70B-Instruct');
-    expect(modelIds).toContain('Llama-3.3-8B-Instruct');
-    expect(modelIds).toContain('Cerebras-Llama-4-Maverick-17B-128E-Instruct');
-    expect(modelIds).toContain('Cerebras-Llama-4-Scout-17B-16E-Instruct');
-    expect(modelIds).toContain('Groq-Llama-4-Maverick-17B-128E-Instruct');
-  });
-
-  it('should have correct modality information', () => {
-    const llama4Maverick = LLAMA_API_MODELS.find(
-      (m) => m.id === 'Llama-4-Maverick-17B-128E-Instruct-FP8',
-    );
-    expect(llama4Maverick?.inputModalities).toEqual(['text', 'image']);
-    expect(llama4Maverick?.outputModalities).toEqual(['text']);
-
-    const llama33 = LLAMA_API_MODELS.find((m) => m.id === 'Llama-3.3-70B-Instruct');
-    expect(llama33?.inputModalities).toEqual(['text']);
-    expect(llama33?.outputModalities).toEqual(['text']);
-  });
-
-  it('should have correct context windows', () => {
-    const llama4Maverick = LLAMA_API_MODELS.find(
-      (m) => m.id === 'Llama-4-Maverick-17B-128E-Instruct-FP8',
-    );
-    expect(llama4Maverick?.contextWindow).toBe(128000);
-
-    const cerebrasModel = LLAMA_API_MODELS.find(
-      (m) => m.id === 'Cerebras-Llama-4-Maverick-17B-128E-Instruct',
-    );
-    expect(cerebrasModel?.contextWindow).toBe(32000);
-  });
-});
-
-describe('LLAMA_API_MULTIMODAL_MODELS', () => {
-  it('should contain only multimodal models', () => {
-    expect(LLAMA_API_MULTIMODAL_MODELS).toEqual([
-      'Llama-4-Maverick-17B-128E-Instruct-FP8',
-      'Llama-4-Scout-17B-16E-Instruct-FP8',
-    ]);
-  });
-
-  it('should not contain text-only models', () => {
-    expect(LLAMA_API_MULTIMODAL_MODELS).not.toContain('Llama-3.3-70B-Instruct');
-    expect(LLAMA_API_MULTIMODAL_MODELS).not.toContain('Llama-3.3-8B-Instruct');
-    expect(LLAMA_API_MULTIMODAL_MODELS).not.toContain(
-      'Cerebras-Llama-4-Maverick-17B-128E-Instruct',
-    );
+    expect(provider.id()).toBe('outer-id');
+    expect(provider.env).toBe(env);
+    expect(provider.config).toMatchObject({
+      temperature: 0.8,
+      max_tokens: 2048,
+      apiBaseUrl: 'https://api.llama.com/compat/v1',
+      apiKeyEnvar: 'LLAMA_API_KEY',
+      passthrough: { custom_param: 'value' },
+    });
   });
 });

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -2,6 +2,7 @@ import path from 'path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isFoundationModelProvider } from '../../src/providers/constants';
+import { LlamaApiProvider } from '../../src/providers/llamaApi';
 import { getProviderFactories, providerMap } from '../../src/providers/registry';
 
 import type { LoadApiProviderContext } from '../../src/types/index';
@@ -311,6 +312,23 @@ describe('Provider Registry', () => {
       expect(provider).toBeDefined();
       expect(provider.id()).toBe('atlascloud:deepseek-v3');
     });
+
+    it.each(['llamaapi:vendor:model', 'llamaapi:chat:vendor:model'])(
+      'routes %s uniquely to the Llama API provider',
+      async (providerPath) => {
+        const matchingFactories = providerMap.filter((factory) => factory.test(providerPath));
+        expect(matchingFactories).toHaveLength(1);
+
+        const provider = await matchingFactories[0].create(
+          providerPath,
+          { ...mockProviderOptions, id: undefined },
+          mockContext,
+        );
+
+        expect(provider).toBeInstanceOf(LlamaApiProvider);
+        expect(provider.id()).toBe('llamaapi:vendor:model');
+      },
+    );
 
     describe.each(['muse-spark-1.1', 'muse-spark-1.3', 'muse-spark-1.3-contributor'])(
       'Meta model %s',


### PR DESCRIPTION
## Summary

- Remove the unused static Meta Llama API model catalog and helper methods that had no runtime or downstream consumers.
- Collapse the equivalent chat and default factory branches into one construction path while preserving model parsing, provider identity, options, and environment behavior.
- Replace catalog self-tests with focused provider behavior and unique registry-routing coverage.

## Validation

- npm run l
- git diff --check
- npx vitest run test/providers/llamaApi.test.ts test/providers/llama.test.ts test/providers/registry.test.ts test/providers/index.test.ts --sequence.shuffle=false — 4 files, 328 tests passed
- npm run tsc
- npm run knip -- --no-progress
- npm run build
- Two-pass native Codex prepublish review plus independent verifier — clean, no findings

## Formatting note

- npm run f checked all 3 changed TypeScript files with no fixes; its Prettier half exited on an empty non-TypeScript file list.