### PR TITLE
fix(replicate): stop local polling when evaluations abort

### DIFF
--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -4,9 +4,7 @@ import { fetchWithCache, getCache, isCacheEnabled } from '../cache';
 import { getEnvFloat, getEnvInt, getEnvString } from '../envars';
 import logger from '../logger';
 import { getRequestTimeoutMs } from '../providers/shared';
-import { getProviderCallExecutionContext } from '../scheduler/providerCallExecutionContext';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
-import { isAbortError } from '../util/fetch/errors';
 import { safeJsonStringify } from '../util/json';
 import { ellipsize } from '../util/text';
 import { sleep, sleepWithAbort } from '../util/time';
@@ -65,6 +63,10 @@ interface ReplicatePrediction {
 }
 
 const REPLICATE_CACHE_KEY_HMAC_KEY = 'promptfoo:replicate:cache-key:v1';
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'AbortException');
+}
 
 function throwIfAborted(signal?: AbortSignal) {
   if (!signal?.aborted) {
@@ -447,18 +449,15 @@ export class ReplicateModerationProvider
     context?: CallApiContextParams,
     options?: CallApiOptionsParams,
   ): Promise<ProviderModerationResponse> {
-    // Modality matchers can invoke the two-argument public interface. Recover their
-    // evaluation signal from the same execution context used by grading providers.
-    const abortSignal = options?.abortSignal ?? getProviderCallExecutionContext()?.abortSignal;
     let response: ProviderResponse;
     try {
       response = await this.callApi(
         `Human: ${prompt}\n\nAssistant: ${assistant}`,
         context,
-        abortSignal ? { ...options, abortSignal } : options,
+        options,
       );
     } catch (err) {
-      throwIfAborted(abortSignal);
+      throwIfAborted(options?.abortSignal);
       if (isAbortError(err)) {
         throw err;
       }
@@ -534,6 +533,19 @@ export class ReplicateImageProvider extends ReplicateProvider {
     options?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
     throwIfAborted(options?.abortSignal);
+    try {
+      return await this.callImageApiInternal(prompt, options);
+    } catch (err) {
+      // Body reads can wrap a custom abort reason in a plain Error after headers arrive.
+      throwIfAborted(options?.abortSignal);
+      throw err;
+    }
+  }
+
+  private async callImageApiInternal(
+    prompt: string,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
     if (!this.apiKey) {
       throw new Error(
         'Replicate API key is not set. Set the REPLICATE_API_TOKEN environment variable or add `apiKey` to the provider config.',

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -4,7 +4,9 @@ import { fetchWithCache, getCache, isCacheEnabled } from '../cache';
 import { getEnvFloat, getEnvInt, getEnvString } from '../envars';
 import logger from '../logger';
 import { getRequestTimeoutMs } from '../providers/shared';
+import { getProviderCallExecutionContext } from '../scheduler/providerCallExecutionContext';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
+import { isAbortError } from '../util/fetch/errors';
 import { safeJsonStringify } from '../util/json';
 import { ellipsize } from '../util/text';
 import { sleep, sleepWithAbort } from '../util/time';
@@ -63,6 +65,19 @@ interface ReplicatePrediction {
 }
 
 const REPLICATE_CACHE_KEY_HMAC_KEY = 'promptfoo:replicate:cache-key:v1';
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (!signal?.aborted) {
+    return;
+  }
+  const reason = signal.reason;
+  if (reason instanceof Error && reason.name === 'AbortError') {
+    throw reason;
+  }
+  const error = new Error(reason instanceof Error ? reason.message : 'Request was aborted');
+  error.name = 'AbortError';
+  throw error;
+}
 
 function normalizeReplicateCacheValue(value: unknown): unknown {
   if (Array.isArray(value)) {
@@ -152,7 +167,7 @@ export class ReplicateProvider implements ApiProvider {
     context?: CallApiContextParams,
     options?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
-    options?.abortSignal?.throwIfAborted();
+    throwIfAborted(options?.abortSignal);
     // Set up tracing context
     const spanContext: GenAISpanContext = {
       system: 'replicate',
@@ -294,6 +309,10 @@ export class ReplicateProvider implements ApiProvider {
 
       response = response.output;
     } catch (err) {
+      throwIfAborted(options?.abortSignal);
+      if (isAbortError(err)) {
+        throw err;
+      }
       return {
         error: `API call error: ${String(err)}`,
         ...(cached && { cached: true, tokenUsage: createEmptyTokenUsage() }),
@@ -357,7 +376,7 @@ export class ReplicateProvider implements ApiProvider {
     const pollInterval = 1000; // 1 second
 
     for (let i = 0; i < maxPolls; i++) {
-      signal?.throwIfAborted();
+      throwIfAborted(signal);
       const pollResponse = await fetchWithCache(
         `https://api.replicate.com/v1/predictions/${predictionId}`,
         {
@@ -383,7 +402,13 @@ export class ReplicateProvider implements ApiProvider {
       }
 
       if (signal) {
-        await sleepWithAbort(pollInterval, signal);
+        try {
+          await sleepWithAbort(pollInterval, signal);
+        } catch (err) {
+          // The shared delay throws a plain Error; preserve the evaluator's abort contract.
+          throwIfAborted(signal);
+          throw err;
+        }
       } else {
         await sleep(pollInterval);
       }
@@ -422,12 +447,24 @@ export class ReplicateModerationProvider
     context?: CallApiContextParams,
     options?: CallApiOptionsParams,
   ): Promise<ProviderModerationResponse> {
+    // Modality matchers can invoke the two-argument public interface. Recover their
+    // evaluation signal from the same execution context used by grading providers.
+    const abortSignal = options?.abortSignal ?? getProviderCallExecutionContext()?.abortSignal;
+    let response: ProviderResponse;
     try {
-      const response = await this.callApi(
+      response = await this.callApi(
         `Human: ${prompt}\n\nAssistant: ${assistant}`,
         context,
-        options,
+        abortSignal ? { ...options, abortSignal } : options,
       );
+    } catch (err) {
+      throwIfAborted(abortSignal);
+      if (isAbortError(err)) {
+        throw err;
+      }
+      return { error: `API call error: ${String(err)}` };
+    }
+    try {
       // LlamaGuard moderation runs as a chat completion. Preserve any token usage
       // reported by that provider response for downstream assertion metrics.
       const tokenUsageResult = response.tokenUsage ? { tokenUsage: response.tokenUsage } : {};
@@ -496,7 +533,7 @@ export class ReplicateImageProvider extends ReplicateProvider {
     _context?: CallApiContextParams,
     options?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
-    options?.abortSignal?.throwIfAborted();
+    throwIfAborted(options?.abortSignal);
     if (!this.apiKey) {
       throw new Error(
         'Replicate API key is not set. Set the REPLICATE_API_TOKEN environment variable or add `apiKey` to the provider config.',

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -7,6 +7,7 @@ import { getRequestTimeoutMs } from '../providers/shared';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
 import { safeJsonStringify } from '../util/json';
 import { ellipsize } from '../util/text';
+import { sleep, sleepWithAbort } from '../util/time';
 import { createEmptyTokenUsage } from '../util/tokenUsageUtils';
 import { parseChatPrompt } from './shared';
 
@@ -146,7 +147,12 @@ export class ReplicateProvider implements ApiProvider {
     return true;
   }
 
-  async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
+    options?.abortSignal?.throwIfAborted();
     // Set up tracing context
     const spanContext: GenAISpanContext = {
       system: 'replicate',
@@ -175,10 +181,13 @@ export class ReplicateProvider implements ApiProvider {
       return result;
     };
 
-    return withGenAISpan(spanContext, () => this.callApiInternal(prompt), resultExtractor);
+    return withGenAISpan(spanContext, () => this.callApiInternal(prompt, options), resultExtractor);
   }
 
-  protected async callApiInternal(prompt: string): Promise<ProviderResponse> {
+  protected async callApiInternal(
+    prompt: string,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
     if (!this.apiKey) {
       throw new Error(
         'Replicate API key is not set. Set the REPLICATE_API_TOKEN environment variable or or add `apiKey` to the provider config.',
@@ -258,6 +267,7 @@ export class ReplicateProvider implements ApiProvider {
           : `https://api.replicate.com/v1/models/${this.modelName}/predictions`,
         {
           method: 'POST',
+          signal: options?.abortSignal,
           headers: {
             Authorization: `Bearer ${this.apiKey}`,
             'Content-Type': 'application/json',
@@ -275,7 +285,7 @@ export class ReplicateProvider implements ApiProvider {
       // If still processing, poll for completion
       if (response.status === 'starting' || response.status === 'processing') {
         cached = false;
-        response = await this.pollForCompletion(response.id);
+        response = await this.pollForCompletion(response.id, options?.abortSignal);
       }
 
       if (response.status === 'failed') {
@@ -339,15 +349,20 @@ export class ReplicateProvider implements ApiProvider {
     };
   }
 
-  protected async pollForCompletion(predictionId: string): Promise<ReplicatePrediction> {
+  protected async pollForCompletion(
+    predictionId: string,
+    signal?: AbortSignal,
+  ): Promise<ReplicatePrediction> {
     const maxPolls = 30; // Max 30 seconds of polling
     const pollInterval = 1000; // 1 second
 
     for (let i = 0; i < maxPolls; i++) {
+      signal?.throwIfAborted();
       const pollResponse = await fetchWithCache(
         `https://api.replicate.com/v1/predictions/${predictionId}`,
         {
           method: 'GET',
+          signal,
           headers: {
             Authorization: `Bearer ${this.apiKey}`,
           },
@@ -367,7 +382,11 @@ export class ReplicateProvider implements ApiProvider {
         return prediction;
       }
 
-      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      if (signal) {
+        await sleepWithAbort(pollInterval, signal);
+      } else {
+        await sleep(pollInterval);
+      }
     }
 
     throw new Error('Prediction timed out');
@@ -397,9 +416,18 @@ export class ReplicateModerationProvider
   extends ReplicateProvider
   implements ApiModerationProvider
 {
-  async callModerationApi(prompt: string, assistant: string): Promise<ProviderModerationResponse> {
+  async callModerationApi(
+    prompt: string,
+    assistant: string,
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderModerationResponse> {
     try {
-      const response = await this.callApi(`Human: ${prompt}\n\nAssistant: ${assistant}`);
+      const response = await this.callApi(
+        `Human: ${prompt}\n\nAssistant: ${assistant}`,
+        context,
+        options,
+      );
       // LlamaGuard moderation runs as a chat completion. Preserve any token usage
       // reported by that provider response for downstream assertion metrics.
       const tokenUsageResult = response.tokenUsage ? { tokenUsage: response.tokenUsage } : {};
@@ -466,8 +494,9 @@ export class ReplicateImageProvider extends ReplicateProvider {
   async callApi(
     prompt: string,
     _context?: CallApiContextParams,
-    _callApiOptions?: CallApiOptionsParams,
+    options?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
+    options?.abortSignal?.throwIfAborted();
     if (!this.apiKey) {
       throw new Error(
         'Replicate API key is not set. Set the REPLICATE_API_TOKEN environment variable or add `apiKey` to the provider config.',
@@ -521,6 +550,7 @@ export class ReplicateImageProvider extends ReplicateProvider {
           : `https://api.replicate.com/v1/models/${this.modelName}/predictions`,
         {
           method: 'POST',
+          signal: options?.abortSignal,
           headers: {
             Authorization: `Bearer ${this.apiKey}`,
             'Content-Type': 'application/json',
@@ -538,7 +568,7 @@ export class ReplicateImageProvider extends ReplicateProvider {
 
       // If still processing, poll for completion
       if (prediction.status === 'starting' || prediction.status === 'processing') {
-        prediction = await this.pollForCompletion(prediction.id);
+        prediction = await this.pollForCompletion(prediction.id, options?.abortSignal);
       }
 
       logger.debug('Final Replicate prediction status', {

--- a/test/evaluator/replicate-cancellation.test.ts
+++ b/test/evaluator/replicate-cancellation.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache, isCacheEnabled } from '../../src/cache';
+import { evaluate } from '../../src/evaluator';
+import logger from '../../src/logger';
+import Eval from '../../src/models/eval';
+import {
+  ReplicateImageProvider,
+  ReplicateModerationProvider,
+  ReplicateProvider,
+} from '../../src/providers/replicate';
+import { ResultFailureReason } from '../../src/types/index';
+
+import type { TestSuite } from '../../src/types/index';
+
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+  isCacheEnabled: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(fetchWithCache)
+    .mockReset()
+    .mockResolvedValue({
+      data: { id: 'fixture-prediction', status: 'processing' },
+      status: 200,
+      statusText: 'OK',
+      cached: false,
+    });
+  vi.mocked(isCacheEnabled).mockReset().mockReturnValue(false);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('Replicate evaluation cancellation', () => {
+  it.each(['text', 'image', 'moderation'])(
+    'stops %s creation/polling after the actual evaluation timeout',
+    async (mode) => {
+      const options = { config: { apiKey: 'fixture' } };
+      const provider =
+        mode === 'image'
+          ? new ReplicateImageProvider('owner/model', options)
+          : new ReplicateProvider('owner/model', options);
+      const testSuite: TestSuite = {
+        providers:
+          mode === 'moderation'
+            ? [
+                {
+                  id: () => 'fixture-target',
+                  callApi: async () => ({ output: 'fixture response' }),
+                },
+              ]
+            : [provider],
+        prompts: [{ raw: 'fixture prompt', label: 'fixture prompt' }],
+        tests:
+          mode === 'moderation'
+            ? [
+                {
+                  assert: [{ type: 'moderation' }],
+                  options: { provider: new ReplicateModerationProvider('owner/model', options) },
+                },
+              ]
+            : [{}],
+      };
+      const errorSpy = vi.spyOn(logger, 'error');
+      const evalRecord = new Eval({});
+      const result = evaluate(testSuite, evalRecord, { timeoutMs: 100, maxConcurrency: 1 });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchWithCache).toHaveBeenCalledTimes(2);
+      const signal = vi.mocked(fetchWithCache).mock.calls[0][1]?.signal;
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(100);
+      await result;
+      await vi.advanceTimersByTimeAsync(2000);
+
+      expect(signal?.aborted).toBe(true);
+      expect(fetchWithCache).toHaveBeenCalledTimes(2);
+      const summary = await evalRecord.toEvaluateSummary();
+      expect(summary.results).toHaveLength(1);
+      expect(summary.results[0]).toMatchObject({
+        error: expect.stringContaining('Evaluation timed out after 100ms'),
+        failureReason: ResultFailureReason.ERROR,
+        score: 0,
+        success: false,
+      });
+      expect(
+        errorSpy.mock.calls.some(
+          ([message]) =>
+            String(message).includes('Provider call failed during eval') ||
+            String(message).includes('Assertion grading failed during eval'),
+        ),
+      ).toBe(false);
+      expect(vi.mocked(fetchWithCache).mock.calls.map(([url]) => url)).toEqual([
+        'https://api.replicate.com/v1/models/owner/model/predictions',
+        'https://api.replicate.com/v1/predictions/fixture-prediction',
+      ]);
+    },
+  );
+});

--- a/test/evaluator/replicate-cancellation.test.ts
+++ b/test/evaluator/replicate-cancellation.test.ts
@@ -3,11 +3,7 @@ import { fetchWithCache, isCacheEnabled } from '../../src/cache';
 import { evaluate } from '../../src/evaluator';
 import logger from '../../src/logger';
 import Eval from '../../src/models/eval';
-import {
-  ReplicateImageProvider,
-  ReplicateModerationProvider,
-  ReplicateProvider,
-} from '../../src/providers/replicate';
+import { ReplicateImageProvider, ReplicateProvider } from '../../src/providers/replicate';
 import { ResultFailureReason } from '../../src/types/index';
 
 import type { TestSuite } from '../../src/types/index';
@@ -38,7 +34,7 @@ afterEach(() => {
 });
 
 describe('Replicate evaluation cancellation', () => {
-  it.each(['text', 'image', 'moderation'])(
+  it.each(['text', 'image'])(
     'stops %s creation/polling after the actual evaluation timeout',
     async (mode) => {
       const options = { config: { apiKey: 'fixture' } };
@@ -47,25 +43,9 @@ describe('Replicate evaluation cancellation', () => {
           ? new ReplicateImageProvider('owner/model', options)
           : new ReplicateProvider('owner/model', options);
       const testSuite: TestSuite = {
-        providers:
-          mode === 'moderation'
-            ? [
-                {
-                  id: () => 'fixture-target',
-                  callApi: async () => ({ output: 'fixture response' }),
-                },
-              ]
-            : [provider],
+        providers: [provider],
         prompts: [{ raw: 'fixture prompt', label: 'fixture prompt' }],
-        tests:
-          mode === 'moderation'
-            ? [
-                {
-                  assert: [{ type: 'moderation' }],
-                  options: { provider: new ReplicateModerationProvider('owner/model', options) },
-                },
-              ]
-            : [{}],
+        tests: [{}],
       };
       const errorSpy = vi.spyOn(logger, 'error');
       const evalRecord = new Eval({});

--- a/test/providers/replicate-body-cancellation.test.ts
+++ b/test/providers/replicate-body-cancellation.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { withCacheEnabled } from '../../src/cache';
+import { ReplicateImageProvider } from '../../src/providers/replicate';
+import { fetchWithRetries } from '../../src/util/fetch/index';
+
+vi.mock('../../src/util/fetch/index', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithRetries: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(fetchWithRetries).mockReset();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe.each(['creation', 'polling'])('Replicate image %s body reads', (phase) => {
+  function startBodyRead() {
+    const abortController = new AbortController();
+    let bodyController: ReadableStreamDefaultController<Uint8Array>;
+    let notifyReadStarted: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      notifyReadStarted = resolve;
+    });
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          bodyController = controller;
+          abortController.signal.addEventListener(
+            'abort',
+            () => {
+              controller.error(abortController.signal.reason);
+            },
+            { once: true },
+          );
+        },
+      }),
+      { status: 200, statusText: 'OK' },
+    );
+    const readText = response.text.bind(response);
+    vi.spyOn(response, 'text').mockImplementation(() => {
+      const result = readText();
+      notifyReadStarted();
+      return result;
+    });
+    if (phase === 'polling') {
+      vi.mocked(fetchWithRetries).mockResolvedValueOnce(
+        Response.json({
+          id: 'fixture-prediction',
+          status: 'processing',
+        }),
+      );
+    }
+    vi.mocked(fetchWithRetries).mockResolvedValueOnce(response);
+    const provider = new ReplicateImageProvider('owner/model', { config: { apiKey: 'fixture' } });
+    const result = withCacheEnabled(false, () =>
+      provider.callApi('Hello', undefined, {
+        abortSignal: abortController.signal,
+      }),
+    ).catch((error) => error);
+    return {
+      abortController,
+      readStarted,
+      result,
+      failBody: (error: Error) => bodyController.error(error),
+    };
+  }
+
+  it.each(['Error', 'TimeoutError'])('normalizes a body-read %s abort', async (name) => {
+    const { abortController, readStarted, result } = startBodyRead();
+    await readStarted;
+    const reason =
+      name === 'Error'
+        ? new Error('fixture body abort')
+        : new DOMException('fixture body timeout', 'TimeoutError');
+    abortController.abort(reason);
+    expect(await result).toMatchObject({ name: 'AbortError', message: reason.message });
+    expect(fetchWithRetries).toHaveBeenCalledTimes(phase === 'creation' ? 1 : 2);
+    expect(
+      vi
+        .mocked(fetchWithRetries)
+        .mock.calls.every(([, options]) => options?.signal === abortController.signal),
+    ).toBe(true);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(fetchWithRetries).toHaveBeenCalledTimes(phase === 'creation' ? 1 : 2);
+  });
+
+  it('preserves ordinary body failures and their cause without cancellation', async () => {
+    const { abortController, readStarted, result, failBody } = startBodyRead();
+    await readStarted;
+    const reason = new Error('fixture broken body');
+    failBody(reason);
+    expect(await result).toMatchObject({
+      name: 'Error',
+      message: expect.stringContaining('Error reading response body'),
+      cause: reason,
+    });
+    expect(abortController.signal.aborted).toBe(false);
+    expect(fetchWithRetries).toHaveBeenCalledTimes(phase === 'creation' ? 1 : 2);
+  });
+});

--- a/test/providers/replicate-cancellation.test.ts
+++ b/test/providers/replicate-cancellation.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache, getCache, isCacheEnabled } from '../../src/cache';
+import { matchesModeration } from '../../src/matchers/moderation';
 import {
   ReplicateImageProvider,
   ReplicateModerationProvider,
   ReplicateProvider,
 } from '../../src/providers/replicate';
+import { withProviderCallExecutionContext } from '../../src/scheduler/providerCallExecutionContext';
 
 vi.mock('../../src/cache', async (importOriginal) => ({
   ...(await importOriginal()),
@@ -15,10 +17,13 @@ vi.mock('../../src/cache', async (importOriginal) => ({
 beforeEach(() => {
   vi.mocked(fetchWithCache).mockReset();
   vi.mocked(getCache).mockReset();
-  vi.mocked(isCacheEnabled).mockReturnValue(false);
+  vi.mocked(isCacheEnabled).mockReset().mockReturnValue(false);
   vi.useFakeTimers();
 });
-afterEach(() => vi.useRealTimers());
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.useRealTimers();
+});
 function reply(status: string, output?: unknown) {
   return {
     data: { id: 'fixture-prediction', status, output },
@@ -35,7 +40,7 @@ describe.each([ReplicateProvider, ReplicateImageProvider])('%s local cancellatio
     const provider = new Provider('owner/model:version', { config: { apiKey: 'fixture' } });
     await expect(
       provider.callApi('Hello', undefined, { abortSignal: controller.signal }),
-    ).rejects.toThrow('fixture abort');
+    ).rejects.toMatchObject({ name: 'AbortError', message: 'fixture abort' });
     expect(fetchWithCache).not.toHaveBeenCalled();
     expect(getCache).not.toHaveBeenCalled();
   });
@@ -75,7 +80,7 @@ describe.each([ReplicateProvider, ReplicateImageProvider])('%s local cancellatio
       .callApi('Hello', undefined, { abortSignal: controller.signal })
       .then(
         (response) => response.error,
-        (error) => String(error),
+        (error) => error,
       );
     await vi.advanceTimersByTimeAsync(0);
     expect(fetchWithCache).toHaveBeenCalledTimes(2);
@@ -83,13 +88,22 @@ describe.each([ReplicateProvider, ReplicateImageProvider])('%s local cancellatio
       expect(request?.signal).toBe(controller.signal);
     }
     controller.abort();
-    expect(await result).toContain('cancelled by user');
+    expect(await result).toMatchObject({ name: 'AbortError' });
     await vi.advanceTimersByTimeAsync(2000);
     expect(fetchWithCache).toHaveBeenCalledTimes(2);
     expect(vi.getTimerCount()).toBe(0);
     expect(
       vi.mocked(fetchWithCache).mock.calls.every(([url]) => !String(url).endsWith('/cancel')),
     ).toBe(true);
+  });
+
+  it('preserves an in-flight transport AbortError', async () => {
+    const error = new Error('transport aborted');
+    error.name = 'AbortError';
+    vi.mocked(fetchWithCache).mockRejectedValue(error);
+    await expect(
+      new Provider('owner/model', { config: { apiKey: 'fixture' } }).callApi('Hello'),
+    ).rejects.toBe(error);
   });
 
   it('finishes an un-aborted prediction using the shared polling path', async () => {
@@ -117,11 +131,80 @@ describe('Replicate moderation cancellation', () => {
   it('forwards cancellation to its prediction call', async () => {
     const controller = new AbortController();
     controller.abort(new Error('fixture abort'));
-    const result = await new ReplicateModerationProvider('owner/model', {
+    const result = new ReplicateModerationProvider('owner/model', {
       config: { apiKey: 'fixture' },
     }).callModerationApi('Hello', 'World', undefined, { abortSignal: controller.signal });
-    expect(result.error).toContain('fixture abort');
+    await expect(result).rejects.toMatchObject({ name: 'AbortError', message: 'fixture abort' });
     expect(fetchWithCache).not.toHaveBeenCalled();
+  });
+
+  it('cancels through the actual two-argument moderation matcher', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue(reply('processing'));
+    const controller = new AbortController();
+    const provider = new ReplicateModerationProvider('owner/model', {
+      config: { apiKey: 'fixture' },
+    });
+    const result = withProviderCallExecutionContext({ abortSignal: controller.signal }, () =>
+      matchesModeration({ userPrompt: 'Hello', assistantResponse: 'World' }, { provider }),
+    ).catch((error) => error);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchWithCache).toHaveBeenCalledTimes(2);
+    controller.abort(new Error('fixture matcher abort'));
+    expect(await result).toMatchObject({ name: 'AbortError', message: 'fixture matcher abort' });
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(fetchWithCache).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(
+      vi
+        .mocked(fetchWithCache)
+        .mock.calls.every(([, request]) => request?.signal === controller.signal),
+    ).toBe(true);
+  });
+
+  it('prefers an explicit signal over the ambient evaluation signal', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue(reply('succeeded', 'safe'));
+    const ambientController = new AbortController();
+    ambientController.abort();
+    const explicitSignal = new AbortController().signal;
+    const provider = new ReplicateModerationProvider('owner/model', {
+      config: { apiKey: 'fixture' },
+    });
+    await expect(
+      withProviderCallExecutionContext({ abortSignal: ambientController.signal }, () =>
+        provider.callModerationApi('Hello', 'World', undefined, { abortSignal: explicitSignal }),
+      ),
+    ).resolves.toMatchObject({ flags: [] });
+    expect(vi.mocked(fetchWithCache).mock.calls[0][1]?.signal).toBe(explicitSignal);
+  });
+
+  it('reports transport failures as API errors rather than malformed moderation', async () => {
+    vi.mocked(fetchWithCache).mockRejectedValue(new Error('fixture transport failure'));
+    const provider = new ReplicateModerationProvider('owner/model', {
+      config: { apiKey: 'fixture' },
+    });
+    await expect(provider.callModerationApi('Hello', 'World')).resolves.toMatchObject({
+      error: 'API call error: Error: fixture transport failure',
+    });
+  });
+
+  it('preserves transport aborts through moderation parsing', async () => {
+    const error = new Error('transport aborted');
+    error.name = 'AbortError';
+    vi.mocked(fetchWithCache).mockRejectedValue(error);
+    const provider = new ReplicateModerationProvider('owner/model', {
+      config: { apiKey: 'fixture' },
+    });
+    await expect(provider.callModerationApi('Hello', 'World')).rejects.toBe(error);
+  });
+
+  it('identifies a rejected prediction call as an API failure', async () => {
+    const provider = new ReplicateModerationProvider('owner/model', {
+      config: { apiKey: 'fixture' },
+    });
+    vi.spyOn(provider, 'callApi').mockRejectedValue(new Error('fixture configuration failure'));
+    await expect(provider.callModerationApi('Hello', 'World')).resolves.toEqual({
+      error: 'API call error: Error: fixture configuration failure',
+    });
   });
 
   it('preserves moderation parsing on a successful signalled call', async () => {

--- a/test/providers/replicate-cancellation.test.ts
+++ b/test/providers/replicate-cancellation.test.ts
@@ -1,12 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache, getCache, isCacheEnabled } from '../../src/cache';
-import { matchesModeration } from '../../src/matchers/moderation';
 import {
   ReplicateImageProvider,
   ReplicateModerationProvider,
   ReplicateProvider,
 } from '../../src/providers/replicate';
-import { withProviderCallExecutionContext } from '../../src/scheduler/providerCallExecutionContext';
 
 vi.mock('../../src/cache', async (importOriginal) => ({
   ...(await importOriginal()),
@@ -138,15 +136,17 @@ describe('Replicate moderation cancellation', () => {
     expect(fetchWithCache).not.toHaveBeenCalled();
   });
 
-  it('cancels through the actual two-argument moderation matcher', async () => {
+  it('cancels moderation polling when call options carry a signal', async () => {
     vi.mocked(fetchWithCache).mockResolvedValue(reply('processing'));
     const controller = new AbortController();
     const provider = new ReplicateModerationProvider('owner/model', {
       config: { apiKey: 'fixture' },
     });
-    const result = withProviderCallExecutionContext({ abortSignal: controller.signal }, () =>
-      matchesModeration({ userPrompt: 'Hello', assistantResponse: 'World' }, { provider }),
-    ).catch((error) => error);
+    const result = provider
+      .callModerationApi('Hello', 'World', undefined, {
+        abortSignal: controller.signal,
+      })
+      .catch((error) => error);
     await vi.advanceTimersByTimeAsync(0);
     expect(fetchWithCache).toHaveBeenCalledTimes(2);
     controller.abort(new Error('fixture matcher abort'));
@@ -161,18 +161,14 @@ describe('Replicate moderation cancellation', () => {
     ).toBe(true);
   });
 
-  it('prefers an explicit signal over the ambient evaluation signal', async () => {
+  it('preserves successful moderation with an explicit signal', async () => {
     vi.mocked(fetchWithCache).mockResolvedValue(reply('succeeded', 'safe'));
-    const ambientController = new AbortController();
-    ambientController.abort();
     const explicitSignal = new AbortController().signal;
     const provider = new ReplicateModerationProvider('owner/model', {
       config: { apiKey: 'fixture' },
     });
     await expect(
-      withProviderCallExecutionContext({ abortSignal: ambientController.signal }, () =>
-        provider.callModerationApi('Hello', 'World', undefined, { abortSignal: explicitSignal }),
-      ),
+      provider.callModerationApi('Hello', 'World', undefined, { abortSignal: explicitSignal }),
     ).resolves.toMatchObject({ flags: [] });
     expect(vi.mocked(fetchWithCache).mock.calls[0][1]?.signal).toBe(explicitSignal);
   });

--- a/test/providers/replicate-cancellation.test.ts
+++ b/test/providers/replicate-cancellation.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache, getCache, isCacheEnabled } from '../../src/cache';
+import {
+  ReplicateImageProvider,
+  ReplicateModerationProvider,
+  ReplicateProvider,
+} from '../../src/providers/replicate';
+
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+  getCache: vi.fn(),
+  isCacheEnabled: vi.fn(),
+}));
+beforeEach(() => {
+  vi.mocked(fetchWithCache).mockReset();
+  vi.mocked(getCache).mockReset();
+  vi.mocked(isCacheEnabled).mockReturnValue(false);
+  vi.useFakeTimers();
+});
+afterEach(() => vi.useRealTimers());
+function reply(status: string, output?: unknown) {
+  return {
+    data: { id: 'fixture-prediction', status, output },
+    status: 200,
+    statusText: 'OK',
+    cached: false,
+  };
+}
+
+describe.each([ReplicateProvider, ReplicateImageProvider])('%s local cancellation', (Provider) => {
+  it('rejects an already-aborted call before cache or network access', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('fixture abort'));
+    const provider = new Provider('owner/model:version', { config: { apiKey: 'fixture' } });
+    await expect(
+      provider.callApi('Hello', undefined, { abortSignal: controller.signal }),
+    ).rejects.toThrow('fixture abort');
+    expect(fetchWithCache).not.toHaveBeenCalled();
+    expect(getCache).not.toHaveBeenCalled();
+  });
+
+  it.each(['owner/model', 'owner/model:version'])(
+    'forwards signal while preserving %s creation and output',
+    async (model) => {
+      vi.mocked(fetchWithCache).mockResolvedValue(
+        reply('succeeded', 'https://example.invalid/fixture.png'),
+      );
+      const signal = new AbortController().signal;
+      const response = await new Provider(model, { config: { apiKey: 'fixture' } }).callApi(
+        'Hello',
+        undefined,
+        { abortSignal: signal },
+      );
+      expect(response.output).toContain('https://example.invalid/fixture.png');
+      expect(fetchWithCache).toHaveBeenCalledWith(
+        model.includes(':')
+          ? 'https://api.replicate.com/v1/predictions'
+          : 'https://api.replicate.com/v1/models/owner/model/predictions',
+        expect.objectContaining({
+          method: 'POST',
+          signal,
+          headers: expect.objectContaining({ Prefer: 'wait=60' }),
+        }),
+        expect.any(Number),
+        'json',
+      );
+    },
+  );
+
+  it('stops during the polling delay without cancelling a remote prediction', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue(reply('processing'));
+    const controller = new AbortController();
+    const result = new Provider('owner/model', { config: { apiKey: 'fixture' } })
+      .callApi('Hello', undefined, { abortSignal: controller.signal })
+      .then(
+        (response) => response.error,
+        (error) => String(error),
+      );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchWithCache).toHaveBeenCalledTimes(2);
+    for (const [, request] of vi.mocked(fetchWithCache).mock.calls) {
+      expect(request?.signal).toBe(controller.signal);
+    }
+    controller.abort();
+    expect(await result).toContain('cancelled by user');
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(fetchWithCache).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(
+      vi.mocked(fetchWithCache).mock.calls.every(([url]) => !String(url).endsWith('/cancel')),
+    ).toBe(true);
+  });
+
+  it('finishes an un-aborted prediction using the shared polling path', async () => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce(reply('processing'))
+      .mockResolvedValueOnce(reply('succeeded', 'https://example.invalid/fixture.png'));
+    const signal = new AbortController().signal;
+    const response = await new Provider('owner/model', { config: { apiKey: 'fixture' } }).callApi(
+      'Hello',
+      undefined,
+      { abortSignal: signal },
+    );
+    expect(response.output).toContain('https://example.invalid/fixture.png');
+    expect(fetchWithCache).toHaveBeenLastCalledWith(
+      'https://api.replicate.com/v1/predictions/fixture-prediction',
+      expect.objectContaining({ method: 'GET', signal }),
+      expect.any(Number),
+      'json',
+      true,
+    );
+  });
+});
+
+describe('Replicate moderation cancellation', () => {
+  it('forwards cancellation to its prediction call', async () => {
+    const controller = new AbortController();
+    controller.abort(new Error('fixture abort'));
+    const result = await new ReplicateModerationProvider('owner/model', {
+      config: { apiKey: 'fixture' },
+    }).callModerationApi('Hello', 'World', undefined, { abortSignal: controller.signal });
+    expect(result.error).toContain('fixture abort');
+    expect(fetchWithCache).not.toHaveBeenCalled();
+  });
+
+  it('preserves moderation parsing on a successful signalled call', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue(reply('succeeded', 'unsafe\nS1,S2'));
+    const signal = new AbortController().signal;
+    const result = await new ReplicateModerationProvider('owner/model', {
+      config: { apiKey: 'fixture' },
+    }).callModerationApi('Hello', 'World', undefined, { abortSignal: signal });
+    expect(result.flags?.map((flag) => flag.code)).toEqual(['S1', 'S2']);
+    expect(vi.mocked(fetchWithCache).mock.calls[0][1]?.signal).toBe(signal);
+  });
+});


### PR DESCRIPTION
Replicate continued polling after an evaluation timed out or was cancelled. Pass the caller's abort signal to prediction creation and polling, interrupt polling delays, and preserve AbortError through text/image calls. Image cancellation during response-body reads also retains AbortError when the abort reason is a custom Error or TimeoutError; ordinary body failures keep their original cause.

The moderation adapter forwards optional context/options supplied by its caller. Evaluator-driven moderation cancellation depends on the matcher/interface forwarding in #10685; this main-based PR does not independently supply that shared propagation. A detached combination with #10685 at 85eb51d verifies the actual moderation matcher and evaluator path.

This stops local requests and waits. Remote predictions can continue running. Existing cache isolation keeps independently cancellable calls from sharing an in-flight fetch: identical concurrent rows with different signals can create separate predictions and incur separate charges. Persisted cache identity and replay remain unchanged.

Validation: 73 focused main-based tests; full CI lint, formatting and architecture checks; package/UI build; four main-based CLI success/timeout cases. The exact #10685 combination passes 19 matcher/provider fixture tests and six built CLI cases, including moderation. Timeout fixtures confirm one creation plus one poll, aborted signals, and no remote cancel request or spurious failure log. All network traffic is mocked.
