### PR TITLE
chore: report architecture reference and reach views

### DIFF
--- a/docs/architecture/packages.md
+++ b/docs/architecture/packages.md
@@ -128,3 +128,38 @@ npm run deps:ownership
 
 The report is intentionally descriptive for now. It gives us the evidence needed
 to move dependencies into future packages without guessing at ownership.
+
+## Architecture Measurement Views
+
+The boundary ratchets still count every literal module reference together, including
+explicit type imports, dynamic imports, and `require.resolve`. They exclude the
+public facade as an importer. No existing allowance changes when using a report:
+
+```bash
+npm run architecture:check -- --report
+npx tsx scripts/checkArchitectureBoundaries.ts --json > architecture-report.json
+npx tsx scripts/checkArchitectureBoundaries.ts --json --entrypoint=src/contracts.ts
+```
+
+JSON goes to stdout; check diagnostics go to stderr and failures retain a nonzero
+exit status. Reports include separate explicit-type, value-capable, deferred
+(`import()`), and resolution-only (`require.resolve`) views, layer cycles, and
+file cycles. Mixed imports count once as value-capable; ordinary imports may
+still be erased by TypeScript. CommonJS `require()` is value-capable, even inside
+a function; this analysis does not infer execution timing or scope bindings.
+
+Entrypoint reports include the facade and compare combined, value-capable, and
+value-capable-plus-deferred reach. Lists of external specifiers describe direct
+source references, not their transitive installed dependencies. Unresolved
+internal references (including non-TypeScript assets) and computed loaders retain
+source locations so incomplete reach is visible. References to files outside the
+scanned scope (such as ignored files and declarations) are listed separately. Aliased loader functions and
+arbitrary runtime resolution are outside the scanner's syntax coverage. The
+CommonJS forms recognized here are single-argument `require(target)` and
+`require.resolve(target)`; computed member access and resolution options are not
+modeled.
+
+These are source graphs, not shipped browser bundles or install-size measurements.
+They do not model Vite substitutions, tree shaking, or compiler import elision.
+Layer cycles do not establish file cycles, and back-edges are violations of the
+configured order, not a minimum cut or an estimate of remaining extraction work.

--- a/scripts/architectureUtils.ts
+++ b/scripts/architectureUtils.ts
@@ -280,62 +280,108 @@ function getStaticModuleSpecifier(node: Node): string | undefined {
   return undefined;
 }
 
