### PR TITLE
fix(providers): preserve MiniMax and Moonshot request overrides

### DIFF
--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -10,8 +10,8 @@ import type {
   CallApiContextParams,
   CallApiOptionsParams,
   ProviderOptions,
-  ProviderResponse,
 } from '../types/index';
+import type { OpenAiChatCompletionCostData } from './openai/chat';
 import type { OpenAiCompletionOptions } from './openai/types';
 
 const MINIMAX_API_BASE_URL = 'https://api.minimax.io/v1';
@@ -112,9 +112,10 @@ export function calculateMiniMaxCost(
     model.cost.longContext && promptTokens! > model.cost.longContext.threshold
       ? model.cost.longContext
       : model.cost;
-  const inputCost = config.inputCost ?? config.cost ?? modelCost.input;
-  const outputCost = config.outputCost ?? config.cost ?? modelCost.output;
-  const cacheReadCost = config.cacheReadCost ?? modelCost.cache_read;
+  const tierMultiplier = modelName === 'MiniMax-M3' && config.service_tier === 'priority' ? 1.5 : 1;
+  const inputCost = config.inputCost ?? config.cost ?? modelCost.input * tierMultiplier;
+  const outputCost = config.outputCost ?? config.cost ?? modelCost.output * tierMultiplier;
+  const cacheReadCost = config.cacheReadCost ?? modelCost.cache_read * tierMultiplier;
 
   const inputCostTotal = inputCost * uncachedPromptTokens;
   const cacheReadCostTotal = cacheReadCost * billableCachedTokens;
@@ -212,8 +213,21 @@ class MiniMaxProvider extends OpenAiChatCompletionProvider {
       );
     }
 
