### PR TITLE
chore(db): remove abandoned output table sketch

### DIFF
--- a/src/__mocks__/database.ts
+++ b/src/__mocks__/database.ts
@@ -39,10 +39,6 @@ export const evalsToDatasets = mockSqliteTable('evals_to_datasets', {
   /* schema definition */
 });
 export const evalsToDatasetsRelations = mockRelations;
-export const llmOutputs = mockSqliteTable('llm_outputs', {
-  /* schema definition */
-});
-export const llmOutputsRelations = mockRelations;
 export const tracesTable = mockSqliteTable('traces', {
   /* schema definition */
 });

--- a/src/database/tables.ts
+++ b/src/database/tables.ts
@@ -337,49 +337,6 @@ export const configsTable = sqliteTable(
   }),
 );
 
-// ------------ Outputs ------------
-// We're just recording these on eval.results for now...
-
-/*
-export const llmOutputs = sqliteTable(
-  'llm_outputs',
-  {
-    id: text('id')
-      .notNull()
-      .unique(),
-    createdAt: integer('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-    evalId: text('eval_id')
-      .notNull()
-      .references(() => evals.id),
-    promptId: text('prompt_id')
-      .notNull()
-      .references(() => prompts.id),
-    providerId: text('provider_id').notNull(),
-    vars: text('vars', {mode: 'json'}),
-    response: text('response', {mode: 'json'}),
-    error: text('error'),
-    latencyMs: integer('latency_ms'),
-    gradingResult: text('grading_result', {mode: 'json'}),
-    namedScores: text('named_scores', {mode: 'json'}),
-    cost: real('cost'),
-  },
-  (t) => ({
-    pk: primaryKey({ columns: [t.id] }),
-  }),
-);
-
-export const llmOutputsRelations = relations(llmOutputs, ({ one }) => ({
-  eval: one(evals, {
-    fields: [llmOutputs.evalId],
-    references: [evals.id],
-  }),
-  prompt: one(prompts, {
-    fields: [llmOutputs.promptId],
-    references: [prompts.id],
-  }),
-}));
-*/
-
 // ------------ Model Audits ------------
 
 export const modelAuditsTable = sqliteTable(


### PR DESCRIPTION
## Summary

- remove the fully commented abandoned `llmOutputs` schema sketch
- remove the matching unused exports from the manual database mock
- preserve all nine live Drizzle relation declarations and all generated schema and migration artifacts

## Validation

- `npm run db:generate`  no schema changes and no migration generated
- 17 focused database, model, and database-utility suites  414 tests passed
- manual database-mock consumers  2 files, 39 tests passed
- Biome changed-file check, TypeScript, architecture boundaries, Knip, and full build passed
- independent deslop audit  CLEAN
- two-pass native prepublication receipt  CLEAN