### PR TITLE
refactor(model-audit): remove obsolete CLI validation

### DIFF
--- a/src/commands/modelScan.ts
+++ b/src/commands/modelScan.ts
@@ -21,7 +21,7 @@ import {
   isHuggingFaceModel,
   parseHuggingFaceModel,
 } from '../util/huggingfaceMetadata';
-import { DEPRECATED_OPTIONS_MAP, parseModelAuditArgs } from '../util/modelAuditCliParser';
+import { parseModelAuditArgs } from '../util/modelAuditCliParser';
 import { checkModelAuditInstalled } from '../util/modelAuditInstall';
 import { getModelAuditVerdict, parseCompleteModelAuditResults } from '../util/modelAuditResults';
 import type { Command } from 'commander';
@@ -173,35 +173,6 @@ function shouldRescan(
     return true;
   }
   return existingVersion !== currentVersion;
-}
-
-/**
- * Warn about deprecated CLI options.
- */
-function warnDeprecatedOptions(options: Record<string, unknown>): void {
-  const deprecatedOptionsUsed = Object.keys(options).filter((opt) => {
-    const fullOption = `--${opt.replace(/([A-Z])/g, '-$1').toLowerCase()}`;
-    return DEPRECATED_OPTIONS_MAP[fullOption] !== undefined;
-  });
-
-  for (const opt of deprecatedOptionsUsed) {
-    const fullOption = `--${opt.replace(/([A-Z])/g, '-$1').toLowerCase()}`;
-    const replacement = DEPRECATED_OPTIONS_MAP[fullOption];
-
-    if (replacement) {
-      logger.warn(`⚠️  Warning: '${fullOption}' is deprecated. Use '${replacement}' instead.`);
-    } else if (fullOption === '--jfrog-api-token') {
-      logger.warn(`⚠️  Warning: '${fullOption}' is deprecated. Set JFROG_API_TOKEN env var.`);
-    } else if (fullOption === '--jfrog-access-token') {
-      logger.warn(`⚠️  Warning: '${fullOption}' is deprecated. Set JFROG_ACCESS_TOKEN env var.`);
-    } else if (fullOption === '--registry-uri') {
-      logger.warn(
-        `⚠️  Warning: '${fullOption}' is deprecated. Set JFROG_URL or MLFLOW_TRACKING_URI env var.`,
-      );
-    } else {
-      logger.warn(`⚠️  Warning: '${fullOption}' is deprecated and has been removed.`);
-    }
-  }
 }
 
 /**
@@ -932,9 +903,6 @@ export function modelScanCommand(program: Command): void {
         return;
       }
 
-      // Warn about deprecated options
-      warnDeprecatedOptions(options as Record<string, unknown>);
-
       // Check modelaudit installation
       const { installed, version: currentScannerVersion } = await checkModelAuditInstalled();
       if (!installed) {
@@ -1002,9 +970,6 @@ export function modelScanCommand(program: Command): void {
         return;
       }
       const args = parsed.args;
-      if (parsed.unsupportedOptions.length > 0) {
-        logger.warn(`Unsupported options detected: ${parsed.unsupportedOptions.join(', ')}`);
-      }
 
       if (saveToDatabase || outputFormat === 'text') {
         logger.info(`Running model scan on: ${paths.join(', ')}`);

--- a/src/util/modelAuditCliParser.ts
+++ b/src/util/modelAuditCliParser.ts
@@ -1,14 +1,10 @@
 /**
- * Utility for parsing and validating ModelAudit CLI arguments
- * Ensures compatibility between promptfoo and modelaudit CLI interfaces
+ * Utility for translating Promptfoo ModelAudit options to CLI arguments.
  */
 
 import { z } from 'zod';
 
