### PR TITLE
fix(claude-agent-sdk): recognize documented model selectors

### DIFF
--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -322,14 +322,19 @@ function deriveSkillCalls(toolCalls: ToolCallEntry[]): SkillCallEntry[] {
 export const FS_READONLY_ALLOWED_TOOLS = ['Read', 'Grep', 'Glob', 'LS'].sort(); // sort and export for tests
 
 // Claude Agent SDK supports these model aliases in addition to full model names
-// See: https://docs.anthropic.com/en/docs/claude-agent-sdk/model-config
+// See: https://code.claude.com/docs/en/model-config
 export const CLAUDE_CODE_MODEL_ALIASES = [
   'default',
+  'best',
+  'fable',
+  'fable[1m]',
   'sonnet',
   'opus',
   'haiku',
   'sonnet[1m]',
+  'opus[1m]',
   'opusplan',
+  'opusplan[1m]',
 ];
 
 /**

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -403,6 +403,19 @@ describe('ClaudeCodeSDKProvider', () => {
       warnSpy.mockRestore();
     });
 
+    it.each(['best', 'fable', 'fable[1m]', 'opus[1m]', 'opusplan[1m]'])(
+      'recognizes the documented Claude Code %s model selector',
+      (model) => {
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(function () {});
+
+        new ClaudeCodeSDKProvider({ config: { model } });
+        new ClaudeCodeSDKProvider({ config: { fallback_model: `sonnet,${model}` } });
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        warnSpy.mockRestore();
+      },
+    );
+
     it('should not warn about known Anthropic models', () => {
       const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(function () {});
 


### PR DESCRIPTION
The Claude Agent SDK provider warns that several documented model selectors are unknown. Recognize `best`, `fable`, `fable[1m]`, `opus[1m]`, and `opusplan[1m]` for both the primary model and comma-separated fallback models, using the current [Claude Code model configuration documentation](https://code.claude.com/docs/en/model-config).

This updates advisory diagnostics. Model selection remains delegated to the SDK, including provider/account-specific alias resolution and defaults. Unknown selectors continue to warn.

Validation: 305 mocked provider tests and the package/UI build pass. Five built-CLI evals with a mocked SDK pass with score 1; all aliases and fallback chains reach the SDK unchanged, without unknown-model warnings.
