### PR TITLE
fix(providers): preserve service connection settings

### DIFF
--- a/src/providers/cerebras.ts
+++ b/src/providers/cerebras.ts
@@ -27,6 +27,10 @@ export function createCerebrasProvider(
 
   // Create a custom provider class that overrides the getOpenAiBody method
   class CerebrasProvider extends OpenAiChatCompletionProvider {
+    override getOrganization(): string | undefined {
+      return this.config.organization;
+    }
+
     async getOpenAiBody(prompt: string, context?: any, callApiOptions?: any) {
       // Get the body from the parent method
       const { body, config } = await super.getOpenAiBody(prompt, context, callApiOptions);

--- a/src/providers/cometapi.ts
+++ b/src/providers/cometapi.ts
@@ -81,7 +81,7 @@ export class CometApiImageProvider extends OpenAiImageProvider {
     if (this.config?.apiKey) {
       return this.config.apiKey;
     }
-    return getEnvString('COMETAPI_KEY');
+    return this.env?.COMETAPI_KEY || getEnvString('COMETAPI_KEY');
   }
 
   getApiUrlDefault(): string {

--- a/src/providers/groq/chat.ts
+++ b/src/providers/groq/chat.ts
@@ -1,3 +1,4 @@
+import { getEnvString } from '../../envars';
 import { OpenAiChatCompletionProvider } from '../openai/chat';
 import { groqSupportsTemperature, isGroqReasoningModel } from './util';
 
@@ -20,6 +21,11 @@ const GROQ_API_BASE_URL = 'https://api.groq.com/openai/v1';
 export class GroqProvider extends OpenAiChatCompletionProvider {
   protected get apiKey(): string | undefined {
     return this.config?.apiKey;
+  }
+
+  override getApiKey(): string | undefined {
+    const apiKeyEnvar = this.config.apiKeyEnvar || 'GROQ_API_KEY';
+    return this.config.apiKey || getEnvString(apiKeyEnvar) || this.env?.[apiKeyEnvar];
   }
 
   protected isReasoningModel(): boolean {

--- a/src/providers/groq/chat.ts
+++ b/src/providers/groq/chat.ts
@@ -39,8 +39,8 @@ export class GroqProvider extends OpenAiChatCompletionProvider {
       ...providerOptions,
       config: {
         ...providerOptions.config,
-        apiKeyEnvar: providerOptions.config?.apiKeyEnvar ?? 'GROQ_API_KEY',
-        apiBaseUrl: providerOptions.config?.apiBaseUrl ?? GROQ_API_BASE_URL,
+        apiKeyEnvar: providerOptions.config?.apiKeyEnvar || 'GROQ_API_KEY',
+        apiBaseUrl: providerOptions.config?.apiBaseUrl || GROQ_API_BASE_URL,
       },
     });
   }

--- a/src/providers/groq/chat.ts
+++ b/src/providers/groq/chat.ts
@@ -39,8 +39,8 @@ export class GroqProvider extends OpenAiChatCompletionProvider {
       ...providerOptions,
       config: {
         ...providerOptions.config,
-        apiKeyEnvar: 'GROQ_API_KEY',
-        apiBaseUrl: GROQ_API_BASE_URL,
+        apiKeyEnvar: providerOptions.config?.apiKeyEnvar ?? 'GROQ_API_KEY',
+        apiBaseUrl: providerOptions.config?.apiBaseUrl ?? GROQ_API_BASE_URL,
       },
     });
   }

--- a/src/providers/groq/responses.ts
+++ b/src/providers/groq/responses.ts
@@ -42,8 +42,8 @@ export class GroqResponsesProvider extends OpenAiResponsesProvider {
       ...providerOptions,
       config: {
         ...providerOptions.config,
-        apiKeyEnvar: providerOptions.config?.apiKeyEnvar ?? 'GROQ_API_KEY',
-        apiBaseUrl: providerOptions.config?.apiBaseUrl ?? GROQ_API_BASE_URL,
+        apiKeyEnvar: providerOptions.config?.apiKeyEnvar || 'GROQ_API_KEY',
+        apiBaseUrl: providerOptions.config?.apiBaseUrl || GROQ_API_BASE_URL,
       },
     });
   }

--- a/src/providers/groq/responses.ts
+++ b/src/providers/groq/responses.ts
@@ -42,8 +42,8 @@ export class GroqResponsesProvider extends OpenAiResponsesProvider {
       ...providerOptions,
       config: {
         ...providerOptions.config,
-        apiKeyEnvar: 'GROQ_API_KEY',
-        apiBaseUrl: GROQ_API_BASE_URL,
+        apiKeyEnvar: providerOptions.config?.apiKeyEnvar ?? 'GROQ_API_KEY',
+        apiBaseUrl: providerOptions.config?.apiBaseUrl ?? GROQ_API_BASE_URL,
       },
     });
   }

--- a/src/providers/groq/responses.ts
+++ b/src/providers/groq/responses.ts
@@ -1,3 +1,4 @@
+import { getEnvString } from '../../envars';
 import { OpenAiResponsesProvider } from '../openai/responses';
 import { groqSupportsTemperature, isGroqReasoningModel } from './util';
 
