### PR TITLE
fix(providers): correct Bedrock embeddings and knowledge base requests

### DIFF
--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1826,6 +1826,10 @@ providers:
 
 The provider ID follows this pattern: `bedrock:kb:[REGIONAL_MODEL_ID]`
 
+A generation model is required: specify it in the provider ID or supply `config.modelArn`. The provider returns a configuration error before contacting AWS if both are missing.
+
+System-defined inference profile IDs with `us.`, `eu.`, `apac.`, `global.`, `jp.`, or `au.` prefixes and full Bedrock ARNs are passed through unchanged, including ARNs for other AWS partitions. Choose a model or profile available to your AWS account and Knowledge Base region; promptfoo does not select a default or create a profile.
+
 For example:
 
 - `bedrock:kb:us.anthropic.claude-3-5-sonnet-20241022-v2:0` (US region)
@@ -1834,6 +1838,7 @@ For example:
 Configuration options include:
 
 - `knowledgeBaseId` (required): The ID of your AWS Bedrock Knowledge Base
+- `modelArn`: Optional explicit generation model ARN, overriding the model in the provider ID
 - `region`: AWS region where your Knowledge Base is deployed (e.g., 'us-east-1', 'us-east-2', 'eu-west-1')
 - `temperature`: Controls randomness in response generation (uses the model default when omitted)
 - `max_tokens`: Maximum number of tokens in the generated response
@@ -1842,6 +1847,8 @@ Configuration options include:
 - `numberOfResults`: Number of chunks to retrieve from the knowledge base (optional, uses AWS default when not specified)
 - `accessKeyId`, `secretAccessKey`, `sessionToken`: AWS credentials (if not using environment variables or IAM roles)
 - `profile`: AWS profile name for SSO authentication
+
+For Claude models that no longer support sampling parameters, such as [Opus 4.7](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html), the provider omits `temperature`, `top_p`, and `top_k` while preserving `max_tokens`. This check uses `config.modelArn` when supplied.
 
 ### Knowledge Base Example
 

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1850,7 +1850,7 @@ Configuration options include:
 
 For Claude models that no longer support sampling parameters, such as [Opus 4.7](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html), the provider omits `temperature`, `top_p`, and `top_k` while preserving `max_tokens`. This check uses `config.modelArn` when supplied.
 
-[Claude Sonnet 4.5 and Haiku 4.5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html) accept either `temperature` or `top_p`. When both are configured, `top_p` takes precedence. For Amazon Nova, `top_k` is mapped to its native `inferenceConfig.topK` request field.
+[Claude Sonnet 4.5 and Haiku 4.5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html) accept either `temperature` or `top_p`. When both are configured, `top_p` takes precedence. The provider applies the same precedence to Sonnet 4.6. For Amazon Nova, `top_k` is mapped to its native `inferenceConfig.topK` request field; for [Cohere Command R and R+](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere-command-r-plus.html), it is mapped to `k`.
 
 ### Knowledge Base Example
 

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1850,6 +1850,8 @@ Configuration options include:
 
 For Claude models that no longer support sampling parameters, such as [Opus 4.7](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-4-7.html), the provider omits `temperature`, `top_p`, and `top_k` while preserving `max_tokens`. This check uses `config.modelArn` when supplied.
 
+[Claude Sonnet 4.5 and Haiku 4.5](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages-request-response.html) accept either `temperature` or `top_p`. When both are configured, `top_p` takes precedence. For Amazon Nova, `top_k` is mapped to its native `inferenceConfig.topK` request field.
+
 ### Knowledge Base Example
 
 Here's a complete example to test your Knowledge Base with a few questions:

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -1585,6 +1585,11 @@ When loading image files as variables, promptfoo automatically converts them to 
 
 ## Embeddings
 
+Cohere embedding models require an input type. Promptfoo defaults to `search_document`;
+set `config.input_type: search_query` when embedding retrieval queries. The embedding
+provider returns a single numeric vector for each input text. Titan continues to use
+its separate `inputText` request format.
+
 To override the embeddings provider for all assertions that require embeddings (such as similarity), use `defaultTest`:
 
 ```yaml
@@ -1830,8 +1835,10 @@ Configuration options include:
 
 - `knowledgeBaseId` (required): The ID of your AWS Bedrock Knowledge Base
 - `region`: AWS region where your Knowledge Base is deployed (e.g., 'us-east-1', 'us-east-2', 'eu-west-1')
-- `temperature`: Controls randomness in response generation (default: 0.0)
+- `temperature`: Controls randomness in response generation (uses the model default when omitted)
 - `max_tokens`: Maximum number of tokens in the generated response
+- `top_p`: Nucleus sampling probability
+- `top_k`: Model-specific top-k sampling, forwarded as an additional model request field when supported by the selected model
 - `numberOfResults`: Number of chunks to retrieve from the knowledge base (optional, uses AWS default when not specified)
 - `accessKeyId`, `secretAccessKey`, `sessionToken`: AWS credentials (if not using environment variables or IAM roles)
 - `profile`: AWS profile name for SSO authentication

--- a/site/docs/providers/bedrock-agents.md
+++ b/site/docs/providers/bedrock-agents.md
@@ -33,7 +33,10 @@ Most configs only need `agentId` (from the provider ID) and `agentAliasId`. The 
 
 :::
 
-The provider exposes the main `InvokeAgent` options:
+The provider exposes the main [`InvokeAgent` options](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_InvokeAgent.html).
+Legacy inference, guardrail, prompt override, action-group, and input filtering settings
+shown below are accepted for compatibility but are omitted from runtime requests by
+the AWS SDK. Configure those settings on the deployed agent.
 
 ```yaml
 providers:
@@ -202,28 +205,17 @@ config:
 
 ### Guardrails
 
-Apply content filtering and safety measures:
-
-```yaml
-config:
-  guardrailConfiguration:
-    guardrailId: 'content-filter-001'
-    guardrailVersion: '2'
-```
+Configure guardrails on the deployed agent. The AWS `InvokeAgent` API does not accept
+`guardrailConfiguration`, so setting that provider option does not apply a guardrail.
+Promptfoo cannot infer whether a guardrail ran from configuration alone; inspect the agent trace.
+The same runtime limitation applies to inference settings, prompt overrides, and action-group definitions.
 
 ### Inference Control
 
-Fine-tune agent response generation:
-
-```yaml
-config:
-  inferenceConfig:
-    temperature: 0.3 # Lower for more deterministic responses
-    topP: 0.95
-    topK: 40
-    maximumLength: 4096
-    stopSequences: ['END_RESPONSE', "\n\n"]
-```
+Set inference parameters when creating or updating the deployed agent. `InvokeAgent`
+does not accept per-request `inferenceConfig`, `promptOverrideConfiguration`, or
+`actionGroups` definitions. Existing provider configuration keys are retained for
+compatibility, but the AWS SDK omits these fields from runtime requests.
 
 ### Trace Information
 
@@ -291,11 +283,6 @@ The provider returns responses with the following structure:
     sessionId?: string;     // Session identifier
     memoryId?: string;      // Memory type used
     trace?: Array<any>;     // Execution traces (if enableTrace: true)
-    guardrails?: {          // Guardrail application info
-      applied: boolean;
-      guardrailId: string;
-      guardrailVersion: string;
-    };
   };
   cached?: boolean;         // Whether response was cached
   error?: string;           // Error message if failed

--- a/site/docs/providers/bedrock-agents.md
+++ b/site/docs/providers/bedrock-agents.md
@@ -91,7 +91,9 @@ providers:
               numberOfResults: 5
               overrideSearchType: HYBRID # or SEMANTIC
               filter:
-                category: 'technical'
+                equals:
+                  key: category
+                  value: 'technical'
         - knowledgeBaseId: KB_ID_2
 
       # Action Groups (Tools)
@@ -175,6 +177,8 @@ Connect agents to knowledge bases for RAG capabilities:
 
 Configure the knowledge-base association on the deployed agent first. Entries with `retrievalConfiguration` override retrieval settings for the request. Legacy entries containing only `knowledgeBaseId` use the deployed settings and are omitted from the request's session overrides.
 
+Use the AWS [RetrievalFilter](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RetrievalFilter.html) operator format for metadata filters. Flat metadata maps are rejected locally. Combine conditions with `andAll` or `orAll`.
+
 ```yaml
 config:
   knowledgeBaseConfigurations:
@@ -184,8 +188,13 @@ config:
           numberOfResults: 10
           overrideSearchType: HYBRID
           filter:
-            documentType: 'manual'
-            product: 'widget-pro'
+            andAll:
+              - equals:
+                  key: documentType
+                  value: 'manual'
+              - equals:
+                  key: product
+                  value: 'widget-pro'
 ```
 
 ### Action Groups (Tools)

--- a/site/docs/providers/bedrock-agents.md
+++ b/site/docs/providers/bedrock-agents.md
@@ -173,6 +173,8 @@ config:
 
 Connect agents to knowledge bases for RAG capabilities:
 
