### PR TITLE
fix(providers): correct Databricks serving endpoint requests

### DIFF
--- a/site/docs/providers/databricks.md
+++ b/site/docs/providers/databricks.md
@@ -78,12 +78,11 @@ providers:
 
 The Databricks provider extends the [OpenAI configuration options](/docs/providers/openai#configuring-parameters) with these Databricks-specific features:
 
-| Parameter         | Description                                                                                   | Default |
-| ----------------- | --------------------------------------------------------------------------------------------- | ------- |
-| `workspaceUrl`    | Databricks workspace URL. Can also be set via `DATABRICKS_WORKSPACE_URL` environment variable | -       |
-| `isPayPerToken`   | Whether this is a pay-per-token endpoint (true) or custom deployed endpoint (false)           | false   |
-| `usageContext`    | Optional metadata for usage tracking and cost attribution                                     | -       |
-| `aiGatewayConfig` | AI Gateway features configuration (safety filters, PII handling)                              | -       |
+| Parameter       | Description                                                                                   | Default |
+| --------------- | --------------------------------------------------------------------------------------------- | ------- |
+| `workspaceUrl`  | Databricks workspace URL. Can also be set via `DATABRICKS_WORKSPACE_URL` environment variable | -       |
+| `isPayPerToken` | Legacy classification; both values use the OpenAI-compatible chat endpoint                    | false   |
+| `usageContext`  | Optional metadata for usage tracking and cost attribution                                     | -       |
 
 ### Advanced Configuration
 
@@ -104,12 +103,11 @@ providers:
         project: 'customer-support'
         team: 'engineering'
         environment: 'production'
-
-      # AI Gateway features (if enabled on endpoint)
-      aiGatewayConfig:
-        enableSafety: true
-        piiHandling: 'mask' # Options: none, block, mask
 ```
+
+Configure safety filters and PII handling on the [Databricks serving endpoint](https://docs.databricks.com/aws/en/ai-gateway/configure-ai-gateway-endpoints#configure-ai-guardrails-in-the-ui). The legacy `aiGatewayConfig` option does not enable these controls.
+
+Both pay-per-token and custom chat endpoints use `/serving-endpoints/chat/completions`, with the serving endpoint name in the `model` field.
 
 ## Environment Variables
 

--- a/src/providers/databricks.ts
+++ b/src/providers/databricks.ts
@@ -57,9 +57,7 @@ export class DatabricksMosaicAiChatCompletionProvider extends OpenAiChatCompleti
 
   constructor(modelName: string, providerOptions: DatabricksMosaicAiProviderOptions) {
     const workspaceUrl =
-      providerOptions.config?.workspaceUrl ||
-      providerOptions.env?.DATABRICKS_WORKSPACE_URL ||
-      getEnvString('DATABRICKS_WORKSPACE_URL');
+      providerOptions.config?.workspaceUrl || getEnvString('DATABRICKS_WORKSPACE_URL');
 
     if (!workspaceUrl) {
       throw new Error(

--- a/src/providers/databricks.ts
+++ b/src/providers/databricks.ts
@@ -18,8 +18,7 @@ export interface DatabricksMosaicAiCompletionOptions extends OpenAiCompletionOpt
   workspaceUrl?: string;
 
   /**
-   * Whether this is a pay-per-token endpoint (true) or custom deployed endpoint (false)
-   * Defaults to false for backward compatibility
+   * Legacy endpoint classification. Both values use the OpenAI-compatible chat endpoint.
    */
   isPayPerToken?: boolean;
 
@@ -30,8 +29,8 @@ export interface DatabricksMosaicAiCompletionOptions extends OpenAiCompletionOpt
   usageContext?: Record<string, string>;
 
   /**
-   * Enable AI Gateway features like guardrails, PII detection, etc.
-   * Only available on endpoints with AI Gateway enabled
+   * @deprecated Configure guardrails on the Databricks serving endpoint.
+   * This option does not configure server-side safety or PII handling.
    */
   aiGatewayConfig?: {
     enableSafety?: boolean;
@@ -58,7 +57,9 @@ export class DatabricksMosaicAiChatCompletionProvider extends OpenAiChatCompleti
 
   constructor(modelName: string, providerOptions: DatabricksMosaicAiProviderOptions) {
     const workspaceUrl =
-      providerOptions.config?.workspaceUrl || getEnvString('DATABRICKS_WORKSPACE_URL');
+      providerOptions.config?.workspaceUrl ||
+      providerOptions.env?.DATABRICKS_WORKSPACE_URL ||
+      getEnvString('DATABRICKS_WORKSPACE_URL');
 
     if (!workspaceUrl) {
       throw new Error(
@@ -69,20 +70,18 @@ export class DatabricksMosaicAiChatCompletionProvider extends OpenAiChatCompleti
     // Ensure workspace URL doesn't have trailing slash
     const cleanWorkspaceUrl = workspaceUrl.replace(/\/$/, '');
 
-    // For pay-per-token endpoints, the model name is the full endpoint name
-    // For custom endpoints, we use the serving-endpoints path
-    const apiBaseUrl = providerOptions.config?.isPayPerToken
-      ? cleanWorkspaceUrl
-      : `${cleanWorkspaceUrl}/serving-endpoints`;
+    // Databricks accepts both foundation and custom endpoint names in the model field.
+    // The inherited chat transport appends /chat/completions to this base URL.
+    const apiBaseUrl = `${cleanWorkspaceUrl}/serving-endpoints`;
 
     const mergedConfig: DatabricksMosaicAiCompletionOptions = {
       ...providerOptions.config,
       apiKeyEnvar: providerOptions.config?.apiKeyEnvar || 'DATABRICKS_TOKEN',
       apiBaseUrl,
-      // Pass through usage context and AI Gateway config as extra body params
+      // The shared OpenAI transport sends additional request fields via passthrough.
       ...(providerOptions.config?.usageContext && {
-        extraBodyParams: {
-          ...providerOptions.config.extraBodyParams,
+        passthrough: {
+          ...providerOptions.config.passthrough,
           usage_context: providerOptions.config.usageContext,
         },
       }),
@@ -95,17 +94,5 @@ export class DatabricksMosaicAiChatCompletionProvider extends OpenAiChatCompleti
 
     // Set the config property with the full Databricks-specific configuration
     this.config = mergedConfig;
-  }
-
-  /**
-   * Override getApiUrl to handle Databricks-specific endpoint patterns
-   */
-  public getApiUrl(): string {
-    // For pay-per-token endpoints, use the model name directly in the path
-    if (this.config.isPayPerToken) {
-      return `${this.config.apiBaseUrl}/serving-endpoints/${this.modelName}/invocations`;
-    }
-    // For custom endpoints, use standard OpenAI chat completions path
-    return super.getApiUrl();
   }
 }

--- a/test/providers/databricks-loader.test.ts
+++ b/test/providers/databricks-loader.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../src/cache';
+import { loadApiProvider } from '../../src/providers';
+
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(fetchWithCache).mockReset();
+});
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('Databricks loader request configuration', () => {
+  it.each([true, false])(
+    'uses Databricks chat endpoint for isPayPerToken=%s with usage metadata',
+    async (isPayPerToken) => {
+      vi.mocked(fetchWithCache).mockResolvedValue({
+        data: {
+          choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+      const provider = await loadApiProvider('databricks:customer-endpoint', {
+        options: {
+          config: {
+            workspaceUrl: 'https://workspace.example.test',
+            apiKey: 'fixture-token',
+            isPayPerToken,
+            usageContext: { project: 'fixture' },
+            passthrough: { custom_field: 'preserved' },
+          },
+        },
+      });
+      expect(await provider.callApi('hello')).toMatchObject({
+        output: 'hello',
+        cached: false,
+        tokenUsage: { total: 5, prompt: 3, completion: 2 },
+      });
+      const [url, init] = vi.mocked(fetchWithCache).mock.calls[0];
+      expect(url).toBe('https://workspace.example.test/serving-endpoints/chat/completions');
+      expect(JSON.parse(init?.body as string)).toMatchObject({
+        model: 'customer-endpoint',
+        usage_context: { project: 'fixture' },
+        custom_field: 'preserved',
+      });
+    },
+  );
+
+  it('uses per-provider Databricks workspace env overrides', async () => {
+    const provider = await loadApiProvider('databricks:customer-endpoint', {
+      env: { DATABRICKS_WORKSPACE_URL: 'https://suite.example.test' },
+      options: { env: { DATABRICKS_WORKSPACE_URL: 'https://provider.example.test' } },
+    });
+    expect((provider as unknown as { getApiUrl(): string }).getApiUrl()).toBe(
+      'https://provider.example.test/serving-endpoints',
+    );
+  });
+
+  it('uses suite credentials when the process token is absent and preserves API errors', async () => {
+    vi.stubEnv('DATABRICKS_TOKEN', '');
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: { error: { message: 'Fixture rate limit', type: 'rate_limit' } },
+      cached: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+    });
+    const provider = await loadApiProvider('databricks:external-endpoint', {
+      env: {
+        DATABRICKS_TOKEN: 'fixture-suite',
+        DATABRICKS_WORKSPACE_URL: 'https://suite.example.test',
+      },
+      options: { id: 'customer-chat', config: { isPayPerToken: true } },
+    });
+    expect(provider.id()).toBe('customer-chat');
+    expect(await provider.callApi('hello')).toHaveProperty(
+      'error',
+      expect.stringContaining('Fixture rate limit'),
+    );
+    expect(vi.mocked(fetchWithCache).mock.calls[0][1]?.headers).toMatchObject({
+      Authorization: 'Bearer fixture-suite',
+    });
+  });
+});

--- a/test/providers/databricks-loader.test.ts
+++ b/test/providers/databricks-loader.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../src/cache';
+import cliState from '../../src/cliState';
 import { loadApiProvider } from '../../src/providers';
 
 vi.mock('../../src/cache', async (importOriginal) => ({
@@ -7,10 +8,28 @@ vi.mock('../../src/cache', async (importOriginal) => ({
   fetchWithCache: vi.fn(),
 }));
 
+let originalConfig: typeof cliState.config;
+
+function expectRequest(url: string, token: string) {
+  expect(fetchWithCache).toHaveBeenCalledTimes(1);
+  const [actualUrl, request] = vi.mocked(fetchWithCache).mock.calls[0];
+  expect(actualUrl).toBe(url);
+  expect(request?.headers).toMatchObject({ Authorization: `Bearer ${token}` });
+}
+
 beforeEach(() => {
+  originalConfig = cliState.config;
+  cliState.config = undefined;
   vi.mocked(fetchWithCache).mockReset();
+  vi.mocked(fetchWithCache).mockResolvedValue({
+    data: { choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }] },
+    cached: false,
+    status: 200,
+    statusText: 'OK',
+  });
 });
 afterEach(() => {
+  cliState.config = originalConfig;
   vi.resetAllMocks();
   vi.unstubAllEnvs();
 });
@@ -54,13 +73,86 @@ describe('Databricks loader request configuration', () => {
     },
   );
 
-  it('uses per-provider Databricks workspace env overrides', async () => {
+  it.each(['process', 'registered suite'])(
+    'keeps the %s workspace and token paired when provider env also supplies a pair',
+    async (source) => {
+      vi.stubEnv('DATABRICKS_WORKSPACE_URL', 'https://process.example.test');
+      vi.stubEnv('DATABRICKS_TOKEN', 'process-token');
+      if (source === 'registered suite') {
+        cliState.config = {
+          env: {
+            DATABRICKS_WORKSPACE_URL: 'https://suite.example.test',
+            DATABRICKS_TOKEN: 'suite-token',
+          },
+        };
+      }
+      const provider = await loadApiProvider('databricks:customer-endpoint', {
+        options: {
+          env: {
+            DATABRICKS_WORKSPACE_URL: 'https://provider.example.test',
+            DATABRICKS_TOKEN: 'provider-token',
+          },
+        },
+      });
+
+      expect(await provider.callApi('hello')).toMatchObject({ output: 'hello' });
+      const expectedSource = source === 'registered suite' ? 'suite' : 'process';
+      expectRequest(
+        `https://${expectedSource}.example.test/serving-endpoints/chat/completions`,
+        `${expectedSource}-token`,
+      );
+    },
+  );
+
+  it('uses the registered suite workspace and token over the process pair', async () => {
+    vi.stubEnv('DATABRICKS_WORKSPACE_URL', 'https://process.example.test');
+    vi.stubEnv('DATABRICKS_TOKEN', 'process-token');
+    cliState.config = {
+      env: {
+        DATABRICKS_WORKSPACE_URL: 'https://suite.example.test',
+        DATABRICKS_TOKEN: 'suite-token',
+      },
+    };
+    const provider = await loadApiProvider('databricks:customer-endpoint');
+    expect(await provider.callApi('hello')).toMatchObject({ output: 'hello' });
+    expectRequest('https://suite.example.test/serving-endpoints/chat/completions', 'suite-token');
+  });
+
+  it('keeps explicit workspace and credentials ahead of environment values', async () => {
+    vi.stubEnv('DATABRICKS_WORKSPACE_URL', 'https://process.example.test');
+    vi.stubEnv('DATABRICKS_TOKEN', 'process-token');
     const provider = await loadApiProvider('databricks:customer-endpoint', {
-      env: { DATABRICKS_WORKSPACE_URL: 'https://suite.example.test' },
-      options: { env: { DATABRICKS_WORKSPACE_URL: 'https://provider.example.test' } },
+      options: {
+        env: {
+          DATABRICKS_WORKSPACE_URL: 'https://provider.example.test',
+          DATABRICKS_TOKEN: 'provider-token',
+        },
+        config: { workspaceUrl: 'https://configured.example.test', apiKey: 'configured-token' },
+      },
     });
-    expect((provider as unknown as { getApiUrl(): string }).getApiUrl()).toBe(
-      'https://provider.example.test/serving-endpoints',
+    expect(await provider.callApi('hello')).toMatchObject({ output: 'hello' });
+    expectRequest(
+      'https://configured.example.test/serving-endpoints/chat/completions',
+      'configured-token',
+    );
+  });
+
+  it('preserves custom apiKeyEnvar precedence alongside the workspace', async () => {
+    vi.stubEnv('DATABRICKS_WORKSPACE_URL', 'https://process.example.test');
+    vi.stubEnv('AZURE_API_KEY', 'custom-process-token');
+    const provider = await loadApiProvider('databricks:customer-endpoint', {
+      options: {
+        env: {
+          DATABRICKS_WORKSPACE_URL: 'https://provider.example.test',
+          AZURE_API_KEY: 'custom-provider-token',
+        },
+        config: { apiKeyEnvar: 'AZURE_API_KEY' },
+      },
+    });
+    expect(await provider.callApi('hello')).toMatchObject({ output: 'hello' });
+    expectRequest(
+      'https://process.example.test/serving-endpoints/chat/completions',
+      'custom-process-token',
     );
   });
 
@@ -75,9 +167,11 @@ describe('Databricks loader request configuration', () => {
     const provider = await loadApiProvider('databricks:external-endpoint', {
       env: {
         DATABRICKS_TOKEN: 'fixture-suite',
-        DATABRICKS_WORKSPACE_URL: 'https://suite.example.test',
       },
-      options: { id: 'customer-chat', config: { isPayPerToken: true } },
+      options: {
+        id: 'customer-chat',
+        config: { isPayPerToken: true, workspaceUrl: 'https://configured.example.test' },
+      },
     });
     expect(provider.id()).toBe('customer-chat');
     expect(await provider.callApi('hello')).toHaveProperty(

--- a/test/providers/databricks.test.ts
+++ b/test/providers/databricks.test.ts
@@ -54,7 +54,7 @@ describe('Databricks Foundation Model APIs Provider', () => {
       );
 
       expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
-      expect(provider.config.apiBaseUrl).toBe(workspaceUrl);
+      expect(provider.config.apiBaseUrl).toBe(`${workspaceUrl}/serving-endpoints`);
       expect(provider.config.apiKeyEnvar).toBe('DATABRICKS_TOKEN');
     });
 
@@ -140,7 +140,7 @@ describe('Databricks Foundation Model APIs Provider', () => {
       };
       const provider = new DatabricksMosaicAiChatCompletionProvider('my-endpoint', options);
 
-      expect((provider.config as any).extraBodyParams).toEqual({
+      expect((provider.config as any).passthrough).toEqual({
         usage_context: {
           project: 'test-project',
           team: 'engineering',
@@ -155,14 +155,14 @@ describe('Databricks Foundation Model APIs Provider', () => {
           usageContext: {
             project: 'test-project',
           },
-          extraBodyParams: {
+          passthrough: {
             custom_param: 'value',
           },
         },
       };
       const provider = new DatabricksMosaicAiChatCompletionProvider('my-endpoint', options);
 
-      expect((provider.config as any).extraBodyParams).toEqual({
+      expect((provider.config as any).passthrough).toEqual({
         custom_param: 'value',
         usage_context: {
           project: 'test-project',
@@ -202,7 +202,7 @@ describe('Databricks Foundation Model APIs Provider', () => {
   });
 
   describe('getApiUrl method', () => {
-    it('should return custom URL for pay-per-token endpoints', () => {
+    it('should return the compatible base URL for pay-per-token endpoints', () => {
       const options: DatabricksMosaicAiProviderOptions = {
         config: {
           workspaceUrl,
@@ -217,9 +217,7 @@ describe('Databricks Foundation Model APIs Provider', () => {
       // Use type assertion to access protected method
       const url = (provider as any).getApiUrl();
 
-      expect(url).toBe(
-        `${workspaceUrl}/serving-endpoints/databricks-meta-llama-3-3-70b-instruct/invocations`,
-      );
+      expect(url).toBe(`${workspaceUrl}/serving-endpoints`);
     });
 
     it('should use parent class URL for custom endpoints', () => {


### PR DESCRIPTION
Pay-per-token requests currently append `/chat/completions` to an `/invocations` URL. Use the serving-endpoint chat route for both endpoint classifications, preserve the configured endpoint name in `model`, and forward `usageContext` through the existing request passthrough.

The `aiGatewayConfig` option never configured safety or PII controls. Retain its type as deprecated and direct users to [Databricks endpoint governance](https://docs.databricks.com/aws/en/ai-gateway/configure-ai-gateway-endpoints).

Validation: 21 mocked provider/loader tests, including paired URL/token checks for process, registered suite, explicit config and custom key settings; type check and package/UI build; 8 built CLI evaluation rows across four environment/configuration combinations and both endpoint classifications, with exact URL/header/body and exported output/usage inspection. Documentation production build passed. No live workspace calls.

CLI configurations with conflicting process and top-level suite workspace/token values retain a pre-existing initialization-order limitation. Use explicit workspace configuration for those cases.