@@ -23,6 +24,11 @@ const GROQ_API_BASE_URL = 'https://api.groq.com/openai/v1';
 export class GroqResponsesProvider extends OpenAiResponsesProvider {
   protected get apiKey(): string | undefined {
     return this.config?.apiKey;
+  }
+
+  override getApiKey(): string | undefined {
+    const apiKeyEnvar = this.config.apiKeyEnvar || 'GROQ_API_KEY';
+    return this.config.apiKey || getEnvString(apiKeyEnvar) || this.env?.[apiKeyEnvar];
   }
 
   protected isReasoningModel(): boolean {

--- a/src/providers/helicone.ts
+++ b/src/providers/helicone.ts
@@ -45,12 +45,6 @@ export class HeliconeGatewayProvider extends OpenAiChatCompletionProvider {
     const openAiConfig: OpenAiCompletionOptions = {
       ...config,
       apiBaseUrl,
-      // Use placeholder API key since Helicone Gateway handles authentication
-      apiKey:
-        config.apiKey ||
-        options.env?.HELICONE_API_KEY ||
-        getEnvString('HELICONE_API_KEY') ||
-        'placeholder-api-key',
     };
 
     // Call parent constructor with the model and modified config
@@ -61,6 +55,15 @@ export class HeliconeGatewayProvider extends OpenAiChatCompletionProvider {
 
     // Store the original Helicone config after super() call
     this.heliconeConfig = config;
+  }
+
+  getApiKey(): string | undefined {
+    return (
+      this.config.apiKey ||
+      this.env?.HELICONE_API_KEY ||
+      getEnvString('HELICONE_API_KEY') ||
+      'placeholder-api-key'
+    );
   }
 
   id(): string {

--- a/src/providers/helicone.ts
+++ b/src/providers/helicone.ts
@@ -46,7 +46,11 @@ export class HeliconeGatewayProvider extends OpenAiChatCompletionProvider {
       ...config,
       apiBaseUrl,
       // Use placeholder API key since Helicone Gateway handles authentication
-      apiKey: config.apiKey || getEnvString('HELICONE_API_KEY') || 'placeholder-api-key',
+      apiKey:
+        config.apiKey ||
+        options.env?.HELICONE_API_KEY ||
+        getEnvString('HELICONE_API_KEY') ||
+        'placeholder-api-key',
     };
 
     // Call parent constructor with the model and modified config

--- a/src/providers/nscale.ts
+++ b/src/providers/nscale.ts
@@ -105,7 +105,7 @@ export function createNscaleProvider(
     return new OpenAiEmbeddingProvider(modelName, nscaleConfig);
   } else if (splits[1] === 'image') {
     return createNscaleImageProvider(providerPath, {
-      config: options.config as any, // Allow flexible config type for Nscale image options
+      config,
       id: options.id,
       env: options.env,
     });

--- a/src/providers/nscale/image.ts
+++ b/src/providers/nscale/image.ts
@@ -57,7 +57,6 @@ export class NscaleImageProvider extends OpenAiImageProvider {
       config: {
         ...nscaleConfig,
         apiBaseUrl: nscaleConfig.apiBaseUrl || 'https://inference.api.nscale.com/v1',
-        apiKey: NscaleImageProvider.getApiKey(options),
       } as OpenAiImageProvider['config'],
     });
   }
@@ -90,7 +89,7 @@ export class NscaleImageProvider extends OpenAiImageProvider {
    * @returns The API key or service token, or undefined if not found
    */
   getApiKey(): string | undefined {
-    return this.config?.apiKey || NscaleImageProvider.getApiKey({ config: this.config });
+    return NscaleImageProvider.getApiKey({ config: this.config, env: this.env });
   }
 
   /**

--- a/src/providers/nscale/image.ts
+++ b/src/providers/nscale/image.ts
@@ -38,7 +38,7 @@ type NscaleImageOptions = OpenAiSharedOptions & {
  * Defaults to base64 JSON response format for compatibility with Nscale API.
  */
 export class NscaleImageProvider extends OpenAiImageProvider {
-  config: NscaleImageOptions & any;
+  declare config: NscaleImageOptions & any;
 
   /**
    * Create a new Nscale image provider instance.
@@ -55,11 +55,10 @@ export class NscaleImageProvider extends OpenAiImageProvider {
       ...options,
       config: {
         ...nscaleConfig,
-        apiBaseUrl: 'https://inference.api.nscale.com/v1',
+        apiBaseUrl: nscaleConfig.apiBaseUrl || 'https://inference.api.nscale.com/v1',
         apiKey: NscaleImageProvider.getApiKey(options),
       } as any, // Use type assertion since Nscale supports OpenAI-compatible parameters
     });
-    this.config = nscaleConfig;
   }
 
   /**

--- a/src/providers/nscale/image.ts
+++ b/src/providers/nscale/image.ts
@@ -2,6 +2,7 @@ import { getEnvString } from '../../envars';
 import logger from '../../logger';
 import invariant from '../../util/invariant';
 import { callOpenAiImageApi, formatOutput, OpenAiImageProvider } from '../openai/image';
+import { appendOpenAiApiPath } from '../openai/util';
 import { getRequestTimeoutMs } from '../shared';
 
 import type { EnvOverrides } from '../../types/env';
@@ -38,7 +39,7 @@ type NscaleImageOptions = OpenAiSharedOptions & {
  * Defaults to base64 JSON response format for compatibility with Nscale API.
  */
 export class NscaleImageProvider extends OpenAiImageProvider {
-  declare config: NscaleImageOptions & any;
+  declare config: OpenAiImageProvider['config'] & NscaleImageOptions & { size?: any };
 
   /**
    * Create a new Nscale image provider instance.
@@ -57,7 +58,7 @@ export class NscaleImageProvider extends OpenAiImageProvider {
         ...nscaleConfig,
         apiBaseUrl: nscaleConfig.apiBaseUrl || 'https://inference.api.nscale.com/v1',
         apiKey: NscaleImageProvider.getApiKey(options),
-      } as any, // Use type assertion since Nscale supports OpenAI-compatible parameters
+      } as OpenAiImageProvider['config'],
     });
   }
 
@@ -187,7 +188,7 @@ export class NscaleImageProvider extends OpenAiImageProvider {
     let cached = false;
     try {
       ({ data, cached, status, statusText } = await callOpenAiImageApi(
-        `${this.getApiUrl()}${endpoint}`,
+        appendOpenAiApiPath(this.getApiUrl(), endpoint),
         body,
         headers,
         getRequestTimeoutMs(),

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1295,16 +1295,9 @@ export const providerMap: ProviderFactory[] = [
   },
   {
     test: (providerPath: string) => providerPath.startsWith('cometapi:'),
-    create: async (
-      providerPath: string,
-      providerOptions: ProviderOptions,
-      context: LoadApiProviderContext,
-    ) => {
+    create: async (providerPath: string, providerOptions: ProviderOptions) => {
       const { createCometApiProvider } = await import('./cometapi');
-      return createCometApiProvider(providerPath, {
-        ...providerOptions,
-        env: context.env,
-      });
+      return createCometApiProvider(providerPath, providerOptions);
     },
   },
   {

--- a/test/providers/groq/connection-config.test.ts
+++ b/test/providers/groq/connection-config.test.ts
@@ -103,17 +103,18 @@ describe.each([
     expect(request().headers).toHaveProperty('Authorization', 'Bearer scoped-key');
   });
 
-  it.each([{}, { apiBaseUrl: undefined, apiKeyEnvar: undefined }])(
-    'keeps Groq defaults when settings are absent: %j',
-    async (config) => {
-      reply(responses);
-      await new Provider('private/model', { config }).callApi('Hello');
-      expect(request()).toMatchObject({
-        url: `https://api.groq.com/openai/v1${path}`,
-        headers: { Authorization: 'Bearer groq-process-key' },
-      });
-    },
-  );
+  it.each([
+    {},
+    { apiBaseUrl: undefined, apiKeyEnvar: undefined },
+    { apiBaseUrl: '', apiKeyEnvar: '' },
+  ])('keeps Groq defaults when settings are absent or empty: %j', async (config) => {
+    reply(responses);
+    await new Provider('private/model', { config }).callApi('Hello');
+    expect(request()).toMatchObject({
+      url: `https://api.groq.com/openai/v1${path}`,
+      headers: { Authorization: 'Bearer groq-process-key' },
+    });
+  });
 
   it('keeps explicit apiHost precedence', async () => {
     reply(responses);

--- a/test/providers/groq/connection-config.test.ts
+++ b/test/providers/groq/connection-config.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../../src/cache';
+import { GroqProvider, GroqResponsesProvider } from '../../../src/providers/groq/index';
+import { mockProcessEnv } from '../../util/utils';
+
+vi.mock('../../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+}));
+
+let restoreEnv: () => void;
+beforeEach(() => {
+  vi.mocked(fetchWithCache).mockReset();
+  restoreEnv = mockProcessEnv({
+    GROQ_API_KEY: 'groq-process-key',
+    GROQ_PROXY_KEY: 'proxy-process-key',
+    GROQ_SCOPED_KEY: undefined,
+    GROQ_MISSING_KEY: undefined,
+    OPENAI_API_KEY: 'unrelated-openai-key',
+    OPENAI_API_BASE_URL: 'https://unrelated.invalid/v1',
+    OPENAI_API_HOST: 'unrelated.invalid',
+  });
+});
+afterEach(() => {
+  restoreEnv();
+  vi.resetAllMocks();
+});
+
+function reply(responses: boolean, status = 200) {
+  const data =
+    status === 200
+      ? responses
+        ? {
+            id: 'fixture-response',
+            output: [
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Hello' }],
+              },
+            ],
+            usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+          }
+        : {
+            choices: [{ message: { content: 'Hello' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+          }
+      : { error: { message: 'Fixture unavailable' } };
+  vi.mocked(fetchWithCache).mockResolvedValue({
+    data,
+    cached: false,
+    status,
+    statusText: status === 200 ? 'OK' : 'Service Unavailable',
+    headers: {},
+  });
+}
+
+function request() {
+  const [url, options] = vi.mocked(fetchWithCache).mock.calls[0];
+  if (!options) {
+    throw new Error('Expected a provider request');
+  }
+  return { url, headers: options.headers, body: JSON.parse(options.body as string) };
+}
+
+describe.each([
+  { name: 'Chat', Provider: GroqProvider, responses: false, path: '/chat/completions' },
+  { name: 'Responses', Provider: GroqResponsesProvider, responses: true, path: '/responses' },
+])('Groq $name connection configuration', ({ Provider, responses, path }) => {
+  it.each([undefined, 'explicit-key'])(
+    'honors the custom endpoint and key variable with key %s',
+    async (apiKey) => {
+      reply(responses);
+      const provider = new Provider('private/model:version', {
+        id: 'custom-provider-id',
+        config: {
+          apiBaseUrl: 'http://127.0.0.1:9000/groq',
+          apiKeyEnvar: 'GROQ_PROXY_KEY',
+          apiKey,
+        },
+      });
+      expect(await provider.callApi('Hello')).toMatchObject({
+        output: 'Hello',
+        tokenUsage: { prompt: 5, completion: 2, total: 7 },
+      });
+      expect(provider.id()).toBe('custom-provider-id');
+      expect(request()).toMatchObject({
+        url: `http://127.0.0.1:9000/groq${path}`,
+        headers: { Authorization: `Bearer ${apiKey ?? 'proxy-process-key'}` },
+        body: { model: 'private/model:version' },
+      });
+      expect(request().body).not.toHaveProperty('apiBaseUrl');
+      expect(request().body).not.toHaveProperty('apiKeyEnvar');
+    },
+  );
+
+  it('resolves a configured key variable from provider-scoped environment', async () => {
+    reply(responses);
+    await new Provider('private/model', {
+      config: { apiKeyEnvar: 'GROQ_SCOPED_KEY' },
+      env: { GROQ_SCOPED_KEY: 'scoped-key' },
+    }).callApi('Hello');
+    expect(request().headers).toHaveProperty('Authorization', 'Bearer scoped-key');
+  });
+
+  it.each([{}, { apiBaseUrl: undefined, apiKeyEnvar: undefined }])(
+    'keeps Groq defaults when settings are absent: %j',
+    async (config) => {
+      reply(responses);
+      await new Provider('private/model', { config }).callApi('Hello');
+      expect(request()).toMatchObject({
+        url: `https://api.groq.com/openai/v1${path}`,
+        headers: { Authorization: 'Bearer groq-process-key' },
+      });
+    },
+  );
+
+  it('keeps explicit apiHost precedence', async () => {
+    reply(responses);
+    await new Provider('private/model', {
+      config: { apiHost: 'proxy.invalid', apiBaseUrl: 'https://secondary.invalid/v1' },
+    }).callApi('Hello');
+    expect(request().url).toBe(`https://proxy.invalid/v1${path}`);
+  });
+
+  it('reports the configured key variable when credentials are missing', async () => {
+    const restoreOpenAiKey = mockProcessEnv({ OPENAI_API_KEY: undefined });
+    try {
+      await expect(
+        new Provider('private/model', {
+          config: { apiKeyEnvar: 'GROQ_MISSING_KEY' },
+        }).callApi('Hello'),
+      ).rejects.toThrow('Set the GROQ_MISSING_KEY environment variable');
+      expect(fetchWithCache).not.toHaveBeenCalled();
+    } finally {
+      restoreOpenAiKey();
+    }
+  });
+
+  it.each([400, 429, 503])(
+    'preserves upstream status %s at the configured endpoint',
+    async (status) => {
+      reply(responses, status);
+      const result = await new Provider('private/model', {
+        config: { apiBaseUrl: 'http://127.0.0.1:9000/groq', apiKeyEnvar: 'GROQ_PROXY_KEY' },
+      }).callApi('Hello');
+      expect(result.error).toContain('Fixture unavailable');
+      expect(request().url).toBe(`http://127.0.0.1:9000/groq${path}`);
+    },
+  );
+});

--- a/test/providers/groq/connection-config.test.ts
+++ b/test/providers/groq/connection-config.test.ts
@@ -128,13 +128,9 @@ describe.each([
     });
   });
 
-  it.each([
-    {},
-    { apiBaseUrl: undefined, apiKeyEnvar: undefined },
-    { apiBaseUrl: '', apiKeyEnvar: '' },
-  ])('keeps Groq defaults when settings are absent or empty: %j', async (config) => {
+  it('keeps Groq defaults when settings are absent', async () => {
     reply(responses);
-    await new Provider('private/model', { config }).callApi('Hello');
+    await new Provider('private/model', { config: {} }).callApi('Hello');
     expect(request()).toMatchObject({
       url: `https://api.groq.com/openai/v1${path}`,
       headers: { Authorization: 'Bearer groq-process-key' },
@@ -168,18 +164,6 @@ describe.each([
       } finally {
         restoreGroqKey();
       }
-    },
-  );
-
-  it.each([400, 429, 503])(
-    'preserves upstream status %s at the configured endpoint',
-    async (status) => {
-      reply(responses, status);
-      const result = await new Provider('private/model', {
-        config: { apiBaseUrl: 'http://127.0.0.1:9000/groq', apiKeyEnvar: 'GROQ_PROXY_KEY' },
-      }).callApi('Hello');
-      expect(result.error).toContain('Fixture unavailable');
-      expect(request().url).toBe(`http://127.0.0.1:9000/groq${path}`);
     },
   );
 });

--- a/test/providers/groq/connection-config.test.ts
+++ b/test/providers/groq/connection-config.test.ts
@@ -103,6 +103,31 @@ describe.each([
     expect(request().headers).toHaveProperty('Authorization', 'Bearer scoped-key');
   });
 
+  it('preserves process precedence for the selected key variable', async () => {
+    reply(responses);
+    await new Provider('private/model', {
+      config: { apiKeyEnvar: 'GROQ_PROXY_KEY' },
+      env: { GROQ_PROXY_KEY: 'scoped-key', OPENAI_API_KEY: 'unrelated-scoped-openai-key' },
+    }).callApi('Hello');
+    expect(request().headers).toHaveProperty('Authorization', 'Bearer proxy-process-key');
+  });
+
+  it('uses an explicit key when the selected environment variable is absent', async () => {
+    reply(responses);
+    await new Provider('private/model', {
+      config: {
+        apiBaseUrl: 'http://127.0.0.1:9000/groq',
+        apiKeyEnvar: 'GROQ_MISSING_KEY',
+        apiKey: 'explicit-key',
+      },
+      env: { OPENAI_API_KEY: 'unrelated-scoped-openai-key' },
+    }).callApi('Hello');
+    expect(request()).toMatchObject({
+      url: `http://127.0.0.1:9000/groq${path}`,
+      headers: { Authorization: 'Bearer explicit-key' },
+    });
+  });
+
   it.each([
     {},
     { apiBaseUrl: undefined, apiKeyEnvar: undefined },
@@ -124,19 +149,27 @@ describe.each([
     expect(request().url).toBe(`https://proxy.invalid/v1${path}`);
   });
 
-  it('reports the configured key variable when credentials are missing', async () => {
-    const restoreOpenAiKey = mockProcessEnv({ OPENAI_API_KEY: undefined });
-    try {
-      await expect(
-        new Provider('private/model', {
-          config: { apiKeyEnvar: 'GROQ_MISSING_KEY' },
-        }).callApi('Hello'),
-      ).rejects.toThrow('Set the GROQ_MISSING_KEY environment variable');
-      expect(fetchWithCache).not.toHaveBeenCalled();
-    } finally {
-      restoreOpenAiKey();
-    }
-  });
+  it.each([undefined, 'GROQ_MISSING_KEY'])(
+    'rejects missing key %s without sending unrelated OpenAI credentials',
+    async (apiKeyEnvar) => {
+      const restoreGroqKey = mockProcessEnv({
+        GROQ_API_KEY: apiKeyEnvar ? 'unselected-groq-key' : undefined,
+      });
+      try {
+        const provider = new Provider('private/model', {
+          config: { apiBaseUrl: 'http://127.0.0.1:9000/groq', apiKeyEnvar },
+          env: { OPENAI_API_KEY: 'unrelated-scoped-openai-key' },
+        });
+        expect(provider.getApiKey()).toBeUndefined();
+        await expect(provider.callApi('Hello')).rejects.toThrow(
+          `Set the ${apiKeyEnvar ?? 'GROQ_API_KEY'} environment variable`,
+        );
+        expect(fetchWithCache).not.toHaveBeenCalled();
+      } finally {
+        restoreGroqKey();
+      }
+    },
+  );
 
   it.each([400, 429, 503])(
     'preserves upstream status %s at the configured endpoint',

--- a/test/providers/helicone.test.ts
+++ b/test/providers/helicone.test.ts
@@ -10,6 +10,20 @@ describe('HeliconeGatewayProvider', () => {
       expect(provider.modelName).toBe('openai/gpt-4o');
     });
 
+    it('uses scoped credentials without storing them in serializable config', () => {
+      const provider = new HeliconeGatewayProvider('openai/gpt-4o', {
+        env: { HELICONE_API_KEY: 'scoped-helicone-secret' },
+      });
+      expect(JSON.stringify(provider.config)).not.toContain('scoped-helicone-secret');
+      expect(provider.getApiKey()).toBe('scoped-helicone-secret');
+      expect(
+        new HeliconeGatewayProvider('openai/gpt-4o', {
+          config: { apiKey: 'explicit-key' },
+          env: { HELICONE_API_KEY: 'scoped-helicone-secret' },
+        }).getApiKey(),
+      ).toBe('explicit-key');
+    });
+
     it('should use model from config when provided', () => {
       const provider = new HeliconeGatewayProvider('default-model', {
         config: {

--- a/test/providers/inherited-auth-config.test.ts
+++ b/test/providers/inherited-auth-config.test.ts
@@ -3,6 +3,7 @@ import { fetchWithCache } from '../../src/cache';
 import { createCerebrasProvider } from '../../src/providers/cerebras';
 import { CometApiImageProvider } from '../../src/providers/cometapi';
 import { HeliconeGatewayProvider } from '../../src/providers/helicone';
+import { createNscaleProvider } from '../../src/providers/nscale';
 import { NscaleImageProvider } from '../../src/providers/nscale/image';
 import { mockProcessEnv } from '../util/utils';
 
@@ -88,19 +89,24 @@ describe('Cerebras organization isolation', () => {
 });
 
 describe('Nscale image resolved configuration', () => {
-  it.each([undefined, 'explicit-key'])(
-    'preserves scoped credentials and explicit key %s',
-    async (apiKey) => {
+  it.each([
+    [undefined, 'http://127.0.0.1:9000/v1/'],
+    ['explicit-key', 'http://127.0.0.1:9000/v1'],
+  ] as const)(
+    'preserves scoped credentials, key %s and base URL %s',
+    async (apiKey, apiBaseUrl) => {
       reply(imageReply);
-      const provider = new NscaleImageProvider('private/image:model', {
+      const provider = createNscaleProvider('nscale:image:private/image:model', {
         id: 'nscale-fixture',
         env: { NSCALE_SERVICE_TOKEN: 'scoped-nscale' },
         config: {
-          apiKey,
-          apiBaseUrl: 'http://127.0.0.1:9000/v1',
-          size: '512x512',
-          response_format: 'url',
-          headers: { 'X-Fixture': 'yes' },
+          config: {
+            apiKey,
+            apiBaseUrl,
+            size: '512x512',
+            response_format: 'url',
+            headers: { 'X-Fixture': 'yes' },
+          },
         },
       });
       const result = await provider.callApi('A blue square');

--- a/test/providers/inherited-auth-config.test.ts
+++ b/test/providers/inherited-auth-config.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../src/cache';
+import { createCerebrasProvider } from '../../src/providers/cerebras';
+import { CometApiImageProvider } from '../../src/providers/cometapi';
+import { HeliconeGatewayProvider } from '../../src/providers/helicone';
+import { NscaleImageProvider } from '../../src/providers/nscale/image';
+import { mockProcessEnv } from '../util/utils';
+
+import type { OpenAiChatCompletionProvider } from '../../src/providers/openai/chat';
+
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+}));
+
+let restoreEnv: () => void;
+beforeEach(() => {
+  vi.mocked(fetchWithCache).mockReset();
+  restoreEnv = mockProcessEnv({
+    CEREBRAS_API_KEY: 'cerebras-fixture',
+    NSCALE_SERVICE_TOKEN: 'process-nscale',
+    NSCALE_API_KEY: 'legacy-nscale',
+    COMETAPI_KEY: 'process-comet',
+    HELICONE_API_KEY: 'process-helicone',
+    OPENAI_API_KEY: 'unrelated-openai',
+    OPENAI_ORGANIZATION: 'unrelated-org',
+    OPENAI_API_BASE_URL: 'https://unrelated.invalid/v1',
+  });
+});
+afterEach(() => restoreEnv());
+
+function reply(data: unknown, cached = false, status = 200) {
+  vi.mocked(fetchWithCache).mockResolvedValue({
+    data,
+    cached,
+    status,
+    statusText: status === 200 ? 'OK' : 'Bad Request',
+    headers: {},
+  });
+}
+
+const chatReply = {
+  choices: [{ message: { content: 'Hello' }, finish_reason: 'stop' }],
+  usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+};
+const imageReply = { data: [{ url: 'https://example.invalid/fixture.png' }] };
+
+function firstRequest() {
+  const [url, request] = vi.mocked(fetchWithCache).mock.calls[0];
+  if (!request) {
+    throw new Error('Expected a provider request');
+  }
+  return { url, headers: request.headers, body: JSON.parse(request.body as string) };
+}
+
+describe('Cerebras organization isolation', () => {
+  it('excludes scoped and process OpenAI organization defaults from requests', async () => {
+    reply(chatReply);
+    const provider = createCerebrasProvider('cerebras:custom:model', {
+      id: 'cerebras-fixture',
+      env: { OPENAI_ORGANIZATION: 'scoped-unrelated-org' },
+    });
+    const result = await provider.callApi('Hello');
+    expect(provider.id()).toBe('cerebras-fixture');
+    expect(result).toMatchObject({
+      output: 'Hello',
+      tokenUsage: { prompt: 5, completion: 2, total: 7 },
+    });
+    expect(firstRequest().headers).not.toHaveProperty('OpenAI-Organization');
+    expect(firstRequest().body.model).toBe('custom:model');
+  });
+
+  it('keeps explicit request header overrides', () => {
+    const provider = createCerebrasProvider(
+      'cerebras:custom:model',
+    ) as OpenAiChatCompletionProvider;
+    expect(provider.getOpenAiRequestHeaders({ 'OpenAI-Organization': 'explicit-org' })).toEqual({
+      'OpenAI-Organization': 'explicit-org',
+    });
+  });
+
+  it('preserves upstream errors', async () => {
+    reply({ error: { message: 'Fixture unavailable' } });
+    expect((await createCerebrasProvider('cerebras:custom').callApi('Hello')).error).toContain(
+      'Fixture unavailable',
+    );
+  });
+});
+
+describe('Nscale image resolved configuration', () => {
+  it.each([undefined, 'explicit-key'])(
+    'preserves scoped credentials and explicit key %s',
+    async (apiKey) => {
+      reply(imageReply);
+      const provider = new NscaleImageProvider('private/image:model', {
+        id: 'nscale-fixture',
+        env: { NSCALE_SERVICE_TOKEN: 'scoped-nscale' },
+        config: {
+          apiKey,
+          apiBaseUrl: 'http://127.0.0.1:9000/v1',
+          size: '512x512',
+          response_format: 'url',
+          headers: { 'X-Fixture': 'yes' },
+        },
+      });
+      const result = await provider.callApi('A blue square');
+      expect(provider.id()).toBe('nscale-fixture');
+      expect(result.output).toContain('https://example.invalid/fixture.png');
+      expect(result.cached).toBe(false);
+      expect(firstRequest()).toMatchObject({
+        url: 'http://127.0.0.1:9000/v1/images/generations',
+        headers: { Authorization: `Bearer ${apiKey ?? 'scoped-nscale'}`, 'X-Fixture': 'yes' },
+        body: { model: 'private/image:model', size: '512x512', n: 1, response_format: 'url' },
+      });
+    },
+  );
+
+  it('keeps its service endpoint and default image format despite OpenAI environment settings', async () => {
+    reply({ data: [{ b64_json: 'Zml4dHVyZQ==' }] }, true);
+    const result = await new NscaleImageProvider('private/image:model').callApi('A blue square');
+    expect(firstRequest()).toMatchObject({
+      url: 'https://inference.api.nscale.com/v1/images/generations',
+      headers: { Authorization: 'Bearer process-nscale' },
+      body: { response_format: 'b64_json' },
+    });
+    expect(result).toMatchObject({ cached: true, cost: 0, isBase64: true, format: 'json' });
+  });
+
+  it('preserves HTTP errors', async () => {
+    reply({ error: 'Fixture unavailable' }, false, 400);
+    expect(
+      (await new NscaleImageProvider('private/image:model').callApi('A square')).error,
+    ).toContain('400 Bad Request');
+  });
+});
+
+describe('Gateway scoped credentials', () => {
+  it.each([undefined, 'explicit-key'])(
+    'uses Comet scoped credentials and explicit key %s',
+    async (apiKey) => {
+      reply(imageReply);
+      const provider = new CometApiImageProvider('private/image:model', {
+        id: 'comet-fixture',
+        env: { COMETAPI_KEY: 'scoped-comet' },
+        config: { apiKey },
+      });
+      const result = await provider.callApi('A blue square');
+      expect(provider.id()).toBe('comet-fixture');
+      expect(result.output).toContain('https://example.invalid/fixture.png');
+      expect(firstRequest()).toMatchObject({
+        url: 'https://api.cometapi.com/v1/images/generations',
+        headers: { Authorization: `Bearer ${apiKey ?? 'scoped-comet'}` },
+      });
+    },
+  );
+
+  it('preserves Comet process credentials and API errors', async () => {
+    reply({ error: { message: 'Fixture unavailable' } });
+    const result = await new CometApiImageProvider('private/image:model').callApi('A square');
+    expect(firstRequest().headers).toMatchObject({ Authorization: 'Bearer process-comet' });
+    expect(result.error).toContain('Fixture unavailable');
+  });
+
+  it.each([undefined, 'explicit-key'])(
+    'uses Helicone scoped credentials and explicit key %s',
+    async (apiKey) => {
+      reply(chatReply);
+      const provider = new HeliconeGatewayProvider('private/model:tag', {
+        id: 'helicone-fixture',
+        env: { HELICONE_API_KEY: 'scoped-helicone' },
+        config: { apiKey, baseUrl: 'http://127.0.0.1:9000', router: 'fixture' },
+      });
+      const result = await provider.callApi('Hello');
+      expect(provider.id()).toBe('helicone-fixture');
+      expect(result).toMatchObject({
+        output: 'Hello',
+        tokenUsage: { prompt: 5, completion: 2, total: 7 },
+      });
+      expect(firstRequest()).toMatchObject({
+        url: 'http://127.0.0.1:9000/router/fixture/chat/completions',
+        headers: { Authorization: `Bearer ${apiKey ?? 'scoped-helicone'}` },
+        body: { model: 'private/model:tag' },
+      });
+    },
+  );
+
+  it('preserves Helicone process credentials and errors', async () => {
+    reply({ error: { message: 'Fixture unavailable' } });
+    const result = await new HeliconeGatewayProvider('private/model').callApi('Hello');
+    expect(firstRequest().headers).toMatchObject({ Authorization: 'Bearer process-helicone' });
+    expect(result.error).toContain('Fixture unavailable');
+  });
+
+  it('keeps the Helicone placeholder when no Helicone credential is set', () => {
+    const restore = mockProcessEnv({ HELICONE_API_KEY: undefined });
+    try {
+      expect(new HeliconeGatewayProvider('private/model').getApiKey()).toBe('placeholder-api-key');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/test/providers/inherited-auth-config.test.ts
+++ b/test/providers/inherited-auth-config.test.ts
@@ -79,13 +79,6 @@ describe('Cerebras organization isolation', () => {
       'OpenAI-Organization': 'explicit-org',
     });
   });
-
-  it('preserves upstream errors', async () => {
-    reply({ error: { message: 'Fixture unavailable' } });
-    expect((await createCerebrasProvider('cerebras:custom').callApi('Hello')).error).toContain(
-      'Fixture unavailable',
-    );
-  });
 });
 
 describe('Nscale image resolved configuration', () => {
@@ -131,13 +124,6 @@ describe('Nscale image resolved configuration', () => {
     });
     expect(result).toMatchObject({ cached: true, cost: 0, isBase64: true, format: 'json' });
   });
-
-  it('preserves HTTP errors', async () => {
-    reply({ error: 'Fixture unavailable' }, false, 400);
-    expect(
-      (await new NscaleImageProvider('private/image:model').callApi('A square')).error,
-    ).toContain('400 Bad Request');
-  });
 });
 
 describe('Gateway scoped credentials', () => {
@@ -160,11 +146,10 @@ describe('Gateway scoped credentials', () => {
     },
   );
 
-  it('preserves Comet process credentials and API errors', async () => {
-    reply({ error: { message: 'Fixture unavailable' } });
-    const result = await new CometApiImageProvider('private/image:model').callApi('A square');
+  it('preserves Comet process credentials', async () => {
+    reply(imageReply);
+    await new CometApiImageProvider('private/image:model').callApi('A square');
     expect(firstRequest().headers).toMatchObject({ Authorization: 'Bearer process-comet' });
-    expect(result.error).toContain('Fixture unavailable');
   });
 
   it.each([undefined, 'explicit-key'])(
@@ -190,11 +175,10 @@ describe('Gateway scoped credentials', () => {
     },
   );
 
-  it('preserves Helicone process credentials and errors', async () => {
-    reply({ error: { message: 'Fixture unavailable' } });
-    const result = await new HeliconeGatewayProvider('private/model').callApi('Hello');
+  it('preserves Helicone process credentials', async () => {
+    reply(chatReply);
+    await new HeliconeGatewayProvider('private/model').callApi('Hello');
     expect(firstRequest().headers).toMatchObject({ Authorization: 'Bearer process-helicone' });
-    expect(result.error).toContain('Fixture unavailable');
   });
 
   it('keeps the Helicone placeholder when no Helicone credential is set', () => {

--- a/test/providers/nscaleRequest.test.ts
+++ b/test/providers/nscaleRequest.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../src/cache', async (importOriginal) => ({
 
 import { fetchWithCache } from '../../src/cache';
 import { createNscaleProvider } from '../../src/providers/nscale';
+import { NscaleImageProvider } from '../../src/providers/nscale/image';
 
 function mockResponse() {
   vi.mocked(fetchWithCache).mockResolvedValue({
@@ -50,6 +51,24 @@ describe('Nscale request construction', () => {
     expect(body).not.toHaveProperty('apiKey');
     expect(JSON.stringify(body)).not.toContain('SERVICE-TOKEN-SECRET');
     expect(headers.Authorization).toBe('Bearer SERVICE-TOKEN-SECRET');
+  });
+
+  it('keeps scoped image credentials out of config and sends them as request authentication', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: { data: [{ url: 'https://example.invalid/image.png' }] },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    });
+    const provider = createNscaleProvider('nscale:image:flux/flux.1-schnell', {
+      env: { NSCALE_SERVICE_TOKEN: 'scoped-nscale-secret' },
+    });
+    expect(JSON.stringify(provider.config)).not.toContain('scoped-nscale-secret');
+    expect((provider as NscaleImageProvider).getApiKey()).toBe('scoped-nscale-secret');
+    await provider.callApi('a garden');
+    expect(vi.mocked(fetchWithCache).mock.calls[0]?.[1]?.headers).toMatchObject({
+      Authorization: 'Bearer scoped-nscale-secret',
+    });
   });
 
   it('applies configured headers as HTTP headers rather than body fields', async () => {

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isFoundationModelProvider } from '../../src/providers/constants';
 import { getProviderFactories, providerMap } from '../../src/providers/registry';
 
+import type { CometApiImageProvider } from '../../src/providers/cometapi';
 import type { LoadApiProviderContext } from '../../src/types/index';
 import type { ProviderOptions } from '../../src/types/providers';
 
@@ -82,6 +83,15 @@ describe('Provider Registry', () => {
 
     beforeEach(() => {
       vi.clearAllMocks();
+    });
+
+    it('keeps a provider-scoped Comet API key for image requests', async () => {
+      const provider = await registry.create('cometapi:image:test-model', {
+        ...mockContext,
+        env: { COMETAPI_KEY: 'suite-key' },
+        options: { env: { COMETAPI_KEY: 'provider-key' } },
+      });
+      expect((provider as CometApiImageProvider).getApiKey()).toBe('provider-key');
     });
 
     describe('getProviderFactories boundary contract', () => {


### PR DESCRIPTION
Nscale image construction discarded its resolved service token and base URL, Comet image and Helicone ignored scoped credentials, and Groq Chat/Responses overwrote explicitly configured URLs and API-key variable names. Preserve those settings and prevent Cerebras requests from inheriting `OPENAI_ORGANIZATION`.

The changes retain explicit credential precedence, custom request headers, provider IDs, image output formats, and upstream errors. Groq keeps its service defaults when options are absent or empty and resolves only the explicit API key or its selected environment variable. Missing Groq credentials fail before a request instead of falling back to an unrelated OpenAI key. The selected variable retains its existing process-before-scoped precedence. Factory input normalization remains in #10692; broader shared named-key resolution remains in #10681.

Validation: 136 focused mocked provider tests; full CI lint, formatting, and architecture checks; TypeScript/package/UI build; 20 built CLI cases covering success, upstream errors, credential precedence, and missing-key preflight with zero requests. Request URLs, headers, models, and exported output/usage are inspected where an evaluation runs. Fixtures make no vendor API calls.
