### PR TITLE
fix(providers): forward Azure request settings

### DIFF
--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -1552,7 +1552,7 @@ For complete working examples, check out the [Azure Foundry Agent example direct
 
 ## Video Generation (Sora)
 
-The `azure:video:<deployment name>` provider sends text prompts to Azure's video generation jobs API. Use the name assigned to your deployment; promptfoo sends it in the request's `model` field. This provider supports text-to-video requests and does not send image inputs or remix requests.
+The `azure:video:<deployment name>` provider sends text prompts to Azure's video generation jobs API. Use the name assigned to your deployment; promptfoo sends it in the request's `model` field. It also forwards legacy `inpaint_items` for image-to-video requests. The OpenAI video options `input_reference` and `remix_video_id` are not supported by this Azure provider.
 
 ### Prerequisites
 

--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -560,6 +560,8 @@ defaultTest:
           apiHost: 'your-resource.openai.azure.com'
 ```
 
+For `text-embedding-3` deployments, set `config.dimensions` to request shorter vectors. Omit it to use the model's default vector size. Use the same embedding model and dimensions for indexed documents and queries; changing either requires rebuilding existing vectors. Azure deployment names are user-defined and remain unchanged by this option.
+
 Note that any moderation tasks will still use the OpenAI API.
 
 ## Configuration
@@ -1550,7 +1552,7 @@ For complete working examples, check out the [Azure Foundry Agent example direct
 
 ## Video Generation (Sora)
 
-Azure AI Foundry provides access to OpenAI's Sora video generation model for text-to-video and image-to-video generation.
+The `azure:video:<deployment name>` provider sends text prompts to Azure's video generation jobs API. Use the name assigned to your deployment; promptfoo sends it in the request's `model` field. This provider supports text-to-video requests and does not send image inputs or remix requests.
 
 ### Prerequisites
 
@@ -1561,7 +1563,7 @@ Azure AI Foundry provides access to OpenAI's Sora video generation model for tex
 
 ```yaml
 providers:
-  - id: azure:video:sora
+  - id: azure:video:my-video-deployment
     config:
       apiBaseUrl: https://your-resource.cognitiveservices.azure.com
       # Authentication (choose one):
@@ -1600,7 +1602,7 @@ providers:
 
 ```yaml
 providers:
-  - azure:video:sora
+  - azure:video:my-video-deployment
 
 prompts:
   - 'A serene Japanese garden with koi fish swimming in a pond'

--- a/src/providers/azure/embedding.ts
+++ b/src/providers/azure/embedding.ts
@@ -17,6 +17,7 @@ export class AzureEmbeddingProvider extends AzureGenericProvider {
     const body = {
       input: text,
       model: this.deploymentName,
+      ...(this.config.dimensions === undefined ? {} : { dimensions: this.config.dimensions }),
     };
     let data,
       cached = false;

--- a/src/providers/azure/types.ts
+++ b/src/providers/azure/types.ts
@@ -50,6 +50,8 @@ export interface AzureCompletionOptions {
   systemPrompt?: string;
 
   // OpenAI params
+  /** Output vector size for embeddings from text-embedding-3 and later models. */
+  dimensions?: number;
   max_tokens?: number;
   temperature?: number;
   top_p?: number;

--- a/src/providers/azure/video.ts
+++ b/src/providers/azure/video.ts
@@ -149,7 +149,7 @@ export class AzureVideoProvider extends AzureGenericProvider {
     const url = `${baseUrl}/openai/v1/video/generations/jobs?api-version=${apiVersion}`;
 
     const body: Record<string, unknown> = {
-      model: 'sora', // Azure always uses 'sora' as model name
+      model: this.deploymentName,
       prompt,
       width: config.width || 1280,
       height: config.height || 720,

--- a/test/providers/azure/embedding.test.ts
+++ b/test/providers/azure/embedding.test.ts
@@ -57,6 +57,31 @@ describe('AzureEmbeddingProvider', () => {
     });
   });
 
+  it.each([undefined, 256])(
+    'preserves the deployment and forwards dimensions %s',
+    async (dimensions) => {
+      provider.config.dimensions = dimensions;
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: { data: [{ embedding: [0.1, 0.2] }], usage: { total_tokens: 2 } },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callEmbeddingApi('A small sample');
+
+      const [url, request] = vi.mocked(fetchWithCache).mock.calls[0];
+      expect(url).toContain('/deployments/test-deployment/embeddings?api-version=');
+      expect(JSON.parse(request?.body as string)).toEqual({
+        input: 'A small sample',
+        model: 'test-deployment',
+        ...(dimensions === undefined ? {} : { dimensions }),
+      });
+      expect(result.embedding).toEqual([0.1, 0.2]);
+      expect(result.cached).toBe(false);
+    },
+  );
+
   it('should handle API call errors', async () => {
     vi.mocked(fetchWithCache).mockRejectedValueOnce(new Error('API error'));
 

--- a/test/providers/azure/video.test.ts
+++ b/test/providers/azure/video.test.ts
@@ -267,8 +267,8 @@ describe('AzureVideoProvider', () => {
   });
 
   describe('callApi - successful flow', () => {
-    it('should create and poll video job successfully', async () => {
-      const provider = new AzureVideoProvider('sora', {
+    it('should create and poll video job using the configured deployment', async () => {
+      const provider = new AzureVideoProvider('my-video-deployment', {
         config: {
           apiBaseUrl: 'https://test.cognitiveservices.azure.com',
           apiKey: 'test-key',
@@ -313,6 +313,9 @@ describe('AzureVideoProvider', () => {
 
       const result = await provider.callApi('A cat playing piano');
 
+      expect(JSON.parse(mockFetchWithProxy.mock.calls[0][1].body).model).toBe(
+        'my-video-deployment',
+      );
       expect(result.error).toBeUndefined();
       expect(result.output).toContain('[Video:');
       expect(result.video).toBeDefined();


### PR DESCRIPTION
Azure embedding requests discard configured dimensions, and video jobs always send `sora` instead of the selected deployment. Forward explicit embedding dimensions, preserve the default when omitted, and pass the configured deployment to video creation. Update the Azure docs to describe the supported request fields and text-only video path.

Validation: 39 focused mocked Azure tests pass. The built CLI passes embedding and video evals with `--no-cache`, using a fetch fixture that rejects every unmatched request; exports have success=true and score=1, and recorded bodies contain dimensions=2 and the selected video deployment. TypeScript, package bundling, and UI build pass; postbuild passed via `node --import tsx` after the sandbox blocked the tsx IPC launcher. The documentation production build also passes.

Azure's [embedding schema](https://learn.microsoft.com/en-us/rest/api/microsoft-foundry/azureopenai/embeddings) and [video jobs example](https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/video-generation) support these fields. This supplements #9792; #10693 changes separate media providers.
