### PR TITLE
refactor(redteam): remove unused materialization bridge

### DIFF
--- a/src/redteam/inputVariables.ts
+++ b/src/redteam/inputVariables.ts
@@ -791,18 +791,6 @@ export function materializeInputValue(
   }
 }
 
-export function materializeInputVariables(
-  variables: Record<string, string>,
-  inputs: Inputs,
-): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(variables).map(([key, value]) => {
-      const definition = inputs[key];
-      return [key, definition ? materializeInputValue(value, definition) : value];
-    }),
-  );
-}
-
 export async function materializeInputVariablesWithMetadata(
   variables: Record<string, string>,
   inputs: Inputs,

--- a/src/redteam/util.ts
+++ b/src/redteam/util.ts
@@ -11,7 +11,6 @@ import { recordGenerationTokenUsage } from './generationTokenUsage';
 import {
   type InputMaterializationContext,
   type MaterializedInputVariablesResult,
-  materializeInputVariables,
   materializeInputVariablesWithMetadata,
 } from './inputVariables';
 import {
@@ -81,13 +80,6 @@ export function extractVariablesFromJson(
     }
   }
   return extractedVars;
-}
-
-export function extractMaterializedVariablesFromJson(
-  parsed: Record<string, unknown>,
-  inputs: Inputs,
-): Record<string, string> {
-  return materializeInputVariables(extractVariablesFromJson(parsed, inputs), inputs);
 }
 
 export async function extractMaterializedVariablesFromJsonWithMetadata(

--- a/test/redteam/inputVariables.test.ts
+++ b/test/redteam/inputVariables.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
   buildPromptInputDescriptions,
   materializeInputValue,
-  materializeInputVariables,
   materializeInputVariablesWithMetadata,
 } from '../../src/redteam/inputVariables';
 import { InputDefinitionObjectSchema } from '../../src/types/shared';
@@ -454,20 +453,5 @@ describe('inputVariables', () => {
 
     expect(value).toMatch(/^data:image\/svg\+xml;base64,/);
     expect(Buffer.from(value.split(',')[1], 'base64').toString('utf-8')).toContain('<svg');
-  });
-
-  it('leaves text inputs untouched when materializing variables', () => {
-    expect(
-      materializeInputVariables(
-        {
-          note: 'hello',
-        },
-        {
-          note: 'plain text note',
-        },
-      ),
-    ).toEqual({
-      note: 'hello',
-    });
   });
 });


### PR DESCRIPTION
## Summary

- remove the unreachable synchronous redteam input-materialization wrapper
- remove the now-unreferenced synchronous variable mapper
- keep the async metadata-aware and MCP/remote materialization paths unchanged

## Safety

- Promptfoo Cloud uses only the live metadata-returning materialization path
- public and in-repo exact-reference searches found no callers of the removed symbols
- open pull requests touching these files are exact-line disjoint

## Validation

- focused redteam suites: 11 files, 248 tests passed
- npm run tsc
- npm run knip -- --no-progress --reporter github-actions
- npm run build
- changed-file Biome lint/format and git diff --check