### PR TITLE
fix(cloudflare): use the versioned Mistral gateway route

### DIFF
--- a/src/providers/cloudflare-gateway.ts
+++ b/src/providers/cloudflare-gateway.ts
@@ -220,6 +220,11 @@ function buildGatewayUrl(
     return `${baseUrl}/azure-openai/${resourceName}/${deploymentName}`;
   }
 
+  // Mistral's native gateway proxy retains the upstream /v1 path.
+  if (provider === 'mistral') {
+    return `${baseUrl}/mistral/v1`;
+  }
+
   if (provider === 'workers-ai') {
     invariant(modelName, 'Workers AI requires a model name (e.g., @cf/meta/llama-3.1-8b-instruct)');
     return `${baseUrl}/workers-ai/${modelName}`;

--- a/test/providers/cloudflare-native-path.test.ts
+++ b/test/providers/cloudflare-native-path.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../src/cache';
+import { CloudflareGatewayOpenAiProvider } from '../../src/providers/cloudflare-gateway';
+
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+}));
+
+afterEach(() => vi.resetAllMocks());
+
+it.each(['openai', 'groq', 'mistral'])(
+  'uses the documented %s native gateway chat path',
+  async (underlyingProvider) => {
+    vi.mocked(fetchWithCache).mockClear();
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: { choices: [{ message: { content: 'Hello' }, finish_reason: 'stop' }] },
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    });
+    const provider = new CloudflareGatewayOpenAiProvider(underlyingProvider, 'served-model:tag', {
+      config: { accountId: 'fixture-account', gatewayId: 'fixture-gateway', apiKey: 'fixture-key' },
+    });
+    const result = await provider.callApi('Hello');
+    expect(result.output).toBe('Hello');
+    const [url, request] = vi.mocked(fetchWithCache).mock.calls[0];
+    const suffix = underlyingProvider === 'mistral' ? 'mistral/v1' : underlyingProvider;
+    expect(url).toBe(
+      `https://gateway.ai.cloudflare.com/v1/fixture-account/fixture-gateway/${suffix}/chat/completions`,
+    );
+    expect(JSON.parse(request?.body as string).model).toBe('served-model:tag');
+    expect(request?.headers).toMatchObject({ Authorization: 'Bearer fixture-key' });
+  },
+);
+
+it('returns the upstream failure for the corrected Mistral route', async () => {
+  vi.mocked(fetchWithCache).mockRejectedValue(new Error('Fixture upstream failure'));
+  const provider = new CloudflareGatewayOpenAiProvider('mistral', 'served-model:tag', {
+    config: { accountId: 'fixture-account', gatewayId: 'fixture-gateway', apiKey: 'fixture-key' },
+    id: 'custom-gateway-id',
+  });
+  const result = await provider.callApi('Hello');
+  expect(provider.id()).toBe('custom-gateway-id');
+  expect(result.error).toContain('Fixture upstream failure');
+  expect(vi.mocked(fetchWithCache).mock.calls[0][0]).toBe(
+    'https://gateway.ai.cloudflare.com/v1/fixture-account/fixture-gateway/mistral/v1/chat/completions',
+  );
+});


### PR DESCRIPTION
Cloudflare AI Gateway's native Mistral requests now use `/mistral/v1/chat/completions`, matching the [documented Mistral route](https://developers.cloudflare.com/ai-gateway/usage/providers/mistral/). The upstream key and selected model continue through the existing OpenAI-compatible transport.

Validation: 59 mocked Cloudflare tests covering successful and failed requests, model/header preservation, and unchanged OpenAI/Groq paths; TypeScript/package/UI builds; built CLI loopback success and HTTP error evals with the exact route and exported results inspected.
