### PR TITLE
fix(n8n): omit request bodies for HEAD webhooks

### DIFF
--- a/site/docs/providers/n8n.md
+++ b/site/docs/providers/n8n.md
@@ -49,16 +49,18 @@ providers:
 
 ### Config Options
 
-| Option              | Type          | Default     | Description                                                                     |
-| ------------------- | ------------- | ----------- | ------------------------------------------------------------------------------- |
-| `url`               | string        | -           | Webhook URL (alternative to provider path)                                      |
-| `method`            | string        | `POST`      | `GET`, `POST`, `PUT`, or `PATCH`; `GET` encodes body fields as query parameters |
-| `headers`           | object        | -           | Additional request headers with Nunjucks templating                             |
-| `body`              | object/string | `{prompt}`  | Request/body-query template; object form is recommended for JSON requests       |
-| `transformResponse` | string        | -           | JavaScript expression to extract output                                         |
-| `sessionHeader`     | string        | -           | Request header name for the session ID                                          |
-| `sessionParser`     | string        | -           | JavaScript expression to extract a session ID                                   |
-| `sessionField`      | string        | `sessionId` | Body field name for a supplied session ID                                       |
+| Option              | Type          | Default     | Description                                                                                                      |
+| ------------------- | ------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| `url`               | string        | -           | Webhook URL (alternative to provider path)                                                                       |
+| `method`            | string        | `POST`      | `GET`, `HEAD`, `POST`, `PUT`, or `PATCH`; `GET` encodes body fields as query parameters and `HEAD` sends no body |
+| `headers`           | object        | -           | Additional request headers with Nunjucks templating                                                              |
+| `body`              | object/string | `{prompt}`  | Request/body-query template; object form is recommended for JSON requests                                        |
+| `transformResponse` | string        | -           | JavaScript expression to extract output                                                                          |
+| `sessionHeader`     | string        | -           | Request header name for the session ID                                                                           |
+| `sessionParser`     | string        | -           | JavaScript expression to extract a session ID                                                                    |
+| `sessionField`      | string        | `sessionId` | Body field name for a supplied session ID                                                                        |
+
+YAML method values are case-insensitive. TypeScript configurations using `N8nProviderConfig` use the uppercase names above.
 
 ## Response Formats
 
@@ -130,7 +132,7 @@ against tokenized webhooks. URLs remain part of your configuration and the outbo
 For non-idempotent methods (`POST` / `PATCH`, the default), the provider passes `maxRetries: 0` to
 the shared fetch helper. Transient network failures fail through to the caller rather than
 re-delivering a workflow that may have already accepted the request and dispatched side-effects
-(sending messages, writing to a database). Idempotent methods (`GET` / `PUT`) keep the default
+(sending messages, writing to a database). Idempotent methods (`GET` / `HEAD` / `PUT`) keep the default
 retry budget.
 
 :::

--- a/src/providers/n8n.ts
+++ b/src/providers/n8n.ts
@@ -22,7 +22,7 @@ export interface N8nProviderConfig {
   /**
    * HTTP method to use (default: POST)
    */
-  method?: 'GET' | 'POST' | 'PUT' | 'PATCH';
+  method?: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH';
 
   /**
    * Additional headers to include in requests

--- a/src/providers/n8n.ts
+++ b/src/providers/n8n.ts
@@ -547,12 +547,12 @@ export class N8nProvider implements ApiProvider {
       ...(callOptions?.abortSignal && { signal: callOptions.abortSignal }),
     };
 
-    if (method !== 'GET') {
+    if (method !== 'GET' && method !== 'HEAD') {
       fetchOptions.body = renderedBody;
     }
 
     logger.debug('[n8n] Calling webhook', {
-      hasBody: method !== 'GET',
+      hasBody: fetchOptions.body !== undefined,
       hasCustomHeaders: Object.keys(this.config.headers ?? {}).length > 0,
       hasSessionId: Boolean(this.getRequestSessionId(context)),
       method,

--- a/test/providers/n8n.test.ts
+++ b/test/providers/n8n.test.ts
@@ -3,6 +3,8 @@ import { fetchWithCache } from '../../src/cache';
 import logger from '../../src/logger';
 import { createN8nProvider, N8nProvider } from '../../src/providers/n8n';
 
+import type { N8nProviderConfig } from '../../src/providers/n8n';
+
 vi.mock('../../src/cache');
 vi.mock('../../src/logger', () => ({
   default: {
@@ -85,14 +87,18 @@ describe('N8nProvider', () => {
   });
 
   describe('callApi', () => {
-    it.each(['HEAD', 'head'])('sends %s requests without a body', async (method) => {
+    it.each([
+      { method: 'HEAD' } satisfies N8nProviderConfig,
+      { method: 'head' },
+      { method: 'HeAd' },
+    ])('sends $method requests without a body', async (config) => {
       vi.mocked(fetchWithCache).mockImplementation(async (url, options) => {
         // Use the native Fetch contract without sending a network request.
         new Request(url, options);
         return createMockResponse('');
       });
       const provider = new N8nProvider('https://n8n.example.com/webhook/agent', {
-        config: { method },
+        config,
       });
 
       const result = await provider.callApi('Hello');

--- a/test/providers/n8n.test.ts
+++ b/test/providers/n8n.test.ts
@@ -85,6 +85,30 @@ describe('N8nProvider', () => {
   });
 
   describe('callApi', () => {
+    it.each(['HEAD', 'head'])('sends %s requests without a body', async (method) => {
+      vi.mocked(fetchWithCache).mockImplementation(async (url, options) => {
+        // Use the native Fetch contract without sending a network request.
+        new Request(url, options);
+        return createMockResponse('');
+      });
+      const provider = new N8nProvider('https://n8n.example.com/webhook/agent', {
+        config: { method },
+      });
+
+      const result = await provider.callApi('Hello');
+
+      expect(result.error).toBeUndefined();
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        'https://n8n.example.com/webhook/agent',
+        expect.objectContaining({ method: 'HEAD' }),
+        expect.any(Number),
+        'text',
+        true,
+        undefined,
+      );
+      expect(vi.mocked(fetchWithCache).mock.calls[0][1]).not.toHaveProperty('body');
+    });
+
     it('should call n8n webhook with default body structure without response caching', async () => {
       const mockResponse = createMockResponse({ output: 'Hello from n8n!' }, { latencyMs: 100 });
       vi.mocked(fetchWithCache).mockResolvedValue(mockResponse);


### PR DESCRIPTION
The n8n provider currently attaches a request body when `method: HEAD` is configured, which native Fetch rejects before sending the webhook request. Omit the body for HEAD and report its absence accurately in debug logging.

Validation: 55 mocked provider tests pass, including uppercase/lowercase HEAD requests checked with native `Request`. The package/UI build passes. Two built-CLI evals against a loopback server pass with score 1 and zero-byte HEAD bodies (`--no-cache`).
