### PR TITLE
fix(providers): recognize Daybreak reasoning aliases

### DIFF
--- a/src/providers/openai/index.ts
+++ b/src/providers/openai/index.ts
@@ -164,6 +164,7 @@ export class OpenAiGenericProvider implements ApiProvider {
       model.includes('/o1') ||
       model.includes('/o3') ||
       model.includes('/o4') ||
+      /(^|\/)gpt-daybreak-(?:blue|red)-latest$/.test(model) ||
       this.isGPT5Model(model) ||
       isGpt6AstraModel(model)
     );

--- a/test/providers/openai/daybreak.test.ts
+++ b/test/providers/openai/daybreak.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { OpenAiChatCompletionProvider } from '../../../src/providers/openai/chat';
+import { OpenAiResponsesProvider } from '../../../src/providers/openai/responses';
+import { mockProcessEnv } from '../../util/utils';
+
+describe.each([
+  { api: 'Chat', Provider: OpenAiChatCompletionProvider, tokenLimit: 'max_completion_tokens' },
+  { api: 'Responses', Provider: OpenAiResponsesProvider, tokenLimit: 'max_output_tokens' },
+])('Daybreak $api requests', ({ Provider, tokenLimit }) => {
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    restoreEnv = mockProcessEnv({
+      OPENAI_MAX_TOKENS: undefined,
+      OPENAI_MAX_COMPLETION_TOKENS: undefined,
+      OPENAI_TEMPERATURE: undefined,
+      OPENAI_TOP_P: undefined,
+    });
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it.each([
+    'gpt-daybreak-blue-latest',
+    'gpt-daybreak-red-latest',
+    'openai/gpt-daybreak-blue-latest',
+    'openai/gpt-daybreak-red-latest',
+  ])('preserves reasoning effort and omits incompatible defaults for %s', async (model) => {
+    const { body } = await new Provider(model, {
+      config: { reasoning_effort: 'high' },
+    }).getOpenAiBody('Hello');
+
+    expect(body.model).toBe(model);
+    expect(body).not.toHaveProperty('temperature');
+    expect(body).not.toHaveProperty('max_tokens');
+    expect(body).not.toHaveProperty('max_completion_tokens');
+    expect(body).not.toHaveProperty('max_output_tokens');
+    if (Provider === OpenAiChatCompletionProvider) {
+      expect(body.reasoning_effort).toBe('high');
+    } else {
+      expect(body.reasoning).toEqual({ effort: 'high' });
+    }
+  });
+
+  it.each(['gpt-daybreak-blue-latest', 'gpt-daybreak-red-latest'])(
+    'respects explicit reasoning token limits and omits temperature for %s',
+    async (model) => {
+      const { body } = await new Provider(model, {
+        config: { [tokenLimit]: 8192, max_tokens: 100, temperature: 0.7 },
+      }).getOpenAiBody('Hello');
+
+      expect(body[tokenLimit]).toBe(8192);
+      expect(body).not.toHaveProperty('max_tokens');
+      expect(body).not.toHaveProperty('temperature');
+    },
+  );
+
+  it.each(['gpt-4.1', 'gpt-daybreak-red-latest-custom', 'custom-gpt-daybreak-blue-latest'])(
+    'keeps standard-model defaults for %s',
+    async (model) => {
+      const { body } = await new Provider(model, {
+        config: { reasoning_effort: 'high' },
+      }).getOpenAiBody('Hello');
+
+      expect(body.temperature).toBe(0);
+      expect(
+        body[Provider === OpenAiChatCompletionProvider ? 'max_tokens' : 'max_output_tokens'],
+      ).toBe(1024);
+      expect(body).not.toHaveProperty('reasoning_effort');
+      expect(body).not.toHaveProperty('reasoning');
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Recognize `gpt-daybreak-blue-latest` and `gpt-daybreak-red-latest` as reasoning models, including vendor-prefixed IDs. Chat Completions and Responses now preserve reasoning effort and explicit reasoning token limits without injecting temperature or the standard 1,024-token default.

## Test plan

- 355 focused OpenAI provider tests pass; 12 new regression cases fail before the fix.
- `npm run build`, `npm run l`, and `npm run f` pass.
- Built CLI eval against a local API fixture: all 8 cases pass across both aliases, both endpoints, and default/explicit token limits. Inspected exported results and captured request bodies.
