### PR TITLE
refactor(model-audit): remove unused query methods

### DIFF
--- a/src/models/modelAudit.ts
+++ b/src/models/modelAudit.ts
@@ -181,18 +181,6 @@ export default class ModelAudit {
     return new ModelAudit({ ...result, persisted: true });
   }
 
-  static async findByModelPath(modelPath: string): Promise<ModelAudit[]> {
-    const db = await getDb();
-    const results = await db
-      .select()
-      .from(modelAuditsTable)
-      .where(eq(modelAuditsTable.modelPath, modelPath))
-      .orderBy(modelAuditsTable.createdAt)
-      .all();
-
-    return results.map((r) => new ModelAudit({ ...r, persisted: true }));
-  }
-
   /**
    * Find existing model audit by revision information for deduplication.
    * Checks both revision_sha and content_hash based on availability.
@@ -253,18 +241,6 @@ export default class ModelAudit {
 
     logger.debug(`Found existing scan for ${modelId} (id: ${result.id})`);
     return new ModelAudit({ ...result, persisted: true });
-  }
-
-  static async findLatestByModelId(modelId: string): Promise<ModelAudit | null> {
-    const db = await getDb();
-    const result = await db
-      .select()
-      .from(modelAuditsTable)
-      .where(eq(modelAuditsTable.modelId, modelId))
-      .orderBy(desc(modelAuditsTable.createdAt))
-      .get();
-
-    return result ? new ModelAudit({ ...result, persisted: true }) : null;
   }
 
   /**

--- a/test/commands/modelScan.test.ts
+++ b/test/commands/modelScan.test.ts
@@ -32,7 +32,6 @@ vi.mock('../../src/models/modelAudit', () => ({
   default: {
     create: vi.fn().mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' }),
     findByRevision: vi.fn().mockResolvedValue(null),
-    findLatestByModelId: vi.fn().mockResolvedValue(null),
   },
 }));
 vi.mock('../../src/updates', async (importOriginal) => {
@@ -131,8 +130,6 @@ async function resetModelScanTestMocks() {
   const ModelAudit = (await import('../../src/models/modelAudit')).default;
   vi.mocked(ModelAudit.findByRevision).mockReset();
   vi.mocked(ModelAudit.findByRevision).mockResolvedValue(null);
-  vi.mocked(ModelAudit.findLatestByModelId).mockReset();
-  vi.mocked(ModelAudit.findLatestByModelId).mockResolvedValue(null);
   vi.mocked(ModelAudit.create).mockReset();
   vi.mocked(ModelAudit.create).mockResolvedValue({ id: 'scan-abc-2025-01-01T00:00:00' } as any);
 
@@ -868,7 +865,6 @@ describe('Re-scan on version change behavior', () => {
     await command?.parseAsync(['node', 'scan-model', 'hf://test-owner/test-model']);
 
     expect(ModelAudit.findByRevision).toHaveBeenCalledWith('test-owner/test-model', 'abc123');
-    expect(ModelAudit.findLatestByModelId).not.toHaveBeenCalled();
     expect(ModelAudit.create).toHaveBeenCalledWith(
       expect.objectContaining({
         modelId: 'test-owner/test-model',


### PR DESCRIPTION
## Summary

- Remove the unused `ModelAudit.findByModelPath` and `findLatestByModelId` query methods.
- Remove the corresponding stale `modelScan` mock, reset, and negative assertion.
- Preserve revision deduplication, list/search/latest routes, sharing, schemas, migrations, and indexes.

## Consumer and overlap audit

- No remaining in-repository callers or references.
- No Promptfoo Cloud consumers outside its vendored Promptfoo checkout.
- No open pull request overlaps either changed file, and no maintained public consumer was identified.

## Validation

- `git diff --check`
- `npm run l`
- Focused Vitest suite: 7 files, 203 tests passed
- `npm run tsc`
- `npm run knip -- --no-progress` (four existing configuration hints only)
- `npm run build`
- Pre-commit lint
- `npm run f`: changed TypeScript files were already clean; the repository script then exited 123 because an empty docs/style file list was passed to Prettier
- Independent deslop review and two-pass native prepublish review: no findings
