### PR TITLE
fix(openclaw): sign the server challenge timestamp

### DIFF
--- a/src/providers/openclaw/agent.ts
+++ b/src/providers/openclaw/agent.ts
@@ -555,7 +555,7 @@ export class OpenClawAgentProvider implements ApiProvider {
       ...(authState.auth && { auth: authState.auth }),
     };
 
-    const device = this.buildSignedDevice(authState, nonce);
+    const device = this.buildSignedDevice(authState, nonce, frame.payload?.ts);
     if (device) {
       params.device = device;
     }
@@ -566,9 +566,18 @@ export class OpenClawAgentProvider implements ApiProvider {
   private buildSignedDevice(
     authState: ConnectAuthState,
     nonce: string,
+    challengeTimestamp: unknown,
   ): ReturnType<typeof buildSignedOpenClawDevice> | undefined {
     if (!authState.deviceIdentity || this.openclawConfig.disable_device_auth) {
       return undefined;
+    }
+
+    if (
+      typeof challengeTimestamp !== 'number' ||
+      !Number.isInteger(challengeTimestamp) ||
+      challengeTimestamp < 0
+    ) {
+      throw new Error('Invalid OpenClaw connect challenge timestamp');
     }
 
     try {
@@ -579,6 +588,7 @@ export class OpenClawAgentProvider implements ApiProvider {
         role: CLIENT_ROLE,
         scopes: authState.scopes,
         nonce,
+        nowMs: challengeTimestamp,
         token: authState.signatureToken,
         platform: process.platform,
         deviceFamily: this.openclawConfig.device_family,

--- a/src/providers/openclaw/agent.ts
+++ b/src/providers/openclaw/agent.ts
@@ -574,7 +574,7 @@ export class OpenClawAgentProvider implements ApiProvider {
 
     if (
       typeof challengeTimestamp !== 'number' ||
-      !Number.isInteger(challengeTimestamp) ||
+      !Number.isSafeInteger(challengeTimestamp) ||
       challengeTimestamp < 0
     ) {
       throw new Error('Invalid OpenClaw connect challenge timestamp');

--- a/test/providers/openclaw.test.ts
+++ b/test/providers/openclaw.test.ts
@@ -1964,42 +1964,44 @@ describe('OpenClaw Provider', () => {
       expect(result.output).toBe('Correct answer');
     });
 
-    it('signs the gateway challenge timestamp instead of the client clock', async () => {
-      const provider = new OpenClawAgentProvider('main', {
-        config: { gateway_url: 'http://test:18789' },
-      });
-      const promise = provider.callApi('Hello');
-      const onMessage = getMessageHandler();
-      const challengeTimestamp = 1737264000000;
-      onMessage(
-        Buffer.from(
-          JSON.stringify({
-            type: 'event',
-            event: 'connect.challenge',
-            payload: { nonce: 'server-challenge', ts: challengeTimestamp },
-          }),
-        ),
-      );
-      const connectReq = JSON.parse(mockWs.send.mock.calls[0][0]);
-      // End the mocked exchange without invoking an agent.
-      onMessage(
-        Buffer.from(
-          JSON.stringify({
-            type: 'res',
-            id: connectReq.id,
-            ok: false,
-            error: { code: 'TEST_COMPLETE', message: 'Fixture complete' },
-          }),
-        ),
-      );
-      await promise;
+    it.each([0, 1737264000000, Number.MAX_SAFE_INTEGER])(
+      'signs the gateway challenge timestamp instead of the client clock (%s)',
+      async (challengeTimestamp) => {
+        const provider = new OpenClawAgentProvider('main', {
+          config: { gateway_url: 'http://test:18789' },
+        });
+        const promise = provider.callApi('Hello');
+        const onMessage = getMessageHandler();
+        onMessage(
+          Buffer.from(
+            JSON.stringify({
+              type: 'event',
+              event: 'connect.challenge',
+              payload: { nonce: 'server-challenge', ts: challengeTimestamp },
+            }),
+          ),
+        );
+        const connectReq = JSON.parse(mockWs.send.mock.calls[0][0]);
+        // End the mocked exchange without invoking an agent.
+        onMessage(
+          Buffer.from(
+            JSON.stringify({
+              type: 'res',
+              id: connectReq.id,
+              ok: false,
+              error: { code: 'TEST_COMPLETE', message: 'Fixture complete' },
+            }),
+          ),
+        );
+        await promise;
 
-      expect(deviceAuthMocks.buildSignedOpenClawDevice).toHaveBeenCalledWith(
-        expect.objectContaining({ nonce: 'server-challenge', nowMs: challengeTimestamp }),
-      );
-    });
+        expect(deviceAuthMocks.buildSignedOpenClawDevice).toHaveBeenCalledWith(
+          expect.objectContaining({ nonce: 'server-challenge', nowMs: challengeTimestamp }),
+        );
+      },
+    );
 
-    it.each([undefined, null, '1737264000000', -1, 1.5])(
+    it.each([undefined, null, '1737264000000', -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
       'rejects an invalid device-auth challenge timestamp (%s)',
       async (ts) => {
         const provider = new OpenClawAgentProvider('main', {
@@ -2016,7 +2018,7 @@ describe('OpenClaw Provider', () => {
             }),
           ),
         );
-        // A baseline implementation sends a connect request; settle it to avoid a timeout.
+        // If a regression sends connect, settle it so the no-send assertion fails without timing out.
         if (mockWs.send.mock.calls.length) {
           const connectReq = JSON.parse(mockWs.send.mock.calls[0][0]);
           onMessage(

--- a/test/providers/openclaw.test.ts
+++ b/test/providers/openclaw.test.ts
@@ -1964,6 +1964,83 @@ describe('OpenClaw Provider', () => {
       expect(result.output).toBe('Correct answer');
     });
 
+    it('signs the gateway challenge timestamp instead of the client clock', async () => {
+      const provider = new OpenClawAgentProvider('main', {
+        config: { gateway_url: 'http://test:18789' },
+      });
+      const promise = provider.callApi('Hello');
+      const onMessage = getMessageHandler();
+      const challengeTimestamp = 1737264000000;
+      onMessage(
+        Buffer.from(
+          JSON.stringify({
+            type: 'event',
+            event: 'connect.challenge',
+            payload: { nonce: 'server-challenge', ts: challengeTimestamp },
+          }),
+        ),
+      );
+      const connectReq = JSON.parse(mockWs.send.mock.calls[0][0]);
+      // End the mocked exchange without invoking an agent.
+      onMessage(
+        Buffer.from(
+          JSON.stringify({
+            type: 'res',
+            id: connectReq.id,
+            ok: false,
+            error: { code: 'TEST_COMPLETE', message: 'Fixture complete' },
+          }),
+        ),
+      );
+      await promise;
+
+      expect(deviceAuthMocks.buildSignedOpenClawDevice).toHaveBeenCalledWith(
+        expect.objectContaining({ nonce: 'server-challenge', nowMs: challengeTimestamp }),
+      );
+    });
+
+    it.each([undefined, null, '1737264000000', -1, 1.5])(
+      'rejects an invalid device-auth challenge timestamp (%s)',
+      async (ts) => {
+        const provider = new OpenClawAgentProvider('main', {
+          config: { gateway_url: 'http://test:18789' },
+        });
+        const promise = provider.callApi('Hello');
+        const onMessage = getMessageHandler();
+        onMessage(
+          Buffer.from(
+            JSON.stringify({
+              type: 'event',
+              event: 'connect.challenge',
+              payload: { nonce: 'challenge', ts },
+            }),
+          ),
+        );
+        // A baseline implementation sends a connect request; settle it to avoid a timeout.
+        if (mockWs.send.mock.calls.length) {
+          const connectReq = JSON.parse(mockWs.send.mock.calls[0][0]);
+          onMessage(
+            Buffer.from(
+              JSON.stringify({
+                type: 'res',
+                id: connectReq.id,
+                ok: false,
+                error: { code: 'TEST_COMPLETE', message: 'Fixture complete' },
+              }),
+            ),
+          );
+        }
+        const result = await promise;
+
+        expect(result.error).toBe(
+          'OpenClaw WebSocket error: Invalid OpenClaw connect challenge timestamp',
+        );
+        expect(deviceAuthMocks.buildSignedOpenClawDevice).not.toHaveBeenCalled();
+        expect(mockWs.send).not.toHaveBeenCalled();
+        expect(mockWs.close).toHaveBeenCalled();
+      },
+    );
+
     it('should handle connect failure', async () => {
       const provider = new OpenClawAgentProvider('main', {
         config: { gateway_url: 'http://test:18789' },


### PR DESCRIPTION
OpenClaw device authentication must sign the timestamp received in `connect.challenge`. Using the client clock can make an otherwise valid handshake fail. Pass the received timestamp to the existing signer and reject missing, malformed or unsafe integer timestamps before signing or sending a connect request.

The [Gateway handshake specification](https://docs.openclaw.ai/gateway/protocol/handshake) defines the received timestamp contract. Regression tests cover clock mismatch, zero, both safe-integer boundaries and malformed challenges; authentication without a device retains its existing behavior.

Validation: 190 provider/device-auth tests, architecture checks, TypeScript and package/UI compilation. The postbuild script passes using Node's TS loader. Built-CLI loopback fixtures verify that the largest safe integer is signed exactly and the next integer is rejected before any request is sent.