-/**
- * Zod schema for ModelAudit CLI options
- */
-export const ModelAuditCliOptionsSchema = z.object({
+const ModelAuditCliOptionsSchema = z.object({
   // Core output control
   blacklist: z.array(z.string()).optional(),
   format: z.enum(['text', 'json', 'sarif']).optional(),
@@ -43,66 +39,12 @@ export const ModelAuditCliOptionsSchema = z.object({
   noShare: z.boolean().optional(),
 });
 
-export type ModelAuditCliOptions = z.infer<typeof ModelAuditCliOptionsSchema>;
+type ModelAuditCliOptions = z.infer<typeof ModelAuditCliOptionsSchema>;
 
-export const ValidatedModelAuditArgsSchema = z.object({
-  args: z.array(z.string()),
-  unsupportedOptions: z.array(z.string()),
-});
-
-export type ValidatedModelAuditArgs = z.infer<typeof ValidatedModelAuditArgsSchema>;
-
-/**
- * Valid ModelAudit CLI options as of version 0.2.37
- */
-export const VALID_MODELAUDIT_OPTIONS = new Set([
-  '--format',
-  '-f',
-  '--output',
-  '-o',
-  '--verbose',
-  '-v',
-  '--quiet',
-  '-q',
-  '--blacklist',
-  '-b',
-  '--strict',
-  '--progress',
-  '--sbom',
-  '--timeout',
-  '-t',
-  '--max-size',
-  '--dry-run',
-  '--no-cache',
-  '--stream',
-  '--scanners',
-  '--exclude-scanner',
-  '--list-scanners',
-]);
-
-/**
- * Options that were removed/changed from previous versions
- */
-export const DEPRECATED_OPTIONS_MAP: Record<string, string | null> = {
-  '--max-file-size': '--max-size',
-  '--max-total-size': null, // No equivalent
-  '--registry-uri': null, // Use environment variables
-  '--jfrog-api-token': null, // Use environment variables
-  '--jfrog-access-token': null, // Use environment variables
-  '--max-download-size': null, // No equivalent
-  '--cache-dir': null, // No equivalent
-  '--preview': '--dry-run',
-  '--all-files': null, // No equivalent
-  '--selective': null, // No equivalent
-  '--skip-files': null, // No equivalent
-  '--no-skip-files': null, // No equivalent
-  '--strict-license': '--strict',
-  '--no-large-model-support': null, // No equivalent
-  '--no-progress': null, // No equivalent (progress is auto-detected)
-  '--progress-log': null, // No equivalent
-  '--progress-format': null, // No equivalent
-  '--progress-interval': null, // No equivalent
-};
+interface ParsedModelAuditArgs {
+  args: string[];
+  unsupportedOptions: [];
+}
 
 /**
  * Configuration mapping from option keys to CLI arguments
@@ -139,7 +81,7 @@ const CLI_ARG_MAP: Partial<
 /**
  * Elegant, configuration-driven CLI argument parser
  */
-export function parseModelAuditArgs(paths: string[], options: unknown): ValidatedModelAuditArgs {
+export function parseModelAuditArgs(paths: string[], options: unknown): ParsedModelAuditArgs {
   const validatedOptions = ModelAuditCliOptionsSchema.parse(options);
   const args: string[] = ['scan', ...paths];
 
@@ -180,99 +122,3 @@ export function parseModelAuditArgs(paths: string[], options: unknown): Validate
 
   return { args, unsupportedOptions: [] };
 }
-
-/**
- * Validates that CLI arguments are supported by modelaudit
- */
-export function validateModelAuditArgs(args: string[]): {
-  valid: boolean;
-  unsupportedArgs: string[];
-} {
-  const unsupportedArgs: string[] = [];
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-
-    // Skip non-option arguments (paths, values)
-    if (!arg.startsWith('--') && !arg.startsWith('-')) {
-      continue;
-    }
-
-    // Skip 'scan' command
-    if (arg === 'scan') {
-      continue;
-    }
-
-    if (!VALID_MODELAUDIT_OPTIONS.has(arg)) {
-      unsupportedArgs.push(arg);
-    }
-  }
-
-  return {
-    valid: unsupportedArgs.length === 0,
-    unsupportedArgs,
-  };
-}
-
-/**
- * Suggests replacements for deprecated options
- */
-export function suggestReplacements(deprecatedOptions: string[]): Record<string, string | null> {
-  const suggestions: Record<string, string | null> = {};
-
-  for (const option of deprecatedOptions) {
-    if (option in DEPRECATED_OPTIONS_MAP) {
-      suggestions[option] = DEPRECATED_OPTIONS_MAP[option];
-    }
-  }
-
-  return suggestions;
-}
-
-/**
- * Creates a user-friendly error message for unsupported arguments
- */
-export function formatUnsupportedArgsError(unsupportedArgs: string[]): string {
-  if (unsupportedArgs.length === 0) {
-    return '';
-  }
-
-  const suggestions = suggestReplacements(unsupportedArgs);
-  let message = `Unsupported ModelAudit arguments: ${unsupportedArgs.join(', ')}`;
-
-  const replacements = Object.entries(suggestions)
-    .filter(([_, replacement]) => replacement !== null)
-    .map(([old, replacement]) => `${old} → ${replacement}`);
-
-  const noReplacements = Object.entries(suggestions)
-    .filter(([_, replacement]) => replacement === null)
-    .map(([old, _]) => old);
-
-  if (replacements.length > 0) {
-    message += `\n\nSuggested replacements:\n${replacements.join('\n')}`;
-  }
-
-  if (noReplacements.length > 0) {
-    message += `\n\nNo replacement available for: ${noReplacements.join(', ')}`;
-    message +=
-      '\nThese options may be handled automatically by modelaudit or use environment variables.';
-  }
-
-  return message;
-}
-
-/**
- * Compact validation utilities using Zod
- */
-export const isValidFormat = (format: unknown): format is 'text' | 'json' | 'sarif' =>
-  z.enum(['text', 'json', 'sarif']).safeParse(format).success;
-
-export const validateModelAuditOptions = (options: unknown): ModelAuditCliOptions =>
-  ModelAuditCliOptionsSchema.parse(options);
-
-export const safeValidateModelAuditOptions = (options: unknown) => {
-  const result = ModelAuditCliOptionsSchema.safeParse(options);
-  return result.success
-    ? { success: true as const, data: result.data }
-    : { success: false as const, error: result.error };
-};

--- a/src/util/modelAuditCliParser.ts
+++ b/src/util/modelAuditCliParser.ts
@@ -41,11 +41,6 @@ const ModelAuditCliOptionsSchema = z.object({
 
 type ModelAuditCliOptions = z.infer<typeof ModelAuditCliOptionsSchema>;
 
-interface ParsedModelAuditArgs {
-  args: string[];
-  unsupportedOptions: [];
-}
-
 /**
  * Configuration mapping from option keys to CLI arguments
  * Note: 'share' and 'noShare' are omitted as they are promptfoo-only options
@@ -81,7 +76,10 @@ const CLI_ARG_MAP: Partial<
 /**
  * Elegant, configuration-driven CLI argument parser
  */
-export function parseModelAuditArgs(paths: string[], options: unknown): ParsedModelAuditArgs {
+export function parseModelAuditArgs(
+  paths: string[],
+  options: unknown,
+): { args: string[]; unsupportedOptions: string[] } {
   const validatedOptions = ModelAuditCliOptionsSchema.parse(options);
   const args: string[] = ['scan', ...paths];
 

--- a/test/commands/modelScan.test.ts
+++ b/test/commands/modelScan.test.ts
@@ -1459,6 +1459,28 @@ describe('Command Options Validation', () => {
     });
   });
 
+  it('should reject obsolete options before the action handler', async () => {
+    modelScanCommand(program);
+
+    const command = program.commands.find((cmd) => cmd.name() === 'scan-model')!;
+    const actionReached = vi.fn();
+    command.hook('preAction', actionReached);
+    command.exitOverride();
+    command.configureOutput({
+      writeErr: vi.fn(),
+      writeOut: vi.fn(),
+    });
+
+    await expect(
+      command.parseAsync(['node', 'scan-model', 'model.pkl', '--max-file-size', '500MB']),
+    ).rejects.toMatchObject({
+      code: 'commander.unknownOption',
+      message: "error: unknown option '--max-file-size'",
+    });
+    expect(actionReached).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
   it('should only pass valid arguments to modelaudit', async () => {
     // Mock for checkModelAuditInstalled (returns { installed, version })
     const versionCheckProcess = {

--- a/test/utils/modelAuditCliParser.test.ts
+++ b/test/utils/modelAuditCliParser.test.ts
@@ -1,473 +1,151 @@
 import { describe, expect, it } from 'vitest';
-import {
-  DEPRECATED_OPTIONS_MAP,
-  formatUnsupportedArgsError,
-  isValidFormat,
-  type ModelAuditCliOptions,
-  parseModelAuditArgs,
-  safeValidateModelAuditOptions,
-  suggestReplacements,
-  VALID_MODELAUDIT_OPTIONS,
-  validateModelAuditArgs,
-  validateModelAuditOptions,
-} from '../../src/util/modelAuditCliParser';
+import { parseModelAuditArgs } from '../../src/util/modelAuditCliParser';
 
-describe('ModelAudit CLI Parser', () => {
-  describe('parseModelAuditArgs', () => {
-    it('should parse basic options correctly', () => {
-      const paths = ['model.pkl'];
-      const options: ModelAuditCliOptions = {
-        format: 'json',
-        verbose: true,
-        timeout: 300,
-      };
-
-      const result = parseModelAuditArgs(paths, options);
-
-      expect(result.args).toEqual([
-        'scan',
-        'model.pkl',
-        '--format',
-        'json',
-        '--verbose',
-        '--timeout',
-        '300',
-      ]);
-      expect(result.unsupportedOptions).toEqual([]);
+describe('parseModelAuditArgs', () => {
+  it('should parse basic options and preserve the return shape', () => {
+    const result = parseModelAuditArgs(['model.pkl'], {
+      format: 'json',
+      verbose: true,
+      timeout: 300,
     });
 
-    it('should handle multiple blacklist patterns', () => {
-      const paths = ['model.pkl'];
-      const options: ModelAuditCliOptions = {
-        blacklist: ['pattern1', 'pattern2', 'pattern3'],
-      };
-
-      const result = parseModelAuditArgs(paths, options);
-
-      expect(result.args).toEqual([
-        'scan',
-        'model.pkl',
-        '--blacklist',
-        'pattern1',
-        '--blacklist',
-        'pattern2',
-        '--blacklist',
-        'pattern3',
-      ]);
-    });
-
-    it('should handle multiple paths', () => {
-      const paths = ['model1.pkl', 'model2.h5', 'model3.onnx'];
-      const options: ModelAuditCliOptions = {
-        format: 'sarif',
-      };
-
-      const result = parseModelAuditArgs(paths, options);
-
-      expect(result.args).toEqual([
-        'scan',
-        'model1.pkl',
-        'model2.h5',
-        'model3.onnx',
-        '--format',
-        'sarif',
-      ]);
-    });
-
-    it('should handle all supported options', () => {
-      const paths = ['model.pkl'];
-      const options: ModelAuditCliOptions = {
-        blacklist: ['unsafe'],
-        format: 'json',
-        output: 'results.json',
-        verbose: true,
-        quiet: false, // Should not add --quiet
-        strict: true,
-        progress: true,
-        sbom: 'sbom.json',
-        timeout: 600,
-        maxSize: '1GB',
-        dryRun: true,
-        cache: false, // Should add --no-cache
-      };
-
-      const result = parseModelAuditArgs(paths, options);
-
-      const expectedArgs = [
-        'scan',
-        'model.pkl',
-        '--blacklist',
-        'unsafe',
-        '--format',
-        'json',
-        '--output',
-        'results.json',
-        '--verbose',
-        '--strict',
-        '--progress',
-        '--sbom',
-        'sbom.json',
-        '--timeout',
-        '600',
-        '--max-size',
-        '1GB',
-        '--dry-run',
-        '--no-cache',
-      ];
-
-      expect(result.args).toEqual(expectedArgs);
-    });
-
-    it('should not add flags for falsy values', () => {
-      const paths = ['model.pkl'];
-      const options: ModelAuditCliOptions = {
-        verbose: false,
-        quiet: false,
-        strict: false,
-        progress: false,
-        dryRun: false,
-        cache: true, // Should not add --no-cache
-      };
-
-      const result = parseModelAuditArgs(paths, options);
-
-      expect(result.args).toEqual(['scan', 'model.pkl']);
+    expect(result).toEqual({
+      args: ['scan', 'model.pkl', '--format', 'json', '--verbose', '--timeout', '300'],
+      unsupportedOptions: [],
     });
   });
 
-  describe('validateModelAuditArgs', () => {
-    it('should validate supported arguments', () => {
-      const args = [
-        'scan',
-        'model.pkl',
-        '--format',
-        'json',
-        '--verbose',
-        '--timeout',
-        '300',
-        '--max-size',
-        '1GB',
-      ];
-
-      const result = validateModelAuditArgs(args);
-
-      expect(result.valid).toBe(true);
-      expect(result.unsupportedArgs).toEqual([]);
+  it('should handle multiple blacklist patterns', () => {
+    const result = parseModelAuditArgs(['model.pkl'], {
+      blacklist: ['pattern1', 'pattern2', 'pattern3'],
     });
 
-    it('should detect unsupported arguments', () => {
-      const args = [
-        'scan',
-        'model.pkl',
-        '--format',
-        'json',
-        '--max-file-size', // Unsupported
-        '1000000',
-        '--registry-uri', // Unsupported
-        'http://mlflow:5000',
-        '--preview', // Unsupported
-      ];
-
-      const result = validateModelAuditArgs(args);
-
-      expect(result.valid).toBe(false);
-      expect(result.unsupportedArgs).toEqual(['--max-file-size', '--registry-uri', '--preview']);
-    });
-
-    it('should ignore non-option arguments', () => {
-      const args = [
-        'scan',
-        'model.pkl',
-        'another-model.h5',
-        '--format',
-        'json',
-        'output-value',
-        '--verbose',
-      ];
-
-      const result = validateModelAuditArgs(args);
-
-      expect(result.valid).toBe(true);
-      expect(result.unsupportedArgs).toEqual([]);
-    });
+    expect(result.args).toEqual([
+      'scan',
+      'model.pkl',
+      '--blacklist',
+      'pattern1',
+      '--blacklist',
+      'pattern2',
+      '--blacklist',
+      'pattern3',
+    ]);
   });
 
-  describe('suggestReplacements', () => {
-    it('should suggest replacements for deprecated options', () => {
-      const deprecated = ['--max-file-size', '--preview', '--strict-license'];
-
-      const suggestions = suggestReplacements(deprecated);
-
-      expect(suggestions).toEqual({
-        '--max-file-size': '--max-size',
-        '--preview': '--dry-run',
-        '--strict-license': '--strict',
-      });
+  it('should handle multiple paths', () => {
+    const result = parseModelAuditArgs(['model1.pkl', 'model2.h5', 'model3.onnx'], {
+      format: 'sarif',
     });
 
-    it('should return null for options with no replacement', () => {
-      const deprecated = ['--registry-uri', '--cache-dir'];
-
-      const suggestions = suggestReplacements(deprecated);
-
-      expect(suggestions).toEqual({
-        '--registry-uri': null,
-        '--cache-dir': null,
-      });
-    });
-
-    it('should handle unknown deprecated options', () => {
-      const deprecated = ['--unknown-option'];
-
-      const suggestions = suggestReplacements(deprecated);
-
-      expect(suggestions).toEqual({});
-    });
+    expect(result.args).toEqual([
+      'scan',
+      'model1.pkl',
+      'model2.h5',
+      'model3.onnx',
+      '--format',
+      'sarif',
+    ]);
   });
 
-  describe('formatUnsupportedArgsError', () => {
-    it('should return empty string for no unsupported args', () => {
-      const result = formatUnsupportedArgsError([]);
-      expect(result).toBe('');
+  it('should handle all supported options', () => {
+    const result = parseModelAuditArgs(['model.pkl'], {
+      blacklist: ['unsafe'],
+      format: 'json',
+      output: 'results.json',
+      verbose: true,
+      quiet: false,
+      strict: true,
+      progress: true,
+      sbom: 'sbom.json',
+      timeout: 600,
+      maxSize: '1GB',
+      dryRun: true,
+      cache: false,
+      stream: true,
     });
 
-    it('should format error with replacements', () => {
-      const unsupported = ['--max-file-size', '--preview'];
-
-      const result = formatUnsupportedArgsError(unsupported);
-
-      expect(result).toContain('Unsupported ModelAudit arguments: --max-file-size, --preview');
-      expect(result).toContain('Suggested replacements:');
-      expect(result).toContain('--max-file-size → --max-size');
-      expect(result).toContain('--preview → --dry-run');
-    });
-
-    it('should format error with no replacements', () => {
-      const unsupported = ['--registry-uri', '--cache-dir'];
-
-      const result = formatUnsupportedArgsError(unsupported);
-
-      expect(result).toContain('Unsupported ModelAudit arguments: --registry-uri, --cache-dir');
-      expect(result).toContain('No replacement available for: --registry-uri, --cache-dir');
-      expect(result).toContain('handled automatically by modelaudit or use environment variables');
-    });
-
-    it('should format error with mixed replacements', () => {
-      const unsupported = ['--max-file-size', '--registry-uri'];
-
-      const result = formatUnsupportedArgsError(unsupported);
-
-      expect(result).toContain('Suggested replacements:');
-      expect(result).toContain('--max-file-size → --max-size');
-      expect(result).toContain('No replacement available for: --registry-uri');
-    });
+    expect(result.args).toEqual([
+      'scan',
+      'model.pkl',
+      '--blacklist',
+      'unsafe',
+      '--format',
+      'json',
+      '--output',
+      'results.json',
+      '--verbose',
+      '--strict',
+      '--progress',
+      '--sbom',
+      'sbom.json',
+      '--timeout',
+      '600',
+      '--max-size',
+      '1GB',
+      '--dry-run',
+      '--no-cache',
+      '--stream',
+    ]);
   });
 
-  describe('isValidFormat', () => {
-    it('should validate correct formats', () => {
-      expect(isValidFormat('text')).toBe(true);
-      expect(isValidFormat('json')).toBe(true);
-      expect(isValidFormat('sarif')).toBe(true);
+  it('should not add flags for falsy values', () => {
+    const result = parseModelAuditArgs(['model.pkl'], {
+      verbose: false,
+      quiet: false,
+      strict: false,
+      progress: false,
+      dryRun: false,
+      cache: true,
+      stream: false,
     });
 
-    it('should reject invalid formats', () => {
-      expect(isValidFormat('xml')).toBe(false);
-      expect(isValidFormat('yaml')).toBe(false);
-      expect(isValidFormat('')).toBe(false);
-      expect(isValidFormat('TEXT')).toBe(false); // Case sensitive
-    });
+    expect(result.args).toEqual(['scan', 'model.pkl']);
   });
 
-  describe('Constants', () => {
-    it('should have correct valid options', () => {
-      const expectedOptions = [
-        '--format',
-        '-f',
-        '--output',
-        '-o',
-        '--verbose',
-        '-v',
-        '--quiet',
-        '-q',
-        '--blacklist',
-        '-b',
-        '--strict',
-        '--progress',
-        '--sbom',
-        '--timeout',
-        '-t',
-        '--max-size',
-        '--dry-run',
-        '--no-cache',
-        '--stream',
-        '--scanners',
-        '--exclude-scanner',
-        '--list-scanners',
-      ];
-
-      expectedOptions.forEach((option) => {
-        expect(VALID_MODELAUDIT_OPTIONS.has(option)).toBe(true);
-      });
-    });
-
-    it('should have correct deprecated options mapping', () => {
-      expect(DEPRECATED_OPTIONS_MAP['--max-file-size']).toBe('--max-size');
-      expect(DEPRECATED_OPTIONS_MAP['--preview']).toBe('--dry-run');
-      expect(DEPRECATED_OPTIONS_MAP['--strict-license']).toBe('--strict');
-      expect(DEPRECATED_OPTIONS_MAP['--registry-uri']).toBeNull();
-      expect(DEPRECATED_OPTIONS_MAP['--cache-dir']).toBeNull();
-    });
+  it('should reject invalid format and timeout options', () => {
+    expect(() =>
+      parseModelAuditArgs(['model.pkl'], {
+        format: 'xml',
+        timeout: -1,
+      }),
+    ).toThrow();
   });
 
-  describe('Zod Schema Validation', () => {
-    describe('validateModelAuditOptions', () => {
-      it('should validate correct options', () => {
-        const validOptions = {
-          format: 'json',
-          verbose: true,
-          timeout: 300,
-          maxSize: '1GB',
-        };
+  it('should reject an invalid maxSize format', () => {
+    expect(() => parseModelAuditArgs(['model.pkl'], { maxSize: 'invalid-size' })).toThrow();
+  });
 
-        expect(() => validateModelAuditOptions(validOptions)).not.toThrow();
-        const result = validateModelAuditOptions(validOptions);
-        expect(result.format).toBe('json');
-        expect(result.verbose).toBe(true);
-        expect(result.timeout).toBe(300);
-        expect(result.maxSize).toBe('1GB');
-      });
+  it.each(['1GB', '500MB', '1.5GB', '100KB', '1024B', '1 GB', '500 MB', ' 1GB ', '2.5 TB'])(
+    'should accept maxSize format %s',
+    (maxSize) => {
+      expect(() => parseModelAuditArgs(['model.pkl'], { maxSize })).not.toThrow();
+    },
+  );
 
-      it('should reject invalid format', () => {
-        const invalidOptions = {
-          format: 'xml',
-        };
-
-        expect(() => validateModelAuditOptions(invalidOptions)).toThrow();
-      });
-
-      it('should reject invalid timeout', () => {
-        const invalidOptions = {
-          timeout: -1,
-        };
-
-        expect(() => validateModelAuditOptions(invalidOptions)).toThrow();
-      });
-
-      it('should reject invalid maxSize format', () => {
-        const invalidOptions = {
-          maxSize: 'invalid-size',
-        };
-
-        expect(() => validateModelAuditOptions(invalidOptions)).toThrow();
-      });
-
-      it('should accept valid maxSize formats', () => {
-        const validSizes = [
-          '1GB',
-          '500MB',
-          '1.5GB',
-          '100KB',
-          '1024B',
-          '1 GB',
-          '500 MB',
-          ' 1GB ',
-          '2.5 TB',
-        ];
-
-        for (const size of validSizes) {
-          expect(() => validateModelAuditOptions({ maxSize: size })).not.toThrow();
-        }
-      });
+  it('should parse selected scanners and excluded scanners', () => {
+    const result = parseModelAuditArgs(['model.pkl'], {
+      scanners: ['pickle,tf_savedmodel', 'PickleScanner'],
+      excludeScanner: ['weight_distribution'],
     });
 
-    describe('safeValidateModelAuditOptions', () => {
-      it('should return success for valid options', () => {
-        const validOptions = {
-          format: 'sarif',
-          strict: true,
-        };
+    expect(result.args).toEqual([
+      'scan',
+      'model.pkl',
+      '--scanners',
+      'pickle,tf_savedmodel',
+      '--scanners',
+      'PickleScanner',
+      '--exclude-scanner',
+      'weight_distribution',
+    ]);
+  });
 
-        const result = safeValidateModelAuditOptions(validOptions);
-        expect(result.success).toBe(true);
-        expect(result.data).toEqual(validOptions);
-        expect(result.error).toBeUndefined();
-      });
-
-      it('should return error for invalid options', () => {
-        const invalidOptions = {
-          format: 'invalid-format',
-          timeout: -5,
-        };
-
-        const result = safeValidateModelAuditOptions(invalidOptions);
-        expect(result.success).toBe(false);
-        expect(result.data).toBeUndefined();
-        expect(result.error).toBeDefined();
-        expect(result.error?.issues).toHaveLength(2); // format and timeout errors
-      });
-
-      it('should handle empty options', () => {
-        const result = safeValidateModelAuditOptions({});
-        expect(result.success).toBe(true);
-        expect(result.data).toEqual({});
-      });
+  it('should parse scanner catalog listing without paths', () => {
+    const result = parseModelAuditArgs([], {
+      listScanners: true,
+      format: 'json',
     });
 
-    describe('parseModelAuditArgs with invalid input', () => {
-      it('should throw on invalid options passed to parseModelAuditArgs', () => {
-        const paths = ['model.pkl'];
-        const invalidOptions = {
-          format: 'xml', // Invalid format
-          timeout: -1, // Invalid timeout
-        };
-
-        expect(() => parseModelAuditArgs(paths, invalidOptions)).toThrow();
-      });
-    });
-
-    describe('scanner selection options', () => {
-      it('should parse selected scanners and excluded scanners', () => {
-        const result = parseModelAuditArgs(['model.pkl'], {
-          scanners: ['pickle,tf_savedmodel', 'PickleScanner'],
-          excludeScanner: ['weight_distribution'],
-        });
-
-        expect(result.args).toEqual([
-          'scan',
-          'model.pkl',
-          '--scanners',
-          'pickle,tf_savedmodel',
-          '--scanners',
-          'PickleScanner',
-          '--exclude-scanner',
-          'weight_distribution',
-        ]);
-      });
-
-      it('should parse scanner catalog listing without paths', () => {
-        const result = parseModelAuditArgs([], {
-          listScanners: true,
-          format: 'json',
-        });
-
-        expect(result.args).toEqual(['scan', '--format', 'json', '--list-scanners']);
-      });
-
-      it('should validate scanner selection arguments as supported', () => {
-        const result = validateModelAuditArgs([
-          'scan',
-          '--list-scanners',
-          '--format',
-          'json',
-          '--scanners',
-          'pickle',
-          '--exclude-scanner',
-          'weight_distribution',
-        ]);
-
-        expect(result.valid).toBe(true);
-        expect(result.unsupportedArgs).toEqual([]);
-      });
-    });
+    expect(result.args).toEqual(['scan', '--format', 'json', '--list-scanners']);
   });
 });


### PR DESCRIPTION
## Summary

- remove unused ModelAudit CLI validation and deprecation helpers
- remove unreachable warning paths for obsolete flags
- preserve supported argument translation, max-size validation, and the `{ args, unsupportedOptions: [] }` return shape
- verify Commander rejects obsolete flags before entering the action handler

## Test Plan

- `npx vitest run test/utils/modelAuditCliParser.test.ts test/commands/modelScan.test.ts --sequence.shuffle=false`
- `npx vitest run test/server/routes/modelAudit.test.ts --sequence.shuffle=false`
- `npx vitest run test/commands/modelScan.tempFile.test.ts`
- explicit Commander obsolete-flag probe
- `npm run l`
- `npm run tsc`
- `npm run knip -- --no-progress`
- direct Biome check and `git diff --check`

`npm run f` completed its Biome stage. Its unconditional Prettier stage had no eligible files in this TypeScript-only diff and exited with `No parser and no file path given`.
