### PR TITLE
fix(providers): isolate SageMaker completion cache

### DIFF
--- a/src/providers/sagemaker.ts
+++ b/src/providers/sagemaker.ts
@@ -647,12 +647,20 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
     // Create a deterministic representation of the request parameters
     const configForKey = {
       endpoint: this.getEndpointName(),
-      modelType: this.config.modelType,
+      modelType: this.modelType,
       contentType: this.getContentType(),
       acceptType: this.getAcceptType(),
-      maxTokens: this.config.maxTokens,
-      temperature: this.config.temperature,
-      topP: this.config.topP,
+      maxTokens: this.config.maxTokens ?? getEnvInt('AWS_SAGEMAKER_MAX_TOKENS') ?? 1024,
+      temperature:
+        typeof this.config.temperature === 'number'
+          ? this.config.temperature
+          : (getEnvFloat('AWS_SAGEMAKER_TEMPERATURE') ?? 0.7),
+      topP:
+        typeof this.config.topP === 'number'
+          ? this.config.topP
+          : (getEnvFloat('AWS_SAGEMAKER_TOP_P') ?? 1.0),
+      stopSequences: this.config.stopSequences || [],
+      responsePath: this.config.responseFormat?.path,
       region: this.getRegion(),
     };
 

--- a/test/providers/sagemaker.test.ts
+++ b/test/providers/sagemaker.test.ts
@@ -23,10 +23,12 @@ vi.mock('../../src/cache', () => ({
 
 // Mock AWS SDK
 vi.mock('@aws-sdk/client-sagemaker-runtime', () => ({
-  SageMakerRuntimeClient: vi.fn().mockImplementation(() => ({
-    send: mockSend,
-  })),
-  InvokeEndpointCommand: vi.fn().mockImplementation((params) => params),
+  SageMakerRuntimeClient: vi.fn().mockImplementation(function () {
+    return { send: mockSend };
+  }),
+  InvokeEndpointCommand: vi.fn().mockImplementation(function (params) {
+    return params;
+  }),
 }));
 
 import {
@@ -101,6 +103,147 @@ describe('SageMakerCompletionProvider', () => {
       expect(result.cached).toBe(true);
       expect(result.metadata?.transformed).toBe(true);
       expect(result.metadata?.originalPrompt).toBe('original prompt');
+    });
+  });
+
+  describe('cache identity', () => {
+    beforeEach(() => {
+      const entries = new Map<string, string>();
+      mockIsCacheEnabled.mockReturnValue(true);
+      mockCacheGet.mockImplementation(async (key: string) => entries.get(key));
+      mockCacheSet.mockImplementation(async (key: string, value: string) => {
+        entries.set(key, value);
+      });
+    });
+
+    it('keeps outputs separate for different stop sequences and replays matching requests', async () => {
+      mockSend.mockImplementation(async ({ Body }) => ({
+        Body: new TextEncoder().encode(
+          JSON.stringify({ choices: [{ text: JSON.parse(Body).stop[0] }] }),
+        ),
+      }));
+      const providers = ['END', 'STOP'].map(
+        (stop) =>
+          new SageMakerCompletionProvider('test-endpoint', {
+            config: { region: 'us-east-1', modelType: 'openai', stopSequences: [stop] },
+          }),
+      );
+
+      for (const provider of providers) {
+        const fresh = await provider.callApi('A quiet garden');
+        expect(fresh.output).toBe(provider.config.stopSequences?.[0]);
+        expect(fresh.cached).not.toBe(true);
+        const cached = await provider.callApi('A quiet garden');
+        expect(cached.output).toBe(fresh.output);
+        expect(cached.cached).toBe(true);
+        expect(cached.tokenUsage?.cached).toBe(fresh.tokenUsage?.total);
+      }
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps differently extracted outputs separate for the same request', async () => {
+      mockSend.mockResolvedValue({
+        Body: new TextEncoder().encode(JSON.stringify({ answer: 'A garden', summary: 'Flowers' })),
+      });
+      for (const [path, output] of [
+        ['json.answer', 'A garden'],
+        ['json.summary', 'Flowers'],
+      ]) {
+        const provider = new SageMakerCompletionProvider('test-endpoint', {
+          config: { region: 'us-east-1', modelType: 'custom', responseFormat: { path } },
+        });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output, cached: true });
+      }
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      ['AWS_SAGEMAKER_MAX_TOKENS', '128', '256', 'max_tokens'],
+      ['AWS_SAGEMAKER_TEMPERATURE', '0.2', '0.8', 'temperature'],
+      ['AWS_SAGEMAKER_TOP_P', '0.5', '0.9', 'top_p'],
+    ])('uses effective %s values when caching requests', async (env, first, second, field) => {
+      mockSend.mockImplementation(async ({ Body }) => ({
+        Body: new TextEncoder().encode(
+          JSON.stringify({ choices: [{ text: String(JSON.parse(Body)[field]) }] }),
+        ),
+      }));
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'openai' },
+      });
+
+      for (const value of [first, second]) {
+        vi.stubEnv(env, value);
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output: value });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({
+          output: value,
+          cached: true,
+        });
+      }
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('reuses explicit zero settings when environment defaults change', async () => {
+      mockSend.mockResolvedValue({
+        Body: new TextEncoder().encode(JSON.stringify({ choices: [{ text: 'A garden' }] })),
+      });
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'openai', maxTokens: 0, temperature: 0, topP: 0 },
+      });
+      await provider.callApi('A quiet garden');
+      vi.stubEnv('AWS_SAGEMAKER_MAX_TOKENS', '256');
+      vi.stubEnv('AWS_SAGEMAKER_TEMPERATURE', '0.8');
+      vi.stubEnv('AWS_SAGEMAKER_TOP_P', '0.9');
+
+      expect(await provider.callApi('A quiet garden')).toMatchObject({
+        output: 'A garden',
+        cached: true,
+      });
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(mockSend.mock.calls[0][0].Body)).toMatchObject({
+        max_tokens: 0,
+        temperature: 0,
+        top_p: 0,
+      });
+    });
+
+    it('uses the model type resolved from the provider ID for response caching', async () => {
+      mockSend.mockResolvedValue({
+        Body: new TextEncoder().encode(
+          JSON.stringify({ generation: 'Llama output', choices: [{ text: 'OpenAI output' }] }),
+        ),
+      });
+      for (const [modelType, output] of [
+        ['openai', 'OpenAI output'],
+        ['llama', 'Llama output'],
+      ]) {
+        const provider = new SageMakerCompletionProvider('test-endpoint', {
+          id: `sagemaker:${modelType}:test-endpoint`,
+          config: { region: 'us-east-1' },
+        });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output, cached: true });
+      }
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not replay a cached success when a changed request fails', async () => {
+      mockSend
+        .mockResolvedValueOnce({
+          Body: new TextEncoder().encode(JSON.stringify({ choices: [{ text: 'A garden' }] })),
+        })
+        .mockRejectedValue(new Error('Endpoint unavailable'));
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'openai', stopSequences: ['END'] },
+      });
+      await provider.callApi('A quiet garden');
+      provider.config.stopSequences = ['STOP'];
+
+      expect(await provider.callApi('A quiet garden')).toEqual({
+        error: 'SageMaker API error: Endpoint unavailable',
+      });
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      expect(mockCacheSet).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
SageMaker completion requests with different stop sequences, response extraction paths, or environment generation settings could reuse the same cached output. Include those effective settings and the model type resolved from the provider ID in the cache key, while preserving explicit configuration precedence and cached token accounting.

Validation: 21 mocked provider tests passed, covering fresh requests, matching cache replays, changed settings, explicit zero values, and endpoint errors. TypeScript, package bundles, and the UI build passed. A built CLI evaluation passed with six cache replays and seven mocked requests, including the expected error path. Lint and formatting passed.

The build's postbuild command hit an environment restriction on the `tsx` IPC socket; the same script passed with `node --import tsx scripts/postbuild.ts`.
