### PR TITLE
fix(google): route stable Omni through Interactions

### DIFF
--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -457,7 +457,7 @@ See the [Google Imagen example](https://github.com/promptfoo/promptfoo/tree/main
 
 The stable [Gemini Omni Flash](https://ai.google.dev/gemini-api/docs/models/gemini-omni-flash) model uses `google:gemini-omni-1.1-flash`. Promptfoo routes it and `google:gemini-omni-flash-preview` through the Gemini Interactions API and stores returned video in blob storage. Use `store: true` and `previousInteractionId` to conversationally edit a prior result. Omni does not support grounding, code execution, or function-calling tools.
 
-The existing `vertex:gemini-omni-flash-preview` route uses OAuth and the configured Google Cloud project; Vertex does not currently support follow-up interactions. Google's [Vertex Omni 1.1 model](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/omni-1-1-flash) has a separate preview ID, `gemini-omni-1.1-flash-preview`. The native stable ID is not a Vertex alias.
+For Vertex, use `vertex:gemini-omni-1.1-flash-preview` or `vertex:gemini-omni-flash-preview`; both route through Interactions with OAuth and the configured Google Cloud project. [Vertex Omni 1.1](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/omni-1-1-flash) uses a different model ID from the native stable model and does not currently support follow-up interactions in promptfoo.
 
 ```yaml
 providers:

--- a/site/docs/providers/google.md
+++ b/site/docs/providers/google.md
@@ -282,7 +282,7 @@ See the [Vertex AI provider documentation](/docs/providers/vertex) for detailed 
 - `google:gemini-3.6-flash` - Previous-generation Gemini Flash model for coding and agentic tasks ($0.75/1M input, $3.75/1M output through December 31, 2026)
 - `google:gemini-3.5-flash` - Gemini 3.5 Flash for agentic and coding tasks ($1.50/1M input, $9/1M output)
 - `google:gemini-3.5-flash-lite` - Fast, cost-efficient Gemini 3.5 model for high-volume agentic workflows ($0.30/1M input, $2.50/1M output)
-- `google:gemini-omni-flash-preview` - Gemini Omni Flash preview for conversational video generation/editing via the Interactions API ($1.50/1M input, $9/1M text/thinking output, $17.50/1M video output)
+- `google:gemini-omni-1.1-flash` - Stable Gemini Omni Flash for conversational video generation/editing via the Interactions API ($1.50/1M input, $9/1M text/thinking output, $17.50/1M video output); `google:gemini-omni-flash-preview` remains available
 - `google:gemini-3.1-pro-preview` - Gemini 3.1 Pro preview with improved reasoning and performance ($2/1M input, $12/1M output; $4/$18 above 200K)
 - `google:gemini-3.1-pro-preview-customtools` - Gemini 3.1 Pro preview variant for custom tools with the same pricing as Gemini 3.1 Pro
 - `google:gemini-3.1-flash-lite` - Gemini 3.1 Flash-Lite GA model optimized for high-volume, low-latency tasks ($0.25/1M text/image/video input, $1.50/1M output)
@@ -455,11 +455,13 @@ See the [Google Imagen example](https://github.com/promptfoo/promptfoo/tree/main
 
 ### Video Generation Models (Gemini Omni Flash)
 
-Gemini Omni Flash uses the Gemini Interactions API rather than `generateContent`; Promptfoo automatically routes both `google:gemini-omni-flash-preview` and `vertex:gemini-omni-flash-preview` to the correct endpoint and stores returned video in blob storage. Vertex uses OAuth and the configured Google Cloud project. Use `store: true` and `previousInteractionId` with the Google AI Studio route to conversationally edit a prior result; Vertex does not currently support follow-up interactions. Omni does not support grounding, code execution, or function-calling tools.
+The stable [Gemini Omni Flash](https://ai.google.dev/gemini-api/docs/models/gemini-omni-flash) model uses `google:gemini-omni-1.1-flash`. Promptfoo routes it and `google:gemini-omni-flash-preview` through the Gemini Interactions API and stores returned video in blob storage. Use `store: true` and `previousInteractionId` to conversationally edit a prior result. Omni does not support grounding, code execution, or function-calling tools.
+
+The existing `vertex:gemini-omni-flash-preview` route uses OAuth and the configured Google Cloud project; Vertex does not currently support follow-up interactions. Google's [Vertex Omni 1.1 model](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/omni-1-1-flash) has a separate preview ID, `gemini-omni-1.1-flash-preview`. The native stable ID is not a Vertex alias.
 
 ```yaml
 providers:
-  - id: google:gemini-omni-flash-preview
+  - id: google:gemini-omni-1.1-flash
     config:
       aspectRatio: '9:16'
       store: true
@@ -468,7 +470,7 @@ prompts:
   - 'Generate a short video of {{subject}}'
 ```
 
-Video output is billed at $17.50/1M tokens (about $0.10/second at 720p); text and thinking output use the $9/1M rate.
+The [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing#gemini-omni-flash) for both Omni models is $1.50/1M input tokens, $9/1M text and thinking output tokens, and $17.50/1M video output tokens (about $0.10/second at 720p).
 
 ### Video Generation Models (Veo)
 

--- a/src/providers/families/google.ts
+++ b/src/providers/families/google.ts
@@ -12,7 +12,7 @@ export const googleProviderFactories: ProviderFactory[] = [
       const firstPart = splits[1];
       const modelName =
         firstPart === 'chat' ? splits.slice(2).join(':') : splits.slice(1).join(':');
-      if (modelName === 'gemini-omni-flash-preview') {
+      if (['gemini-omni-flash-preview', 'gemini-omni-1.1-flash-preview'].includes(modelName)) {
         const { GoogleInteractionsProvider } = await import('../google/interactions');
         return new GoogleInteractionsProvider(modelName, {
           ...providerOptions,

--- a/src/providers/families/google.ts
+++ b/src/providers/families/google.ts
@@ -79,7 +79,7 @@ export const googleProviderFactories: ProviderFactory[] = [
       // Default to regular Google API
       const modelName = splits[1];
 
-      if (modelName === 'gemini-omni-flash-preview') {
+      if (modelName === 'gemini-omni-flash-preview' || modelName === 'gemini-omni-1.1-flash') {
         const { GoogleInteractionsProvider } = await import('../google/interactions');
         return new GoogleInteractionsProvider(modelName, providerOptions);
       }

--- a/src/providers/families/google.ts
+++ b/src/providers/families/google.ts
@@ -81,7 +81,10 @@ export const googleProviderFactories: ProviderFactory[] = [
 
       if (modelName === 'gemini-omni-flash-preview' || modelName === 'gemini-omni-1.1-flash') {
         const { GoogleInteractionsProvider } = await import('../google/interactions');
-        return new GoogleInteractionsProvider(modelName, providerOptions);
+        return new GoogleInteractionsProvider(modelName, {
+          ...providerOptions,
+          config: { ...providerOptions.config, vertexai: false },
+        });
       }
 
       // Check if this is a Gemini native image generation model. Dispatch is on

--- a/src/providers/google/interactions.ts
+++ b/src/providers/google/interactions.ts
@@ -205,7 +205,11 @@ function getInteractionsEndpoint(config: CompletionOptions, env?: EnvOverrides):
     return `${config.apiBaseUrl.replace(/\/$/, '')}/v1beta/interactions`;
   }
 
-  const apiHost = env?.GOOGLE_API_HOST || getEnvString('GOOGLE_API_HOST');
+  const apiHost =
+    env?.GOOGLE_API_HOST ||
+    env?.PALM_API_HOST ||
+    getEnvString('GOOGLE_API_HOST') ||
+    getEnvString('PALM_API_HOST');
   if (apiHost) {
     return endpointFromHost(apiHost);
   }

--- a/src/providers/google/interactions.ts
+++ b/src/providers/google/interactions.ts
@@ -274,6 +274,9 @@ export class GoogleInteractionsProvider implements ApiProvider {
       this.config,
       context?.prompt?.config as Partial<CompletionOptions> | undefined,
     ) as GoogleProviderConfig;
+    if (this.modelName === 'gemini-omni-1.1-flash') {
+      config.vertexai = false;
+    }
     const passthroughPreviousInteractionId =
       config.passthrough?.previous_interaction_id ?? config.passthrough?.previousInteractionId;
     if (config.vertexai && (config.previousInteractionId || passthroughPreviousInteractionId)) {

--- a/src/providers/google/shared.ts
+++ b/src/providers/google/shared.ts
@@ -123,15 +123,15 @@ export const GOOGLE_MODELS: GoogleModel[] = [
     vertexCost: GEMINI_3_5_FLASH_LITE_COST,
     vertexRegionalMultiplier: 1.1,
   })),
-  {
-    id: 'gemini-omni-flash-preview',
+  ...['gemini-omni-flash-preview', 'gemini-omni-1.1-flash'].map((id) => ({
+    id,
     cost: {
       input: 1.5 / 1e6,
       output: 9.0 / 1e6,
       audioInput: 1.5 / 1e6,
       videoOutput: 17.5 / 1e6,
     },
-  },
+  })),
 
   // Gemini 3.1 models.
   ...['gemini-3.1-pro-preview', 'gemini-3.1-pro-preview-customtools', 'gemini-pro-latest'].map(

--- a/src/providers/google/shared.ts
+++ b/src/providers/google/shared.ts
@@ -123,15 +123,17 @@ export const GOOGLE_MODELS: GoogleModel[] = [
     vertexCost: GEMINI_3_5_FLASH_LITE_COST,
     vertexRegionalMultiplier: 1.1,
   })),
-  ...['gemini-omni-flash-preview', 'gemini-omni-1.1-flash'].map((id) => ({
-    id,
-    cost: {
-      input: 1.5 / 1e6,
-      output: 9.0 / 1e6,
-      audioInput: 1.5 / 1e6,
-      videoOutput: 17.5 / 1e6,
-    },
-  })),
+  ...['gemini-omni-flash-preview', 'gemini-omni-1.1-flash', 'gemini-omni-1.1-flash-preview'].map(
+    (id) => ({
+      id,
+      cost: {
+        input: 1.5 / 1e6,
+        output: 9.0 / 1e6,
+        audioInput: 1.5 / 1e6,
+        videoOutput: 17.5 / 1e6,
+      },
+    }),
+  ),
 
   // Gemini 3.1 models.
   ...['gemini-3.1-pro-preview', 'gemini-3.1-pro-preview-customtools', 'gemini-pro-latest'].map(

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -34,130 +34,133 @@ describe('GoogleInteractionsProvider', () => {
     vi.unstubAllEnvs();
   });
 
-  it('routes Omni Flash through the Interactions API and prices video output tokens', async () => {
-    mockFetchWithCache.mockResolvedValue({
-      data: {
-        id: 'interaction-1',
-        status: 'completed',
-        steps: [
-          {
-            type: 'model_output',
-            content: [{ type: 'video', mime_type: 'video/mp4', data: 'b2xk' }],
-          },
-          {
-            type: 'model_output',
-            content: [{ type: 'video', mime_type: 'video/webm', data: 'dmlkZW8=' }],
-          },
-        ],
-        usage: {
-          total_input_tokens: 100,
-          total_output_tokens: 600,
-          total_reasoning_tokens: 20,
-          total_tokens: 720,
-          output_tokens_by_modality: [
-            { modality: 'text', tokens: 100 },
-            { modality: 'video', tokens: 500 },
+  it.each(['gemini-omni-flash-preview', 'gemini-omni-1.1-flash'])(
+    'routes %s through the Interactions API and prices video output tokens',
+    async (modelName) => {
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          id: 'interaction-1',
+          status: 'completed',
+          steps: [
+            {
+              type: 'model_output',
+              content: [{ type: 'video', mime_type: 'video/mp4', data: 'b2xk' }],
+            },
+            {
+              type: 'model_output',
+              content: [{ type: 'video', mime_type: 'video/webm', data: 'dmlkZW8=' }],
+            },
           ],
-        },
-      },
-      cached: false,
-    } as any);
-    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
-      config: {
-        apiKey: 'test-key',
-        aspectRatio: '9:16',
-        previousInteractionId: 'interaction-0',
-        store: true,
-        safetySettings: [
-          { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_LOW_AND_ABOVE' },
-          { category: 'HARM_CATEGORY_HARASSMENT', probability: 'BLOCK_MEDIUM_AND_ABOVE' },
-        ],
-        service_tier: 'priority',
-        maxOutputTokens: 2_048,
-        generationConfig: {
-          maxOutputTokens: 2_048,
-          thinking_level: 'low',
-          video_config: { task: 'text_to_video' },
-          temperature: 0.2,
-          topP: 0.8,
-          top_p: 0.8,
-          stopSequences: ['stop'],
-          stop_sequences: ['stop'],
-          negative_prompt: 'do not include text',
-          system_instruction: 'unsupported',
-        } as any,
-        passthrough: {
-          generation_config: {
-            seed: 42,
-            temperature: 0.4,
-            negative_prompt: 'unsupported passthrough prompt',
+          usage: {
+            total_input_tokens: 100,
+            total_output_tokens: 600,
+            total_reasoning_tokens: 20,
+            total_tokens: 720,
+            output_tokens_by_modality: [
+              { modality: 'text', tokens: 100 },
+              { modality: 'video', tokens: 500 },
+            ],
           },
-          generationConfig: { temperature: 0.6 },
-          system_instruction: { parts: [{ text: 'unsupported passthrough instruction' }] },
-          temperature: 0.8,
-          service_tier: 'priority',
-          serviceTier: 'priority',
         },
-      },
-    });
-
-    const result = await provider.callApi('A city at dusk', { evaluationId: 'eval-1' } as any);
-
-    expect(mockFetchWithCache).toHaveBeenCalledWith(
-      'https://generativelanguage.googleapis.com/v1beta/interactions',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          'Api-Revision': '2026-05-20',
-          'x-goog-api-key': 'test-key',
-        }),
-        body: JSON.stringify({
-          model: 'gemini-omni-flash-preview',
-          input: 'A city at dusk',
-          response_format: { type: 'video', aspect_ratio: '9:16' },
-          previous_interaction_id: 'interaction-0',
+        cached: false,
+      } as any);
+      const provider = new GoogleInteractionsProvider(modelName, {
+        config: {
+          apiKey: 'test-key',
+          aspectRatio: '9:16',
+          previousInteractionId: 'interaction-0',
           store: true,
-          safety_settings: [
-            { type: 'hate_speech', threshold: 'block_low_and_above' },
-            { type: 'harassment', threshold: 'block_medium_and_above' },
+          safetySettings: [
+            { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_LOW_AND_ABOVE' },
+            { category: 'HARM_CATEGORY_HARASSMENT', probability: 'BLOCK_MEDIUM_AND_ABOVE' },
           ],
-          generation_config: {
-            max_output_tokens: 2_048,
+          service_tier: 'priority',
+          maxOutputTokens: 2_048,
+          generationConfig: {
+            maxOutputTokens: 2_048,
             thinking_level: 'low',
             video_config: { task: 'text_to_video' },
-            seed: 42,
+            temperature: 0.2,
+            topP: 0.8,
+            top_p: 0.8,
+            stopSequences: ['stop'],
+            stop_sequences: ['stop'],
+            negative_prompt: 'do not include text',
+            system_instruction: 'unsupported',
+          } as any,
+          passthrough: {
+            generation_config: {
+              seed: 42,
+              temperature: 0.4,
+              negative_prompt: 'unsupported passthrough prompt',
+            },
+            generationConfig: { temperature: 0.6 },
+            system_instruction: { parts: [{ text: 'unsupported passthrough instruction' }] },
+            temperature: 0.8,
+            service_tier: 'priority',
+            serviceTier: 'priority',
           },
-          background: false,
-          stream: false,
+        },
+      });
+
+      const result = await provider.callApi('A city at dusk', { evaluationId: 'eval-1' } as any);
+
+      expect(mockFetchWithCache).toHaveBeenCalledWith(
+        'https://generativelanguage.googleapis.com/v1beta/interactions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Api-Revision': '2026-05-20',
+            'x-goog-api-key': 'test-key',
+          }),
+          body: JSON.stringify({
+            model: modelName,
+            input: 'A city at dusk',
+            response_format: { type: 'video', aspect_ratio: '9:16' },
+            previous_interaction_id: 'interaction-0',
+            store: true,
+            safety_settings: [
+              { type: 'hate_speech', threshold: 'block_low_and_above' },
+              { type: 'harassment', threshold: 'block_medium_and_above' },
+            ],
+            generation_config: {
+              max_output_tokens: 2_048,
+              thinking_level: 'low',
+              video_config: { task: 'text_to_video' },
+              seed: 42,
+            },
+            background: false,
+            stream: false,
+          }),
         }),
-      }),
-      expect.any(Number),
-      'json',
-      true,
-    );
-    expect(mockFetchWithCache.mock.calls[0]?.[1]).not.toHaveProperty('_authHash');
-    expect(mockStoreBlob).toHaveBeenCalledWith(
-      Buffer.from('video'),
-      'video/webm',
-      expect.objectContaining({ evalId: 'eval-1', kind: 'video' }),
-    );
-    expect(result.video).toMatchObject({
-      id: 'interaction-1',
-      url: 'blob://video/omni',
-      format: 'webm',
-      model: 'gemini-omni-flash-preview',
-      aspectRatio: '9:16',
-    });
-    expect(result.tokenUsage).toEqual({
-      prompt: 100,
-      completion: 600,
-      total: 720,
-      cached: 0,
-      numRequests: 1,
-      completionDetails: { reasoning: 20 },
-    });
-    expect(result.cost).toBeCloseTo((100 * 1.5 + 120 * 9 + 500 * 17.5) / 1e6, 12);
-  });
+        expect.any(Number),
+        'json',
+        true,
+      );
+      expect(mockFetchWithCache.mock.calls[0]?.[1]).not.toHaveProperty('_authHash');
+      expect(mockStoreBlob).toHaveBeenCalledWith(
+        Buffer.from('video'),
+        'video/webm',
+        expect.objectContaining({ evalId: 'eval-1', kind: 'video' }),
+      );
+      expect(result.video).toMatchObject({
+        id: 'interaction-1',
+        url: 'blob://video/omni',
+        format: 'webm',
+        model: modelName,
+        aspectRatio: '9:16',
+      });
+      expect(result.tokenUsage).toEqual({
+        prompt: 100,
+        completion: 600,
+        total: 720,
+        cached: 0,
+        numRequests: 1,
+        completionDetails: { reasoning: 20 },
+      });
+      expect(result.cost).toBeCloseTo((100 * 1.5 + 120 * 9 + 500 * 17.5) / 1e6, 12);
+    },
+  );
 
   it('returns a useful error when the Interactions API does not return video', async () => {
     mockFetchWithCache.mockResolvedValue({
@@ -1109,21 +1112,24 @@ describe('GoogleInteractionsProvider', () => {
     });
   });
 
-  it('surfaces gateway errors without a Google-shaped error body', async () => {
-    mockFetchWithCache.mockResolvedValue({
-      data: { message: 'Service Unavailable' },
-      cached: false,
-      status: 503,
-      statusText: 'Service Unavailable',
-    } as any);
-    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
-      config: { apiKey: 'test-key' },
-    });
+  it.each(['gemini-omni-flash-preview', 'gemini-omni-1.1-flash'])(
+    'surfaces gateway errors for %s without a Google-shaped error body',
+    async (modelName) => {
+      mockFetchWithCache.mockResolvedValue({
+        data: { message: 'Service Unavailable' },
+        cached: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+      } as any);
+      const provider = new GoogleInteractionsProvider(modelName, {
+        config: { apiKey: 'test-key' },
+      });
 
-    await expect(provider.callApi('make it rainy')).resolves.toMatchObject({
-      error: 'Gemini Interactions API error: HTTP 503 Service Unavailable',
-    });
-  });
+      await expect(provider.callApi('make it rainy')).resolves.toMatchObject({
+        error: 'Gemini Interactions API error: HTTP 503 Service Unavailable',
+      });
+    },
+  );
 
   it('surfaces polling gateway errors without a Google-shaped error body', async () => {
     mockFetchWithCache

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -736,6 +736,7 @@ describe('GoogleInteractionsProvider', () => {
     mockFetchWithCache.mockResolvedValue({
       data: {
         status: 'completed',
+        usage: { total_input_tokens: 100, total_output_tokens: 600 },
         steps: [
           {
             type: 'model_output',
@@ -745,8 +746,8 @@ describe('GoogleInteractionsProvider', () => {
       },
       cached: false,
     } as any);
-    const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
-      id: 'vertex:gemini-omni-flash-preview',
+    const provider = new GoogleInteractionsProvider('gemini-omni-1.1-flash-preview', {
+      id: 'vertex:gemini-omni-1.1-flash-preview',
       config: {
         vertexai: true,
         projectId: 'configured-project',
@@ -759,6 +760,7 @@ describe('GoogleInteractionsProvider', () => {
     const result = await provider.callApi('A city at dusk');
 
     expect(result.error).toBeUndefined();
+    expect(result.cost).toBeCloseTo((100 * 1.5 + 600 * 9) / 1e6, 12);
     expect(mockFetchWithCache).toHaveBeenCalledWith(
       'https://aiplatform.googleapis.com/v1beta1/projects/configured-project/locations/global/interactions',
       expect.objectContaining({
@@ -768,7 +770,7 @@ describe('GoogleInteractionsProvider', () => {
           'x-goog-user-project': 'quota-project',
         }),
         body: JSON.stringify({
-          model: 'gemini-omni-flash-preview',
+          model: 'gemini-omni-1.1-flash-preview',
           input: [{ type: 'text', text: 'A city at dusk' }],
           response_format: [{ type: 'video', aspect_ratio: '16:9' }],
           generation_config: { temperature: 0.2, top_p: 0.9 },

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -24,6 +24,7 @@ describe('GoogleInteractionsProvider', () => {
     vi.stubEnv('GOOGLE_CLOUD_LOCATION', '');
     vi.stubEnv('VERTEX_API_HOST', '');
     vi.stubEnv('GOOGLE_API_HOST', '');
+    vi.stubEnv('PALM_API_HOST', '');
     mockStoreBlob.mockResolvedValue({
       ref: { uri: 'blob://video/omni', hash: 'omni', mimeType: 'video/mp4', sizeBytes: 5 },
       deduplicated: false,
@@ -1008,6 +1009,7 @@ describe('GoogleInteractionsProvider', () => {
 
   it.each([
     [{ GOOGLE_API_HOST: 'proxy-host.example' }, 'https://proxy-host.example/v1beta/interactions'],
+    [{ PALM_API_HOST: 'palm-proxy.example' }, 'https://palm-proxy.example/v1beta/interactions'],
     [
       { GOOGLE_API_BASE_URL: 'https://proxy.example/google' },
       'https://proxy.example/google/v1beta/interactions',
@@ -1042,14 +1044,81 @@ describe('GoogleInteractionsProvider', () => {
   });
 
   it.each([
+    {
+      env: { GOOGLE_API_HOST: 'scoped-google.example', PALM_API_HOST: 'scoped-palm.example' },
+      processEnv: {
+        GOOGLE_API_HOST: 'process-google.example',
+        PALM_API_HOST: 'process-palm.example',
+      },
+      endpoint: 'https://scoped-google.example/v1beta/interactions',
+    },
+    {
+      env: { PALM_API_HOST: 'http://scoped-palm.example/proxy/' },
+      processEnv: {
+        GOOGLE_API_HOST: 'process-google.example',
+        PALM_API_HOST: 'process-palm.example',
+      },
+      endpoint: 'http://scoped-palm.example/proxy/v1beta/interactions',
+    },
+    {
+      env: {},
+      processEnv: {
+        GOOGLE_API_HOST: 'process-google.example',
+        PALM_API_HOST: 'process-palm.example',
+      },
+      endpoint: 'https://process-google.example/v1beta/interactions',
+    },
+    {
+      env: {},
+      processEnv: { GOOGLE_API_HOST: '', PALM_API_HOST: 'http://process-palm.example/proxy/' },
+      endpoint: 'http://process-palm.example/proxy/v1beta/interactions',
+    },
+  ])(
+    'preserves Google/Palm host precedence for $endpoint',
+    async ({ env, processEnv, endpoint }) => {
+      for (const [name, value] of Object.entries(processEnv)) {
+        vi.stubEnv(name, value);
+      }
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          status: 'completed',
+          steps: [
+            {
+              type: 'model_output',
+              content: [{ type: 'video', mime_type: 'video/mp4', data: 'aGVsbG8=' }],
+            },
+          ],
+        },
+        cached: false,
+      } as any);
+      const provider = new GoogleInteractionsProvider('gemini-omni-1.1-flash', {
+        config: { apiKey: 'test-key' },
+        env,
+      });
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toContain('[Video:');
+      expect(mockFetchWithCache).toHaveBeenCalledWith(
+        endpoint,
+        expect.any(Object),
+        expect.any(Number),
+        'json',
+        true,
+      );
+    },
+  );
+
+  it.each([
     [
-      { apiHost: 'http://127.0.0.1:15500/proxy' },
-      { GOOGLE_API_HOST: 'wrong.example' },
+      { apiHost: 'http://127.0.0.1:15500/proxy', apiBaseUrl: 'http://wrong-base.example' },
+      { GOOGLE_API_HOST: 'wrong.example', PALM_API_HOST: 'palm-wrong.example' },
       'http://127.0.0.1:15500/proxy/v1beta/interactions',
     ],
     [
       { apiBaseUrl: 'http://127.0.0.1:15500/proxy' },
-      { GOOGLE_API_HOST: 'wrong.example' },
+      { GOOGLE_API_HOST: 'wrong.example', PALM_API_HOST: 'palm-wrong.example' },
       'http://127.0.0.1:15500/proxy/v1beta/interactions',
     ],
   ])(

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -1098,7 +1098,10 @@ describe('GoogleInteractionsProvider', () => {
         env,
       });
 
-      const result = await provider.callApi('Describe a quiet garden');
+      const result = await provider.callApi('Describe a quiet garden', {
+        prompt: { raw: 'Describe a quiet garden', label: 'garden', config: { vertexai: true } },
+        vars: {},
+      });
 
       expect(result.error).toBeUndefined();
       expect(result.output).toContain('[Video:');

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -1474,6 +1474,11 @@ describe('Provider Registry', () => {
         async () =>
           (await import('../../src/providers/google/interactions')).GoogleInteractionsProvider,
       ],
+      [
+        'vertex:chat:gemini-omni-1.1-flash-preview',
+        async () =>
+          (await import('../../src/providers/google/interactions')).GoogleInteractionsProvider,
+      ],
       // Bare vertex:<model> default route exercises the splits.slice(1) chat fallback
       // (distinct from the vertex:chat: branch, which slices from index 2).
       [
@@ -1482,6 +1487,11 @@ describe('Provider Registry', () => {
       ],
       [
         'vertex:gemini-omni-flash-preview',
+        async () =>
+          (await import('../../src/providers/google/interactions')).GoogleInteractionsProvider,
+      ],
+      [
+        'vertex:gemini-omni-1.1-flash-preview',
         async () =>
           (await import('../../src/providers/google/interactions')).GoogleInteractionsProvider,
       ],

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -1398,9 +1398,32 @@ describe('Provider Registry', () => {
       ],
       // Bare google:<model> default chat route (no service-type segment).
       [
+        'google:gemini-omni-1.1-flash',
+        async () =>
+          (await import('../../src/providers/google/interactions')).GoogleInteractionsProvider,
+      ],
+      [
+        'palm:gemini-omni-1.1-flash',
+        async () =>
+          (await import('../../src/providers/google/interactions')).GoogleInteractionsProvider,
+      ],
+      [
         'google:gemini-omni-flash-preview',
         async () =>
           (await import('../../src/providers/google/interactions')).GoogleInteractionsProvider,
+      ],
+      [
+        'palm:gemini-omni-flash-preview',
+        async () =>
+          (await import('../../src/providers/google/interactions')).GoogleInteractionsProvider,
+      ],
+      [
+        'google:gemini-omni-1.1-flash-custom',
+        async () => (await import('../../src/providers/google/ai.studio')).AIStudioChatProvider,
+      ],
+      [
+        'vertex:gemini-omni-1.1-flash',
+        async () => (await import('../../src/providers/google/vertex')).VertexChatProvider,
       ],
       [
         'google:gemini-3.8-flash',
@@ -1496,6 +1519,28 @@ describe('Provider Registry', () => {
       expect((provider as any).config?.vertexai).toBe(true);
       expect(provider.id()).toBe(providerPath);
     });
+
+    it.each(['google:gemini-omni-1.1-flash', 'palm:gemini-omni-1.1-flash'])(
+      'preserves explicit provider options for %s',
+      async (providerPath) => {
+        const factory = (await getProviderFactories(providerPath)).find((f) =>
+          f.test(providerPath),
+        );
+        const options = {
+          id: 'custom-omni-id',
+          config: { apiKey: 'test-key', aspectRatio: '9:16' },
+          env: { GOOGLE_API_KEY: 'env-test-key' },
+        };
+        const provider = await factory!.create(providerPath, options, bareContext);
+        expect(provider.id()).toBe('custom-omni-id');
+        expect(provider).toMatchObject({
+          modelName: 'gemini-omni-1.1-flash',
+          config: options.config,
+          env: options.env,
+        });
+        expect((provider as any).config.vertexai).toBeUndefined();
+      },
+    );
 
     it.each(['vertex:gemini-omni-flash-preview', 'vertex:chat:gemini-omni-flash-preview'])(
       'applies vertexai config and provider id for %s',

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -1529,7 +1529,7 @@ describe('Provider Registry', () => {
         const options = {
           id: 'custom-omni-id',
           config: { apiKey: 'test-key', aspectRatio: '9:16' },
-          env: { GOOGLE_API_KEY: 'env-test-key' },
+          env: { GOOGLE_API_KEY: 'env-test-key', PALM_API_HOST: 'scoped-palm.example' },
         };
         const provider = await factory!.create(providerPath, options, bareContext);
         expect(provider.id()).toBe('custom-omni-id');

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -1538,17 +1538,16 @@ describe('Provider Registry', () => {
         );
         const options = {
           id: 'custom-omni-id',
-          config: { apiKey: 'test-key', aspectRatio: '9:16' },
+          config: { apiKey: 'test-key', aspectRatio: '9:16', vertexai: true },
           env: { GOOGLE_API_KEY: 'env-test-key', PALM_API_HOST: 'scoped-palm.example' },
         };
         const provider = await factory!.create(providerPath, options, bareContext);
         expect(provider.id()).toBe('custom-omni-id');
         expect(provider).toMatchObject({
           modelName: 'gemini-omni-1.1-flash',
-          config: options.config,
+          config: { ...options.config, vertexai: false },
           env: options.env,
         });
-        expect((provider as any).config.vertexai).toBeUndefined();
       },
     );
 


### PR DESCRIPTION
`google:gemini-omni-1.1-flash` currently falls through to GenerateContent. Route the stable model and its `palm:` alias through the existing Interactions video provider and add its documented native pricing. Preserve the existing preview route, provider options, and legacy `PALM_API_HOST` proxy overrides with the existing Google/Palm precedence.

Update the Omni example and distinguish the [stable native model](https://ai.google.dev/gemini-api/docs/models/gemini-omni-flash) from the separate [Vertex preview ID](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/omni-1-1-flash). Both native Omni IDs use Google's published [token rates](https://ai.google.dev/gemini-api/docs/pricing#gemini-omni-flash).

Validation:

- 487 mocked Google provider and registry tests passed.
- TypeScript, ESM/CJS, and UI compilation passed; the postbuild asset step completed with `node --import tsx scripts/postbuild.ts` after the `tsx` launcher encountered an IPC permission error.
- Docs build, changed-file lint/format, and commit hooks passed.
- Built CLI with local fetch fixtures and `--no-cache`: stable/preview video storage, usage, and cost passed; both Google/Palm aliases preserve scoped/process proxy and explicit endpoint priority; HTTP 503 surfaced as the expected provider error. No vendor inference calls.