-export function extractModuleSpecifiers(sourceText: string, filePath: string): string[] {
+export type ModuleReferenceKind = 'type' | 'value' | 'deferred' | 'resolution';
+
+export interface ModuleReference {
+  /** Undefined for computed loaders whose target cannot be determined statically. */
+  specifier?: string;
+  kind: ModuleReferenceKind;
+  syntax:
+    | 'import'
+    | 'export'
+    | 'dynamic-import'
+    | 'import-equals'
+    | 'import-type'
+    | 'require'
+    | 'require-resolve';
+  /** One-based source line for diagnostics. */
+  line: number;
+}
+
+/** Classifies syntax, not emitted JavaScript: ordinary imports may still be erased by tsc. */
+export function extractModuleReferences(sourceText: string, filePath: string): ModuleReference[] {
   const result = parseSync(filePath, sourceText);
   if (result.errors.length > 0) {
     throw new Error(`Could not parse ${filePath}: ${result.errors[0].message}`);
   }
-
-  const specifiers: string[] = [];
-
+  const references: ModuleReference[] = [];
+  const add = (
+    node: Node,
+    specifier: string | undefined,
+    kind: ModuleReferenceKind,
+    syntax: ModuleReference['syntax'],
+  ) => {
+    references.push({
+      specifier,
+      kind,
+      syntax,
+      line: sourceText.slice(0, node.start).split('\n').length,
+    });
+  };
   new Visitor({
     ImportDeclaration(node) {
-      specifiers.push(node.source.value);
+      const typeOnly =
+        node.importKind === 'type' ||
+        (node.specifiers.length > 0 &&
+          node.specifiers.every(
+            (specifier) => specifier.type === 'ImportSpecifier' && specifier.importKind === 'type',
+          ));
+      add(node, node.source.value, typeOnly ? 'type' : 'value', 'import');
     },
     ExportAllDeclaration(node) {
-      specifiers.push(node.source.value);
+      add(node, node.source.value, node.exportKind === 'type' ? 'type' : 'value', 'export');
     },
     ExportNamedDeclaration(node) {
       if (node.source) {
-        specifiers.push(node.source.value);
+        const typeOnly =
+          node.exportKind === 'type' ||
+          (node.specifiers.length > 0 &&
+            node.specifiers.every((specifier) => specifier.exportKind === 'type'));
+        add(node, node.source.value, typeOnly ? 'type' : 'value', 'export');
       }
     },
     ImportExpression(node) {
-      const specifier = getStaticModuleSpecifier(node.source);
-      if (specifier !== undefined) {
-        specifiers.push(specifier);
-      }
+      add(node, getStaticModuleSpecifier(node.source), 'deferred', 'dynamic-import');
     },
     TSImportEqualsDeclaration(node) {
       if (node.moduleReference.type === 'TSExternalModuleReference') {
-        specifiers.push(node.moduleReference.expression.value);
+        add(
+          node,
+          node.moduleReference.expression.value,
+          node.importKind === 'type' ? 'type' : 'value',
+          'import-equals',
+        );
       }
     },
     TSImportType(node) {
-      specifiers.push(node.source.value);
+      add(node, node.source.value, 'type', 'import-type');
     },
     CallExpression(node) {
       if (node.arguments.length !== 1) {
         return;
       }
-
-      const specifier = getStaticModuleSpecifier(node.arguments[0]);
-      if (
-        specifier !== undefined &&
-        ((node.callee.type === 'Identifier' && node.callee.name === 'require') ||
-          (node.callee.type === 'MemberExpression' &&
-            !node.callee.computed &&
-            node.callee.object.type === 'Identifier' &&
-            node.callee.object.name === 'require' &&
-            node.callee.property.type === 'Identifier' &&
-            node.callee.property.name === 'resolve'))
+      if (node.callee.type === 'Identifier' && node.callee.name === 'require') {
+        add(node, getStaticModuleSpecifier(node.arguments[0]), 'value', 'require');
+      } else if (
+        node.callee.type === 'MemberExpression' &&
+        !node.callee.computed &&
+        node.callee.object.type === 'Identifier' &&
+        node.callee.object.name === 'require' &&
+        node.callee.property.type === 'Identifier' &&
+        node.callee.property.name === 'resolve'
       ) {
-        specifiers.push(specifier);
+        add(node, getStaticModuleSpecifier(node.arguments[0]), 'resolution', 'require-resolve');
       }
     },
   }).visit(result.program);
+  return references;
+}
 
-  return specifiers;
+/** Compatibility view used by the conservative ratchet and dependency ownership report. */
+export function extractModuleSpecifiers(sourceText: string, filePath: string): string[] {
+  return extractModuleReferences(sourceText, filePath).flatMap((reference) =>
+    reference.specifier === undefined ? [] : [reference.specifier],
+  );
 }
 
 export function resolveInternalModule(
@@ -437,7 +483,7 @@ export interface BoundaryViolation {
   importedLayer: string;
 }
 
-export interface ArchitectureModuleReference {
+export interface ArchitectureModuleReference extends ModuleReference {
   importer: string;
   importerLayer: string;
   specifier: string;
@@ -447,7 +493,9 @@ export interface ArchitectureModuleReference {
 
 export interface ArchitectureSourceScan {
   sourceFiles: string[];
+  includesFacade: boolean;
   references: ArchitectureModuleReference[];
+  computedReferences: Array<ModuleReference & { importer: string; importerLayer: string }>;
 }
 
 /**
@@ -457,21 +505,29 @@ export interface ArchitectureSourceScan {
 export function scanArchitectureSources(
   repoRoot: string,
   config: LayerConfig,
+  options: { includeFacade?: boolean } = {},
 ): ArchitectureSourceScan {
   const publicFacade = normalizePath(config.publicFacade);
   const sourceFiles = getSourceFiles(repoRoot, true, config.ignoredRoots);
   const references: ArchitectureModuleReference[] = [];
+  const computedReferences: ArchitectureSourceScan['computedReferences'] = [];
 
   for (const importer of sourceFiles) {
-    if (normalizePath(importer) === publicFacade) {
+    if (!options.includeFacade && normalizePath(importer) === publicFacade) {
       continue;
     }
 
     const importerLayer = getLayerForFile(importer, config);
     const sourceText = fs.readFileSync(path.join(repoRoot, importer), 'utf8');
-    for (const specifier of extractModuleSpecifiers(sourceText, importer)) {
+    for (const reference of extractModuleReferences(sourceText, importer)) {
+      const { specifier } = reference;
+      if (specifier === undefined) {
+        computedReferences.push({ ...reference, importer, importerLayer });
+        continue;
+      }
       const resolvedImport = resolveInternalModule(repoRoot, importer, specifier, config.aliases);
       references.push({
+        ...reference,
         importer,
         importerLayer,
         specifier,
@@ -482,7 +538,12 @@ export function scanArchitectureSources(
     }
   }
 
-  return { sourceFiles, references };
+  return {
+    sourceFiles,
+    references,
+    computedReferences,
+    includesFacade: options.includeFacade ?? false,
+  };
 }
 
 export function findUnclassifiedFiles(
@@ -641,7 +702,12 @@ export function computeCrossLayerEdges(
   const tallies = new Map<string, { count: number; files: Set<string> }>();
 
   for (const { importer, importerLayer, resolvedImport, importedLayer } of sourceScan.references) {
-    if (!resolvedImport || !importedLayer || importedLayer === importerLayer) {
+    if (
+      normalizePath(importer) === normalizePath(config.publicFacade) ||
+      !resolvedImport ||
+      !importedLayer ||
+      importedLayer === importerLayer
+    ) {
       continue;
     }
 
@@ -670,7 +736,16 @@ export function computeStronglyConnectedComponents(
   config: LayerConfig,
   edges: CrossLayerEdge[],
 ): string[][] {
-  const nodes = config.layers.map((layer) => layer.name);
+  return stronglyConnectedComponents(
+    config.layers.map((layer) => layer.name),
+    edges,
+  );
+}
+
+function stronglyConnectedComponents(
+  nodes: string[],
+  edges: Array<{ from: string; to: string }>,
+): string[][] {
   const adjacency = new Map<string, string[]>(nodes.map((node) => [node, []]));
   for (const edge of edges) {
     if (adjacency.has(edge.from) && adjacency.has(edge.to)) {
@@ -719,14 +794,16 @@ export function computeStronglyConnectedComponents(
     }
   }
 
-  return components.sort((left, right) => right.length - left.length);
+  return components.sort(
+    (left, right) => right.length - left.length || left[0].localeCompare(right[0]),
+  );
 }
 
 /**
  * Given a target topological order (`tierOrder`, most-depended-upon first),
  * returns the cross-layer edges that violate it — a lower-tier layer importing
- * a higher-tier layer. These are the cycle-causing "back edges" to eliminate on
- * the way to a DAG. Edges touching a layer absent from `tierOrder` are ignored.
+ * a higher-tier layer. These are order violations, not a minimum cut or an estimate of the work
+ * required to reach a DAG. Edges touching a layer absent from `tierOrder` are ignored.
  */
 export function findBackEdges(edges: CrossLayerEdge[], tierOrder: string[]): CrossLayerEdge[] {
   const rank = new Map(tierOrder.map((layer, index) => [layer, index]));
@@ -892,4 +969,140 @@ export function readEdgeBaseline(repoRoot: string, config: LayerConfig): EdgeBas
   }
 
   return baseline as EdgeBaseline;
+}
+
+/** Source graph diagnostics only; this does not model bundler substitutions or tree shaking. */
+export function buildArchitectureReport(
+  repoRoot: string,
+  config: LayerConfig,
+  sourceScan: ArchitectureSourceScan,
+  entrypoints: string[] = [config.publicFacade],
+) {
+  if (!sourceScan.includesFacade) {
+    throw new Error('Architecture reports require a scan with includeFacade: true.');
+  }
+  const scannedFiles = new Set(sourceScan.sourceFiles);
+  const unscannedInternal = sourceScan.references.filter(
+    (reference) => reference.resolvedImport && !scannedFiles.has(reference.resolvedImport),
+  );
+  const views = Object.fromEntries(
+    (['combined', 'type', 'value', 'deferred', 'resolution'] as const).map((kind) => {
+      const references = sourceScan.references.filter(
+        (reference) => kind === 'combined' || reference.kind === kind,
+      );
+      const edges = computeCrossLayerEdges(repoRoot, config, { ...sourceScan, references });
+      const fileEdges = references.flatMap((reference) =>
+        reference.resolvedImport
+          ? [{ from: reference.importer, to: reference.resolvedImport }]
+          : [],
+      );
+      const fileCycles = stronglyConnectedComponents(sourceScan.sourceFiles, fileEdges).filter(
+        (component) =>
+          component.length > 1 ||
+          fileEdges.some((edge) => edge.from === component[0] && edge.to === component[0]),
+      );
+      return [
+        kind,
+        {
+          references: references.length,
+          crossLayerReferences: edges.reduce((sum, edge) => sum + edge.count, 0),
+          edges,
+          layerCycles: computeStronglyConnectedComponents(config, edges).filter(
+            (component) => component.length > 1,
+          ),
+          fileCycles,
+        },
+      ];
+    }),
+  );
+  const unresolvedInternal = sourceScan.references.filter(
+    (reference) =>
+      !reference.resolvedImport &&
+      (reference.specifier.startsWith('.') ||
+        reference.specifier.startsWith('/') ||
+        reference.specifier.startsWith('#') ||
+        reference.specifier === 'src' ||
+        reference.specifier.startsWith('src/') ||
+        Object.keys(config.aliases ?? {}).some(
+          (alias) => reference.specifier === alias || reference.specifier.startsWith(`${alias}/`),
+        )),
+  );
+  const byImporter = new Map<string, ArchitectureModuleReference[]>();
+  for (const reference of sourceScan.references) {
+    const outgoing = byImporter.get(reference.importer) ?? [];
+    outgoing.push(reference);
+    byImporter.set(reference.importer, outgoing);
+  }
+  const reach = (entrypoint: string, mode: 'combined' | 'value' | 'value-and-deferred') => {
+    const files = new Set([entrypoint]);
+    const externalSpecifiers = new Set<string>();
+    const unresolvedReferences: ArchitectureModuleReference[] = [];
+    const unresolvedSet = new Set(unresolvedInternal);
+    for (const file of files) {
+      for (const reference of byImporter.get(file) ?? []) {
+        if (
+          mode !== 'combined' &&
+          reference.kind !== 'value' &&
+          !(mode === 'value-and-deferred' && reference.kind === 'deferred')
+        ) {
+          continue;
+        }
+        if (reference.resolvedImport) {
+          files.add(reference.resolvedImport);
+        } else if (unresolvedSet.has(reference)) {
+          unresolvedReferences.push(reference);
+        } else {
+          externalSpecifiers.add(reference.specifier);
+        }
+      }
+    }
+    return {
+      files: [...files].sort(),
+      externalSpecifiers: [...externalSpecifiers].sort(),
+      unresolvedReferences,
+      unscannedInternal: unscannedInternal.filter(
+        (reference) =>
+          files.has(reference.importer) &&
+          (mode === 'combined' ||
+            reference.kind === 'value' ||
+            (mode === 'value-and-deferred' && reference.kind === 'deferred')),
+      ),
+      computedReferences: sourceScan.computedReferences.filter(
+        (reference) =>
+          files.has(reference.importer) &&
+          (mode === 'combined' ||
+            reference.kind === 'value' ||
+            (mode === 'value-and-deferred' && reference.kind === 'deferred')),
+      ),
+    };
+  };
+  for (const entrypoint of entrypoints) {
+    if (!sourceScan.sourceFiles.includes(entrypoint)) {
+      throw new Error(
+        `Architecture report entrypoint "${entrypoint}" is not in the checked source tree.`,
+      );
+    }
+  }
+  return {
+    schemaVersion: 1,
+    scope: {
+      sourceFiles: sourceScan.sourceFiles.length,
+      facadeIncluded: true,
+      ratchetExcludesFacade: true,
+    },
+    views,
+    unresolvedInternal,
+    unscannedInternal,
+    computedReferences: sourceScan.computedReferences,
+    entrypoints: Object.fromEntries(
+      entrypoints.map((entrypoint) => [
+        entrypoint,
+        {
+          combined: reach(entrypoint, 'combined'),
+          value: reach(entrypoint, 'value'),
+          valueAndDeferred: reach(entrypoint, 'value-and-deferred'),
+        },
+      ]),
+    ),
+  };
 }

--- a/scripts/architectureUtils.ts
+++ b/scripts/architectureUtils.ts
@@ -304,6 +304,24 @@ export function extractModuleReferences(sourceText: string, filePath: string): M
   if (result.errors.length > 0) {
     throw new Error(`Could not parse ${filePath}: ${result.errors[0].message}`);
   }
+  // Oxc's JavaScript AST offsets use UTF-16 code units, like string/RegExp indices.
+  const lineStarts = [0];
+  for (const match of sourceText.matchAll(/\r\n|[\n\r\u2028\u2029]/gu)) {
+    lineStarts.push(match.index + match[0].length);
+  }
+  const lineAtOffset = (offset: number): number => {
+    let low = 0;
+    let high = lineStarts.length;
+    while (low < high) {
+      const middle = Math.floor((low + high) / 2);
+      if (lineStarts[middle] <= offset) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return low;
+  };
   const references: ModuleReference[] = [];
   const add = (
     node: Node,
@@ -315,7 +333,7 @@ export function extractModuleReferences(sourceText: string, filePath: string): M
       specifier,
       kind,
       syntax,
-      line: sourceText.slice(0, node.start).split(/\r\n|[\n\r\u2028\u2029]/u).length,
+      line: lineAtOffset(node.start),
     });
   };
   new Visitor({
@@ -981,6 +999,15 @@ export function buildArchitectureReport(
   if (!sourceScan.includesFacade) {
     throw new Error('Architecture reports require a scan with includeFacade: true.');
   }
+  const normalizedEntrypoints = [
+    ...new Set(
+      entrypoints.map((entrypoint) =>
+        normalizePath(
+          path.relative(repoRoot, path.resolve(repoRoot, entrypoint.replace(/\\/g, '/'))),
+        ),
+      ),
+    ),
+  ];
   const scannedFiles = new Set(sourceScan.sourceFiles);
   const unscannedInternal = sourceScan.references.filter(
     (reference) => reference.resolvedImport && !scannedFiles.has(reference.resolvedImport),
@@ -1076,8 +1103,8 @@ export function buildArchitectureReport(
       ),
     };
   };
-  for (const entrypoint of entrypoints) {
-    if (!sourceScan.sourceFiles.includes(entrypoint)) {
+  for (const entrypoint of normalizedEntrypoints) {
+    if (!scannedFiles.has(entrypoint)) {
       throw new Error(
         `Architecture report entrypoint "${entrypoint}" is not in the checked source tree.`,
       );
@@ -1095,7 +1122,7 @@ export function buildArchitectureReport(
     unscannedInternal,
     computedReferences: sourceScan.computedReferences,
     entrypoints: Object.fromEntries(
-      entrypoints.map((entrypoint) => [
+      normalizedEntrypoints.map((entrypoint) => [
         entrypoint,
         {
           combined: reach(entrypoint, 'combined'),

--- a/scripts/architectureUtils.ts
+++ b/scripts/architectureUtils.ts
@@ -315,7 +315,7 @@ export function extractModuleReferences(sourceText: string, filePath: string): M
       specifier,
       kind,
       syntax,
-      line: sourceText.slice(0, node.start).split('\n').length,
+      line: sourceText.slice(0, node.start).split(/\r\n|[\n\r\u2028\u2029]/u).length,
     });
   };
   new Visitor({
@@ -1015,14 +1015,14 @@ export function buildArchitectureReport(
       ];
     }),
   );
+  const sourceRoots = ['src', 'packages', ...config.layers.flatMap((layer) => layer.roots)];
   const unresolvedInternal = sourceScan.references.filter(
     (reference) =>
       !reference.resolvedImport &&
       (reference.specifier.startsWith('.') ||
         reference.specifier.startsWith('/') ||
         reference.specifier.startsWith('#') ||
-        reference.specifier === 'src' ||
-        reference.specifier.startsWith('src/') ||
+        sourceRoots.some((root) => isWithinRoot(reference.specifier, root)) ||
         Object.keys(config.aliases ?? {}).some(
           (alias) => reference.specifier === alias || reference.specifier.startsWith(`${alias}/`),
         )),

--- a/scripts/checkArchitectureBoundaries.ts
+++ b/scripts/checkArchitectureBoundaries.ts
@@ -17,7 +17,9 @@ import {
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const config = readLayerConfig(repoRoot);
-const reportMode = process.argv.includes('--report') || process.argv.includes('--json');
+const jsonMode = process.argv.includes('--json');
+const reportMode = process.argv.includes('--report') || jsonMode;
+const log = jsonMode ? console.error : console.log;
 const sourceScan = scanArchitectureSources(repoRoot, config, { includeFacade: reportMode });
 if (reportMode) {
   const entrypoints = process.argv
@@ -29,26 +31,25 @@ if (reportMode) {
     sourceScan,
     entrypoints.length > 0 ? entrypoints : undefined,
   );
-  if (process.argv.includes('--json')) {
+  if (jsonMode) {
     console.log(JSON.stringify(report, null, 2));
-    // Keep stdout machine-readable; the normal checks still run and set the exit status.
-    console.log = (...args) => console.error(...args);
+    // Keep stdout machine-readable; normal checks still run and set the exit status.
   } else {
-    console.log('Architecture source views (syntax classification; not emitted or bundled code):');
+    log('Architecture source views (syntax classification; not emitted or bundled code):');
     for (const [kind, view] of Object.entries(report.views)) {
-      console.log(
+      log(
         `- ${kind}: ${view.references} references, ${view.crossLayerReferences} cross-layer references, ${view.fileCycles.length} file cycles`,
       );
     }
-    console.log(
+    log(
       `- ${report.unresolvedInternal.length} unresolved internal references (including non-TypeScript assets); ${report.computedReferences.length} computed loaders; ${report.unscannedInternal.length} references beyond the scanned scope`,
     );
     for (const [entrypoint, reach] of Object.entries(report.entrypoints)) {
-      console.log(
+      log(
         `- ${entrypoint}: ${reach.combined.files.length} combined / ${reach.value.files.length} value-capable / ${reach.valueAndDeferred.files.length} value-capable plus deferred reachable files`,
       );
     }
-    console.log('Use --json for reference locations, cycles, and reachable files.');
+    log('Use --json for reference locations, cycles, and reachable files.');
   }
 }
 const violations = findViolations(repoRoot, config, sourceScan);
@@ -145,7 +146,7 @@ if (config.maxStronglyConnectedComponentSize !== undefined) {
       '\nBreaking a cross-layer cycle should lower maxStronglyConnectedComponentSize in architecture/layers.json; new cycles are not allowed.',
     );
   } else if (largestCycle < config.maxStronglyConnectedComponentSize) {
-    console.log(
+    log(
       `Note: largest dependency cycle is now ${largestCycle} layers (ratchet is ${config.maxStronglyConnectedComponentSize}). ` +
         'Lower maxStronglyConnectedComponentSize in architecture/layers.json to lock in the progress.',
     );
@@ -169,7 +170,7 @@ if (regressions.length > 0) {
   );
 }
 if (improvements.length > 0) {
-  console.log(
+  log(
     `Note: ${improvements.length} cross-layer edge(s) shrank below baseline. Run \`npm run architecture:baseline\` to lock in the reduction.`,
   );
 }
@@ -198,11 +199,11 @@ if (config.tierOrder !== undefined) {
   const backEdges = findBackEdges(edges, config.tierOrder);
   if (backEdges.length > 0) {
     const totalBackImports = backEdges.reduce((sum, edge) => sum + edge.count, 0);
-    console.log(
+    log(
       `\nRemaining back-edges versus target order (${backEdges.length} edges / ${totalBackImports} references; informational order violations):`,
     );
     for (const edge of [...backEdges].sort((left, right) => left.count - right.count)) {
-      console.log(`- ${edge.from} -> ${edge.to}: ${edge.count} imports`);
+      log(`- ${edge.from} -> ${edge.to}: ${edge.count} imports`);
     }
   }
 }
@@ -213,5 +214,5 @@ const dagChecksFailed =
 if (violations.length > 0 || unclassifiedFiles.length > 0 || dagChecksFailed) {
   process.exitCode = 1;
 } else {
-  console.log('Architecture boundaries passed.');
+  log('Architecture boundaries passed.');
 }

--- a/scripts/checkArchitectureBoundaries.ts
+++ b/scripts/checkArchitectureBoundaries.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  buildArchitectureReport,
   compareEdgesToBaseline,
   computeCrossLayerEdges,
   computeStronglyConnectedComponents,
@@ -16,7 +17,40 @@ import {
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const config = readLayerConfig(repoRoot);
-const sourceScan = scanArchitectureSources(repoRoot, config);
+const reportMode = process.argv.includes('--report') || process.argv.includes('--json');
+const sourceScan = scanArchitectureSources(repoRoot, config, { includeFacade: reportMode });
+if (reportMode) {
+  const entrypoints = process.argv
+    .filter((arg) => arg.startsWith('--entrypoint='))
+    .map((arg) => arg.slice('--entrypoint='.length));
+  const report = buildArchitectureReport(
+    repoRoot,
+    config,
+    sourceScan,
+    entrypoints.length > 0 ? entrypoints : undefined,
+  );
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify(report, null, 2));
+    // Keep stdout machine-readable; the normal checks still run and set the exit status.
+    console.log = (...args) => console.error(...args);
+  } else {
+    console.log('Architecture source views (syntax classification; not emitted or bundled code):');
+    for (const [kind, view] of Object.entries(report.views)) {
+      console.log(
+        `- ${kind}: ${view.references} references, ${view.crossLayerReferences} cross-layer references, ${view.fileCycles.length} file cycles`,
+      );
+    }
+    console.log(
+      `- ${report.unresolvedInternal.length} unresolved internal references (including non-TypeScript assets); ${report.computedReferences.length} computed loaders; ${report.unscannedInternal.length} references beyond the scanned scope`,
+    );
+    for (const [entrypoint, reach] of Object.entries(report.entrypoints)) {
+      console.log(
+        `- ${entrypoint}: ${reach.combined.files.length} combined / ${reach.value.files.length} value-capable / ${reach.valueAndDeferred.files.length} value-capable plus deferred reachable files`,
+      );
+    }
+    console.log('Use --json for reference locations, cycles, and reachable files.');
+  }
+}
 const violations = findViolations(repoRoot, config, sourceScan);
 
 const facadeViolations = violations.filter((v) => v.kind === 'facade');
@@ -165,7 +199,7 @@ if (config.tierOrder !== undefined) {
   if (backEdges.length > 0) {
     const totalBackImports = backEdges.reduce((sum, edge) => sum + edge.count, 0);
     console.log(
-      `\nRemaining back-edges versus target order (${backEdges.length} edges / ${totalBackImports} imports to reach a DAG):`,
+      `\nRemaining back-edges versus target order (${backEdges.length} edges / ${totalBackImports} references; informational order violations):`,
     );
     for (const edge of [...backEdges].sort((left, right) => left.count - right.count)) {
       console.log(`- ${edge.from} -> ${edge.to}: ${edge.count} imports`);

--- a/test/scripts/architectureDag.test.ts
+++ b/test/scripts/architectureDag.test.ts
@@ -109,6 +109,28 @@ describe('computeCrossLayerEdges', () => {
     ).toThrow('includeFacade: true');
   });
 
+  it('reports unresolved package and configured-root paths as internal references', () => {
+    const config = configWith([
+      { name: 'facade', roots: ['src/index.ts'], allowedDependencies: [] },
+      { name: 'shared', roots: ['internal/shared'], allowedDependencies: [] },
+    ]);
+    write(
+      'src/index.ts',
+      "import 'packages/missing'; import 'internal/shared/missing'; import 'external';",
+    );
+    write('internal/shared/index.ts');
+    const report = buildArchitectureReport(
+      repoRoot,
+      config,
+      scanArchitectureSources(repoRoot, config, { includeFacade: true }),
+    );
+    expect(report.unresolvedInternal.map(({ specifier }) => specifier)).toEqual([
+      'packages/missing',
+      'internal/shared/missing',
+    ]);
+    expect(report.entrypoints['src/index.ts'].value.externalSpecifiers).toEqual(['external']);
+  });
+
   it('runs the real JSON checker with clean stdout and preserves failure exit status', () => {
     const config = configWith([
       { name: 'facade', roots: ['src/index.ts'], allowedDependencies: [] },

--- a/test/scripts/architectureDag.test.ts
+++ b/test/scripts/architectureDag.test.ts
@@ -89,6 +89,28 @@ describe('computeCrossLayerEdges', () => {
     );
   });
 
+  it('normalizes entrypoint spellings before validating and traversing the source graph', () => {
+    const config = configWith([
+      { name: 'facade', roots: ['src/index.ts'], allowedDependencies: [] },
+      { name: 'a', roots: ['src/a.ts'], allowedDependencies: [] },
+    ]);
+    write('src/index.ts', "export * from './a';");
+    write('src/a.ts', "import 'external';");
+    const scan = scanArchitectureSources(repoRoot, config, { includeFacade: true });
+    const report = buildArchitectureReport(repoRoot, config, scan, [
+      './src/index.ts',
+      'src\\index.ts',
+      'src/nested/../index.ts',
+      path.join(repoRoot, 'src/index.ts'),
+    ]);
+    expect(Object.keys(report.entrypoints)).toEqual(['src/index.ts']);
+    expect(report.entrypoints['src/index.ts'].value.files).toEqual(['src/a.ts', 'src/index.ts']);
+    expect(report.entrypoints['src/index.ts'].value.externalSpecifiers).toEqual(['external']);
+    expect(() => buildArchitectureReport(repoRoot, config, scan, ['../outside.ts'])).toThrow(
+      'not in the checked source tree',
+    );
+  });
+
   it('surfaces reach that crosses ignored/declaration files and requires a facade-inclusive scan', () => {
     const config = {
       ...configWith([{ name: 'facade', roots: ['src'], allowedDependencies: [] }]),

--- a/test/scripts/architectureDag.test.ts
+++ b/test/scripts/architectureDag.test.ts
@@ -1,9 +1,11 @@
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  buildArchitectureReport,
   buildEdgeBaseline,
   type CrossLayerEdge,
   compareEdgesToBaseline,
@@ -42,6 +44,115 @@ describe('computeCrossLayerEdges', () => {
     fs.mkdirSync(path.dirname(absolute), { recursive: true });
     fs.writeFileSync(absolute, contents);
   }
+
+  it('reports facade reach, type-only cycles, deferred edges, and incomplete resolution without changing ratchets', () => {
+    const config = configWith([
+      { name: 'facade', roots: ['src/index.ts'], allowedDependencies: [] },
+      { name: 'a', roots: ['src/a'], allowedDependencies: ['b'] },
+      { name: 'b', roots: ['src/b'], allowedDependencies: ['a'] },
+    ]);
+    write('src/index.ts', "export * from './a/entry';");
+    write(
+      'src/a/entry.ts',
+      "import type { B } from '../b/types'; import('./later'); import './missing'; require.resolve('./resolved'); import(target); import 'external';",
+    );
+    write('src/b/types.ts', "import type { A } from '../a/entry';");
+    write('src/a/later.ts', "import './later';");
+    write('src/a/resolved.ts');
+    const ordinaryScan = scanArchitectureSources(repoRoot, config);
+    const fullScan = scanArchitectureSources(repoRoot, config, { includeFacade: true });
+    expect(computeCrossLayerEdges(repoRoot, config, fullScan)).toEqual(
+      computeCrossLayerEdges(repoRoot, config, ordinaryScan),
+    );
+    const report = buildArchitectureReport(repoRoot, config, fullScan);
+    expect(report.views.type.fileCycles).toEqual([['src/a/entry.ts', 'src/b/types.ts']]);
+    expect(report.views.value.fileCycles).toEqual([['src/a/later.ts']]);
+    expect(report.entrypoints['src/index.ts'].value.files).toEqual([
+      'src/a/entry.ts',
+      'src/index.ts',
+    ]);
+    expect(report.entrypoints['src/index.ts'].valueAndDeferred.files).toEqual([
+      'src/a/entry.ts',
+      'src/a/later.ts',
+      'src/index.ts',
+    ]);
+    expect(report.entrypoints['src/index.ts'].combined.files).toHaveLength(5);
+    expect(report.entrypoints['src/index.ts'].value.externalSpecifiers).toEqual(['external']);
+    expect(report.unresolvedInternal).toEqual([
+      expect.objectContaining({ importer: 'src/a/entry.ts', specifier: './missing', line: 1 }),
+    ]);
+    expect(report.computedReferences).toEqual([
+      expect.objectContaining({ importer: 'src/a/entry.ts', kind: 'deferred', line: 1 }),
+    ]);
+    expect(() => buildArchitectureReport(repoRoot, config, fullScan, ['src/missing.ts'])).toThrow(
+      'not in the checked source tree',
+    );
+  });
+
+  it('surfaces reach that crosses ignored/declaration files and requires a facade-inclusive scan', () => {
+    const config = {
+      ...configWith([{ name: 'facade', roots: ['src'], allowedDependencies: [] }]),
+      ignoredRoots: ['src/ignored'],
+    };
+    write('src/index.ts', "import './ignored/load'; import type { A } from './types.d.ts';");
+    write('src/ignored/load.ts', "import 'hidden';");
+    write('src/types.d.ts');
+    const scan = scanArchitectureSources(repoRoot, config, { includeFacade: true });
+    const report = buildArchitectureReport(repoRoot, config, scan);
+    expect(report.unscannedInternal.map((reference) => reference.resolvedImport)).toEqual([
+      'src/ignored/load.ts',
+      'src/types.d.ts',
+    ]);
+    expect(report.entrypoints['src/index.ts'].value.unscannedInternal).toHaveLength(1);
+    expect(() =>
+      buildArchitectureReport(repoRoot, config, scanArchitectureSources(repoRoot, config)),
+    ).toThrow('includeFacade: true');
+  });
+
+  it('runs the real JSON checker with clean stdout and preserves failure exit status', () => {
+    const config = configWith([
+      { name: 'facade', roots: ['src/index.ts'], allowedDependencies: [] },
+      { name: 'a', roots: ['src/a'], allowedDependencies: ['b'] },
+      { name: 'b', roots: ['src/b'], allowedDependencies: [] },
+    ]);
+    write('architecture/layers.json', JSON.stringify(config));
+    write('architecture/edge-baseline.json', JSON.stringify({ 'a -> b': 1 }));
+    write('src/index.ts', "export * from './a/entry';");
+    write('src/a/entry.ts', "import '../b/entry';");
+    write('src/b/entry.ts');
+    for (const script of ['architectureUtils.ts', 'checkArchitectureBoundaries.ts']) {
+      write(
+        `scripts/${script}`,
+        fs.readFileSync(path.join(process.cwd(), 'scripts', script), 'utf8'),
+      );
+    }
+    write('package.json', JSON.stringify({ type: 'module' }));
+    fs.symlinkSync(
+      path.join(process.cwd(), 'node_modules'),
+      path.join(repoRoot, 'node_modules'),
+      'dir',
+    );
+    const run = () =>
+      spawnSync(
+        process.execPath,
+        [
+          '--import',
+          import.meta.resolve('tsx'),
+          path.join(repoRoot, 'scripts/checkArchitectureBoundaries.ts'),
+          '--json',
+        ],
+        { encoding: 'utf8', cwd: repoRoot },
+      );
+    const passing = run();
+    expect(passing.status, passing.stderr).toBe(0);
+    expect(JSON.parse(passing.stdout).views.combined.crossLayerReferences).toBe(1);
+    expect(passing.stderr).toContain('Architecture boundaries passed.');
+    write('src/a/entry.ts', "import '../b/entry'; export * from '../b/entry';");
+    const failing = run();
+    expect(failing.status, failing.stderr).toBe(1);
+    expect(JSON.parse(failing.stdout).views.combined.crossLayerReferences).toBe(2);
+    expect(failing.stderr).toContain('baseline regressions');
+  });
 
   it('tallies cross-layer import edges and skips the facade importer and same-layer imports', () => {
     write(

--- a/test/scripts/architectureUtils.test.ts
+++ b/test/scripts/architectureUtils.test.ts
@@ -61,6 +61,16 @@ require.resolve('path');`;
     ]);
   });
 
+  it('uses UTF-16 offsets after long Unicode prefixes and across every line terminator', () => {
+    const prefix = `/* ${'é漢😀'.repeat(1000)} */`;
+    const source =
+      `${prefix} import 'same-line';\r\nimport 'crlf';\rimport 'cr';` +
+      "\u2028import 'line-separator';\u2029import 'paragraph-separator';\nimport 'lf';";
+    expect(extractModuleReferences(source, 'fixture.ts').map(({ line }) => line)).toEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
+  });
+
   it('surfaces computed loaders without inventing literal dependencies', () => {
     const source =
       "import(target); require(target); require.resolve(target); import(`fixed`); // import('fake')";

--- a/test/scripts/architectureUtils.test.ts
+++ b/test/scripts/architectureUtils.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  extractModuleReferences,
   extractModuleSpecifiers,
   findUnclassifiedFiles,
   findViolations,
@@ -14,6 +15,64 @@ import {
   readLayerConfig,
   resolveInternalModule,
 } from '../../scripts/architectureUtils';
+
+describe('extractModuleReferences', () => {
+  it('separates explicit types, mixed/side-effect imports, loads, and resolution', () => {
+    const source = `import type { A } from 'a';
+import { type B } from 'b';
+import { type C, D } from 'c';
+import 'side';
+export type * from 'types';
+export { type E } from 'e';
+export { type F, G } from 'f';
+import type H = require('h');
+type I = import('i').I;
+import('later');
+require('now');
+require.resolve('path');`;
+    expect(
+      extractModuleReferences(source, 'fixture.ts').map(({ specifier, kind, line }) => [
+        specifier,
+        kind,
+        line,
+      ]),
+    ).toEqual([
+      ['a', 'type', 1],
+      ['b', 'type', 2],
+      ['c', 'value', 3],
+      ['side', 'value', 4],
+      ['types', 'type', 5],
+      ['e', 'type', 6],
+      ['f', 'value', 7],
+      ['h', 'type', 8],
+      ['i', 'type', 9],
+      ['later', 'deferred', 10],
+      ['now', 'value', 11],
+      ['path', 'resolution', 12],
+    ]);
+    expect(extractModuleSpecifiers(source, 'fixture.ts')).toHaveLength(12);
+  });
+
+  it('surfaces computed loaders without inventing literal dependencies', () => {
+    const source =
+      "import(target); require(target); require.resolve(target); import(`fixed`); // import('fake')";
+    expect(
+      extractModuleReferences(source, 'fixture.ts').map(({ specifier, kind }) => [specifier, kind]),
+    ).toEqual([
+      [undefined, 'deferred'],
+      [undefined, 'value'],
+      [undefined, 'resolution'],
+      ['fixed', 'deferred'],
+    ]);
+    expect(extractModuleSpecifiers(source, 'fixture.ts')).toEqual(['fixed']);
+  });
+
+  it('fails on invalid syntax instead of reporting a partial graph', () => {
+    expect(() => extractModuleReferences('import {', 'broken.ts')).toThrow(
+      'Could not parse broken.ts',
+    );
+  });
+});
 
 describe('extractModuleSpecifiers', () => {
   it('collects static ESM and CommonJS module specifiers', () => {

--- a/test/scripts/architectureUtils.test.ts
+++ b/test/scripts/architectureUtils.test.ts
@@ -53,6 +53,14 @@ require.resolve('path');`;
     expect(extractModuleSpecifiers(source, 'fixture.ts')).toHaveLength(12);
   });
 
+  it('counts all JavaScript line terminators with CRLF as one line', () => {
+    const source =
+      "import 'a';\r\nimport 'b';\rimport 'c';\u2028import 'd';\u2029import 'e';\nimport 'f';";
+    expect(extractModuleReferences(source, 'fixture.ts').map(({ line }) => line)).toEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
+  });
+
   it('surfaces computed loaders without inventing literal dependencies', () => {
     const source =
       "import(target); require(target); require.resolve(target); import(`fixed`); // import('fake')";


### PR DESCRIPTION
## Summary

The architecture checker counts type, value, and deferred references together and omits the public facade from its scan. Add diagnostic reference views, file/layer cycles, and facade-inclusive entrypoint reach while preserving the combined enforcement ratchet. JSON reports expose computed loaders, unresolved references, and traversal beyond the scanned scope; they remain source analysis rather than bundle or install-size claims.

The old #9608 proposal has runtime closure helpers based on the former TypeScript parser. This change is limited to additive diagnostics on the current OXC scanner; it does not replace that PR’s package budgets, consumer checks, or release work.

## Validation

- 88 focused architecture tests, including real checker subprocess success/failure and JSON stdout checks
- `npm run tsc`, Knip, changed-file lint/format
- Actual checker JSON and contracts-entrypoint report: existing 2,832 cross-layer references unchanged; contracts closure remains 12 source files
- Existing dependency ownership script runs against the compatible literal-specifier API
- Independent review findings on ignored/declaration traversal and JS line terminators addressed and rechecked
- CodeQL feedback addressed by selecting a local diagnostics writer; no global console mutation

Local CLI QA used `node --import tsx` because the sandbox blocks the tsx wrapper’s IPC socket. No ratchet baseline or product runtime changes.

Entrypoint spellings (`./`, separators, dot segments, and absolute paths within the checked tree) normalize before reach traversal. A single newline index avoids repeated source-prefix scans; Unicode and all JavaScript line terminators retain correct locations. Verified Oxc JavaScript offsets are UTF-16, so no byte conversion is applied.
