### PR TITLE
fix(providers): align billing rates and zero-token usage

### DIFF
--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -673,7 +673,7 @@ controls at the model level:
   `thinking: { type: 'enabled', budget_tokens: N }` config is converted to
   `thinking: { type: 'adaptive' }`; use `effort` to control reasoning depth.
 
-Sonnet 5 uses a 1M-token context window billed at a flat **$3 per million input / $15 per million output** — the full context window bills at the standard rate, with no long-context surcharge above 200K tokens (a 900K-token request bills at the same per-token rate as a 9K-token request). Anthropic's launch introductory pricing ($2 / $10 through Aug 31, 2026) is not encoded in promptfoo's cost calculation; set `inputCost: 2 / 1e6` and `outputCost: 10 / 1e6` to track the introductory rate (a single `cost` is applied as both the input and output rate, so it cannot express the two).
+Sonnet 5 uses a 1M-token context window billed at **$2 per million input / $10 per million output**, with no long-context surcharge above 200K tokens. Anthropic made these rates permanent on August 10, 2026, canceling the planned September increase. See [Anthropic's pricing documentation](https://platform.claude.com/docs/en/about-claude/pricing). The newer tokenizer can produce more tokens for the same text, so compare total request costs when migrating from Sonnet 4.6.
 
 ### Claude Opus 4.8 notes
 

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1122,8 +1122,8 @@ The Responses API stores conversation state by default. Set `store: false` on ev
 when inputs or outputs must not be retained; Bedrock otherwise keeps stored responses for 30
 days in the source Region and allows follow-up requests with `previous_response_id`.
 
-GPT-5.6 pricing on Bedrock includes a 10% regional-processing uplift: Sol is $5.50 input /
-$33 output, Terra $2.20 / $13.20, and Luna $0.22 / $1.32 per million tokens. Cache reads
+GPT-5.6 pricing on Bedrock includes a 10% regional-processing uplift: [Sol](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html) is $4.40 input /
+$22 output, Terra $2.20 / $13.20, and Luna $0.22 / $1.32 per million tokens. Cache reads
 receive a 90% discount, cache writes cost 1.25x the uncached input rate, and cached prefixes
 remain available for at least 30 minutes. Place
 `prompt_cache_breakpoint: { mode: explicit }` on a stable

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -601,9 +601,11 @@ the explicit `openai:chat:` or `openai:responses:` prefix when endpoint selectio
 
 | Model           | Tier                    | Input      | Cached input | Output      |
 | --------------- | ----------------------- | ---------- | ------------ | ----------- |
-| `gpt-5.6-sol`   | Flagship                | $5.00 / 1M | $0.50 / 1M   | $30.00 / 1M |
+| `gpt-5.6-sol`   | Flagship                | $4.00 / 1M | $0.40 / 1M   | $20.00 / 1M |
 | `gpt-5.6-terra` | Balanced                | $2.00 / 1M | $0.20 / 1M   | $12.00 / 1M |
 | `gpt-5.6-luna`  | Fast and cost-efficient | $0.20 / 1M | $0.02 / 1M   | $1.20 / 1M  |
+
+Sol's [current promotional pricing](https://developers.openai.com/api/docs/models/gpt-5.6-sol) is available at least through November 21, 2026.
 
 GPT-5.6 supports `max` reasoning and `reasoning.mode: pro` across Sol, Terra, and Luna. Codex `ultra` is available for Sol and Terra through the [Codex SDK](/docs/providers/openai-codex-sdk) or [Codex app-server](/docs/providers/openai-codex-app-server) provider as a multi-agent mode, not a Responses API reasoning value.
 
@@ -2235,8 +2237,8 @@ OpenAI's Responses API is the most advanced interface for generating model respo
 
 The Responses API supports a wide range of models, including:
 
-- `gpt-5.6` - Alias for GPT-5.6 Sol ($5/$30 per 1M tokens)
-- `gpt-5.6-sol` - GPT-5.6 flagship model ($5/$30 per 1M tokens)
+- `gpt-5.6` - Alias for GPT-5.6 Sol ($4/$20 per 1M tokens)
+- `gpt-5.6-sol` - GPT-5.6 flagship model ($4/$20 per 1M tokens)
 - `gpt-5.6-terra` - GPT-5.6 balanced model ($2/$12 per 1M tokens)
 - `gpt-5.6-luna` - GPT-5.6 efficient model ($0.20/$1.20 per 1M tokens)
 - `gpt-5.5` - GPT-5.5 model ($5/$30 per 1M tokens)

--- a/src/providers/anthropic/util.ts
+++ b/src/providers/anthropic/util.ts
@@ -36,14 +36,14 @@ export const ANTHROPIC_MODELS = [
     },
   })),
   // Claude Sonnet 5 — the most agentic Sonnet, with a 1M context window and effort
