### PR TITLE
fix(providers): preserve local model parameters

### DIFF
--- a/src/providers/llama.ts
+++ b/src/providers/llama.ts
@@ -46,7 +46,7 @@ export class LlamaProvider implements ApiProvider {
   async callApi(prompt: string): Promise<ProviderResponse> {
     const body = {
       prompt,
-      n_predict: this.config?.n_predict || 512,
+      n_predict: this.config?.n_predict ?? 512,
       temperature: this.config?.temperature,
       top_k: this.config?.top_k,
       top_p: this.config?.top_p,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -796,7 +796,7 @@ export const providerMap: ProviderFactory[] = [
     ) => {
       const splits = providerPath.split(':');
       const modelType = splits[1];
-      const modelName = splits[2];
+      const modelName = splits.slice(2).join(':');
       if (modelType === 'chat') {
         return new LocalAiChatProvider(modelName, providerOptions);
       }
@@ -806,7 +806,7 @@ export const providerMap: ProviderFactory[] = [
       if (modelType === 'embedding' || modelType === 'embeddings') {
         return new LocalAiEmbeddingProvider(modelName, providerOptions);
       }
-      return new LocalAiChatProvider(modelType, providerOptions);
+      return new LocalAiChatProvider(splits.slice(1).join(':'), providerOptions);
     },
   },
   {

--- a/test/providers/llama.test.ts
+++ b/test/providers/llama.test.ts
@@ -92,6 +92,23 @@ describe('LlamaProvider', () => {
         getRequestTimeoutMs(),
       );
     });
+    it.each([0, -1, 128])(
+      'preserves an explicit n_predict=%s in the native request',
+      async (nPredict) => {
+        vi.mocked(fetchWithCache).mockResolvedValue({
+          data: { content: '' },
+          cached: false,
+          status: 200,
+          statusText: 'OK',
+        });
+        const provider = new LlamaProvider(modelName, { config: { n_predict: nPredict } });
+        const result = await provider.callApi('Hello');
+        const request = vi.mocked(fetchWithCache).mock.calls[0][1];
+        expect(JSON.parse(request?.body as string).n_predict).toBe(nPredict);
+        expect(result).toMatchObject({ output: '', cached: false });
+      },
+    );
+
     it('should return the correct response on success', async () => {
       vi.mocked(fetchWithCache).mockResolvedValue({
         data: { content: 'test response' },

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -55,6 +55,26 @@ vi.mock('../../src/redteam/remoteGeneration', async (importOriginal) => {
 });
 
 describe('Provider Registry', () => {
+  it.each([
+    ['localai:chat:served-model:q4:latest', 'LocalAiChatProvider'],
+    ['localai:completion:served-model:q4:latest', 'LocalAiCompletionProvider'],
+    ['localai:embedding:served-model:q4:latest', 'LocalAiEmbeddingProvider'],
+    ['localai:embeddings:served-model:q4:latest', 'LocalAiEmbeddingProvider'],
+    ['localai:served-model:q4:latest', 'LocalAiChatProvider'],
+  ])('preserves the full served model name for %s', async (providerPath, className) => {
+    const factories = await getProviderFactories(providerPath);
+    const factory = factories.find((entry) => entry.test(providerPath));
+    const provider = await factory!.create(
+      providerPath,
+      { id: 'custom-local-id', env: { LOCALAI_BASE_URL: 'http://localhost:1234/v1' } },
+      { basePath: '.', options: {} },
+    );
+    expect(provider.constructor.name).toBe(className);
+    expect(provider).toHaveProperty('modelName', 'served-model:q4:latest');
+    expect(provider.id()).toBe('custom-local-id');
+    expect(provider).toHaveProperty('apiBaseUrl', 'http://localhost:1234/v1');
+  });
+
   describe('Provider Factories', () => {
     const mockProviderOptions: ProviderOptions = {
       id: 'test-provider',


### PR DESCRIPTION
LocalAI provider IDs now preserve colon-bearing served model names across chat, completion, embedding, and default chat routes. The llama.cpp provider also preserves an explicit `n_predict: 0`, allowing prompt evaluation without token generation instead of substituting 512.

Validation: 142 mocked registry/local provider tests, including tagged aliases, custom IDs, scoped URLs, zero/unlimited counts, and error responses; TypeScript/package/UI builds; built CLI loopback evals covering tagged chat/completion/default routes, empty output with a zero count, and an expected upstream error.
