### PR TITLE
chore(deps): remove unused type and test packages

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -37,8 +37,6 @@
         // code-scan-action/package.json rather than the root manifest.
         "@actions/*",
         "@octokit/rest",
-        // Types for a dynamically-imported dependency.
-        "@types/pdf-parse",
         // Install-side-effect git-hook tool; never imported.
         "block-no-verify",
         // Transitive pin for google-auth-library behavior (see comments in
@@ -57,7 +55,6 @@
       "ignoreFiles": ["src/polyfills/scroll-timeline.d.ts"],
       "ignoreDependencies": [
         // Build-tool/CSS deps invisible to import analysis (Tailwind v4 pipeline).
-        "@kurkle/color",
         "lightningcss",
         "tailwindcss"
       ],
@@ -84,7 +81,6 @@
         "@generated/*",
         "@docusaurus/plugin-content-blog",
         "@swc/core",
-        "@swc/jest",
         // Transitive pins for the Docusaurus build; never imported directly.
         "dompurify",
         "langium"

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,6 @@
         "@types/node": "^24.12.0",
         "@types/nunjucks": "^3.2.6",
         "@types/opener": "^1.4.3",
-        "@types/pdf-parse": "^1.1.5",
         "@types/pem": "^1.14.4",
         "@types/proxy-from-env": "^1.0.4",
         "@types/semver": "^7.7.1",
@@ -11279,95 +11278,6 @@
         }
       }
     },
-    "node_modules/@jest/create-cache-key-function": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.4.1.tgz",
-      "integrity": "sha512-R+xGEtzA95NIsvpXJSROG4t01956dDOt17KpamguY4XOnGvdHNFFXE7Er0C1OAsRjOwiIxpKqOvGlznIGZIQlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@jest/types/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
@@ -11880,13 +11790,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "license": "MIT"
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.4.0.tgz",
-      "integrity": "sha512-H4MGdCNqaMQW2gz47VNOE7zLy8s1NLLpvzxFTpWIPJzlmkYQMkOD9pRwrMWRDYjyErxL297mbgK6yyLuGdGEbg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@kwsites/file-exists": {
@@ -16645,13 +16548,6 @@
         "@simple-git/args-pathspec": "^1.0.3"
       }
     },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.34.52",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
-      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -17633,24 +17529,6 @@
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "devOptional": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@swc/jest": {
-      "version": "0.2.39",
-      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.39.tgz",
-      "integrity": "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/create-cache-key-function": "^30.0.0",
-        "@swc/counter": "^0.1.3",
-        "jsonc-parser": "^3.2.0"
-      },
-      "engines": {
-        "npm": ">= 7.0.0"
-      },
-      "peerDependencies": {
-        "@swc/core": "*"
-      }
     },
     "node_modules/@swc/types": {
       "version": "0.1.28",
@@ -19207,16 +19085,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
-    },
-    "node_modules/@types/pdf-parse": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
-      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/pegjs": {
       "version": "0.10.6",
@@ -29242,16 +29110,6 @@
       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
       "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
       "license": "MIT"
-    },
-    "node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
     },
     "node_modules/jest-util": {
       "version": "29.7.0",
@@ -46165,7 +46023,6 @@
         "@mui/icons-material": "^9.0.0",
         "@segment/ajv-human-errors": "^2.16.0",
         "@swc/core": "^1.16.1",
-        "@swc/jest": "^0.2.39",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
@@ -46224,7 +46081,6 @@
       "devDependencies": {
         "@babel/core": "^7.29.6",
         "@chromatic-com/storybook": "^5.2.1",
-        "@kurkle/color": "^0.4.0",
         "@storybook/addon-a11y": "^10.4.0",
         "@storybook/addon-docs": "^10.4.0",
         "@storybook/react-vite": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -245,7 +245,6 @@
     "@types/node": "^24.12.0",
     "@types/nunjucks": "^3.2.6",
     "@types/opener": "^1.4.3",
-    "@types/pdf-parse": "^1.1.5",
     "@types/pem": "^1.14.4",
     "@types/proxy-from-env": "^1.0.4",
     "@types/semver": "^7.7.1",

--- a/site/package.json
+++ b/site/package.json
@@ -36,7 +36,6 @@
     "@mui/icons-material": "^9.0.0",
     "@segment/ajv-human-errors": "^2.16.0",
     "@swc/core": "^1.16.1",
-    "@swc/jest": "^0.2.39",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@babel/core": "^7.29.6",
     "@chromatic-com/storybook": "^5.2.1",
-    "@kurkle/color": "^0.4.0",
     "@storybook/addon-a11y": "^10.4.0",
     "@storybook/addon-docs": "^10.4.0",
     "@storybook/react-vite": "^10.4.0",


### PR DESCRIPTION
## Summary

- remove unused root @types/pdf-parse, site @swc/jest, and app direct @kurkle/color 0.4 declarations
- remove their matching Knip exceptions
- regenerate the root lockfile, deleting only their orphaned nodes while preserving @swc/core, pdf-parse, and Chart.js nested @kurkle/color 0.3.4

## Validation

- locked npm install under repository Node 24.20.0 and npm 11.19.0
- package manifest tests: 43 passed
- evaluator helper tests: 139 passed
- ResultsCharts tests: 18 passed
- site tests: 257 passed
- root, site, and app TypeScript checks
- site and app production builds
- dependency-only Knip, dependency-version consistency, Biome checks, lockfile JSON parse, and git diff check

## Notes

- the normal site build wrapper could not refresh live npm download statistics in the constrained devbox, so the same Docusaurus production compilation was run directly with the generated fallback and passed
- strict Knip config-hint mode reports only four unchanged baseline hints outside this cleanup; the dependency audit passes