-  // levels. Uses standard list pricing ($3/$15); the launch introductory pricing
-  // ($2/$10, through Aug 31, 2026) is intentionally not encoded here. The full 1M
+  // levels. The launch pricing ($2/$10) became permanent on August 10, 2026;
+  // Anthropic canceled the previously announced September price increase. The full 1M
   // context bills at this flat rate — prompt size never changes the per-token price.
   ...['claude-sonnet-5'].map((model) => ({
     id: model,
     cost: {
-      input: 3 / 1e6, // $3 / MTok
-      output: 15 / 1e6, // $15 / MTok
+      input: 2 / 1e6, // $2 / MTok
+      output: 10 / 1e6, // $10 / MTok
     },
   })),
   // Claude Mythos Preview - gated research preview for defensive cybersecurity (Project Glasswing)
@@ -680,7 +680,13 @@ export function calculateAnthropicCost(
   cacheCreationTokens?: number,
 ): number | undefined {
   const pricingModelName = normalizeAnthropicModelName(modelName);
-  const modelInfo = ANTHROPIC_MODELS.find((model) => model.id === pricingModelName);
+  // Bedrock has an independent price table. Keep its existing Sonnet 5 estimate
+  // until the AWS rate is reconciled separately from native Claude pricing.
+  const pricingModels =
+    pricingModelName !== modelName && pricingModelName === 'claude-sonnet-5'
+      ? [{ id: pricingModelName, cost: { input: 3 / 1e6, output: 15 / 1e6 } }]
+      : ANTHROPIC_MODELS;
+  const modelInfo = pricingModels.find((model) => model.id === pricingModelName);
   // A model name that normalizeAnthropicModelName rewrote carries a Bedrock
   // prefix. Bare and geo-prefixed Bedrock IDs bill at the regional premium;
   // only the `global.` endpoint bills at base rate.
@@ -731,7 +737,7 @@ export function calculateAnthropicCost(
       effectiveConfig,
       promptTokens,
       completionTokens,
-      ANTHROPIC_MODELS,
+      pricingModels,
     ),
   );
 }