+Configure the knowledge-base association on the deployed agent first. Entries with `retrievalConfiguration` override retrieval settings for the request. Legacy entries containing only `knowledgeBaseId` use the deployed settings and are omitted from the request's session overrides.
+
 ```yaml
 config:
   knowledgeBaseConfigurations:

--- a/src/providers/bedrock/agents.ts
+++ b/src/providers/bedrock/agents.ts
@@ -10,6 +10,7 @@ import type {
   InferenceConfig,
   InvokeAgentCommandInput,
   InvokeAgentCommandOutput,
+  KnowledgeBaseRetrievalConfiguration,
   SessionState,
 } from '@aws-sdk/client-bedrock-agent-runtime';
 
@@ -106,13 +107,7 @@ interface BedrockAgentsOptions {
   // Knowledge Base Configuration
   knowledgeBaseConfigurations?: Array<{
     knowledgeBaseId: string;
-    retrievalConfiguration?: {
-      vectorSearchConfiguration: {
-        numberOfResults?: number;
-        overrideSearchType?: 'HYBRID' | 'SEMANTIC';
-        filter?: Record<string, any>;
-      };
-    };
+    retrievalConfiguration?: KnowledgeBaseRetrievalConfiguration;
   }>;
 
   // Action Group Configuration
@@ -249,6 +244,56 @@ export class AwsBedrockAgentsProvider extends AwsBedrockGenericProvider implemen
       }
     }
     return this.agentRuntimeClient;
+  }
+
+  /**
+   * Check operator shapes before the SDK silently drops unknown filter keys.
+   */
+  private hasRetrievalFilterShape(filter: unknown): boolean {
+    if (!filter || typeof filter !== 'object' || Array.isArray(filter)) {
+      return false;
+    }
+    const entries = Object.entries(filter).filter(([, value]) => value !== undefined);
+    if (entries.length !== 1) {
+      return false;
+    }
+    const [operator, operand] = entries[0];
+    if (operator === 'andAll' || operator === 'orAll') {
+      return (
+        Array.isArray(operand) &&
+        operand.length >= 2 &&
+        operand.every((child) => this.hasRetrievalFilterShape(child))
+      );
+    }
+    // Preserve the SDK's explicit escape hatch for a newer union member.
+    if (operator === '$unknown') {
+      return (
+        Array.isArray(operand) &&
+        operand.length === 2 &&
+        typeof operand[0] === 'string' &&
+        operand[1] !== undefined
+      );
+    }
+    return (
+      [
+        'equals',
+        'notEquals',
+        'greaterThan',
+        'greaterThanOrEquals',
+        'lessThan',
+        'lessThanOrEquals',
+        'in',
+        'notIn',
+        'startsWith',
+        'listContains',
+        'stringContains',
+      ].includes(operator) &&
+      operand !== null &&
+      typeof operand === 'object' &&
+      !Array.isArray(operand) &&
+      typeof operand.key === 'string' &&
+      operand.value !== undefined
+    );
   }
 
   /**
@@ -395,6 +440,17 @@ export class AwsBedrockAgentsProvider extends AwsBedrockGenericProvider implemen
       return {
         error: 'Agent Alias ID is required. Set agentAliasId in the provider config.',
       };
+    }
+
+    for (const [index, configuration] of (
+      this.config.knowledgeBaseConfigurations ?? []
+    ).entries()) {
+      const filter = configuration.retrievalConfiguration?.vectorSearchConfiguration?.filter;
+      if (filter !== undefined && !this.hasRetrievalFilterShape(filter)) {
+        return {
+          error: `Invalid knowledgeBaseConfigurations[${index}].retrievalConfiguration.vectorSearchConfiguration.filter: use an AWS RetrievalFilter with one operator, such as equals or andAll. Flat metadata maps are not supported.`,
+        };
+      }
     }
 
     const client = await this.getAgentRuntimeClient();

--- a/src/providers/bedrock/agents.ts
+++ b/src/providers/bedrock/agents.ts
@@ -255,20 +255,21 @@ export class AwsBedrockAgentsProvider extends AwsBedrockGenericProvider implemen
    * Build the session state from configuration
    */
   private buildSessionState(): SessionState | undefined {
-    if (!this.config.sessionState) {
+    if (!this.config.sessionState && !this.config.knowledgeBaseConfigurations) {
       return undefined;
     }
 
     // Build session state according to AWS SDK types
     // Note: Using partial typing due to AWS SDK type constraints
     const sessionState: SessionState = {
-      sessionAttributes: this.config.sessionState.sessionAttributes,
-      promptSessionAttributes: this.config.sessionState.promptSessionAttributes,
-      invocationId: this.config.sessionState.invocationId,
+      sessionAttributes: this.config.sessionState?.sessionAttributes,
+      promptSessionAttributes: this.config.sessionState?.promptSessionAttributes,
+      invocationId: this.config.sessionState?.invocationId,
+      knowledgeBaseConfigurations: this.config.knowledgeBaseConfigurations,
     } as SessionState;
 
     // Handle returnControlInvocationResults if present
-    if (this.config.sessionState.returnControlInvocationResults) {
+    if (this.config.sessionState?.returnControlInvocationResults) {
       (sessionState as any).returnControlInvocationResults =
         this.config.sessionState.returnControlInvocationResults;
     }
@@ -416,18 +417,14 @@ export class AwsBedrockAgentsProvider extends AwsBedrockGenericProvider implemen
       sessionState: this.buildSessionState(),
       memoryId: this.config.memoryId,
 
-      // Advanced configurations - using type assertions for preview features
-      // The AWS SDK types may not be fully up to date with all Bedrock Agents features
-      // These configurations are validated by AWS at runtime
+      // Legacy configuration keys are retained for compatibility, but the SDK
+      // omits these control-plane settings from InvokeAgent requests.
       ...(inferenceConfig && { inferenceConfig }),
       ...(this.config.guardrailConfiguration && {
         guardrailConfiguration: this.config.guardrailConfiguration,
       }),
       ...(this.config.promptOverrideConfiguration && {
         promptOverrideConfiguration: this.config.promptOverrideConfiguration as any,
-      }),
-      ...(this.config.knowledgeBaseConfigurations && {
-        knowledgeBaseConfigurations: this.config.knowledgeBaseConfigurations as any,
       }),
       ...(this.config.actionGroups && {
         actionGroups: this.config.actionGroups as any,
@@ -441,7 +438,8 @@ export class AwsBedrockAgentsProvider extends AwsBedrockGenericProvider implemen
 
     // Cache key based on agent ID and prompt (excluding volatile fields)
     const cache = await getCache();
-    const cacheKey = `bedrock-agent:${this.config.agentId}:${this.config.agentAliasId}:${this.getRegion()}:${sha256(
+    // Earlier cached results omitted KB overrides and could claim an unapplied guardrail.
+    const cacheKey = `bedrock-agent:v2:${this.config.agentId}:${this.config.agentAliasId}:${this.getRegion()}:${sha256(
       JSON.stringify({
         prompt,
         actionGroups: this.config.actionGroups,
@@ -493,13 +491,6 @@ export class AwsBedrockAgentsProvider extends AwsBedrockGenericProvider implemen
           ...(responseSessionId && { sessionId: responseSessionId }),
           ...(trace && { trace }),
           ...(this.config.memoryId && { memoryId: this.config.memoryId }),
-          ...(this.config.guardrailConfiguration && {
-            guardrails: {
-              applied: true,
-              guardrailId: this.config.guardrailConfiguration.guardrailId,
-              guardrailVersion: this.config.guardrailConfiguration.guardrailVersion,
-            },
-          }),
         },
       };
 

--- a/src/providers/bedrock/agents.ts
+++ b/src/providers/bedrock/agents.ts
@@ -255,7 +255,12 @@ export class AwsBedrockAgentsProvider extends AwsBedrockGenericProvider implemen
    * Build the session state from configuration
    */
   private buildSessionState(): SessionState | undefined {
-    if (!this.config.sessionState && !this.config.knowledgeBaseConfigurations) {
+    // ID-only entries use the agent's deployed configuration. Runtime overrides
+    // require retrievalConfiguration, so do not send those legacy entries.
+    const knowledgeBaseConfigurations = this.config.knowledgeBaseConfigurations?.filter(
+      (configuration) => configuration.retrievalConfiguration,
+    );
+    if (!this.config.sessionState && !knowledgeBaseConfigurations?.length) {
       return undefined;
     }
 
@@ -265,7 +270,7 @@ export class AwsBedrockAgentsProvider extends AwsBedrockGenericProvider implemen
       sessionAttributes: this.config.sessionState?.sessionAttributes,
       promptSessionAttributes: this.config.sessionState?.promptSessionAttributes,
       invocationId: this.config.sessionState?.invocationId,
-      knowledgeBaseConfigurations: this.config.knowledgeBaseConfigurations,
+      ...(knowledgeBaseConfigurations?.length && { knowledgeBaseConfigurations }),
     } as SessionState;
 
     // Handle returnControlInvocationResults if present

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -20,7 +20,6 @@ import { AwsBedrockGenericProvider, type BedrockOptions, createBedrockCacheKeyHa
 import { calculateBedrockInvokeModelCost } from './pricing';
 import { novaOutputFromMessage, novaParseMessages } from './util';
 
-import type { EnvOverrides } from '../../types/env';
 import type {
   ApiEmbeddingProvider,
   ApiProvider,
@@ -2969,7 +2968,11 @@ export class AwsBedrockEmbeddingProvider
 
   constructor(
     modelName: string,
-    options: { config?: BedrockEmbeddingOptions; id?: string; env?: EnvOverrides } = {},
+    options: {
+      config?: BedrockEmbeddingOptions;
+      id?: string;
+      env?: AwsBedrockGenericProvider['env'];
+    } = {},
   ) {
     super(modelName, options);
   }

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -20,6 +20,7 @@ import { AwsBedrockGenericProvider, type BedrockOptions, createBedrockCacheKeyHa
 import { calculateBedrockInvokeModelCost } from './pricing';
 import { novaOutputFromMessage, novaParseMessages } from './util';
 
+import type { EnvOverrides } from '../../types/env';
 import type {
   ApiEmbeddingProvider,
   ApiProvider,
@@ -2956,10 +2957,23 @@ export class AwsBedrockCompletionProvider extends AwsBedrockGenericProvider impl
   }
 }
 
+interface BedrockEmbeddingOptions extends BedrockOptions {
+  input_type?: 'search_document' | 'search_query' | 'classification' | 'clustering';
+}
+
 export class AwsBedrockEmbeddingProvider
   extends AwsBedrockGenericProvider
   implements ApiEmbeddingProvider
 {
+  declare config: BedrockEmbeddingOptions;
+
+  constructor(
+    modelName: string,
+    options: { config?: BedrockEmbeddingOptions; id?: string; env?: EnvOverrides } = {},
+  ) {
+    super(modelName, options);
+  }
+
   async callApi(): Promise<ProviderEmbeddingResponse> {
     throw new Error('callApi is not implemented for embedding provider');
   }
@@ -2968,6 +2982,7 @@ export class AwsBedrockEmbeddingProvider
     const params = this.modelName.includes('cohere.embed')
       ? {
           texts: [text],
+          input_type: this.config.input_type ?? 'search_document',
         }
       : {
           inputText: text,
@@ -2996,9 +3011,16 @@ export class AwsBedrockEmbeddingProvider
       const data = JSON.parse(response.body.transformToString());
       // Titan Text API returns embeddings in the `embedding` field
       // Cohere API returns embeddings in the `embeddings` field
-      const embedding = data?.embedding || data?.embeddings;
-      if (!embedding) {
-        throw new Error('No embedding found in AWS Bedrock API response');
+      const embeddings = data?.embeddings?.float ?? data?.embeddings;
+      const embedding =
+        data?.embedding ??
+        (Array.isArray(embeddings) && embeddings.length === 1 ? embeddings[0] : undefined);
+      if (
+        !Array.isArray(embedding) ||
+        embedding.length === 0 ||
+        !embedding.every((value: unknown) => typeof value === 'number' && Number.isFinite(value))
+      ) {
+        throw new Error('No valid embedding found in AWS Bedrock API response');
       }
       return {
         embedding,

--- a/src/providers/bedrock/knowledgeBase.ts
+++ b/src/providers/bedrock/knowledgeBase.ts
@@ -139,8 +139,12 @@ export class AwsBedrockKnowledgeBaseProvider
     const { temperature, top_p, top_k } = isSamplingParamsDeprecatedClaudeModel(modelArn)
       ? {}
       : this.kbConfig;
+    // Sonnet/Haiku 4.5 accept either temperature or top_p. Prefer top_p, as
+    // the Anthropic Messages provider does, without changing older models.
+    const omitTemperature =
+      top_p !== undefined && /(^|[^a-z0-9])claude-(?:sonnet|haiku)-4-5(?![0-9])/i.test(modelArn);
     const textInferenceConfig = {
-      ...(temperature !== undefined && { temperature }),
+      ...(temperature !== undefined && !omitTemperature && { temperature }),
       ...(max_tokens !== undefined && { maxTokens: max_tokens }),
       ...(top_p !== undefined && { topP: top_p }),
     };
@@ -149,7 +153,11 @@ export class AwsBedrockKnowledgeBaseProvider
         ...(Object.keys(textInferenceConfig).length > 0 && {
           inferenceConfig: { textInferenceConfig },
         }),
-        ...(top_k !== undefined && { additionalModelRequestFields: { top_k } }),
+        ...(top_k !== undefined && {
+          additionalModelRequestFields: /(^|[/.])amazon\.nova-/.test(modelArn)
+            ? { inferenceConfig: { topK: top_k } }
+            : { top_k },
+        }),
       };
     }
 

--- a/src/providers/bedrock/knowledgeBase.ts
+++ b/src/providers/bedrock/knowledgeBase.ts
@@ -4,6 +4,7 @@ import logger from '../../logger';
 import telemetry from '../../telemetry';
 import { sha256 } from '../../util/createHash';
 import { createEmptyTokenUsage } from '../../util/tokenUsageUtils';
+import { isSamplingParamsDeprecatedClaudeModel } from '../anthropic/util';
 import { AwsBedrockGenericProvider } from './base';
 import { createBedrockRequestHandler, hasProxyEnv } from './util';
 import type {
@@ -133,23 +134,47 @@ export class AwsBedrockKnowledgeBaseProvider
     return this.knowledgeBaseClient;
   }
 
+  private buildGenerationConfiguration(modelArn: string) {
+    const { max_tokens } = this.kbConfig;
+    const { temperature, top_p, top_k } = isSamplingParamsDeprecatedClaudeModel(modelArn)
+      ? {}
+      : this.kbConfig;
+    const textInferenceConfig = {
+      ...(temperature !== undefined && { temperature }),
+      ...(max_tokens !== undefined && { maxTokens: max_tokens }),
+      ...(top_p !== undefined && { topP: top_p }),
+    };
+    if (Object.keys(textInferenceConfig).length > 0 || top_k !== undefined) {
+      return {
+        ...(Object.keys(textInferenceConfig).length > 0 && {
+          inferenceConfig: { textInferenceConfig },
+        }),
+        ...(top_k !== undefined && { additionalModelRequestFields: { top_k } }),
+      };
+    }
+
+    return undefined;
+  }
+
   async callApi(prompt: string): Promise<ProviderResponse> {
+    if (!this.kbConfig.modelArn && (!this.modelName || this.modelName === 'default')) {
+      return {
+        error:
+          'A generation model is required for Bedrock Knowledge Bases. Set bedrock:kb:<model-id> or provide config.modelArn.',
+      };
+    }
+
     const client = await this.getKnowledgeBaseClient();
 
     // Prepare the request parameters
     let modelArn = this.kbConfig.modelArn;
 
     if (!modelArn) {
-      if (this.modelName.includes('arn:aws:bedrock')) {
+      if (/^arn:aws(?:-[^:]+)?:bedrock:/.test(this.modelName)) {
         modelArn = this.modelName; // Already has full ARN format
-      } else if (
-        this.modelName.startsWith('us.') ||
-        this.modelName.startsWith('eu.') ||
-        this.modelName.startsWith('apac.')
-      ) {
-        // This is a cross-region inference profile - use inference-profile ARN format
-        // Note: We'll use the modelName directly as the inference profile ID since Knowledge Bases
-        // expect the inference profile ID, not a full ARN for these
+      } else if (/^(?:us|eu|apac|global|jp|au)\./.test(this.modelName)) {
+        // Preserve system-defined inference profile IDs instead of wrapping them
+        // in a foundation-model ARN.
         modelArn = this.modelName;
       } else {
         // Regular foundation model
@@ -159,12 +184,9 @@ export class AwsBedrockKnowledgeBaseProvider
 
     const knowledgeBaseConfiguration: any = {
       knowledgeBaseId: this.kbConfig.knowledgeBaseId,
+      modelArn,
+      generationConfiguration: this.buildGenerationConfiguration(modelArn),
     };
-
-    // Only include modelArn if explicitly configured or if it's a valid model
-    if (this.kbConfig.modelArn || this.modelName !== 'default') {
-      knowledgeBaseConfiguration.modelArn = modelArn;
-    }
 
     // Only add retrieval configuration when numberOfResults is explicitly configured
     // This preserves backwards compatibility with AWS default behavior
@@ -173,21 +195,6 @@ export class AwsBedrockKnowledgeBaseProvider
         vectorSearchConfiguration: {
           numberOfResults: this.kbConfig.numberOfResults,
         },
-      };
-    }
-
-    const { temperature, max_tokens, top_p, top_k } = this.kbConfig;
-    const textInferenceConfig = {
-      ...(temperature !== undefined && { temperature }),
-      ...(max_tokens !== undefined && { maxTokens: max_tokens }),
-      ...(top_p !== undefined && { topP: top_p }),
-    };
-    if (Object.keys(textInferenceConfig).length > 0 || top_k !== undefined) {
-      knowledgeBaseConfiguration.generationConfiguration = {
-        ...(Object.keys(textInferenceConfig).length > 0 && {
-          inferenceConfig: { textInferenceConfig },
-        }),
-        ...(top_k !== undefined && { additionalModelRequestFields: { top_k } }),
       };
     }
 

--- a/src/providers/bedrock/knowledgeBase.ts
+++ b/src/providers/bedrock/knowledgeBase.ts
@@ -176,6 +176,21 @@ export class AwsBedrockKnowledgeBaseProvider
       };
     }
 
+    const { temperature, max_tokens, top_p, top_k } = this.kbConfig;
+    const textInferenceConfig = {
+      ...(temperature !== undefined && { temperature }),
+      ...(max_tokens !== undefined && { maxTokens: max_tokens }),
+      ...(top_p !== undefined && { topP: top_p }),
+    };
+    if (Object.keys(textInferenceConfig).length > 0 || top_k !== undefined) {
+      knowledgeBaseConfiguration.generationConfiguration = {
+        ...(Object.keys(textInferenceConfig).length > 0 && {
+          inferenceConfig: { textInferenceConfig },
+        }),
+        ...(top_k !== undefined && { additionalModelRequestFields: { top_k } }),
+      };
+    }
+
     const params: RetrieveAndGenerateCommandInput = {
       input: { text: prompt },
       retrieveAndGenerateConfiguration: {
@@ -203,7 +218,8 @@ export class AwsBedrockKnowledgeBaseProvider
     };
 
     const configStr = JSON.stringify(cacheConfig, Object.keys(cacheConfig).sort());
-    const cacheKey = `bedrock-kb:${this.kbConfig.knowledgeBaseId}:${modelArn}:${this.getRegion()}:${sha256(
+    // Earlier cached results did not apply configured generation parameters.
+    const cacheKey = `bedrock-kb:v2:${this.kbConfig.knowledgeBaseId}:${modelArn}:${this.getRegion()}:${sha256(
       JSON.stringify({
         configStr,
         prompt,

--- a/src/providers/bedrock/knowledgeBase.ts
+++ b/src/providers/bedrock/knowledgeBase.ts
@@ -139,10 +139,11 @@ export class AwsBedrockKnowledgeBaseProvider
     const { temperature, top_p, top_k } = isSamplingParamsDeprecatedClaudeModel(modelArn)
       ? {}
       : this.kbConfig;
-    // Sonnet/Haiku 4.5 accept either temperature or top_p. Prefer top_p, as
+    // Sonnet 4.5/4.6 and Haiku 4.5 accept either temperature or top_p. Prefer top_p, as
     // the Anthropic Messages provider does, without changing older models.
     const omitTemperature =
-      top_p !== undefined && /(^|[^a-z0-9])claude-(?:sonnet|haiku)-4-5(?![0-9])/i.test(modelArn);
+      top_p !== undefined &&
+      /(^|[^a-z0-9])claude-(?:sonnet-4-[56]|haiku-4-5)(?![0-9])/i.test(modelArn);
     const textInferenceConfig = {
       ...(temperature !== undefined && !omitTemperature && { temperature }),
       ...(max_tokens !== undefined && { maxTokens: max_tokens }),
@@ -156,7 +157,9 @@ export class AwsBedrockKnowledgeBaseProvider
         ...(top_k !== undefined && {
           additionalModelRequestFields: /(^|[/.])amazon\.nova-/.test(modelArn)
             ? { inferenceConfig: { topK: top_k } }
-            : { top_k },
+            : /(^|[/.])cohere\.command-r(?:-plus)?-v\d+(?::\d+)?$/.test(modelArn)
+              ? { k: top_k }
+              : { top_k },
         }),
       };
     }

--- a/test/providers/bedrock/agents.test.ts
+++ b/test/providers/bedrock/agents.test.ts
@@ -158,6 +158,7 @@ describe('AwsBedrockAgentsProvider', () => {
         knowledgeBaseId: 'kb-123',
         retrievalConfiguration: { vectorSearchConfiguration: { numberOfResults: 3 } },
       },
+      { knowledgeBaseId: 'kb-deployed-defaults' },
     ];
     const provider = new AwsBedrockAgentsProvider('agent-123', {
       config: {
@@ -171,11 +172,28 @@ describe('AwsBedrockAgentsProvider', () => {
     mockSend.mockResolvedValueOnce(makeCompletionResponse('A quiet garden'));
     const result = await provider.callApi('Describe the garden');
     expect(result.output).toBe('A quiet garden');
-    expect(mockSend.mock.calls[0][0].sessionState.knowledgeBaseConfigurations).toEqual(
-      knowledgeBaseConfigurations,
-    );
+    expect(mockSend.mock.calls[0][0].sessionState.knowledgeBaseConfigurations).toEqual([
+      knowledgeBaseConfigurations[0],
+    ]);
+    expect(knowledgeBaseConfigurations).toHaveLength(2);
     expect(mockSend.mock.calls[0][0]).not.toHaveProperty('knowledgeBaseConfigurations');
     expect(result.metadata).not.toHaveProperty('guardrails');
+  });
+
+  it('uses deployed knowledge-base defaults for legacy ID-only configuration', async () => {
+    const provider = new AwsBedrockAgentsProvider('agent-123', {
+      config: {
+        agentId: 'agent-123',
+        agentAliasId: 'alias-456',
+        knowledgeBaseConfigurations: [{ knowledgeBaseId: 'kb-123' }],
+      },
+    });
+    mockSend.mockResolvedValueOnce(makeCompletionResponse('A quiet garden'));
+
+    const result = await provider.callApi('Describe the garden');
+
+    expect(result.output).toBe('A quiet garden');
+    expect(mockSend.mock.calls[0][0].sessionState).toBeUndefined();
   });
 
   it('does not replay legacy cached guardrail claims', async () => {

--- a/test/providers/bedrock/agents.test.ts
+++ b/test/providers/bedrock/agents.test.ts
@@ -91,7 +91,7 @@ function buildAgentCacheKey({
   sessionId?: string;
   sessionState?: Record<string, unknown>;
 }) {
-  return `bedrock-agent:${agentId}:${agentAliasId}:${region}:${sha256(
+  return `bedrock-agent:v2:${agentId}:${agentAliasId}:${region}:${sha256(
     JSON.stringify({
       prompt,
       actionGroups,
@@ -150,6 +150,55 @@ describe('AwsBedrockAgentsProvider', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
+  });
+
+  it('places knowledge-base retrieval overrides in sessionState without explicit session attributes', async () => {
+    const knowledgeBaseConfigurations = [
+      {
+        knowledgeBaseId: 'kb-123',
+        retrievalConfiguration: { vectorSearchConfiguration: { numberOfResults: 3 } },
+      },
+    ];
+    const provider = new AwsBedrockAgentsProvider('agent-123', {
+      config: {
+        agentId: 'agent-123',
+        agentAliasId: 'alias-456',
+        region: 'us-east-1',
+        knowledgeBaseConfigurations,
+        guardrailConfiguration: { guardrailId: 'configured-only', guardrailVersion: '1' },
+      },
+    });
+    mockSend.mockResolvedValueOnce(makeCompletionResponse('A quiet garden'));
+    const result = await provider.callApi('Describe the garden');
+    expect(result.output).toBe('A quiet garden');
+    expect(mockSend.mock.calls[0][0].sessionState.knowledgeBaseConfigurations).toEqual(
+      knowledgeBaseConfigurations,
+    );
+    expect(mockSend.mock.calls[0][0]).not.toHaveProperty('knowledgeBaseConfigurations');
+    expect(result.metadata).not.toHaveProperty('guardrails');
+  });
+
+  it('does not replay legacy cached guardrail claims', async () => {
+    mockIsCacheEnabled.mockReturnValue(true);
+    mockGet.mockImplementation(async (key: string) =>
+      key.startsWith('bedrock-agent:v2:')
+        ? null
+        : JSON.stringify({
+            output: 'legacy response',
+            metadata: { guardrails: { applied: true } },
+          }),
+    );
+    const provider = new AwsBedrockAgentsProvider('agent-123', {
+      config: { agentId: 'agent-123', agentAliasId: 'alias-456', region: 'us-east-1' },
+    });
+    mockSend.mockResolvedValueOnce(makeCompletionResponse('fresh response'));
+
+    const result = await provider.callApi('Describe a quiet garden');
+
+    expect(result.output).toBe('fresh response');
+    expect(result.metadata).not.toHaveProperty('guardrails');
+    expect(result.cached).not.toBe(true);
+    expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
   it('should hash prompt and config values while reusing the same cache key', async () => {

--- a/test/providers/bedrock/agents.test.ts
+++ b/test/providers/bedrock/agents.test.ts
@@ -196,6 +196,53 @@ describe('AwsBedrockAgentsProvider', () => {
     expect(mockSend.mock.calls[0][0].sessionState).toBeUndefined();
   });
 
+  it.each([
+    { category: 'technical' },
+    { documentType: 'manual', product: 'widget-pro' },
+    {},
+    null,
+    [],
+    'category',
+    { equals: 'technical' },
+    { equals: { key: 'category' } },
+    { equals: { key: 'category', value: 'technical' }, product: 'widget-pro' },
+    {
+      equals: { key: 'category', value: 'technical' },
+      notEquals: { key: 'product', value: 'old' },
+    },
+    { andAll: [{ equals: { key: 'category', value: 'technical' } }] },
+    { orAll: [{ equals: { key: 'category', value: 'technical' } }, { product: 'widget-pro' }] },
+  ])(
+    'rejects unsupported retrieval filter %j before client creation or cache lookup',
+    async (filter) => {
+      const provider = new AwsBedrockAgentsProvider('agent-123', {
+        config: {
+          agentId: 'agent-123',
+          agentAliasId: 'alias-456',
+          knowledgeBaseConfigurations: [
+            {
+              knowledgeBaseId: 'kb-123',
+              retrievalConfiguration: { vectorSearchConfiguration: { filter: filter as any } },
+            },
+          ],
+        },
+      });
+      const getClient = vi.spyOn(provider, 'getAgentRuntimeClient');
+      mockIsCacheEnabled.mockReturnValue(true);
+      mockGet.mockResolvedValueOnce(JSON.stringify({ output: 'cached response' }));
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result).toEqual({
+        error:
+          'Invalid knowledgeBaseConfigurations[0].retrievalConfiguration.vectorSearchConfiguration.filter: use an AWS RetrievalFilter with one operator, such as equals or andAll. Flat metadata maps are not supported.',
+      });
+      expect(getClient).not.toHaveBeenCalled();
+      expect(mockGet).not.toHaveBeenCalled();
+      expect(mockSend).not.toHaveBeenCalled();
+    },
+  );
+
   it('does not replay legacy cached guardrail claims', async () => {
     mockIsCacheEnabled.mockReturnValue(true);
     mockGet.mockImplementation(async (key: string) =>
@@ -238,7 +285,7 @@ describe('AwsBedrockAgentsProvider', () => {
             retrievalConfiguration: {
               vectorSearchConfiguration: {
                 filter: {
-                  sensitiveFilter: 'SECRET_FILTER_VALUE',
+                  equals: { key: 'sensitiveFilter', value: 'SECRET_FILTER_VALUE' },
                 },
               },
             },
@@ -279,7 +326,7 @@ describe('AwsBedrockAgentsProvider', () => {
             retrievalConfiguration: {
               vectorSearchConfiguration: {
                 filter: {
-                  sensitiveFilter: 'SECRET_FILTER_VALUE',
+                  equals: { key: 'sensitiveFilter', value: 'SECRET_FILTER_VALUE' },
                 },
               },
             },

--- a/test/providers/bedrock/embedding.test.ts
+++ b/test/providers/bedrock/embedding.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AwsBedrockEmbeddingProvider } from '../../../src/providers/bedrock/index';
+
+function mockEmbedding(model: string, data: unknown, inputType?: 'search_query') {
+  const provider = new AwsBedrockEmbeddingProvider(model, {
+    id: 'custom-embedding',
+    config: { region: 'us-east-1', input_type: inputType },
+  });
+  const invokeModel = vi.fn().mockResolvedValue({
+    body: { transformToString: () => JSON.stringify(data) },
+  });
+  vi.spyOn(provider, 'getBedrockInstance').mockResolvedValue({ invokeModel } as any);
+  return { provider, invokeModel };
+}
+
+describe('AwsBedrockEmbeddingProvider wire contract', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  it.each([
+    ['cohere.embed-english-v3', { embeddings: [[0.1, 0.2]] }],
+    ['cohere.embed-v4:0', { embeddings: [[0.1, 0.2]] }],
+    ['cohere.embed-v4:0', { embeddings: { float: [[0.1, 0.2]] } }],
+  ])('sends required Cohere input_type and normalizes %s vectors', async (model, data) => {
+    const { provider, invokeModel } = mockEmbedding(model, data);
+    expect(await provider.callEmbeddingApi('A quiet garden')).toEqual({ embedding: [0.1, 0.2] });
+    expect(provider.id()).toBe('custom-embedding');
+    expect(invokeModel).toHaveBeenCalledWith({
+      modelId: model,
+      accept: 'application/json',
+      contentType: 'application/json',
+      body: JSON.stringify({ texts: ['A quiet garden'], input_type: 'search_document' }),
+    });
+  });
+
+  it('preserves an explicit retrieval query input type', async () => {
+    const { provider, invokeModel } = mockEmbedding(
+      'cohere.embed-english-v3',
+      { embeddings: [[0.1]] },
+      'search_query',
+    );
+    await provider.callEmbeddingApi('Where is the garden?');
+    expect(JSON.parse(invokeModel.mock.calls[0][0].body)).toEqual({
+      texts: ['Where is the garden?'],
+      input_type: 'search_query',
+    });
+  });
+
+  it('keeps Titan requests and flat vectors unchanged', async () => {
+    const { provider, invokeModel } = mockEmbedding('amazon.titan-embed-text-v2:0', {
+      embedding: [0.1, 0.2],
+    });
+    expect(await provider.callEmbeddingApi('A quiet garden')).toEqual({ embedding: [0.1, 0.2] });
+    expect(JSON.parse(invokeModel.mock.calls[0][0].body)).toEqual({ inputText: 'A quiet garden' });
+  });
+
+  it.each([
+    {},
+    { embeddings: [] },
+    { embeddings: [['invalid']] },
+    { embedding: [null] },
+    { embeddings: [[0.1], [0.2]] },
+    { embeddings: { float: [[0.1], [0.2]] } },
+    { embeddings: { int8: [[1, 2]] } },
+  ])('returns a normalized error for malformed vectors %j', async (data) => {
+    const { provider } = mockEmbedding('cohere.embed-english-v3', data);
+    expect(await provider.callEmbeddingApi('A quiet garden')).toEqual({
+      error: expect.stringContaining('No valid embedding found'),
+    });
+  });
+
+  it('returns a normalized transport error', async () => {
+    const { provider, invokeModel } = mockEmbedding('cohere.embed-english-v3', {});
+    invokeModel.mockRejectedValue(new Error('mock service failure'));
+    expect(await provider.callEmbeddingApi('A quiet garden')).toEqual({
+      error: 'API call error: Error: mock service failure',
+    });
+  });
+});

--- a/test/providers/bedrock/knowledgeBase.test.ts
+++ b/test/providers/bedrock/knowledgeBase.test.ts
@@ -461,7 +461,7 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
           knowledgeBaseConfiguration: expect.objectContaining({
             generationConfiguration: {
               inferenceConfig: { textInferenceConfig: { temperature: 0, maxTokens: 128, topP: 0 } },
-              additionalModelRequestFields: { top_k: 4 },
+              additionalModelRequestFields: { inferenceConfig: { topK: 4 } },
             },
           }),
         }),
@@ -495,6 +495,30 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
       }),
     );
   });
+
+  it.each(['sonnet-4-5-20250929', 'haiku-4-5-20251001'])(
+    'preserves top_p and top_k when Claude %s cannot also use temperature',
+    async (model) => {
+      mockSend.mockResolvedValueOnce({ output: { text: 'A quiet garden' }, citations: [] });
+      const provider = new AwsBedrockKnowledgeBaseProvider(`anthropic.claude-${model}-v1:0`, {
+        config: { knowledgeBaseId: 'kb-123', temperature: 0, top_p: 0.75, top_k: 20 },
+      });
+
+      expect((await provider.callApi('Describe the garden')).output).toBe('A quiet garden');
+      expect(RetrieveAndGenerateCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          retrieveAndGenerateConfiguration: expect.objectContaining({
+            knowledgeBaseConfiguration: expect.objectContaining({
+              generationConfiguration: {
+                inferenceConfig: { textInferenceConfig: { topP: 0.75 } },
+                additionalModelRequestFields: { top_k: 20 },
+              },
+            }),
+          }),
+        }),
+      );
+    },
+  );
 
   it('should not include retrievalConfiguration when numberOfResults is not provided', async () => {
     const mockResponse = {

--- a/test/providers/bedrock/knowledgeBase.test.ts
+++ b/test/providers/bedrock/knowledgeBase.test.ts
@@ -92,7 +92,7 @@ function buildKnowledgeBaseCacheKey({
   };
   const configStr = JSON.stringify(cacheConfig, Object.keys(cacheConfig).sort());
 
-  return `bedrock-kb:${knowledgeBaseId}:${modelArn}:${region}:${sha256(
+  return `bedrock-kb:v2:${knowledgeBaseId}:${modelArn}:${region}:${sha256(
     JSON.stringify({
       configStr,
       prompt,
@@ -369,7 +369,7 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
     expect(RetrieveAndGenerateCommand).toHaveBeenCalledWith(expectedCommand);
   });
 
-  it('should pass along config parameters but not create generationConfiguration', async () => {
+  it('should leave generationConfiguration omitted when no generation settings are provided', async () => {
     const mockResponse = {
       output: {
         text: 'This is the response from the knowledge base',
@@ -400,6 +400,34 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
     };
 
     expect(RetrieveAndGenerateCommand).toHaveBeenCalledWith(expectedCommand);
+  });
+
+  it('serializes configured generation settings, including zero values', async () => {
+    mockSend.mockResolvedValueOnce({ output: { text: 'A quiet garden' }, citations: [] });
+    const provider = new AwsBedrockKnowledgeBaseProvider('amazon.nova-lite-v1:0', {
+      config: {
+        knowledgeBaseId: 'kb-123',
+        region: 'us-east-1',
+        temperature: 0,
+        max_tokens: 128,
+        top_p: 0,
+        top_k: 4,
+      },
+    });
+
+    expect((await provider.callApi('Describe the garden')).output).toBe('A quiet garden');
+    expect(RetrieveAndGenerateCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retrieveAndGenerateConfiguration: expect.objectContaining({
+          knowledgeBaseConfiguration: expect.objectContaining({
+            generationConfiguration: {
+              inferenceConfig: { textInferenceConfig: { temperature: 0, maxTokens: 128, topP: 0 } },
+              additionalModelRequestFields: { top_k: 4 },
+            },
+          }),
+        }),
+      }),
+    );
   });
 
   it('should not include retrievalConfiguration when numberOfResults is not provided', async () => {
@@ -478,6 +506,25 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
     };
 
     expect(RetrieveAndGenerateCommand).toHaveBeenCalledWith(expectedCommand);
+  });
+
+  it('does not replay legacy results that ignored generation settings', async () => {
+    mockIsCacheEnabled.mockReturnValue(true);
+    mockGet.mockImplementation(async (key: string) =>
+      key.startsWith('bedrock-kb:v2:')
+        ? null
+        : JSON.stringify({ output: 'legacy response', citations: [] }),
+    );
+    const provider = new AwsBedrockKnowledgeBaseProvider('custom-model', {
+      config: { knowledgeBaseId: 'kb-123', region: 'us-east-1', temperature: 0 },
+    });
+    mockSend.mockResolvedValueOnce({ output: { text: 'fresh response' }, citations: [] });
+
+    const result = await provider.callApi('Describe a quiet garden');
+
+    expect(result.output).toBe('fresh response');
+    expect(result.cached).not.toBe(true);
+    expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
   it('should retrieve citations from cache when available', async () => {

--- a/test/providers/bedrock/knowledgeBase.test.ts
+++ b/test/providers/bedrock/knowledgeBase.test.ts
@@ -369,6 +369,45 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
     expect(RetrieveAndGenerateCommand).toHaveBeenCalledWith(expectedCommand);
   });
 
+  it.each(['default', ''])(
+    'rejects missing generation model %j before acquiring a client',
+    async (modelName) => {
+      const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
+        config: { knowledgeBaseId: 'kb-123' },
+      });
+      const getClient = vi.spyOn(provider, 'getKnowledgeBaseClient');
+
+      const result = await provider.callApi('Describe the garden');
+
+      expect(result.error).toContain('Set bedrock:kb:<model-id> or provide config.modelArn');
+      expect(getClient).not.toHaveBeenCalled();
+      expect(mockSend).not.toHaveBeenCalled();
+    },
+  );
+
+  it('accepts an explicit modelArn with the default route and preserves custom identity', async () => {
+    mockSend.mockResolvedValueOnce({ output: { text: 'A quiet garden' }, citations: [] });
+    const provider = new AwsBedrockKnowledgeBaseProvider('default', {
+      id: 'custom-kb',
+      config: {
+        knowledgeBaseId: 'kb-123',
+        modelArn: 'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0',
+      },
+    });
+
+    expect((await provider.callApi('Describe the garden')).output).toBe('A quiet garden');
+    expect(provider.id()).toBe('custom-kb');
+    expect(RetrieveAndGenerateCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retrieveAndGenerateConfiguration: expect.objectContaining({
+          knowledgeBaseConfiguration: expect.objectContaining({
+            modelArn: provider.kbConfig.modelArn,
+          }),
+        }),
+      }),
+    );
+  });
+
   it('should leave generationConfiguration omitted when no generation settings are provided', async () => {
     const mockResponse = {
       output: {
@@ -423,6 +462,33 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
             generationConfiguration: {
               inferenceConfig: { textInferenceConfig: { temperature: 0, maxTokens: 128, topP: 0 } },
               additionalModelRequestFields: { top_k: 4 },
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('preserves max_tokens when the effective model does not support sampling', async () => {
+    mockSend.mockResolvedValueOnce({ output: { text: 'A quiet garden' }, citations: [] });
+    const provider = new AwsBedrockKnowledgeBaseProvider('amazon.nova-lite-v1:0', {
+      config: {
+        knowledgeBaseId: 'kb-123',
+        modelArn: 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-7',
+        temperature: 0,
+        max_tokens: 128,
+        top_p: 0.75,
+        top_k: 20,
+      },
+    });
+
+    expect((await provider.callApi('Describe the garden')).output).toBe('A quiet garden');
+    expect(RetrieveAndGenerateCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retrieveAndGenerateConfiguration: expect.objectContaining({
+          knowledgeBaseConfiguration: expect.objectContaining({
+            generationConfiguration: {
+              inferenceConfig: { textInferenceConfig: { maxTokens: 128 } },
             },
           }),
         }),

--- a/test/providers/bedrock/requestSerialization.test.ts
+++ b/test/providers/bedrock/requestSerialization.test.ts
@@ -18,8 +18,17 @@ describe('Bedrock agent-runtime SDK serialization', () => {
     vi.restoreAllMocks();
   });
 
-  function captureRequest() {
+  function captureRequest(responseBody?: Record<string, unknown>) {
     const handle = vi.fn(async (_request: { body?: unknown }) => {
+      if (responseBody) {
+        return {
+          response: {
+            statusCode: 200,
+            headers: { 'content-type': 'application/json' },
+            body: new TextEncoder().encode(JSON.stringify(responseBody)),
+          },
+        };
+      }
       throw new Error('Local serialization fixture');
     });
     const client = new BedrockAgentRuntimeClient({
@@ -210,6 +219,52 @@ describe('Bedrock agent-runtime SDK serialization', () => {
   );
 
   it.each([
+    ['cohere.command-r-v1:0', undefined, 0],
+    ['cohere.command-r-plus-v1:0', undefined, 20],
+    ['arn:aws:bedrock:us-east-1::foundation-model/cohere.command-r-v1:0', undefined, 20],
+    [
+      'amazon.nova-lite-v1:0',
+      'arn:aws:bedrock:us-west-2::foundation-model/cohere.command-r-plus-v1:0',
+      0,
+    ],
+  ] as const)(
+    'serializes Cohere top-k as k and preserves responses for %s / %s',
+    async (modelName, modelArn, top_k) => {
+      const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
+        config: {
+          knowledgeBaseId: 'KB12345678',
+          modelArn,
+          temperature: 0,
+          top_p: 0.75,
+          top_k,
+          max_tokens: 128,
+        },
+      });
+      const citations = [{ retrievedReferences: [{ content: { text: 'Garden fixture' } }] }];
+      const { client, handle } = captureRequest({
+        output: { text: 'A quiet garden' },
+        citations,
+      });
+      vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe('A quiet garden');
+      expect(result.metadata?.citations).toEqual(citations);
+      expect(result.tokenUsage?.numRequests).toBe(1);
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(
+        request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration,
+      ).toEqual({
+        inferenceConfig: { textInferenceConfig: { temperature: 0, topP: 0.75, maxTokens: 128 } },
+        additionalModelRequestFields: { k: top_k },
+      });
+    },
+  );
+
+  it.each([
     ['anthropic.claude-sonnet-4-5-20250929-v1:0', undefined],
     ['anthropic.claude-haiku-4-5-20251001-v1:0', undefined],
     ['us.anthropic.claude-sonnet-4-5-20250929-v1:0', undefined],
@@ -221,8 +276,15 @@ describe('Bedrock agent-runtime SDK serialization', () => {
       'amazon.nova-lite-v1:0',
       'arn:aws:bedrock:us-east-1:123456789012:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0',
     ],
+    ['anthropic.claude-sonnet-4-6', undefined],
+    ['global.anthropic.claude-sonnet-4-6', undefined],
+    ['arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6', undefined],
+    [
+      'cohere.command-r-v1:0',
+      'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6',
+    ],
   ] as const)(
-    'prefers top_p over temperature for Claude 4.5 %s / %s',
+    'prefers top_p over temperature for affected Claude model %s / %s',
     async (modelName, modelArn) => {
       const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
         config: {
@@ -252,17 +314,32 @@ describe('Bedrock agent-runtime SDK serialization', () => {
   );
 
   it.each([
-    { sampling: { temperature: 0 }, expected: { temperature: 0 } },
-    { sampling: { top_p: 0.75 }, expected: { topP: 0.75 } },
+    {
+      modelName: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+      sampling: { temperature: 0 },
+      expected: { temperature: 0 },
+    },
+    {
+      modelName: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+      sampling: { top_p: 0.75 },
+      expected: { topP: 0.75 },
+    },
+    {
+      modelName: 'anthropic.claude-sonnet-4-6',
+      sampling: { temperature: 0 },
+      expected: { temperature: 0 },
+    },
+    {
+      modelName: 'anthropic.claude-sonnet-4-6',
+      sampling: { top_p: 0.75 },
+      expected: { topP: 0.75 },
+    },
   ])(
-    'preserves individual Claude 4.5 sampling option $sampling',
-    async ({ sampling, expected }) => {
-      const provider = new AwsBedrockKnowledgeBaseProvider(
-        'anthropic.claude-sonnet-4-5-20250929-v1:0',
-        {
-          config: { knowledgeBaseId: 'KB12345678', ...sampling },
-        },
-      );
+    'preserves individual sampling option $sampling for $modelName',
+    async ({ modelName, sampling, expected }) => {
+      const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
+        config: { knowledgeBaseId: 'KB12345678', ...sampling },
+      });
       const { client, handle } = captureRequest();
       vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
 
@@ -283,7 +360,10 @@ describe('Bedrock agent-runtime SDK serialization', () => {
     ['anthropic.claude-3-5-sonnet-20241022-v2:0', undefined],
     ['custom-model', undefined],
     ['custom-amazon.nova-model', undefined],
+    ['custom-cohere.command-r-v1:0', undefined],
+    ['cohere.command-r-custom', undefined],
     ['anthropic.claude-sonnet-4-50', undefined],
+    ['anthropic.claude-sonnet-4-60', undefined],
     [
       'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/claude-prod-5',
       undefined,
@@ -293,6 +373,8 @@ describe('Bedrock agent-runtime SDK serialization', () => {
       'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0',
     ],
     ['anthropic.claude-sonnet-4-5-20250929-v1:0', 'custom-model'],
+    ['anthropic.claude-sonnet-4-6', 'custom-model'],
+    ['cohere.command-r-v1:0', 'custom-model'],
   ] as const)(
     'preserves other model sampling and top-k shapes for %s / %s',
     async (modelName, modelArn) => {

--- a/test/providers/bedrock/requestSerialization.test.ts
+++ b/test/providers/bedrock/requestSerialization.test.ts
@@ -1,4 +1,8 @@
-import { BedrockAgentRuntimeClient } from '@aws-sdk/client-bedrock-agent-runtime';
+import {
+  BedrockAgentRuntimeClient,
+  type KnowledgeBaseVectorSearchConfiguration,
+  type RetrievalFilter,
+} from '@aws-sdk/client-bedrock-agent-runtime';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AwsBedrockAgentsProvider } from '../../../src/providers/bedrock/agents';
 import { AwsBedrockKnowledgeBaseProvider } from '../../../src/providers/bedrock/knowledgeBase';
@@ -98,6 +102,125 @@ describe('Bedrock agent-runtime SDK serialization', () => {
       expect(handle).toHaveBeenCalledTimes(1);
       const request = JSON.parse(String(handle.mock.calls[0][0].body));
       expect(request.sessionState).toEqual(sessionState);
+    },
+  );
+
+  it.each([
+    { equals: { key: 'category', value: 'technical' } },
+    {
+      andAll: [
+        { equals: { key: 'documentType', value: 'manual' } },
+        { equals: { key: 'product', value: 'widget-pro' } },
+      ],
+    },
+    {
+      orAll: [
+        { equals: { key: 'category', value: 'technical' } },
+        { equals: { key: 'category', value: 'reference' } },
+      ],
+    },
+    { notEquals: { key: 'archived', value: false } },
+    { greaterThan: { key: 'revision', value: 0 } },
+    { greaterThanOrEquals: { key: 'revision', value: 0 } },
+    { lessThan: { key: 'revision', value: 10 } },
+    { lessThanOrEquals: { key: 'revision', value: 10 } },
+    { in: { key: 'category', value: ['technical', 'reference'] } },
+    { notIn: { key: 'category', value: ['obsolete'] } },
+    { startsWith: { key: 'product', value: 'widget' } },
+    { listContains: { key: 'products', value: 'widget-pro' } },
+    { stringContains: { key: 'product', value: 'widget' } },
+  ] satisfies RetrievalFilter[])(
+    'preserves the SDK retrieval filter %j and other search options',
+    async (filter) => {
+      const vectorSearchConfiguration: KnowledgeBaseVectorSearchConfiguration = {
+        numberOfResults: 10,
+        overrideSearchType: 'HYBRID',
+        filter,
+        implicitFilterConfiguration: {
+          modelArn: 'arn:aws:bedrock:us-east-1::foundation-model/local-filter-model',
+          metadataAttributes: [
+            { key: 'category', type: 'STRING', description: 'Document category' },
+          ],
+        },
+        rerankingConfiguration: {
+          type: 'BEDROCK_RERANKING_MODEL',
+          bedrockRerankingConfiguration: {
+            modelConfiguration: {
+              modelArn: 'arn:aws:bedrock:us-east-1::foundation-model/local-reranker',
+              additionalModelRequestFields: { localFixture: true },
+            },
+            numberOfRerankedResults: 2,
+          },
+        },
+      };
+      const provider = new AwsBedrockAgentsProvider('AGENT12345', {
+        config: {
+          agentId: 'AGENT12345',
+          agentAliasId: 'ALIAS12345',
+          sessionId: 'local-fixture-session',
+          sessionState: { sessionAttributes: { topic: 'garden' } },
+          knowledgeBaseConfigurations: [
+            {
+              knowledgeBaseId: 'KB12345678',
+              retrievalConfiguration: { vectorSearchConfiguration },
+            },
+          ],
+        },
+      });
+      const { client, handle } = captureRequest();
+      vi.spyOn(provider, 'getAgentRuntimeClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toContain('Local serialization fixture');
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(request.sessionState.sessionAttributes).toEqual({ topic: 'garden' });
+      expect(
+        request.sessionState.knowledgeBaseConfigurations[0].retrievalConfiguration
+          .vectorSearchConfiguration,
+      ).toEqual(vectorSearchConfiguration);
+      expect(vectorSearchConfiguration.filter).toEqual(filter);
+    },
+  );
+
+  it.each([
+    {
+      filter: { equals: { key: 'category', value: 'technical' }, notEquals: undefined },
+      expected: { equals: { key: 'category', value: 'technical' } },
+    },
+    {
+      filter: { $unknown: ['futureOperator', { key: 'category', value: 'technical' }] },
+      expected: { futureOperator: { key: 'category', value: 'technical' } },
+    },
+  ] satisfies { filter: RetrievalFilter; expected: unknown }[])(
+    'preserves SDK union compatibility for $filter',
+    async ({ filter, expected }) => {
+      const provider = new AwsBedrockAgentsProvider('AGENT12345', {
+        config: {
+          agentId: 'AGENT12345',
+          agentAliasId: 'ALIAS12345',
+          sessionId: 'local-fixture-session',
+          knowledgeBaseConfigurations: [
+            {
+              knowledgeBaseId: 'KB12345678',
+              retrievalConfiguration: { vectorSearchConfiguration: { filter } },
+            },
+          ],
+        },
+      });
+      const { client, handle } = captureRequest();
+      vi.spyOn(provider, 'getAgentRuntimeClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toContain('Local serialization fixture');
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(
+        request.sessionState.knowledgeBaseConfigurations[0].retrievalConfiguration
+          .vectorSearchConfiguration.filter,
+      ).toEqual(expected);
     },
   );
 

--- a/test/providers/bedrock/requestSerialization.test.ts
+++ b/test/providers/bedrock/requestSerialization.test.ts
@@ -46,7 +46,10 @@ describe('Bedrock agent-runtime SDK serialization', () => {
         sessionId: 'local-fixture-session',
         region: 'us-east-1',
         sessionState: { sessionAttributes: { topic: 'garden' } },
-        knowledgeBaseConfigurations,
+        knowledgeBaseConfigurations: [
+          ...knowledgeBaseConfigurations,
+          { knowledgeBaseId: 'KB98765432' },
+        ],
       },
     });
     const { client, handle } = captureRequest();
@@ -63,6 +66,31 @@ describe('Bedrock agent-runtime SDK serialization', () => {
     });
     expect(request).not.toHaveProperty('knowledgeBaseConfigurations');
   });
+
+  it.each([undefined, { sessionAttributes: { topic: 'garden' } }])(
+    'omits ID-only knowledge-base overrides while preserving session state %j',
+    async (sessionState) => {
+      const provider = new AwsBedrockAgentsProvider('AGENT12345', {
+        config: {
+          agentId: 'AGENT12345',
+          agentAliasId: 'ALIAS12345',
+          sessionId: 'local-fixture-session',
+          region: 'us-east-1',
+          sessionState,
+          knowledgeBaseConfigurations: [{ knowledgeBaseId: 'KB12345678' }],
+        },
+      });
+      const { client, handle } = captureRequest();
+      vi.spyOn(provider, 'getAgentRuntimeClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toContain('Local serialization fixture');
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(request.sessionState).toEqual(sessionState);
+    },
+  );
 
   it('serializes knowledge-base generation settings in the AWS request', async () => {
     const provider = new AwsBedrockKnowledgeBaseProvider('custom-model', {
@@ -89,5 +117,136 @@ describe('Bedrock agent-runtime SDK serialization', () => {
       inferenceConfig: { textInferenceConfig: { temperature: 0, maxTokens: 128, topP: 0.75 } },
       additionalModelRequestFields: { top_k: 20 },
     });
+  });
+
+  it.each([
+    ['anthropic.claude-opus-4-7', undefined],
+    ['us.anthropic.claude-opus-4-7', undefined],
+    ['arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-opus-4-7', undefined],
+    [
+      'custom-model',
+      'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-opus-4-7',
+    ],
+  ] as const)(
+    'filters unsupported sampling for effective model %s / %s',
+    async (modelName, modelArn) => {
+      const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
+        config: {
+          knowledgeBaseId: 'KB12345678',
+          modelArn,
+          temperature: 0,
+          max_tokens: 128,
+          top_p: 0.75,
+          top_k: 20,
+        },
+      });
+      const { client, handle } = captureRequest();
+      vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toContain('Local serialization fixture');
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(
+        request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration,
+      ).toEqual({ inferenceConfig: { textInferenceConfig: { maxTokens: 128 } } });
+    },
+  );
+
+  it('preserves sampling for a supported modelArn override', async () => {
+    const provider = new AwsBedrockKnowledgeBaseProvider('anthropic.claude-opus-4-7', {
+      config: {
+        knowledgeBaseId: 'KB12345678',
+        modelArn: 'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0',
+        temperature: 0,
+        top_p: 0.75,
+        top_k: 20,
+      },
+    });
+    const { client, handle } = captureRequest();
+    vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+    const result = await provider.callApi('Describe a quiet garden');
+
+    expect(result.error).toContain('Local serialization fixture');
+    expect(handle).toHaveBeenCalledTimes(1);
+    const request = JSON.parse(String(handle.mock.calls[0][0].body));
+    expect(
+      request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration,
+    ).toEqual({
+      inferenceConfig: { textInferenceConfig: { temperature: 0, topP: 0.75 } },
+      additionalModelRequestFields: { top_k: 20 },
+    });
+  });
+
+  it('omits generationConfiguration when all configured fields are unsupported', async () => {
+    const provider = new AwsBedrockKnowledgeBaseProvider('anthropic.claude-opus-4-7', {
+      config: { knowledgeBaseId: 'KB12345678', temperature: 0, top_p: 0.75, top_k: 20 },
+    });
+    const { client, handle } = captureRequest();
+    vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+    const result = await provider.callApi('Describe a quiet garden');
+
+    expect(result.error).toContain('Local serialization fixture');
+    expect(handle).toHaveBeenCalledTimes(1);
+    const request = JSON.parse(String(handle.mock.calls[0][0].body));
+    expect(request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration).not.toHaveProperty(
+      'generationConfiguration',
+    );
+  });
+
+  it.each([
+    'us.anthropic.claude-opus-4-7',
+    'eu.anthropic.claude-opus-4-7',
+    'apac.anthropic.claude-sonnet-4-20250514-v1:0',
+    'global.anthropic.claude-opus-4-7',
+    'jp.anthropic.claude-opus-4-7',
+    'au.anthropic.claude-opus-4-7',
+    'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0',
+    'arn:aws-us-gov:bedrock:us-gov-west-1:123456789012:application-inference-profile/localfixture',
+    'arn:aws-cn:bedrock:cn-north-1:123456789012:inference-profile/localfixture',
+  ])(
+    'preserves the selected model/profile identifier %s in SDK serialization',
+    async (modelName) => {
+      const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
+        config: { knowledgeBaseId: 'KB12345678' },
+      });
+      const { client, handle } = captureRequest();
+      vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toContain('Local serialization fixture');
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.modelArn).toBe(
+        modelName,
+      );
+    },
+  );
+
+  it.each([
+    'amazon.nova-lite-v1:0',
+    'custom-model',
+    'global-custom-model',
+    'custom-arn:aws:bedrock:us-east-1::foundation-model/local-model',
+    'arn:aws:bedrock-invalid:us-east-1::foundation-model/local-model',
+  ])('keeps foundation-model construction for nonmatching identifier %s', async (modelName) => {
+    const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
+      config: { knowledgeBaseId: 'KB12345678', region: 'us-east-1' },
+    });
+    const { client, handle } = captureRequest();
+    vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+    const result = await provider.callApi('Describe a quiet garden');
+
+    expect(result.error).toContain('Local serialization fixture');
+    expect(handle).toHaveBeenCalledTimes(1);
+    const request = JSON.parse(String(handle.mock.calls[0][0].body));
+    expect(request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.modelArn).toBe(
+      `arn:aws:bedrock:us-east-1::foundation-model/${modelName}`,
+    );
   });
 });

--- a/test/providers/bedrock/requestSerialization.test.ts
+++ b/test/providers/bedrock/requestSerialization.test.ts
@@ -1,0 +1,93 @@
+import { BedrockAgentRuntimeClient } from '@aws-sdk/client-bedrock-agent-runtime';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AwsBedrockAgentsProvider } from '../../../src/providers/bedrock/agents';
+import { AwsBedrockKnowledgeBaseProvider } from '../../../src/providers/bedrock/knowledgeBase';
+
+vi.mock('../../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/cache')>()),
+  isCacheEnabled: () => false,
+  getCache: async () => ({}),
+}));
+
+describe('Bedrock agent-runtime SDK serialization', () => {
+  const clients: BedrockAgentRuntimeClient[] = [];
+
+  afterEach(() => {
+    clients.forEach((client) => client.destroy());
+    clients.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  function captureRequest() {
+    const handle = vi.fn(async (_request: { body?: unknown }) => {
+      throw new Error('Local serialization fixture');
+    });
+    const client = new BedrockAgentRuntimeClient({
+      region: 'us-east-1',
+      credentials: { accessKeyId: 'LOCAL_FIXTURE', secretAccessKey: 'LOCAL_FIXTURE' },
+      maxAttempts: 1,
+      requestHandler: { handle },
+    });
+    clients.push(client);
+    return { client, handle };
+  }
+
+  it('serializes agent knowledge-base overrides with existing session state', async () => {
+    const knowledgeBaseConfigurations = [
+      {
+        knowledgeBaseId: 'KB12345678',
+        retrievalConfiguration: { vectorSearchConfiguration: { numberOfResults: 3 } },
+      },
+    ];
+    const provider = new AwsBedrockAgentsProvider('AGENT12345', {
+      config: {
+        agentId: 'AGENT12345',
+        agentAliasId: 'ALIAS12345',
+        sessionId: 'local-fixture-session',
+        region: 'us-east-1',
+        sessionState: { sessionAttributes: { topic: 'garden' } },
+        knowledgeBaseConfigurations,
+      },
+    });
+    const { client, handle } = captureRequest();
+    vi.spyOn(provider, 'getAgentRuntimeClient').mockResolvedValue(client);
+
+    const result = await provider.callApi('Describe a quiet garden');
+
+    expect(result.error).toContain('Local serialization fixture');
+    expect(handle).toHaveBeenCalledTimes(1);
+    const request = JSON.parse(String(handle.mock.calls[0][0].body));
+    expect(request.sessionState).toEqual({
+      sessionAttributes: { topic: 'garden' },
+      knowledgeBaseConfigurations,
+    });
+    expect(request).not.toHaveProperty('knowledgeBaseConfigurations');
+  });
+
+  it('serializes knowledge-base generation settings in the AWS request', async () => {
+    const provider = new AwsBedrockKnowledgeBaseProvider('custom-model', {
+      config: {
+        knowledgeBaseId: 'KB12345678',
+        modelArn: 'arn:aws:bedrock:us-east-1::foundation-model/custom-model',
+        temperature: 0,
+        max_tokens: 128,
+        top_p: 0.75,
+        top_k: 20,
+      },
+    });
+    const { client, handle } = captureRequest();
+    vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+    const result = await provider.callApi('Describe a quiet garden');
+
+    expect(result.error).toContain('Local serialization fixture');
+    expect(handle).toHaveBeenCalledTimes(1);
+    const request = JSON.parse(String(handle.mock.calls[0][0].body));
+    expect(
+      request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration,
+    ).toEqual({
+      inferenceConfig: { textInferenceConfig: { temperature: 0, maxTokens: 128, topP: 0.75 } },
+      additionalModelRequestFields: { top_k: 20 },
+    });
+  });
+});

--- a/test/providers/bedrock/requestSerialization.test.ts
+++ b/test/providers/bedrock/requestSerialization.test.ts
@@ -176,9 +176,145 @@ describe('Bedrock agent-runtime SDK serialization', () => {
       request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration,
     ).toEqual({
       inferenceConfig: { textInferenceConfig: { temperature: 0, topP: 0.75 } },
-      additionalModelRequestFields: { top_k: 20 },
+      additionalModelRequestFields: { inferenceConfig: { topK: 20 } },
     });
   });
+
+  it.each([
+    ['amazon.nova-lite-v1:0', undefined],
+    ['amazon.nova-pro-v1:0', undefined],
+    ['amazon.nova-micro-v1:0', undefined],
+    ['us.amazon.nova-premier-v1:0', undefined],
+    ['arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0', undefined],
+    ['custom-model', 'arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-pro-v1:0'],
+  ] as const)(
+    'serializes Nova top-k in native inferenceConfig for %s / %s',
+    async (modelName, modelArn) => {
+      const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
+        config: { knowledgeBaseId: 'KB12345678', modelArn, top_k: 0 },
+      });
+      const { client, handle } = captureRequest();
+      vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toContain('Local serialization fixture');
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(
+        request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration,
+      ).toEqual({
+        additionalModelRequestFields: { inferenceConfig: { topK: 0 } },
+      });
+    },
+  );
+
+  it.each([
+    ['anthropic.claude-sonnet-4-5-20250929-v1:0', undefined],
+    ['anthropic.claude-haiku-4-5-20251001-v1:0', undefined],
+    ['us.anthropic.claude-sonnet-4-5-20250929-v1:0', undefined],
+    [
+      'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0',
+      undefined,
+    ],
+    [
+      'amazon.nova-lite-v1:0',
+      'arn:aws:bedrock:us-east-1:123456789012:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    ],
+  ] as const)(
+    'prefers top_p over temperature for Claude 4.5 %s / %s',
+    async (modelName, modelArn) => {
+      const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
+        config: {
+          knowledgeBaseId: 'KB12345678',
+          modelArn,
+          temperature: 0.5,
+          top_p: 0,
+          top_k: 20,
+          max_tokens: 128,
+        },
+      });
+      const { client, handle } = captureRequest();
+      vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toContain('Local serialization fixture');
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(
+        request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration,
+      ).toEqual({
+        inferenceConfig: { textInferenceConfig: { topP: 0, maxTokens: 128 } },
+        additionalModelRequestFields: { top_k: 20 },
+      });
+    },
+  );
+
+  it.each([
+    { sampling: { temperature: 0 }, expected: { temperature: 0 } },
+    { sampling: { top_p: 0.75 }, expected: { topP: 0.75 } },
+  ])(
+    'preserves individual Claude 4.5 sampling option $sampling',
+    async ({ sampling, expected }) => {
+      const provider = new AwsBedrockKnowledgeBaseProvider(
+        'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        {
+          config: { knowledgeBaseId: 'KB12345678', ...sampling },
+        },
+      );
+      const { client, handle } = captureRequest();
+      vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toContain('Local serialization fixture');
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(
+        request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration,
+      ).toEqual({
+        inferenceConfig: { textInferenceConfig: expected },
+      });
+    },
+  );
+
+  it.each([
+    ['anthropic.claude-3-5-sonnet-20241022-v2:0', undefined],
+    ['custom-model', undefined],
+    ['custom-amazon.nova-model', undefined],
+    ['anthropic.claude-sonnet-4-50', undefined],
+    [
+      'arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/claude-prod-5',
+      undefined,
+    ],
+    [
+      'amazon.nova-lite-v1:0',
+      'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0',
+    ],
+    ['anthropic.claude-sonnet-4-5-20250929-v1:0', 'custom-model'],
+  ] as const)(
+    'preserves other model sampling and top-k shapes for %s / %s',
+    async (modelName, modelArn) => {
+      const provider = new AwsBedrockKnowledgeBaseProvider(modelName, {
+        config: { knowledgeBaseId: 'KB12345678', modelArn, temperature: 0, top_p: 0.75, top_k: 20 },
+      });
+      const { client, handle } = captureRequest();
+      vi.spyOn(provider, 'getKnowledgeBaseClient').mockResolvedValue(client);
+
+      const result = await provider.callApi('Describe a quiet garden');
+
+      expect(result.error).toContain('Local serialization fixture');
+      expect(handle).toHaveBeenCalledTimes(1);
+      const request = JSON.parse(String(handle.mock.calls[0][0].body));
+      expect(
+        request.retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration,
+      ).toEqual({
+        inferenceConfig: { textInferenceConfig: { temperature: 0, topP: 0.75 } },
+        additionalModelRequestFields: { top_k: 20 },
+      });
+    },
+  );
 
   it('omits generationConfiguration when all configured fields are unsupported', async () => {
     const provider = new AwsBedrockKnowledgeBaseProvider('anthropic.claude-opus-4-7', {


### PR DESCRIPTION
Cohere Bedrock embeddings omit the required input type and can return nested vectors to callers expecting a single numeric vector. Knowledge Base generation settings are ignored, while Agent knowledge-base overrides are dropped by SDK serialization and metadata can incorrectly claim a guardrail was applied.

Forward supported fields and normalize one float embedding vector. Preserve Agent session state and deployed defaults for ID-only KB entries. Correct the documented retrieval filters to AWS operator objects and return a clear local error for unsupported flat maps. Preserve valid filters and other retrieval options. Map model-specific sampling fields, apply Claude sampling restrictions to the effective KB model, require a generation model before client creation, and preserve inference-profile IDs and partition ARNs. Version the affected caches and document the deployed-agent/runtime boundary.

Sources, verified September 8, 2026: AWS [RetrievalFilter](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_RetrievalFilter.html), [generation configuration](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_GenerationConfiguration.html), and [Cohere embedding parameters](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v3.html).

Validation: 131 mocked tests, including real AWS SDK serialization for all 13 retrieval filter operators; all seven CI style checks; package/UI and documentation builds. The built CLI reads both actual YAML filter examples and checks legacy-map errors locally, alongside the earlier compatibility cases. No vendor inference calls.
