### PR TITLE
fix(huggingface): normalize classification and embedding responses

### DIFF
--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -315,17 +315,12 @@ export class HuggingfaceTextClassificationProvider implements ApiProvider {
       parameters: {},
     };
 
-    interface HuggingfaceTextClassificationResponse {
-      error?: string;
-      [0]?: Array<{ label: string; score: number }>;
-    }
-
-    let response: FetchWithCacheResult<HuggingfaceTextClassificationResponse> | undefined;
+    let response: FetchWithCacheResult<unknown> | undefined;
     try {
       const url = this.config.apiEndpoint
         ? this.config.apiEndpoint
         : `${HF_INFERENCE_API_URL}/models/${this.modelName}`;
-      response = await fetchWithCache<HuggingfaceTextClassificationResponse>(
+      response = await fetchWithCache<unknown>(
         url,
         {
           method: 'POST',
@@ -338,19 +333,37 @@ export class HuggingfaceTextClassificationProvider implements ApiProvider {
         getRequestTimeoutMs(),
       );
 
-      if (response.data.error) {
+      if (response.data && typeof response.data === 'object' && 'error' in response.data) {
         return {
           error: `API call error: ${response.data.error}`,
         };
       }
-      if (!response.data[0] || !Array.isArray(response.data[0])) {
+      // Current Inference Providers return one flat list; older task endpoints
+      // wrap a single input's scores in an outer list.
+      const items =
+        Array.isArray(response.data) &&
+        response.data.length === 1 &&
+        Array.isArray(response.data[0])
+          ? response.data[0]
+          : response.data;
+      if (
+        !Array.isArray(items) ||
+        items.length === 0 ||
+        !items.every(
+          (item) =>
+            item &&
+            typeof item.label === 'string' &&
+            typeof item.score === 'number' &&
+            Number.isFinite(item.score),
+        )
+      ) {
         return {
           error: `Malformed response data: ${response.data}`,
         };
       }
 
       const scores: Record<string, number> = {};
-      response.data[0].forEach((item) => {
+      items.forEach((item) => {
         scores[item.label] = item.score;
       });
 
@@ -418,17 +431,13 @@ export class HuggingfaceFeatureExtractionProvider implements ApiProvider {
       },
     };
 
-    interface HuggingfaceFeatureExtractionResponse {
-      error?: string;
-    }
-
-    let response: FetchWithCacheResult<HuggingfaceFeatureExtractionResponse | number[]> | undefined;
+    let response: FetchWithCacheResult<unknown> | undefined;
     try {
       const url = this.config.apiEndpoint
         ? this.config.apiEndpoint
         : `${HF_INFERENCE_API_URL}/models/${this.modelName}`;
       logger.debug('Huggingface API request', { url, params });
-      response = await fetchWithCache<HuggingfaceFeatureExtractionResponse | number[]>(
+      response = await fetchWithCache<unknown>(
         url,
         {
           method: 'POST',
@@ -441,19 +450,31 @@ export class HuggingfaceFeatureExtractionProvider implements ApiProvider {
         getRequestTimeoutMs(),
       );
 
-      if (typeof response.data === 'object' && 'error' in response.data) {
+      if (response.data && typeof response.data === 'object' && 'error' in response.data) {
         return {
           error: `API call error: ${response.data.error}`,
         };
       }
-      if (!Array.isArray(response.data)) {
+      // A single input can be returned as one row or as a legacy flat vector.
+      // Do not flatten token-level or multiple-input matrices into one embedding.
+      const embedding =
+        Array.isArray(response.data) &&
+        response.data.length === 1 &&
+        Array.isArray(response.data[0])
+          ? response.data[0]
+          : response.data;
+      if (
+        !Array.isArray(embedding) ||
+        embedding.length === 0 ||
+        !embedding.every((value) => typeof value === 'number' && Number.isFinite(value))
+      ) {
         return {
           error: `Malformed response data: ${response.data}`,
         };
       }
 
       return {
-        embedding: response.data,
+        embedding,
       };
     } catch (err) {
       return {

--- a/src/providers/huggingface.ts
+++ b/src/providers/huggingface.ts
@@ -19,6 +19,10 @@ import type {
 const HF_INFERENCE_API_URL = 'https://router.huggingface.co/hf-inference';
 const HF_CHAT_API_BASE_URL = 'https://router.huggingface.co/v1';
 
+function singleRow(data: unknown): unknown {
+  return Array.isArray(data) && data.length === 1 && Array.isArray(data[0]) ? data[0] : data;
+}
+
 interface HuggingfaceProviderOptions {
   apiKey?: string;
   apiEndpoint?: string;
@@ -338,14 +342,7 @@ export class HuggingfaceTextClassificationProvider implements ApiProvider {
           error: `API call error: ${response.data.error}`,
         };
       }
-      // Current Inference Providers return one flat list; older task endpoints
-      // wrap a single input's scores in an outer list.
-      const items =
-        Array.isArray(response.data) &&
-        response.data.length === 1 &&
-        Array.isArray(response.data[0])
-          ? response.data[0]
-          : response.data;
+      const items = singleRow(response.data);
       if (
         !Array.isArray(items) ||
         items.length === 0 ||
@@ -455,14 +452,7 @@ export class HuggingfaceFeatureExtractionProvider implements ApiProvider {
           error: `API call error: ${response.data.error}`,
         };
       }
-      // A single input can be returned as one row or as a legacy flat vector.
-      // Do not flatten token-level or multiple-input matrices into one embedding.
-      const embedding =
-        Array.isArray(response.data) &&
-        response.data.length === 1 &&
-        Array.isArray(response.data[0])
-          ? response.data[0]
-          : response.data;
+      const embedding = singleRow(response.data);
       if (
         !Array.isArray(embedding) ||
         embedding.length === 0 ||

--- a/test/providers/huggingface-response-shapes.test.ts
+++ b/test/providers/huggingface-response-shapes.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../src/cache';
+import {
+  HuggingfaceFeatureExtractionProvider,
+  HuggingfaceTextClassificationProvider,
+} from '../../src/providers/huggingface';
+
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+}));
+beforeEach(() => vi.mocked(fetchWithCache).mockReset());
+afterEach(() => vi.restoreAllMocks());
+function reply(data: unknown) {
+  vi.mocked(fetchWithCache).mockResolvedValue({
+    data,
+    cached: false,
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+  });
+}
+
+describe('Hugging Face task response compatibility', () => {
+  const classification = new HuggingfaceTextClassificationProvider('fixture/classifier');
+  const embedding = new HuggingfaceFeatureExtractionProvider('fixture/embedder');
+  const scores = [
+    { label: 'positive', score: 0.9 },
+    { label: 'negative', score: 0.1 },
+  ];
+
+  it.each([scores, [scores]].map((data) => [data]))(
+    'normalizes current and legacy classification shapes: %j',
+    async (data) => {
+      reply(data);
+      expect(await classification.callClassificationApi('A pleasant day')).toEqual({
+        classification: { positive: 0.9, negative: 0.1 },
+      });
+    },
+  );
+
+  it.each([[0.1, 0.2], [[0.1, 0.2]]].map((data) => [data]))(
+    'normalizes a single embedding vector: %j',
+    async (data) => {
+      reply(data);
+      expect(await embedding.callEmbeddingApi('A pleasant day')).toEqual({ embedding: [0.1, 0.2] });
+    },
+  );
+
+  it.each(
+    [null, [], [{ label: 'positive', score: '0.9' }], [[scores, scores]]].map((data) => [data]),
+  )('rejects malformed classifications: %j', async (data) => {
+    reply(data);
+    expect((await classification.callClassificationApi('Hello')).error).toContain(
+      'Malformed response',
+    );
+  });
+
+  it.each(
+    [
+      null,
+      [],
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      ['invalid'],
+      [Number.NaN],
+      [[]],
+    ].map((data) => [data]),
+  )('rejects malformed or ambiguous embeddings: %j', async (data) => {
+    reply(data);
+    expect((await embedding.callEmbeddingApi('Hello')).error).toContain('Malformed response');
+  });
+
+  it('preserves vendor errors for both task APIs', async () => {
+    reply({ error: 'Fixture model unavailable' });
+    expect((await classification.callClassificationApi('Hello')).error).toContain(
+      'Fixture model unavailable',
+    );
+    expect((await embedding.callEmbeddingApi('Hello')).error).toContain(
+      'Fixture model unavailable',
+    );
+  });
+});


### PR DESCRIPTION
Hugging Face text classification returns a flat array of label/score objects, and feature extraction can return a single embedding row. Accept these responses alongside the existing single-input forms and normalize embeddings to `number[]`.

Reject malformed values and multiple-row/token-level embeddings instead of passing nested arrays into similarity calculations. The request format and model IDs are unchanged.

Validation: mocked current/legacy response and error tests; TypeScript/package/UI build; built CLI classification and embedding-similarity fixtures, including malformed embeddings.

Response contracts: [text classification](https://huggingface.co/docs/inference-providers/tasks/text-classification), [feature extraction](https://huggingface.co/docs/inference-providers/tasks/feature-extraction).