--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -59,7 +59,14 @@ export function calculateDeepSeekCost(
   completionTokens?: number,
   cachedTokens?: number,
 ): number | undefined {
-  if (!promptTokens || !completionTokens) {
+  if (
+    typeof promptTokens !== 'number' ||
+    !Number.isFinite(promptTokens) ||
+    promptTokens < 0 ||
+    typeof completionTokens !== 'number' ||
+    !Number.isFinite(completionTokens) ||
+    completionTokens < 0
+  ) {
     return undefined;
   }
 

--- a/src/providers/openai/billing.ts
+++ b/src/providers/openai/billing.ts
@@ -63,7 +63,7 @@ function buildRateTable<T>(groups: RateGroup<T>[]): Record<string, T> {
 
 const STANDARD_CACHED_INPUT_RATES = buildRateTable<number>([
   { models: ['gpt-6-astra'], rates: perMillion(1) },
-  { models: ['gpt-5.6', 'gpt-5.6-sol'], rates: perMillion(0.5) },
+  { models: ['gpt-5.6', 'gpt-5.6-sol'], rates: perMillion(0.4) },
   { models: ['gpt-5.6-terra'], rates: perMillion(0.2) },
   { models: ['gpt-5.6-luna'], rates: perMillion(0.02) },
   { models: ['chat-latest'], rates: perMillion(0.5) },
@@ -187,7 +187,7 @@ const FINE_TUNED_BATCH_OVERRIDES = buildRateTable<OpenAITextRates>([
 
 const LONG_CONTEXT_CACHED_INPUT_RATES = buildRateTable<number>([
   { models: ['gpt-6-astra'], rates: perMillion(2) },
-  { models: ['gpt-5.6', 'gpt-5.6-sol'], rates: perMillion(1) },
+  { models: ['gpt-5.6', 'gpt-5.6-sol'], rates: perMillion(0.8) },
   { models: ['gpt-5.6-terra'], rates: perMillion(0.4) },
   { models: ['gpt-5.6-luna'], rates: perMillion(0.04) },
   { models: ['gpt-5.5', 'gpt-5.5-2026-04-23'], rates: perMillion(1) },
@@ -246,10 +246,10 @@ const PRIORITY_TEXT_RATES = buildRateTable<OpenAITextRates>([
   {
     models: ['gpt-5.6', 'gpt-5.6-sol'],
     rates: {
-      input: perMillion(10),
-      cachedInput: perMillion(1),
-      cacheWriteInput: perMillion(12.5),
-      output: perMillion(60),
+      input: perMillion(8),
+      cachedInput: perMillion(0.8),
+      cacheWriteInput: perMillion(10),
+      output: perMillion(40),
     },
   },
   {

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -341,12 +341,12 @@ export const OPENAI_CHAT_MODELS: OpenAIModelInfo[] = [
   ...['gpt-5.6', 'gpt-5.6-sol'].map((model) => ({
     id: model,
     cost: {
-      input: 5 / 1e6,
-      output: 30 / 1e6,
+      input: 4 / 1e6,
+      output: 20 / 1e6,
       longContext: {
         threshold: GPT_LONG_CONTEXT_THRESHOLD,
-        input: 10 / 1e6,
-        output: 45 / 1e6,
+        input: 8 / 1e6,
+        output: 30 / 1e6,
       },
     },
   })),

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -241,24 +241,25 @@ describe('Anthropic utilities', () => {
 
     it('should calculate default cost for Claude Sonnet 5 model', () => {
       const cost = calculateAnthropicCost('claude-sonnet-5', {}, 100, 200);
-      expect(cost).toBeCloseTo(0.0022); // $2/MTok input and $10/MTok output
+      expect(cost).toBeCloseTo(0.0022, 10); // $2/MTok input and $10/MTok output
     });
 
     it('should calculate standard cost for Claude Sonnet 5 at or below 200k tokens', () => {
       const cost = calculateAnthropicCost('claude-sonnet-5', {}, 150_000, 10_000);
-      expect(cost).toBeCloseTo(0.4);
+      expect(cost).toBeCloseTo(0.4, 10);
     });
 
     it('bills Claude Sonnet 5 at the standard rate above 200k tokens (no long-context tier)', () => {
       // Per Anthropic pricing, Sonnet 5 bills its full 1M context at the standard rate —
       // there is no >200K surcharge.
       const cost = calculateAnthropicCost('claude-sonnet-5', {}, 300_000, 20_000);
-      expect(cost).toBeCloseTo(0.8);
+      expect(cost).toBeCloseTo(0.8, 10);
     });
 
     it('applies Sonnet 5 cache rates while preserving explicit pricing overrides', () => {
       expect(calculateAnthropicCost('claude-sonnet-5', {}, 1000, 100, 2000, 400)).toBeCloseTo(
         0.0044,
+        10,
       );
       expect(
         calculateAnthropicCost(
@@ -269,7 +270,7 @@ describe('Anthropic utilities', () => {
           2000,
           400,
         ),
-      ).toBeCloseTo(0.0066);
+      ).toBeCloseTo(0.0066, 10);
     });
 
     it.each([
@@ -277,11 +278,15 @@ describe('Anthropic utilities', () => {
       ['us.anthropic.claude-sonnet-5', 1.1],
       ['global.anthropic.claude-sonnet-5', 1],
     ])('preserves independent Bedrock Sonnet 5 estimates for %s', (model, premium) => {
-      expect(calculateAnthropicCost(model, {}, 1000, 100)).toBeCloseTo(0.0045 * premium);
-      expect(calculateAnthropicCost(model, {}, 1000, 100, 2000, 400)).toBeCloseTo(0.0066 * premium);
+      expect(calculateAnthropicCost(model, {}, 1000, 100)).toBeCloseTo(0.0045 * premium, 10);
+      expect(calculateAnthropicCost(model, {}, 1000, 100, 2000, 400)).toBeCloseTo(
+        0.0066 * premium,
+        10,
+      );
+      // Explicit rates are final and suppress the regional premium.
       expect(
         calculateAnthropicCost(model, { inputCost: 2 / 1e6, outputCost: 10 / 1e6 }, 1000, 100),
-      ).toBeCloseTo(0.003 * premium);
+      ).toBeCloseTo(0.003, 10);
     });
 
     it('should use base pricing for other Claude Sonnet 4 models', () => {

--- a/test/providers/anthropic/util.test.ts
+++ b/test/providers/anthropic/util.test.ts
@@ -241,20 +241,47 @@ describe('Anthropic utilities', () => {
 
     it('should calculate default cost for Claude Sonnet 5 model', () => {
       const cost = calculateAnthropicCost('claude-sonnet-5', {}, 100, 200);
-      expect(cost).toBe(0.0033); // (0.000003 * 100) + (0.000015 * 200) - $3/MTok input, $15/MTok output
+      expect(cost).toBeCloseTo(0.0022); // $2/MTok input and $10/MTok output
     });
 
     it('should calculate standard cost for Claude Sonnet 5 at or below 200k tokens', () => {
       const cost = calculateAnthropicCost('claude-sonnet-5', {}, 150_000, 10_000);
-      expect(cost).toBe(0.6); // (3/1e6 * 150,000) + (15/1e6 * 10,000) = 0.45 + 0.15 = 0.6
+      expect(cost).toBeCloseTo(0.4);
     });
 
     it('bills Claude Sonnet 5 at the standard rate above 200k tokens (no long-context tier)', () => {
       // Per Anthropic pricing, Sonnet 5 bills its full 1M context at the standard rate —
       // there is no >200K surcharge.
       const cost = calculateAnthropicCost('claude-sonnet-5', {}, 300_000, 20_000);
-      // (3/1e6 * 300,000) + (15/1e6 * 20,000) = 0.9 + 0.3 = 1.2 (no >200K surcharge applies)
-      expect(cost).toBe(1.2);
+      expect(cost).toBeCloseTo(0.8);
+    });
+
+    it('applies Sonnet 5 cache rates while preserving explicit pricing overrides', () => {
+      expect(calculateAnthropicCost('claude-sonnet-5', {}, 1000, 100, 2000, 400)).toBeCloseTo(
+        0.0044,
+      );
+      expect(
+        calculateAnthropicCost(
+          'claude-sonnet-5',
+          { inputCost: 3 / 1e6, outputCost: 15 / 1e6 },
+          1000,
+          100,
+          2000,
+          400,
+        ),
+      ).toBeCloseTo(0.0066);
+    });
+
+    it.each([
+      ['anthropic.claude-sonnet-5', 1.1],
+      ['us.anthropic.claude-sonnet-5', 1.1],
+      ['global.anthropic.claude-sonnet-5', 1],
+    ])('preserves independent Bedrock Sonnet 5 estimates for %s', (model, premium) => {
+      expect(calculateAnthropicCost(model, {}, 1000, 100)).toBeCloseTo(0.0045 * premium);
+      expect(calculateAnthropicCost(model, {}, 1000, 100, 2000, 400)).toBeCloseTo(0.0066 * premium);
+      expect(
+        calculateAnthropicCost(model, { inputCost: 2 / 1e6, outputCost: 10 / 1e6 }, 1000, 100),
+      ).toBeCloseTo(0.003 * premium);
     });
 
     it('should use base pricing for other Claude Sonnet 4 models', () => {

--- a/test/providers/bedrock/openaiResponses.test.ts
+++ b/test/providers/bedrock/openaiResponses.test.ts
@@ -277,7 +277,7 @@ describe('bedrock openaiResponses helper', () => {
     );
 
     it.each([
-      ['openai.gpt-5.6-sol', 5.5, 33],
+      ['openai.gpt-5.6-sol', 4.4, 22],
       ['openai.gpt-5.6-terra', 2.2, 13.2],
       ['openai.gpt-5.6-luna', 0.22, 1.32],
     ])(
@@ -305,7 +305,7 @@ describe('bedrock openaiResponses helper', () => {
     );
 
     it.each([
-      ['openai.gpt-5.6-sol', 5.5, 0.55, 33],
+      ['openai.gpt-5.6-sol', 4.4, 0.44, 22],
       ['openai.gpt-5.6-terra', 2.2, 0.22, 13.2],
       ['openai.gpt-5.6-luna', 0.22, 0.022, 1.32],
     ])('prices %s when cache-write usage is missing', (modelId, input, cachedInput, output) => {
@@ -333,7 +333,7 @@ describe('bedrock openaiResponses helper', () => {
     });
 
     it.each([
-      ['openai.gpt-5.6-sol', 5.5, 33],
+      ['openai.gpt-5.6-sol', 4.4, 22],
       ['openai.gpt-5.6-terra', 2.2, 13.2],
       ['openai.gpt-5.6-luna', 0.22, 1.32],
     ])(

--- a/test/providers/deepseek.test.ts
+++ b/test/providers/deepseek.test.ts
@@ -5,6 +5,22 @@ import {
   DEEPSEEK_CHAT_MODELS,
 } from '../../src/providers/deepseek';
 
+describe('DeepSeek usage boundaries', () => {
+  it('bills input-only and output-only responses and preserves valid zero usage', () => {
+    expect(calculateDeepSeekCost('deepseek-chat', { inputCost: 0.01 }, 10, 0)).toBeCloseTo(0.1);
+    expect(calculateDeepSeekCost('deepseek-chat', { outputCost: 0.02 }, 0, 10)).toBeCloseTo(0.2);
+    expect(calculateDeepSeekCost('deepseek-chat', {}, 0, 0)).toBe(0);
+  });
+
+  it.each([undefined, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid usage %s',
+    (count) => {
+      expect(calculateDeepSeekCost('deepseek-chat', {}, count, 1)).toBeUndefined();
+      expect(calculateDeepSeekCost('deepseek-chat', {}, 1, count)).toBeUndefined();
+    },
+  );
+});
+
 describe('calculateDeepSeekCost', () => {
   it('should calculate cost without cache', () => {
     const cost = calculateDeepSeekCost('deepseek-chat', {}, 1000000, 1000000);

--- a/test/providers/openai-codex-app-server.test.ts
+++ b/test/providers/openai-codex-app-server.test.ts
@@ -1055,7 +1055,7 @@ describe('OpenAICodexAppServerProvider', () => {
 
       const result = await resultPromise;
       expect(result.output).toBe('On Bedrock');
-      expect(result.cost).toBeCloseTo(0.041525, 10);
+      expect(result.cost).toBeCloseTo(0.02882, 10);
 
       const spawnEnv = mocks.spawn.mock.calls[0][2].env as Record<string, string>;
       expect(spawnEnv.OPENAI_API_KEY).toBeUndefined();

--- a/test/providers/openai-codex-sdk.test.ts
+++ b/test/providers/openai-codex-sdk.test.ts
@@ -3124,10 +3124,10 @@ describe('OpenAICodexSDKProvider', () => {
 
       it.each([
         ['gpt-6-astra', 10, 1, 50],
-        ['gpt-5.6-sol', 5, 0.5, 30],
+        ['gpt-5.6-sol', 4, 0.4, 20],
         ['gpt-5.6-terra', 2, 0.2, 12],
         ['gpt-5.6-luna', 0.2, 0.02, 1.2],
-        ['openai.gpt-5.6-sol', 5.5, 0.55, 33],
+        ['openai.gpt-5.6-sol', 4.4, 0.44, 22],
         ['openai.gpt-5.6-terra', 2.2, 0.22, 13.2],
         ['openai.gpt-5.6-luna', 0.22, 0.022, 1.32],
       ])(

--- a/test/providers/openai/billing.test.ts
+++ b/test/providers/openai/billing.test.ts
@@ -351,8 +351,8 @@ describe('OpenAI billing helpers', () => {
   });
 
   it.each([
-    ['gpt-5.6', 5, 0.5, 30],
-    ['gpt-5.6-sol', 5, 0.5, 30],
+    ['gpt-5.6', 4, 0.4, 20],
+    ['gpt-5.6-sol', 4, 0.4, 20],
     ['gpt-5.6-terra', 2, 0.2, 12],
     ['gpt-5.6-luna', 0.2, 0.02, 1.2],
   ])(
@@ -372,8 +372,8 @@ describe('OpenAI billing helpers', () => {
   );
 
   it.each([
-    ['gpt-5.6', 5, 30],
-    ['gpt-5.6-sol', 5, 30],
+    ['gpt-5.6', 4, 20],
+    ['gpt-5.6-sol', 4, 20],
     ['gpt-5.6-terra', 2, 12],
     ['gpt-5.6-luna', 0.2, 1.2],
   ])('prices %s image input tokens at the text input rate', (model, inputRate, outputRate) => {
@@ -407,11 +407,11 @@ describe('OpenAI billing helpers', () => {
           },
         },
       ),
-    ).toBeCloseTo((800 * 5 + 200 * 0.5 + 100 * 30) / 1e6, 10);
+    ).toBeCloseTo((800 * 4 + 200 * 0.4 + 100 * 20) / 1e6, 10);
   });
 
   it.each([
-    ['gpt-5.6-sol', 5, 0.5, 6.25, 30],
+    ['gpt-5.6-sol', 4, 0.4, 5, 20],
     ['gpt-5.6-terra', 2, 0.2, 2.5, 12],
     ['gpt-5.6-luna', 0.2, 0.02, 0.25, 1.2],
   ])('prices %s explicit cache writes at 1.25x input', (model, input, cached, write, output) => {
@@ -429,8 +429,8 @@ describe('OpenAI billing helpers', () => {
   });
 
   it.each([
-    ['gpt-5.6', 5, 0.5, 30],
-    ['gpt-5.6-sol', 5, 0.5, 30],
+    ['gpt-5.6', 4, 0.4, 20],
+    ['gpt-5.6-sol', 4, 0.4, 20],
     ['gpt-5.6-terra', 2, 0.2, 12],
     ['gpt-5.6-luna', 0.2, 0.02, 1.2],
   ])(
@@ -461,7 +461,7 @@ describe('OpenAI billing helpers', () => {
           input_tokens_details: { cached_tokens: 500 },
         },
       ),
-    ).toBeCloseTo((2_000 * 2 + 1_000 * 30) / 1e6, 10);
+    ).toBeCloseTo((2_000 * 2 + 1_000 * 20) / 1e6, 10);
   });
 
   it('accepts an explicit top-level zero cache-write count for GPT-5.6', () => {
@@ -490,7 +490,7 @@ describe('OpenAI billing helpers', () => {
     };
 
     expect(calculateOpenAIUsageCost('gpt-5.6', config, usage, options)).toBeCloseTo(
-      ((1_250 * 5 + 500 * 0.5 + 250 * 6.25 + 1_000 * 30) / 1e6) * 1.1,
+      ((1_250 * 4 + 500 * 0.4 + 250 * 5 + 1_000 * 20) / 1e6) * 1.1,
       10,
     );
   });
@@ -553,7 +553,7 @@ describe('OpenAI billing helpers', () => {
         },
         usage,
       ),
-    ).toBeCloseTo((2_000 * 2 + 1_000 * 30 * 1.1) / 1e6, 10);
+    ).toBeCloseTo((2_000 * 2 + 1_000 * 20 * 1.1) / 1e6, 10);
   });
 
   it.each(['proxy.api.openai.com', 'au.api.openai.com'])(
@@ -566,18 +566,18 @@ describe('OpenAI billing helpers', () => {
       };
 
       expect(calculateOpenAIUsageCost('gpt-5.6', { apiHost }, usage)).toBeCloseTo(
-        (1_250 * 5 + 500 * 0.5 + 250 * 6.25 + 1_000 * 30) / 1e6,
+        (1_250 * 4 + 500 * 0.4 + 250 * 5 + 1_000 * 20) / 1e6,
         10,
       );
     },
   );
 
   it.each([
-    ['gpt-5.6', 5, 0.5, 30],
-    ['gpt-5.6-sol', 5, 0.5, 30],
+    ['gpt-5.6', 4, 0.4, 20],
+    ['gpt-5.6-sol', 4, 0.4, 20],
     ['gpt-5.6-terra', 2, 0.2, 12],
     ['gpt-5.6-luna', 0.2, 0.02, 1.2],
-    ['openai.gpt-5.6-sol', 5.5, 0.55, 33],
+    ['openai.gpt-5.6-sol', 4.4, 0.44, 22],
     ['openai.gpt-5.6-terra', 2.2, 0.22, 13.2],
     ['openai.gpt-5.6-luna', 0.22, 0.022, 1.32],
     ['openai.gpt-5.5', 5.5, 0.55, 33],
@@ -603,7 +603,7 @@ describe('OpenAI billing helpers', () => {
         cached: 500,
         completionDetails: { cacheCreationInputTokens: 250 },
       }),
-    ).toBeCloseTo((1_250 * 5 + 500 * 0.5 + 250 * 6.25 + 1_000 * 30) / 1e6, 10);
+    ).toBeCloseTo((1_250 * 4 + 500 * 0.4 + 250 * 5 + 1_000 * 20) / 1e6, 10);
   });
 
   it('uses GPT-5.6 Flex and Fast long-context rates', () => {
@@ -626,7 +626,27 @@ describe('OpenAI billing helpers', () => {
   });
 
   it.each([
-    ['gpt-5.6-sol', 10, 1, 12.5, 60],
+    [272_000, 4.4, 0.44, 5.5, 22],
+    [272_001, 8.8, 0.88, 11, 33],
+  ])(
+    'prices Bedrock Sol summarized usage at the %s-token boundary',
+    (prompt, input, cached, write, output) => {
+      expect(
+        calculateOpenAIUsageCostFromTokenUsage('openai.gpt-5.6-sol', {
+          prompt,
+          completion: 1_000,
+          cached: 100_000,
+          completionDetails: { cacheCreationInputTokens: 50_000 },
+        }),
+      ).toBeCloseTo(
+        ((prompt - 150_000) * input + 100_000 * cached + 50_000 * write + 1_000 * output) / 1e6,
+        10,
+      );
+    },
+  );
+
+  it.each([
+    ['gpt-5.6-sol', 8, 0.8, 10, 40],
     ['gpt-5.6-terra', 4, 0.4, 5, 24],
     ['gpt-5.6-luna', 0.4, 0.04, 0.5, 2.4],
   ])('uses current Fast rates for %s', (model, input, cached, write, output) => {

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -395,8 +395,8 @@ describe('calculateOpenAICost', () => {
   });
 
   it.each([
-    ['gpt-5.6', 5, 30],
-    ['gpt-5.6-sol', 5, 30],
+    ['gpt-5.6', 4, 20],
+    ['gpt-5.6-sol', 4, 20],
     ['gpt-5.6-terra', 2, 12],
     ['gpt-5.6-luna', 0.2, 1.2],
   ])('should calculate cost correctly for %s', (model, inputRate, outputRate) => {
@@ -405,8 +405,8 @@ describe('calculateOpenAICost', () => {
   });
 
   it.each([
-    ['gpt-5.6', 5, 30, 10, 45],
-    ['gpt-5.6-sol', 5, 30, 10, 45],
+    ['gpt-5.6', 4, 20, 8, 30],
+    ['gpt-5.6-sol', 4, 20, 8, 30],
     ['gpt-5.6-terra', 2, 12, 4, 18],
     ['gpt-5.6-luna', 0.2, 1.2, 0.4, 1.8],
   ])(


### PR DESCRIPTION
Correct native Sonnet 5 estimates to its permanent $2/$10 rates and Sol estimates to the current $4/$20 standard rates, including cache reads/writes, Fast mode, long context, and Codex consumers. Align Bedrock Sol documentation and consumer tests with its separately verified $4.40/$22 regional rates. Preserve the existing independently billed Bedrock Sonnet estimates. Also calculate DeepSeek costs when input or output usage is explicitly zero, while rejecting invalid usage counts.

Rates were checked against [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing), [OpenAI pricing](https://developers.openai.com/api/docs/pricing), [Google partner pricing](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing?hl=en), and the separate [AWS Sol model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html). Sol's promotional rate is available at least through November 21, 2026; no automatic reversal is scheduled. This supplements #9792 without adding model catalog entries.

Validation: 967 mocked tests across nine billing/provider suites pass, including Vertex, Bedrock Messages and Responses, Codex SDK and app-server consumers, usage boundaries, cache arithmetic and pricing overrides.

The built CLI also passes three `--no-cache` evals through a fetch fixture that rejects unmatched requests: Sol $0.02645, Sonnet $0.0044, and an input-only DeepSeek response $0.00005 using an explicit rate. Each exported result has success=true, score=1, and no error. TypeScript, package bundling, UI build, postbuild and documentation production build pass.
