### PR TITLE
fix(providers): align Vercel generation with AI SDK 6

### DIFF
--- a/src/providers/vercel.ts
+++ b/src/providers/vercel.ts
@@ -7,6 +7,7 @@ import logger from '../logger';
 import { sha256 } from '../util/createHash';
 import { getRequestTimeoutMs, parseChatPrompt } from './shared';
 import { hasActiveTracingSpan } from './tracing';
+import type { LanguageModelUsage } from 'ai';
 
 import type { EnvOverrides } from '../types/env';
 import type {
@@ -119,15 +120,13 @@ async function createGatewayInstance(
 /**
  * Maps Vercel AI SDK usage to promptfoo TokenUsage format.
  */
-function mapTokenUsage(usage?: {
-  promptTokens?: number;
-  completionTokens?: number;
-  totalTokens?: number;
-}): TokenUsage {
+function mapTokenUsage(
+  usage?: Partial<Pick<LanguageModelUsage, 'inputTokens' | 'outputTokens' | 'totalTokens'>>,
+): TokenUsage {
   return {
-    prompt: usage?.promptTokens,
-    completion: usage?.completionTokens,
-    total: usage?.totalTokens ?? (usage?.promptTokens ?? 0) + (usage?.completionTokens ?? 0),
+    prompt: usage?.inputTokens,
+    completion: usage?.outputTokens,
+    total: usage?.totalTokens ?? (usage?.inputTokens ?? 0) + (usage?.outputTokens ?? 0),
     numRequests: 1,
   };
 }
@@ -182,7 +181,7 @@ function pickGenerateOptions(config: VercelAiConfig) {
   return Object.fromEntries(
     Object.entries({
       temperature,
-      maxTokens,
+      maxOutputTokens: maxTokens,
       topP,
       topK,
       frequencyPenalty,
@@ -277,7 +276,8 @@ export class VercelAiProvider implements ApiProvider {
   }
 
   private getCacheKey(prompt: string): string {
-    return `vercel:${this.modelName}:${sha256(
+    // Version generation responses because AI SDK 6 caps and usage changed.
+    return `vercel:v2:${this.modelName}:${sha256(
       JSON.stringify({
         prompt,
         gateway: getGatewayCacheConfig(this.config, this.env),
@@ -325,12 +325,8 @@ export class VercelAiProvider implements ApiProvider {
       });
 
       let output = '';
-      try {
-        for await (const chunk of result.textStream) {
-          output += chunk;
-        }
-      } finally {
-        cleanup();
+      for await (const chunk of result.textStream) {
+        output += chunk;
       }
 
       const [usage, finishReason] = await Promise.all([result.usage, result.finishReason]);
@@ -344,6 +340,8 @@ export class VercelAiProvider implements ApiProvider {
       return { output, tokenUsage: mapTokenUsage(usage), finishReason };
     } catch (error) {
       return handleApiError(error, timeout, 'streaming API call');
+    } finally {
+      cleanup();
     }
   }
 

--- a/test/providers/vercel.test.ts
+++ b/test/providers/vercel.test.ts
@@ -183,7 +183,7 @@ describe('VercelAiProvider', () => {
         expectActiveEvaluationParent();
         return {
           text: 'Traced response',
-          usage: { promptTokens: 10, completionTokens: 20 },
+          usage: { inputTokens: 10, outputTokens: 20 },
           finishReason: 'stop',
         } as any;
       });
@@ -274,7 +274,7 @@ describe('VercelAiProvider', () => {
       const { generateText } = await import('ai');
       vi.mocked(generateText).mockResolvedValueOnce({
         text: 'Hello from GPT-4o!',
-        usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
         finishReason: 'stop',
       } as any);
 
@@ -297,7 +297,7 @@ describe('VercelAiProvider', () => {
       const { generateText } = await import('ai');
       vi.mocked(generateText).mockResolvedValueOnce({
         text: 'Response',
-        usage: { promptTokens: 5, completionTokens: 15, totalTokens: 20 },
+        usage: { inputTokens: 5, outputTokens: 15, totalTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -316,7 +316,7 @@ describe('VercelAiProvider', () => {
       const { generateText } = await import('ai');
       vi.mocked(generateText).mockResolvedValueOnce({
         text: 'Response to chat',
-        usage: { promptTokens: 10, completionTokens: 15 },
+        usage: { inputTokens: 10, outputTokens: 15 },
         finishReason: 'stop',
       } as any);
 
@@ -341,7 +341,7 @@ describe('VercelAiProvider', () => {
       const { generateText } = await import('ai');
       vi.mocked(generateText).mockResolvedValueOnce({
         text: 'Response',
-        usage: { promptTokens: 5, completionTokens: 10 },
+        usage: { inputTokens: 5, outputTokens: 10 },
         finishReason: 'stop',
       } as any);
 
@@ -358,7 +358,7 @@ describe('VercelAiProvider', () => {
         expect.objectContaining({
           messages: [{ role: 'user', content: 'Test' }],
           temperature: 0.8,
-          maxTokens: 500,
+          maxOutputTokens: 500,
           topP: 0.9,
         }),
       );
@@ -404,7 +404,7 @@ describe('VercelAiProvider', () => {
         expectActiveEvaluationParent();
         return {
           textStream: textStream(),
-          usage: Promise.resolve({ promptTokens: 1, completionTokens: 2 }),
+          usage: Promise.resolve({ inputTokens: 1, outputTokens: 2 }),
           finishReason: Promise.resolve('stop'),
         } as any;
       });
@@ -442,7 +442,7 @@ describe('VercelAiProvider', () => {
 
       vi.mocked(streamText).mockReturnValueOnce({
         textStream: mockTextStream(),
-        usage: Promise.resolve({ promptTokens: 5, completionTokens: 15, totalTokens: 20 }),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 15, totalTokens: 20 }),
         finishReason: Promise.resolve('stop'),
       } as any);
 
@@ -472,7 +472,7 @@ describe('VercelAiProvider', () => {
 
       vi.mocked(streamText).mockReturnValueOnce({
         textStream: mockTextStream(),
-        usage: Promise.resolve({ promptTokens: 5, completionTokens: 10 }),
+        usage: Promise.resolve({ inputTokens: 5, outputTokens: 10 }),
         finishReason: Promise.resolve('stop'),
       } as any);
 
@@ -489,7 +489,7 @@ describe('VercelAiProvider', () => {
         expect.objectContaining({
           messages: [{ role: 'user', content: 'Test' }],
           temperature: 0.5,
-          maxTokens: 1000,
+          maxOutputTokens: 1000,
         }),
       );
     });
@@ -508,6 +508,28 @@ describe('VercelAiProvider', () => {
       expect(result).toEqual({
         error: 'API call error: Stream connection failed',
       });
+    });
+
+    it('cleans up the timeout when stream creation fails before iteration', async () => {
+      const setTimer = vi.spyOn(globalThis, 'setTimeout');
+      const clearTimer = vi.spyOn(globalThis, 'clearTimeout');
+      try {
+        const { streamText } = await import('ai');
+        vi.mocked(streamText).mockImplementationOnce(() => {
+          throw new Error('Fixture failure');
+        });
+        const provider = new VercelAiProvider('provider/model', {
+          config: { streaming: true, timeout: 12345 },
+        });
+        const result = await provider.callApi('Hello');
+        expect(result.error).toBe('API call error: Fixture failure');
+        const timerIndex = setTimer.mock.calls.findIndex((call) => call[1] === 12345);
+        expect(timerIndex).toBeGreaterThanOrEqual(0);
+        expect(clearTimer).toHaveBeenCalledWith(setTimer.mock.results[timerIndex].value);
+      } finally {
+        setTimer.mockRestore();
+        clearTimer.mockRestore();
+      }
     });
 
     it('should handle streaming timeout errors', async () => {
@@ -530,6 +552,40 @@ describe('VercelAiProvider', () => {
   });
 
   describe('caching', () => {
+    it('bypasses legacy generation entries and reuses corrected response entries', async () => {
+      const { generateText } = await import('ai');
+      vi.mocked(isCacheEnabled).mockReturnValue(true);
+      // Exact key produced before the AI SDK 6 option and usage correction.
+      const legacyKey =
+        'vercel:fixture/model:66dab383c61060b0301d3774d959f13a43ff2b121d9c9336262d8739ef2fb1ea';
+      const entries = new Map([
+        [legacyKey, JSON.stringify({ output: 'Old uncapped response', tokenUsage: { total: 99 } })],
+      ]);
+      mockCache.get.mockImplementation(async (key: string) => entries.get(key));
+      mockCache.set.mockImplementation(async (key: string, value: string) => {
+        entries.set(key, value);
+      });
+      vi.mocked(generateText).mockResolvedValueOnce({
+        text: 'Fresh',
+        usage: { inputTokens: 7, outputTokens: 1, totalTokens: 8 },
+        finishReason: 'length',
+      } as any);
+      const provider = new VercelAiProvider('fixture/model', {
+        config: { apiKey: 'fixture-key', baseUrl: 'https://example.invalid/ai', maxTokens: 1 },
+      });
+      const fresh = await provider.callApi('cache migration fixture');
+      expect(fresh).toMatchObject({
+        output: 'Fresh',
+        tokenUsage: { prompt: 7, completion: 1, total: 8 },
+      });
+      expect(fresh.cached).toBeUndefined();
+      expect(generateText).toHaveBeenCalledWith(expect.objectContaining({ maxOutputTokens: 1 }));
+      expect(mockCache.get).not.toHaveBeenCalledWith(legacyKey);
+      const cached = await provider.callApi('cache migration fixture');
+      expect(cached).toEqual({ ...fresh, cached: true });
+      expect(generateText).toHaveBeenCalledTimes(1);
+    });
+
     it('does not invoke the SDK for a traced cache hit', async () => {
       const { generateText } = await import('ai');
       vi.mocked(isCacheEnabled).mockReturnValue(true);
@@ -567,7 +623,7 @@ describe('VercelAiProvider', () => {
         cached: true,
       });
       const cacheKey = mockCache.get.mock.calls[0][0] as string;
-      expect(cacheKey).toMatch(/^vercel:openai\/gpt-4o-mini:[a-f0-9]{64}$/);
+      expect(cacheKey).toMatch(/^vercel:v2:openai\/gpt-4o-mini:[a-f0-9]{64}$/);
       expect(cacheKey).not.toContain(prompt);
     });
 
@@ -576,7 +632,7 @@ describe('VercelAiProvider', () => {
       vi.mocked(isCacheEnabled).mockReturnValue(true);
       vi.mocked(generateText).mockResolvedValueOnce({
         text: 'Fresh response',
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -585,7 +641,7 @@ describe('VercelAiProvider', () => {
       await provider.callApi(prompt);
 
       const cacheKey = mockCache.set.mock.calls[0][0] as string;
-      expect(cacheKey).toMatch(/^vercel:openai\/gpt-4o-mini:[a-f0-9]{64}$/);
+      expect(cacheKey).toMatch(/^vercel:v2:openai\/gpt-4o-mini:[a-f0-9]{64}$/);
       expect(cacheKey).not.toContain(prompt);
       expect(mockCache.get).toHaveBeenCalledWith(cacheKey);
       expect(mockCache.set).toHaveBeenCalledWith(
@@ -599,7 +655,7 @@ describe('VercelAiProvider', () => {
       vi.mocked(isCacheEnabled).mockReturnValue(true);
       vi.mocked(generateText).mockResolvedValue({
         text: 'Fresh response',
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -638,7 +694,7 @@ describe('VercelAiProvider', () => {
       vi.mocked(isCacheEnabled).mockReturnValue(true);
       vi.mocked(generateText).mockResolvedValue({
         text: 'Fresh response',
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -675,7 +731,7 @@ describe('VercelAiProvider', () => {
       vi.mocked(isCacheEnabled).mockReturnValue(true);
       vi.mocked(generateText).mockResolvedValue({
         text: 'Fresh response',
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -712,7 +768,7 @@ describe('VercelAiProvider', () => {
       vi.mocked(isCacheEnabled).mockReturnValue(true);
       vi.mocked(generateText).mockResolvedValue({
         text: 'Fresh response',
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -751,7 +807,7 @@ describe('VercelAiProvider', () => {
       vi.mocked(isCacheEnabled).mockReturnValue(true);
       vi.mocked(generateText).mockResolvedValue({
         text: 'Fresh response',
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -786,7 +842,7 @@ describe('VercelAiProvider', () => {
       vi.mocked(isCacheEnabled).mockReturnValue(true);
       vi.mocked(generateText).mockResolvedValue({
         text: 'Fresh response',
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -818,7 +874,7 @@ describe('VercelAiProvider', () => {
       vi.mocked(isCacheEnabled).mockReturnValue(true);
       vi.mocked(generateText).mockResolvedValue({
         text: 'Fresh response',
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -863,7 +919,7 @@ describe('VercelAiProvider', () => {
       );
       vi.mocked(generateText).mockResolvedValueOnce({
         text: 'Fresh response',
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -882,7 +938,7 @@ describe('VercelAiProvider', () => {
         expectActiveEvaluationParent();
         return {
           object: { value: 'result' },
-          usage: { promptTokens: 1, completionTokens: 2 },
+          usage: { inputTokens: 1, outputTokens: 2 },
           finishReason: 'stop',
         } as any;
       });
@@ -911,7 +967,7 @@ describe('VercelAiProvider', () => {
       const { generateObject } = await import('ai');
       vi.mocked(generateObject).mockResolvedValueOnce({
         object: { sentiment: 'positive', confidence: 0.95 },
-        usage: { promptTokens: 15, completionTokens: 25, totalTokens: 40 },
+        usage: { inputTokens: 15, outputTokens: 25, totalTokens: 40 },
         finishReason: 'stop',
       } as any);
 
@@ -945,7 +1001,7 @@ describe('VercelAiProvider', () => {
       const { generateObject } = await import('ai');
       vi.mocked(generateObject).mockResolvedValueOnce({
         object: { name: 'Test', value: 42 },
-        usage: { promptTokens: 10, completionTokens: 20 },
+        usage: { inputTokens: 10, outputTokens: 20 },
         finishReason: 'stop',
       } as any);
 
@@ -961,6 +1017,7 @@ describe('VercelAiProvider', () => {
         config: {
           responseSchema: testSchema,
           temperature: 0.5,
+          maxTokens: 48,
         },
       });
       await provider.callApi('Generate data');
@@ -971,6 +1028,7 @@ describe('VercelAiProvider', () => {
           // OpenAI requires additionalProperties: false, so provider auto-adds it
           schema: { ...testSchema, additionalProperties: false },
           temperature: 0.5,
+          maxOutputTokens: 48,
         }),
       );
     });
@@ -1017,7 +1075,7 @@ describe('VercelAiProvider', () => {
       const { generateObject, streamText } = await import('ai');
       vi.mocked(generateObject).mockResolvedValueOnce({
         object: { result: 'structured' },
-        usage: { promptTokens: 10, completionTokens: 15 },
+        usage: { inputTokens: 10, outputTokens: 15 },
         finishReason: 'stop',
       } as any);
 


### PR DESCRIPTION
Vercel generation requests now translate the existing `maxTokens` setting to AI SDK 6 `maxOutputTokens` and report prompt/completion counts from `inputTokens`/`outputTokens` for text, streaming, and structured output. Streaming failures clean up the request timer, and a generation cache version prevents old uncapped responses from being replayed.

Validation: 58 mocked provider tests; TypeScript, package and UI builds; built CLI loopback evals for all three modes and an HTTP 400 failure. Wire requests preserve output caps and exports contain the expected token counts. The build postprocessor ran with `node --import tsx` because the `tsx` CLI IPC listener is restricted in the validation environment.