-    // MiniMax's OpenAI-compatible API accepts max_completion_tokens, not max_tokens.
-    const maxCompletionTokens = config.max_completion_tokens ?? config.max_tokens;
+    // Normalize explicit token limits without letting a provider-level alias
+    // override a prompt-level limit. Passthrough wins within each layer.
+    const promptConfig = (context?.prompt?.config ?? {}) as OpenAiCompletionOptions;
+    const promptPassthrough = promptConfig.passthrough as
+      | { max_completion_tokens?: unknown; max_tokens?: unknown }
+      | undefined;
+    const maxCompletionTokens =
+      promptPassthrough?.max_completion_tokens ??
+      promptPassthrough?.max_tokens ??
+      promptConfig.max_completion_tokens ??
+      promptConfig.max_tokens ??
+      config.passthrough?.max_completion_tokens ??
+      config.passthrough?.max_tokens ??
+      config.max_completion_tokens ??
+      config.max_tokens;
     if (maxCompletionTokens === undefined) {
       delete body.max_completion_tokens;
     } else {
@@ -221,8 +235,8 @@ class MiniMaxProvider extends OpenAiChatCompletionProvider {
     }
     delete body.max_tokens;
 
-    // The base provider defaults temperature to 0, but MiniMax requires (0, 1].
-    if (config.temperature === undefined) {
+    // Let MiniMax apply its sampling default unless temperature is configured.
+    if (config.temperature === undefined && config.passthrough?.temperature === undefined) {
       delete body.temperature;
     }
 
@@ -230,60 +244,46 @@ class MiniMaxProvider extends OpenAiChatCompletionProvider {
     // OPENAI_TOP_P / OPENAI_PRESENCE_PENALTY / OPENAI_FREQUENCY_PENALTY whenever
     // those env vars are set, regardless of MiniMax config. Strip them so OpenAI
     // sampling defaults configured for another provider don't leak into MiniMax.
-    if (config.top_p === undefined) {
+    if (config.top_p === undefined && config.passthrough?.top_p === undefined) {
       delete body.top_p;
     }
-    if (config.presence_penalty === undefined) {
+    if (
+      config.presence_penalty === undefined &&
+      config.passthrough?.presence_penalty === undefined
+    ) {
       delete body.presence_penalty;
     }
-    if (config.frequency_penalty === undefined) {
+    if (
+      config.frequency_penalty === undefined &&
+      config.passthrough?.frequency_penalty === undefined
+    ) {
       delete body.frequency_penalty;
     }
 
     return result;
   }
 
-  override async callApi(
-    prompt: string,
-    context?: CallApiContextParams,
-    callApiOptions?: CallApiOptionsParams,
-  ): Promise<ProviderResponse> {
-    const response = await super.callApi(prompt, context, callApiOptions);
-
-    if (!response || response.error) {
-      return response;
+  protected override calculateResponseCost(
+    data: OpenAiChatCompletionCostData,
+    config: OpenAiCompletionOptions,
+    cached: boolean,
+  ): number | undefined {
+    if (cached) {
+      return 0;
     }
-
-    // The inherited OpenAI adapter normalizes MiniMax prompt-cache usage into token metadata.
-    let cachedTokens = response.tokenUsage?.completionDetails?.cacheReadInputTokens ?? 0;
-    if (cachedTokens === 0 && typeof response.raw === 'string') {
-      try {
-        const rawData = JSON.parse(response.raw);
-        if (typeof rawData?.usage?.prompt_tokens_details?.cached_tokens === 'number') {
-          cachedTokens = rawData.usage.prompt_tokens_details.cached_tokens;
-        }
-      } catch (err) {
-        logger.debug(`Failed to parse raw response for cache info: ${err}`);
-      }
-    } else if (cachedTokens === 0 && typeof response.raw === 'object' && response.raw !== null) {
-      const rawData = response.raw;
-      if (typeof rawData?.usage?.prompt_tokens_details?.cached_tokens === 'number') {
-        cachedTokens = rawData.usage.prompt_tokens_details.cached_tokens;
-      }
-    }
-
-    // Calculate cost with cache information
-    if (response.tokenUsage && !response.cached) {
-      response.cost = calculateMiniMaxCost(
-        this.modelName,
-        this.config || {},
-        response.tokenUsage.prompt,
-        response.tokenUsage.completion,
-        cachedTokens,
-      );
-    }
-
-    return response;
+    const passthroughModel = (config.passthrough as { model?: unknown } | undefined)?.model;
+    const modelName = typeof passthroughModel === 'string' ? passthroughModel : this.modelName;
+    return calculateMiniMaxCost(
+      modelName,
+      {
+        ...config,
+        service_tier:
+          (data.service_tier ?? config.service_tier) === 'priority' ? 'priority' : undefined,
+      },
+      data.usage?.prompt_tokens,
+      data.usage?.completion_tokens,
+      data.usage?.prompt_tokens_details?.cached_tokens,
+    );
   }
 }
 

--- a/src/providers/minimax.ts
+++ b/src/providers/minimax.ts
@@ -1,7 +1,8 @@
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import { OpenAiChatCompletionProvider } from './openai/chat';
-import { calculateCost, clampCachedTokens } from './shared';
+import { getOpenAICompletionTokenDetails } from './openai/util';
+import { clampCachedTokens } from './shared';
 
 import type { EnvVarKey } from '../envars';
 import type { EnvOverrides } from '../types/env';
@@ -102,20 +103,23 @@ export function calculateMiniMaxCost(
   }
 
   const model = MINIMAX_CHAT_MODELS.find((m) => m.id === modelName);
-  if (!model || !model.cost) {
-    return calculateCost(modelName, config, promptTokens, completionTokens, MINIMAX_CHAT_MODELS);
-  }
-
   const billableCachedTokens = clampCachedTokens(cachedTokens, promptTokens!);
   const uncachedPromptTokens = promptTokens! - billableCachedTokens;
   const modelCost =
-    model.cost.longContext && promptTokens! > model.cost.longContext.threshold
+    model?.cost.longContext && promptTokens! > model.cost.longContext.threshold
       ? model.cost.longContext
-      : model.cost;
+      : model?.cost;
   const tierMultiplier = modelName === 'MiniMax-M3' && config.service_tier === 'priority' ? 1.5 : 1;
-  const inputCost = config.inputCost ?? config.cost ?? modelCost.input * tierMultiplier;
-  const outputCost = config.outputCost ?? config.cost ?? modelCost.output * tierMultiplier;
-  const cacheReadCost = config.cacheReadCost ?? modelCost.cache_read * tierMultiplier;
+  const inputCost =
+    config.inputCost ?? config.cost ?? (modelCost && modelCost.input * tierMultiplier);
+  const outputCost =
+    config.outputCost ?? config.cost ?? (modelCost && modelCost.output * tierMultiplier);
+  // Explicit rates also price private deployment aliases without a model-table entry.
+  if (inputCost === undefined || outputCost === undefined) {
+    return undefined;
+  }
+  const cacheReadCost =
+    config.cacheReadCost ?? (modelCost && modelCost.cache_read * tierMultiplier) ?? inputCost;
 
   const inputCostTotal = inputCost * uncachedPromptTokens;
   const cacheReadCostTotal = cacheReadCost * billableCachedTokens;
@@ -282,7 +286,7 @@ class MiniMaxProvider extends OpenAiChatCompletionProvider {
       },
       data.usage?.prompt_tokens,
       data.usage?.completion_tokens,
-      data.usage?.prompt_tokens_details?.cached_tokens,
+      getOpenAICompletionTokenDetails(data.usage ?? {})?.cacheReadInputTokens,
     );
   }
 }

--- a/src/providers/moonshot.ts
+++ b/src/providers/moonshot.ts
@@ -187,29 +187,7 @@ class MoonshotProvider extends OpenAiChatCompletionProvider {
       );
     }
 
-    if (!pinsSamplingParams(modelName)) {
-      return result;
-    }
-
     const { body, config } = result;
-    if (config.temperature === undefined && config.passthrough?.temperature === undefined) {
-      delete body.temperature;
-    }
-    if (config.top_p === undefined && config.passthrough?.top_p === undefined) {
-      delete body.top_p;
-    }
-    if (
-      config.presence_penalty === undefined &&
-      config.passthrough?.presence_penalty === undefined
-    ) {
-      delete body.presence_penalty;
-    }
-    if (
-      config.frequency_penalty === undefined &&
-      config.passthrough?.frequency_penalty === undefined
-    ) {
-      delete body.frequency_penalty;
-    }
     // Moonshot's canonical field is max_completion_tokens (max_tokens is a
     // deprecated alias). Honor an explicit value on either field — prompt-level
     // config beats provider-level regardless of which alias each layer used —
@@ -228,11 +206,35 @@ class MoonshotProvider extends OpenAiChatCompletionProvider {
       config.passthrough?.max_tokens ??
       config.max_completion_tokens ??
       config.max_tokens;
-    delete body.max_tokens;
-    if (maxTokens === undefined) {
-      delete body.max_completion_tokens;
-    } else {
-      body.max_completion_tokens = maxTokens;
+    if (maxTokens !== undefined || pinsSamplingParams(modelName)) {
+      delete body.max_tokens;
+      if (maxTokens === undefined) {
+        delete body.max_completion_tokens;
+      } else {
+        body.max_completion_tokens = maxTokens;
+      }
+    }
+
+    if (!pinsSamplingParams(modelName)) {
+      return result;
+    }
+    if (config.temperature === undefined && config.passthrough?.temperature === undefined) {
+      delete body.temperature;
+    }
+    if (config.top_p === undefined && config.passthrough?.top_p === undefined) {
+      delete body.top_p;
+    }
+    if (
+      config.presence_penalty === undefined &&
+      config.passthrough?.presence_penalty === undefined
+    ) {
+      delete body.presence_penalty;
+    }
+    if (
+      config.frequency_penalty === undefined &&
+      config.passthrough?.frequency_penalty === undefined
+    ) {
+      delete body.frequency_penalty;
     }
     return result;
   }

--- a/src/providers/moonshot.ts
+++ b/src/providers/moonshot.ts
@@ -169,13 +169,15 @@ class MoonshotProvider extends OpenAiChatCompletionProvider {
   ) {
     const result = await super.getOpenAiBody(prompt, context, callApiOptions);
 
+    const modelName = typeof result.body.model === 'string' ? result.body.model : this.modelName;
+
     // reasoning_effort is K3-only per Moonshot's parameter matrix; fail fast on
     // other models instead of silently dropping it or sending it unsupported.
     // https://platform.kimi.ai/docs/api/models-overview
     if (result.config.reasoning_effort !== undefined) {
-      if (!/^kimi-k3/i.test(this.modelName)) {
+      if (!/^kimi-k3/i.test(modelName)) {
         throw new Error(
-          `Moonshot model ${this.modelName} does not support reasoning_effort (kimi-k3 family only). ` +
+          `Moonshot model ${modelName} does not support reasoning_effort (kimi-k3 family only). ` +
             'Remove it, use `passthrough: { thinking: ... }` on K2.x, or force-send it via `passthrough: { reasoning_effort: ... }`.',
         );
       }
@@ -185,21 +187,27 @@ class MoonshotProvider extends OpenAiChatCompletionProvider {
       );
     }
 
-    if (!pinsSamplingParams(this.modelName)) {
+    if (!pinsSamplingParams(modelName)) {
       return result;
     }
 
     const { body, config } = result;
-    if (config.temperature === undefined) {
+    if (config.temperature === undefined && config.passthrough?.temperature === undefined) {
       delete body.temperature;
     }
-    if (config.top_p === undefined) {
+    if (config.top_p === undefined && config.passthrough?.top_p === undefined) {
       delete body.top_p;
     }
-    if (config.presence_penalty === undefined) {
+    if (
+      config.presence_penalty === undefined &&
+      config.passthrough?.presence_penalty === undefined
+    ) {
       delete body.presence_penalty;
     }
-    if (config.frequency_penalty === undefined) {
+    if (
+      config.frequency_penalty === undefined &&
+      config.passthrough?.frequency_penalty === undefined
+    ) {
       delete body.frequency_penalty;
     }
     // Moonshot's canonical field is max_completion_tokens (max_tokens is a
@@ -208,9 +216,16 @@ class MoonshotProvider extends OpenAiChatCompletionProvider {
     // and drop the base provider's injected max_tokens: 1024 default so
     // reasoning can use Moonshot's server budget (32k for K2.x, 131k for K3).
     const promptConfig = (context?.prompt?.config ?? {}) as OpenAiCompletionOptions;
+    const promptPassthrough = promptConfig.passthrough as
+      | { max_completion_tokens?: unknown; max_tokens?: unknown }
+      | undefined;
     const maxTokens =
+      promptPassthrough?.max_completion_tokens ??
+      promptPassthrough?.max_tokens ??
       promptConfig.max_completion_tokens ??
       promptConfig.max_tokens ??
+      config.passthrough?.max_completion_tokens ??
+      config.passthrough?.max_tokens ??
       config.max_completion_tokens ??
       config.max_tokens;
     delete body.max_tokens;

--- a/test/providers/minimax-moonshot-request.test.ts
+++ b/test/providers/minimax-moonshot-request.test.ts
@@ -98,6 +98,30 @@ describe('Moonshot effective model policy', () => {
     ).rejects.toThrow('kimi-k2.6 does not support reasoning_effort');
   });
 
+  it.each([
+    [{ max_completion_tokens: 2000 }, {}, 2000],
+    [{ max_tokens: 2000 }, { max_completion_tokens: 7 }, 7],
+    [
+      { max_completion_tokens: 2000 },
+      { passthrough: { model: 'moonshot-v1-8k', max_tokens: 9 } },
+      9,
+    ],
+  ])(
+    'preserves explicit token limits for legacy model overrides',
+    async (config, promptConfig, expected) => {
+      const { body } = await makeProvider('moonshot', {
+        ...config,
+        passthrough: { model: 'moonshot-v1-8k' },
+      }).getOpenAiBody('Hello', promptContext(promptConfig));
+      expect(body).toMatchObject({
+        model: 'moonshot-v1-8k',
+        temperature: 0,
+        max_completion_tokens: expected,
+      });
+      expect(body).not.toHaveProperty('max_tokens');
+    },
+  );
+
   it('does not apply Kimi sampling rules to an overridden legacy model', async () => {
     const { body } = await makeProvider('moonshot', {
       passthrough: { model: 'moonshot-v1-private' },
@@ -107,7 +131,11 @@ describe('Moonshot effective model policy', () => {
 });
 
 describe('MiniMax effective billing', () => {
-  function reply(cached = false, serviceTier?: 'priority' | 'default') {
+  function reply(
+    cached = false,
+    serviceTier?: 'priority' | 'default',
+    cacheUsage: Record<string, unknown> = { prompt_tokens_details: { cached_tokens: 40 } },
+  ) {
     vi.mocked(fetchWithCache).mockResolvedValue({
       data: {
         choices: [{ message: { content: 'Hello' }, finish_reason: 'stop' }],
@@ -115,7 +143,7 @@ describe('MiniMax effective billing', () => {
           prompt_tokens: 100,
           completion_tokens: 50,
           total_tokens: 150,
-          prompt_tokens_details: { cached_tokens: 40 },
+          ...cacheUsage,
         },
         ...(serviceTier ? { service_tier: serviceTier } : {}),
       },
@@ -162,6 +190,47 @@ describe('MiniMax effective billing', () => {
       (512001 * 0.6 * 1.5) / 1e6,
       12,
     );
+  });
+
+  it.each([
+    { prompt_tokens_details: { cached_tokens: 40 } },
+    { input_tokens_details: { cached_tokens: 40 } },
+    { cached_tokens: 40 },
+  ])('preserves normalized cached-token billing for %j', async (cacheUsage) => {
+    reply(false, undefined, cacheUsage);
+    const result = await makeProvider('minimax', { apiKey: 'fixture' }).callApi('Hello');
+    expect(result.tokenUsage?.completionDetails?.cacheReadInputTokens).toBe(40);
+    expect(result.cost).toBeCloseTo(0.0000804, 14);
+  });
+
+  it('preserves an explicit native zero before alternate cache counters', async () => {
+    reply(false, undefined, { prompt_tokens_details: { cached_tokens: 0 }, cached_tokens: 40 });
+    const result = await makeProvider('minimax', { apiKey: 'fixture' }).callApi('Hello');
+    expect(result.cost).toBeCloseTo(0.00009, 14);
+  });
+
+  it.each([
+    [{ inputCost: 0.01, outputCost: 0.02, cacheReadCost: 0.001 }, 40, 1.64],
+    [{ inputCost: 0.01, outputCost: 0.02 }, 0, 2],
+    [{ inputCost: 0.01, outputCost: 0.02 }, 40, 2],
+    [{ cost: 0.0001, cacheReadCost: 0 }, 40, 0.011],
+    [{ inputCost: 0, outputCost: 0, cacheReadCost: 0 }, 40, 0],
+  ])(
+    'honors custom pricing for an unlisted effective alias',
+    async (config, cachedTokens, expected) => {
+      reply(false, 'priority', { input_tokens_details: { cached_tokens: cachedTokens } });
+      const result = await makeProvider('minimax', { apiKey: 'fixture' }).callApi(
+        'Hello',
+        promptContext({ ...config, passthrough: { model: 'private-minimax-deployment' } }),
+      );
+      expect(result.cost).toBeCloseTo(expected, 14);
+    },
+  );
+
+  it('leaves unlisted aliases without sufficient rates unpriced', () => {
+    expect(
+      calculateMiniMaxCost('private-deployment', { inputCost: 0.01 }, 100, 50),
+    ).toBeUndefined();
   });
 
   it('retains zero incremental cost on a promptfoo cache hit', async () => {

--- a/test/providers/minimax-moonshot-request.test.ts
+++ b/test/providers/minimax-moonshot-request.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../src/cache';
+import { calculateMiniMaxCost, createMiniMaxProvider } from '../../src/providers/minimax';
+import { createMoonshotProvider } from '../../src/providers/moonshot';
+import { mockProcessEnv } from '../util/utils';
+
+import type { OpenAiChatCompletionProvider } from '../../src/providers/openai/chat';
+import type { OpenAiCompletionOptions } from '../../src/providers/openai/types';
+import type { CallApiContextParams } from '../../src/types/index';
+
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+}));
+let restoreEnv: () => void;
+beforeEach(() => {
+  vi.mocked(fetchWithCache).mockReset();
+  restoreEnv = mockProcessEnv({
+    OPENAI_TEMPERATURE: '0',
+    OPENAI_TOP_P: '0.1',
+    OPENAI_MAX_TOKENS: '12',
+    OPENAI_PRESENCE_PENALTY: '0.2',
+    OPENAI_FREQUENCY_PENALTY: '0.3',
+  });
+});
+afterEach(() => restoreEnv());
+
+function makeProvider(name: string, config: OpenAiCompletionOptions) {
+  return (
+    name === 'minimax'
+      ? createMiniMaxProvider('minimax:MiniMax-M3', { config: { config } })
+      : createMoonshotProvider('moonshot:kimi-k3', { config })
+  ) as OpenAiChatCompletionProvider;
+}
+function promptContext(config: OpenAiCompletionOptions): CallApiContextParams {
+  return { vars: {}, prompt: { raw: 'Hello', label: 'fixture', config } };
+}
+
+describe.each(['minimax', 'moonshot'])('%s explicit request options', (name) => {
+  it('preserves explicit passthrough sampling while excluding unrelated OpenAI defaults', async () => {
+    const { body } = await makeProvider(name, {
+      passthrough: { temperature: 0, top_p: 0.7, frequency_penalty: 0 },
+    }).getOpenAiBody('Hello');
+    expect(body).toMatchObject({ temperature: 0, top_p: 0.7, frequency_penalty: 0 });
+    expect(body).not.toHaveProperty('presence_penalty');
+    expect(body).not.toHaveProperty('max_tokens');
+    expect(body).not.toHaveProperty('max_completion_tokens');
+  });
+
+  it.each(['max_tokens', 'max_completion_tokens'])('normalizes passthrough %s', async (field) => {
+    const { body } = await makeProvider(name, { passthrough: { [field]: 17 } }).getOpenAiBody(
+      'Hello',
+    );
+    expect(body.max_completion_tokens).toBe(17);
+    expect(body).not.toHaveProperty('max_tokens');
+  });
+
+  it.each([
+    [{ max_completion_tokens: 100 }, { max_tokens: 7 }],
+    [{ max_tokens: 100 }, { max_completion_tokens: 7 }],
+    [{ passthrough: { max_completion_tokens: 100 } }, { max_tokens: 7 }],
+    [{ max_completion_tokens: 100 }, { passthrough: { max_tokens: 7 } }],
+  ])('prefers prompt token limits across aliases', async (config, promptConfig) => {
+    const { body } = await makeProvider(name, config).getOpenAiBody(
+      'Hello',
+      promptContext(promptConfig),
+    );
+    expect(body.max_completion_tokens).toBe(7);
+    expect(body).not.toHaveProperty('max_tokens');
+  });
+
+  it('lets passthrough override a same-layer top-level token limit', async () => {
+    const { body } = await makeProvider(name, {
+      max_completion_tokens: 100,
+      passthrough: { max_tokens: 9 },
+    }).getOpenAiBody('Hello');
+    expect(body.max_completion_tokens).toBe(9);
+  });
+});
+
+describe('Moonshot effective model policy', () => {
+  it('uses the passthrough K3 model for reasoning effort support', async () => {
+    const provider = createMoonshotProvider('moonshot:kimi-k2.6', {
+      config: { reasoning_effort: 'low', passthrough: { model: 'kimi-k3-private' } },
+    }) as OpenAiChatCompletionProvider;
+    expect((await provider.getOpenAiBody('Hello')).body).toMatchObject({
+      model: 'kimi-k3-private',
+      reasoning_effort: 'low',
+    });
+  });
+
+  it('rejects top-level effort when the effective model is not K3', async () => {
+    await expect(
+      makeProvider('moonshot', {
+        reasoning_effort: 'max',
+        passthrough: { model: 'kimi-k2.6' },
+      }).getOpenAiBody('Hello'),
+    ).rejects.toThrow('kimi-k2.6 does not support reasoning_effort');
+  });
+
+  it('does not apply Kimi sampling rules to an overridden legacy model', async () => {
+    const { body } = await makeProvider('moonshot', {
+      passthrough: { model: 'moonshot-v1-private' },
+    }).getOpenAiBody('Hello');
+    expect(body).toMatchObject({ model: 'moonshot-v1-private', temperature: 0, max_tokens: 12 });
+  });
+});
+
+describe('MiniMax effective billing', () => {
+  function reply(cached = false, serviceTier?: 'priority' | 'default') {
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: {
+        choices: [{ message: { content: 'Hello' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          prompt_tokens_details: { cached_tokens: 40 },
+        },
+        ...(serviceTier ? { service_tier: serviceTier } : {}),
+      },
+      cached,
+      status: 200,
+      statusText: 'OK',
+    });
+  }
+
+  it('bills the model and rates selected by prompt overrides', async () => {
+    reply();
+    const result = await makeProvider('minimax', { apiKey: 'fixture', inputCost: 0.01 }).callApi(
+      'Hello',
+      promptContext({ inputCost: 0.02, passthrough: { model: 'MiniMax-M2.7-highspeed' } }),
+    );
+    expect(result.cost).toBeCloseTo(60 * 0.02 + (40 * 0.06) / 1e6 + (50 * 2.4) / 1e6, 10);
+  });
+
+  it.each([{}, { passthrough: { service_tier: 'priority' } }])(
+    'bills priority selected by response or request',
+    async (config) => {
+      reply(false, Object.keys(config).length ? undefined : 'priority');
+      const result = await makeProvider('minimax', { apiKey: 'fixture', ...config }).callApi(
+        'Hello',
+      );
+      expect(result.cost).toBeCloseTo(((60 * 0.3 + 40 * 0.06 + 50 * 1.2) * 1.5) / 1e6, 12);
+    },
+  );
+
+  it('does not multiply explicit user rates by the priority tier', () => {
+    expect(
+      calculateMiniMaxCost(
+        'MiniMax-M3',
+        { service_tier: 'priority', inputCost: 0.01, outputCost: 0.02, cacheReadCost: 0.001 },
+        100,
+        50,
+        40,
+      ),
+    ).toBeCloseTo(1.64);
+  });
+
+  it('applies priority to long-context fallback rates', () => {
+    expect(calculateMiniMaxCost('MiniMax-M3', { service_tier: 'priority' }, 512001, 0)).toBeCloseTo(
+      (512001 * 0.6 * 1.5) / 1e6,
+      12,
+    );
+  });
+
+  it('retains zero incremental cost on a promptfoo cache hit', async () => {
+    reply(true);
+    expect(
+      (
+        await makeProvider('minimax', { apiKey: 'fixture', service_tier: 'priority' }).callApi(
+          'Hello',
+        )
+      ).cost,
+    ).toBe(0);
+  });
+});

--- a/test/providers/minimax.test.ts
+++ b/test/providers/minimax.test.ts
@@ -5,7 +5,6 @@ import {
   createMiniMaxProvider,
   MINIMAX_CHAT_MODELS,
 } from '../../src/providers/minimax';
-import { OpenAiChatCompletionProvider } from '../../src/providers/openai/chat';
 import { HttpRateLimitError } from '../../src/util/fetch/errors';
 import { mockProcessEnv } from '../util/utils';
 
@@ -464,102 +463,46 @@ describe('MiniMaxProvider', () => {
     expect(result.metadata?.rateLimitKind).toBe('rate_limit');
   });
 
-  it('should calculate cost from cached token metadata in string raw responses', async () => {
-    vi.spyOn(OpenAiChatCompletionProvider.prototype, 'callApi').mockResolvedValueOnce({
-      output: 'MiniMax response',
-      tokenUsage: {
-        total: 150,
-        prompt: 100,
-        completion: 50,
-      },
-      raw: JSON.stringify({
-        usage: {
-          prompt_tokens_details: {
-            cached_tokens: 40,
+  it.each([0, 25, 100])(
+    'calculates native cached token usage %s before normalization',
+    async (cachedTokens) => {
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: {
+          choices: [{ message: { content: 'MiniMax response' }, finish_reason: 'stop' }],
+          usage: {
+            prompt_tokens: 100,
+            completion_tokens: 50,
+            total_tokens: 150,
+            prompt_tokens_details: { cached_tokens: cachedTokens },
           },
         },
-      }),
-    });
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+      const provider = createMiniMaxProvider('minimax:MiniMax-M2.7', {
+        config: { config: { apiKey: 'fixture-key' } },
+      });
+      const result = await provider.callApi('Test prompt');
+      expect(result.cost).toBe(calculateMiniMaxCost('MiniMax-M2.7', {}, 100, 50, cachedTokens));
+      expect(result.tokenUsage?.prompt).toBe(100);
+    },
+  );
 
-    const provider = createMiniMaxProvider('minimax:MiniMax-M2.7');
-    const result = await provider.callApi('Test prompt');
-
-    expect(result.cost).toBe(calculateMiniMaxCost('MiniMax-M2.7', {}, 100, 50, 40));
-  });
-
-  it('should calculate cost from cached token metadata in object raw responses', async () => {
-    vi.spyOn(OpenAiChatCompletionProvider.prototype, 'callApi').mockResolvedValueOnce({
-      output: 'MiniMax response',
-      tokenUsage: {
-        total: 150,
-        prompt: 100,
-        completion: 50,
-      },
-      raw: {
-        usage: {
-          prompt_tokens_details: {
-            cached_tokens: 25,
-          },
-        },
-      },
-    });
-
-    const provider = createMiniMaxProvider('minimax:MiniMax-M2.7-highspeed');
-    const result = await provider.callApi('Test prompt');
-
-    expect(result.cost).toBe(calculateMiniMaxCost('MiniMax-M2.7-highspeed', {}, 100, 50, 25));
-  });
-
-  it('should still calculate cost when cache metadata is malformed', async () => {
-    vi.spyOn(OpenAiChatCompletionProvider.prototype, 'callApi').mockResolvedValueOnce({
-      output: 'MiniMax response',
-      tokenUsage: {
-        total: 150,
-        prompt: 100,
-        completion: 50,
-      },
-      raw: '{"usage":',
-    });
-
-    const provider = createMiniMaxProvider('minimax:MiniMax-M3');
-    const result = await provider.callApi('Test prompt');
-
-    expect(result.cost).toBe(calculateMiniMaxCost('MiniMax-M3', {}, 100, 50, 0));
-  });
-
-  it('should preserve cached responses without recalculating cost', async () => {
-    vi.spyOn(OpenAiChatCompletionProvider.prototype, 'callApi').mockResolvedValueOnce({
-      output: 'Cached MiniMax response',
-      tokenUsage: {
-        total: 150,
-        prompt: 100,
-        completion: 50,
-      },
-      raw: {
-        usage: {
-          prompt_tokens_details: {
-            cached_tokens: 100,
-          },
-        },
+  it('reports zero incremental cost for promptfoo cache hits', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValueOnce({
+      data: {
+        choices: [{ message: { content: 'Cached MiniMax response' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
       },
       cached: true,
+      status: 200,
+      statusText: 'OK',
     });
-
-    const provider = createMiniMaxProvider('minimax:MiniMax-M2.7-highspeed');
+    const provider = createMiniMaxProvider('minimax:MiniMax-M2.7-highspeed', {
+      config: { config: { apiKey: 'fixture-key' } },
+    });
     const result = await provider.callApi('Test prompt');
-
-    expect(result.cached).toBe(true);
-    expect(result.cost).toBeUndefined();
-  });
-
-  it('should pass through empty and error parent responses', async () => {
-    const callApi = vi.spyOn(OpenAiChatCompletionProvider.prototype, 'callApi');
-    callApi.mockResolvedValueOnce(undefined as any);
-    callApi.mockResolvedValueOnce({ error: 'API error' });
-
-    const provider = createMiniMaxProvider('minimax:MiniMax-M2.7');
-
-    await expect(provider.callApi('Empty response')).resolves.toBeUndefined();
-    await expect(provider.callApi('Error response')).resolves.toEqual({ error: 'API error' });
+    expect(result).toMatchObject({ cached: true, cost: 0 });
   });
 });


### PR DESCRIPTION
MiniMax and Moonshot dropped explicitly configured passthrough sampling and token limits after building the request. Preserve those fields, let prompt limits override provider limits across token aliases, and apply Moonshot model rules to the model actually sent. Explicit limits also survive legacy Moonshot model overrides while keeping their sampling defaults.

MiniMax billing now uses the existing response-cost hook so prompt-specific rates, effective model overrides, normalized cached-token counts, and M3 priority pricing affect the estimate. Explicit rates also support unlisted deployment aliases. User rates retain precedence, and locally cached responses retain zero incremental cost. The built-in priority multiplier follows the [native MiniMax pricing guide](https://platform.minimax.io/docs/guides/pricing-paygo).

Validation: 122 focused tests; TypeScript/package/UI build; eight built CLI fixtures inspect request bodies, exported costs, cache-usage variants, and unsupported effective-model errors. Fixtures make no vendor API calls.
