### PR TITLE
fix(assertions): keep custom reason when inverting a GradingResult pass

### DIFF
--- a/src/assertions/javascript.ts
+++ b/src/assertions/javascript.ts
@@ -193,7 +193,9 @@ function normalizeJavascriptAssertionResult(
         ? result.reason
         : pass
           ? 'Assertion passed'
-          : `Custom function returned ${result.pass ? 'true' : 'false'}`,
+          : // Inverted failure: keep the caller's reason, falling back to the
+            // raw outcome only when they gave none.
+            (result.reason ?? `Custom function returned ${result.pass ? 'true' : 'false'}`),
     assertion: normalizeResultAssertion(result.assertion, assertion),
   };
 }

--- a/test/assertions/javascript.test.ts
+++ b/test/assertions/javascript.test.ts
@@ -904,7 +904,8 @@ describe('JavaScript file references', () => {
       },
       false,
       0.75,
-      'Custom function returned true',
+      // Inverted failure keeps the caller's reason, not the generic outcome string.
+      'Custom reason',
     ],
   ];
 
@@ -968,7 +969,7 @@ describe('JavaScript file references', () => {
       },
       false,
       0.75,
-      'Custom function returned true',
+      'Custom reason',
     ],
   ];
 


### PR DESCRIPTION
## Summary

Fixes #10674. When a javascript assertion's value returns a full GradingResult and the assertion is inverted (`not-javascript`), the verdict flips correctly but the caller's custom reason was silently discarded: the inverted-failure branch always produced the generic `Custom function returned true/false`.

The fix keeps `result.reason` on the inverted-failure path, falling back to the outcome string only when the caller gave none.

## Verification

- The two existing `not-javascript` + GradingResult cases (direct function value and inline script) now assert that the custom reason survives the inversion; previously they pinned the generic string.
- Red-green: without the fix both cases fail on the new expectation; with it, all 92 tests in `test/assertions/javascript.test.ts` pass.
- `biome check` clean on both touched files.
