### PR TITLE
fix(slack): preserve scoped auth and returned DM conversations

### DIFF
--- a/site/docs/providers/slack.md
+++ b/site/docs/providers/slack.md
@@ -115,6 +115,8 @@ providers:
 
 \*Token is required either in config or as environment variable
 
+Token precedence is `config.token`, provider-scoped `env.SLACK_BOT_TOKEN`, then the process `SLACK_BOT_TOKEN`. Eval-level `env` values are also supported; provider-scoped values take precedence.
+
 ## Response Strategies
 
 ### First Response (Default)
@@ -235,6 +237,8 @@ tests:
 
 ### Thread-based Conversations
 
+`threadTs` controls where the prompt is posted. Response collection currently reads conversation history, so replies that remain only in the thread are not collected.
+
 ```yaml
 description: Continue conversation in thread
 
@@ -292,8 +296,8 @@ module.exports = {
    - Use Slack's markdown for better readability
 
 5. **Rate Limits**: Be aware of Slack's rate limits
-   - Web API: ~1 request per second per method
-   - Consider adding delays for bulk evaluations
+   - Limits vary by method and app distribution; see [Slack conversation history limits](https://docs.slack.dev/reference/methods/conversations.history/).
+   - The provider polls every second and does not expose a polling-interval option.
 
 ## Testing Other Slack Bots
 
@@ -589,7 +593,7 @@ tests:
 
 - **Bot not in channel**: Always invite the bot first with `/invite @YourBotName`
 - **No response captured**: Check the bot has all required scopes
-- **Rate limits**: The provider polls every 1 second. For non-Marketplace apps with strict rate limits, consider increasing timeouts and using longer polling intervals
+- **Rate limits**: The provider polls every second. Increasing the timeout does not reduce the polling rate; check whether your app is subject to stricter conversation history limits.
 
 ## See Also
 

--- a/site/static/config-schema.json
+++ b/site/static/config-schema.json
@@ -512,6 +512,9 @@
         "SHAREPOINT_TENANT_ID": {
           "type": "string"
         },
+        "SLACK_BOT_TOKEN": {
+          "type": "string"
+        },
         "VERCEL_AI_GATEWAY_API_KEY": {
           "type": "string"
         },
@@ -1987,6 +1990,9 @@
                       "type": "string"
                     },
                     "SHAREPOINT_TENANT_ID": {
+                      "type": "string"
+                    },
+                    "SLACK_BOT_TOKEN": {
                       "type": "string"
                     },
                     "VERCEL_AI_GATEWAY_API_KEY": {

--- a/src/contracts/env.ts
+++ b/src/contracts/env.ts
@@ -116,6 +116,7 @@ export const ProviderEnvOverridesSchema = z.object({
   SHAREPOINT_CERT_PATH: z.string().optional(),
   SHAREPOINT_CLIENT_ID: z.string().optional(),
   SHAREPOINT_TENANT_ID: z.string().optional(),
+  SLACK_BOT_TOKEN: z.string().optional(),
   VERCEL_AI_GATEWAY_API_KEY: z.string().optional(),
   VERCEL_AI_GATEWAY_BASE_URL: z.string().optional(),
   VERTEX_API_HOST: z.string().optional(),

--- a/src/providers/slack.ts
+++ b/src/providers/slack.ts
@@ -2,6 +2,7 @@ import { WebAPIPlatformError, WebAPIRateLimitedError, WebClient } from '@slack/w
 import logger from '../logger';
 import { fetchWithProviderProxy } from './fetch';
 
+import type { EnvOverrides } from '../types/env';
 import type {
   ApiProvider,
   CallApiContextParams,
@@ -11,6 +12,7 @@ import type {
 
 export interface SlackProviderOptions {
   id?: string;
+  env?: EnvOverrides;
   config?: {
     /** Slack Bot User OAuth Token (xoxb-...) */
     token?: string;
@@ -49,7 +51,8 @@ export class SlackProvider implements ApiProvider {
   constructor(options: SlackProviderOptions = {}) {
     this.options = options;
 
-    const token = options.config?.token || process.env.SLACK_BOT_TOKEN;
+    const token =
+      options.config?.token || options.env?.SLACK_BOT_TOKEN || process.env.SLACK_BOT_TOKEN;
     if (!token) {
       throw new Error(
         'Slack provider requires a token. Set SLACK_BOT_TOKEN or provide it in config.',
@@ -103,18 +106,24 @@ export class SlackProvider implements ApiProvider {
       }
 
       const messageTs = postResult.ts;
+      // User targets open a DM whose conversation ID is returned by Slack.
+      const responseChannel = postResult.channel || channel;
 
       // Handle different response collection strategies
       let responseText: string;
       const responseMetadata: Record<string, any> = {
         messageTs,
-        channel,
+        channel: responseChannel,
       };
 
       switch (responseStrategy) {
         case 'timeout':
           // Just wait for the timeout and collect all responses
-          responseText = await this.collectResponsesUntilTimeout(channel, messageTs, timeout);
+          responseText = await this.collectResponsesUntilTimeout(
+            responseChannel,
+            messageTs,
+            timeout,
+          );
           break;
 
         case 'user':
@@ -122,7 +131,7 @@ export class SlackProvider implements ApiProvider {
             throw new Error('waitForUser must be specified when using "user" response strategy');
           }
           responseText = await this.waitForUserResponse(
-            channel,
+            responseChannel,
             messageTs,
             config.waitForUser,
             timeout,
@@ -132,7 +141,7 @@ export class SlackProvider implements ApiProvider {
 
         case 'first':
         default:
-          responseText = await this.waitForFirstResponse(channel, messageTs, timeout);
+          responseText = await this.waitForFirstResponse(responseChannel, messageTs, timeout);
           break;
       }
 

--- a/src/providers/slack.ts
+++ b/src/providers/slack.ts
@@ -2,11 +2,11 @@ import { WebAPIPlatformError, WebAPIRateLimitedError, WebClient } from '@slack/w
 import logger from '../logger';
 import { fetchWithProviderProxy } from './fetch';
 
-import type { EnvOverrides } from '../types/env';
 import type {
   ApiProvider,
   CallApiContextParams,
   CallApiOptionsParams,
+  EnvOverrides,
   ProviderResponse,
 } from '../types/index';
 
@@ -86,6 +86,7 @@ export class SlackProvider implements ApiProvider {
     const channel = config.channel!;
     const timeout = config.timeout || 60000;
     const responseStrategy = config.responseStrategy || 'first';
+    let responseChannel = channel;
 
     try {
       // Format the message if a custom formatter is provided
@@ -107,7 +108,7 @@ export class SlackProvider implements ApiProvider {
 
       const messageTs = postResult.ts;
       // User targets open a DM whose conversation ID is returned by Slack.
-      const responseChannel = postResult.channel || channel;
+      responseChannel = postResult.channel || channel;
 
       // Handle different response collection strategies
       let responseText: string;
@@ -168,9 +169,11 @@ export class SlackProvider implements ApiProvider {
         const slackError = error.data.error;
         switch (slackError) {
           case 'channel_not_found':
-            return { error: `Channel ${channel} not found. Please check the channel ID.` };
+            return { error: `Channel ${responseChannel} not found. Please check the channel ID.` };
           case 'not_in_channel':
-            return { error: `Bot is not in channel ${channel}. Please invite the bot first.` };
+            return {
+              error: `Bot is not in channel ${responseChannel}. Please invite the bot first.`,
+            };
           case 'missing_scope':
             return { error: 'Bot token is missing required scopes. Please check permissions.' };
           case 'ratelimited':

--- a/test/providers.slack.test.ts
+++ b/test/providers.slack.test.ts
@@ -1,5 +1,7 @@
 import { WebAPIPlatformError, WebAPIRateLimitedError, WebClient } from '@slack/web-api';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProviderEnvOverridesSchema } from '../src/contracts/env';
+import { loadApiProvider } from '../src/providers/index';
 import { SlackProvider } from '../src/providers/slack';
 import { fetchWithProxy } from '../src/util/fetch/index';
 import { mockProcessEnv } from './util/utils';
@@ -85,6 +87,44 @@ describe('SlackProvider', () => {
       });
       expect(WebClient).toHaveBeenCalledWith('xoxb-test-token', { fetch: expect.any(Function) });
       expect(provider).toBeDefined();
+    });
+
+    it('uses a scoped token before the process token', () => {
+      new SlackProvider({
+        config: { channel: 'C123' },
+        env: { SLACK_BOT_TOKEN: 'xoxb-scoped-token' },
+      });
+      expect(WebClient).toHaveBeenCalledWith('xoxb-scoped-token', { fetch: expect.any(Function) });
+    });
+
+    it('uses the explicit token before scoped and process tokens', () => {
+      new SlackProvider({
+        config: { channel: 'C123', token: 'xoxb-explicit-token' },
+        env: { SLACK_BOT_TOKEN: 'xoxb-scoped-token' },
+      });
+      expect(WebClient).toHaveBeenCalledWith('xoxb-explicit-token', {
+        fetch: expect.any(Function),
+      });
+    });
+
+    it.each(['slack', 'slack:C123', 'slack:user:U456'])(
+      'preserves validated scoped tokens through the %s loader',
+      async (providerPath) => {
+        mockProcessEnv({ SLACK_BOT_TOKEN: undefined });
+        const env = ProviderEnvOverridesSchema.parse({ SLACK_BOT_TOKEN: 'xoxb-scoped-token' });
+        const provider = await loadApiProvider(providerPath, {
+          env: { SLACK_BOT_TOKEN: 'xoxb-suite-token' },
+          options: { config: { channel: 'C123' }, env },
+        });
+        expect(provider).toBeInstanceOf(SlackProvider);
+        expect(WebClient).toHaveBeenCalledWith('xoxb-scoped-token', {
+          fetch: expect.any(Function),
+        });
+      },
+    );
+
+    it('rejects non-string scoped tokens at the public schema boundary', () => {
+      expect(() => ProviderEnvOverridesSchema.parse({ SLACK_BOT_TOKEN: 123 })).toThrow();
     });
 
     it('routes Slack requests through the proxy-aware fetch implementation', async () => {
@@ -296,6 +336,55 @@ describe('SlackProvider', () => {
   });
 
   describe('response strategies', () => {
+    it.each(['first', 'user', 'timeout'] as const)(
+      'collects %s responses from the conversation returned for a user target',
+      async (responseStrategy) => {
+        const provider = new SlackProvider({
+          config: {
+            channel: 'U456',
+            responseStrategy,
+            waitForUser: 'U456',
+            timeout: 1000,
+          },
+        });
+        mockWebClient.chat.postMessage.mockResolvedValue({
+          ok: true,
+          channel: 'D789',
+          ts: '1234567890.123456',
+        });
+        mockWebClient.conversations.history.mockImplementation(
+          async ({ channel }: { channel: string }) => {
+            if (channel !== 'D789') {
+              throw new WebAPIPlatformError({ ok: false, error: 'channel_not_found' });
+            }
+            return {
+              messages: [
+                {
+                  type: 'message',
+                  ts: '1234567890.123457',
+                  text: 'Feedback from the direct message',
+                  user: 'U456',
+                },
+              ],
+            };
+          },
+        );
+
+        const resultPromise = provider.callApi('Please provide feedback');
+        await vi.runAllTimersAsync();
+        const result = await resultPromise;
+
+        expect(mockWebClient.chat.postMessage).toHaveBeenCalledWith(
+          expect.objectContaining({ channel: 'U456' }),
+        );
+        expect(result).toMatchObject({
+          output: 'Feedback from the direct message',
+          metadata: { channel: 'D789' },
+        });
+        expect(result.error).toBeUndefined();
+      },
+    );
+
     it('should wait for specific user when responseStrategy is "user"', async () => {
       const provider = new SlackProvider({
         config: {

--- a/test/providers.slack.test.ts
+++ b/test/providers.slack.test.ts
@@ -301,6 +301,19 @@ describe('SlackProvider', () => {
       expect(result.error).toBe('Slack API rate limit exceeded. Please try again later.');
     });
 
+    it.each([
+      ['channel_not_found', 'Channel U456 not found. Please check the channel ID.'],
+      ['not_in_channel', 'Bot is not in channel U456. Please invite the bot first.'],
+    ])('uses the requested target for %s post errors', async (error, message) => {
+      const dmProvider = new SlackProvider({ config: { channel: 'U456' } });
+      mockWebClient.chat.postMessage.mockRejectedValue(
+        new WebAPIPlatformError({ ok: false, error }),
+      );
+
+      expect(await dmProvider.callApi('Test prompt')).toEqual({ error: message });
+      expect(mockWebClient.conversations.history).not.toHaveBeenCalled();
+    });
+
     it('should use custom message formatter if provided', async () => {
       provider = new SlackProvider({
         config: {
@@ -336,6 +349,33 @@ describe('SlackProvider', () => {
   });
 
   describe('response strategies', () => {
+    describe.each(['first', 'user', 'timeout'] as const)(
+      '%s polling errors',
+      (responseStrategy) => {
+        it.each([
+          ['channel_not_found', 'Channel D789 not found. Please check the channel ID.'],
+          ['not_in_channel', 'Bot is not in channel D789. Please invite the bot first.'],
+        ])('uses the returned conversation for %s', async (error, message) => {
+          const provider = new SlackProvider({
+            config: { channel: 'U456', responseStrategy, waitForUser: 'U456', timeout: 1000 },
+          });
+          mockWebClient.chat.postMessage.mockResolvedValue({
+            ok: true,
+            channel: 'D789',
+            ts: '1234567890.123456',
+          });
+          mockWebClient.conversations.history.mockRejectedValue(
+            new WebAPIPlatformError({ ok: false, error }),
+          );
+
+          expect(await provider.callApi('Test prompt')).toEqual({ error: message });
+          expect(mockWebClient.conversations.history).toHaveBeenCalledWith(
+            expect.objectContaining({ channel: 'D789' }),
+          );
+        });
+      },
+    );
+
     it.each(['first', 'user', 'timeout'] as const)(
       'collects %s responses from the conversation returned for a user target',
       async (responseStrategy) => {


### PR DESCRIPTION
Slack user targets can open a DM whose conversation ID differs from the requested user ID. Use the conversation returned by `chat.postMessage` for every response strategy, response metadata, and polling-error diagnostics. Post failures continue to report the requested target.

Support scoped `SLACK_BOT_TOKEN` values with explicit-token precedence, add the optional environment schema field, and document polling/thread limits. Reuse the existing type import so the architecture baseline stays unchanged.

Validation: 116 focused Slack/contract/manifest tests, the package/UI build, and all seven CI style checks pass. A built-CLI fetch fixture verifies three successful DM responses and two deliberate polling errors with exact DM IDs (`--no-cache`); no real Slack messages are sent.
