### PR TITLE
chore(build): stage Docker production dependencies

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@
 # runs the Docker container, performs a health check to ensure the application
 # is running correctly, and then publishes the image to GitHub Container Registry
 # if all checks pass. This action is triggered by the release-please workflow,
-# published human-created releases, workflow dispatch, pull requests to main that
+# published human-created releases, workflow dispatch, pull requests that
 # modify the Docker/runtime update contract, and matching pushes to main.
 
 name: Test and Publish Multi-arch Docker Image
@@ -32,11 +32,13 @@ on:
     types:
       - published
   pull_request:
-    branches:
-      - main
+    # Include stacked PRs so their final images receive the same runtime checks.
     paths:
       - '.github/workflows/docker.yml'
       - 'Dockerfile'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/testDockerImage.js'
       - 'src/envars.ts'
       - 'src/server/routes/version*.ts'
       - 'src/types/api/version.ts'
@@ -48,6 +50,9 @@ on:
     paths:
       - '.github/workflows/docker.yml'
       - 'Dockerfile'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/testDockerImage.js'
       - 'src/envars.ts'
       - 'src/server/routes/version*.ts'
       - 'src/types/api/version.ts'
@@ -148,6 +153,12 @@ jobs:
             BUILD_DATE=${{ env.BUILD_DATE }}
             GIT_SHA=${{ steps.source.outputs.sha }}
             PROMPTFOO_OFFICIAL_DOCKER_IMAGE=0
+
+      - name: Test final-image runtime dependencies
+        run: |
+          docker run --rm --network none -i \
+            -e PROMPTFOO_TEST_PRODUCTION_DEPS=1 \
+            local-test-image:official node --input-type=module < scripts/testDockerImage.js
 
       - name: Run Docker containers for testing
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,24 @@ COPY . .
 WORKDIR /app
 RUN npm run build
 
+# Install a separate runtime tree: the app and docs workspaces are build inputs,
+# and their dependencies must not be copied into the final image. Keep optional
+# native packages and peers, and retain esbuild for user TypeScript modules via tsx.
+FROM base AS production-deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+# npm treats a dependency declared in both devDependencies and optionalDependencies
+# as development-only. Normalize only this stage's manifest so --omit=dev retains
+# those runtime SDKs; npm ci still uses the unchanged lockfile. The final image
+# keeps the original package.json from the builder.
+RUN --mount=type=cache,target=/root/.npm \
+    npm pkg delete devDependencies && \
+    npm ci --omit=dev --workspaces=false --install-links --include=peer --ignore-scripts && \
+    npm rebuild ./node_modules/esbuild
+
 FROM base AS server
 WORKDIR /app
-COPY --from=builder --chown=promptfoo:promptfoo /app/node_modules ./node_modules
+COPY --from=production-deps --chown=promptfoo:promptfoo /app/node_modules ./node_modules
 COPY --from=builder --chown=promptfoo:promptfoo /app/package.json ./package.json
 COPY --from=builder --chown=promptfoo:promptfoo /app/dist ./dist
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,10 +139,7 @@
         "node-sql-parser": "^5.4.0",
         "oxc-parser": "^0.147.0",
         "pdf-parse": "^2.4.5",
-        "playwright": "^1.60.0",
-        "playwright-extra": "^4.3.6",
         "prettier": "^3.8.1",
-        "puppeteer-extra-plugin-stealth": "^2.11.2",
         "read-excel-file": "^9.3.9",
         "shx": "^0.4.0",
         "source-map-support": "^0.5.21",
@@ -199,6 +196,7 @@
         "pem": "~1.14.8",
         "playwright": "^1.60.0",
         "playwright-extra": "^4.3.6",
+        "puppeteer-extra-plugin-stealth": "^2.11.2",
         "read-excel-file": "^9.3.9",
         "sharp": "^0.35.4"
       }
@@ -18881,7 +18879,7 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -19079,7 +19077,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -21010,8 +21008,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22542,8 +22540,8 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "for-own": "^0.1.3",
         "is-plain-object": "^2.0.1",
@@ -22780,7 +22778,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -24434,7 +24432,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -26436,8 +26434,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26446,8 +26444,8 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "for-in": "^1.0.1"
       },
@@ -26623,8 +26621,8 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -26638,14 +26636,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -27123,7 +27120,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphql": {
@@ -28312,8 +28309,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -28692,8 +28689,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-ci": {
       "version": "3.0.1",
@@ -28754,7 +28751,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28939,7 +28936,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -29057,7 +29054,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29507,7 +29504,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -29634,8 +29631,8 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -30514,8 +30511,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -31775,8 +31772,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
       "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "arr-union": "^3.1.0",
         "clone-deep": "^0.2.4",
@@ -33992,8 +33989,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "for-in": "^0.1.3",
         "is-extendable": "^0.1.1"
@@ -34006,8 +34003,8 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
       "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35457,8 +35454,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35800,7 +35797,7 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
       "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.62.1"
@@ -35832,8 +35829,8 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
       "integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -38315,8 +38312,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.3.tgz",
       "integrity": "sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/debug": "^4.1.0",
         "debug": "^4.1.1",
@@ -38342,8 +38339,8 @@
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.11.2.tgz",
       "integrity": "sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "puppeteer-extra-plugin": "^3.2.3",
@@ -38369,8 +38366,8 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
       "integrity": "sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "fs-extra": "^10.0.0",
@@ -38397,8 +38394,8 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.4.1.tgz",
       "integrity": "sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "deepmerge": "^4.2.2",
@@ -39832,8 +39829,8 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -39848,15 +39845,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -39867,8 +39864,8 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -39888,8 +39885,8 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -40716,8 +40713,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-extendable": "^0.1.1",
         "kind-of": "^2.0.1",
@@ -40732,8 +40729,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
       "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-buffer": "^1.0.2"
       },
@@ -40745,8 +40742,8 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
       "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -43668,7 +43665,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -261,10 +261,7 @@
     "node-sql-parser": "^5.4.0",
     "oxc-parser": "^0.147.0",
     "pdf-parse": "^2.4.5",
-    "playwright": "^1.60.0",
-    "playwright-extra": "^4.3.6",
     "prettier": "^3.8.1",
-    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "read-excel-file": "^9.3.9",
     "shx": "^0.4.0",
     "source-map-support": "^0.5.21",
@@ -318,6 +315,7 @@
     "pem": "~1.14.8",
     "playwright": "^1.60.0",
     "playwright-extra": "^4.3.6",
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "read-excel-file": "^9.3.9",
     "sharp": "^0.35.4"
   },

--- a/scripts/testDockerImage.js
+++ b/scripts/testDockerImage.js
@@ -1,0 +1,288 @@
+// Run against the final image, without host node_modules or network access:
+// docker run --rm --network none -i IMAGE node --input-type=module < scripts/testDockerImage.js
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const app = process.cwd();
+const require = createRequire(path.join(app, 'package.json'));
+const base = 'http://127.0.0.1:3000';
+const temporaryDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-docker-'));
+const env = {
+  ...process.env,
+  PROMPTFOO_CONFIG_DIR: path.join(temporaryDir, 'config'),
+  PROMPTFOO_CACHE_PATH: path.join(temporaryDir, 'cache'),
+  PROMPTFOO_DISABLE_TELEMETRY: '1',
+  PROMPTFOO_DISABLE_UPDATE: 'true',
+  PROMPTFOO_DISABLE_REMOTE_GENERATION: 'true',
+  PROMPTFOO_NO_PROGRESS_BAR: '1',
+  NO_COLOR: '1',
+};
+
+function run(command, args, expectedStatus = 0) {
+  const result = spawnSync(command, args, {
+    cwd: app,
+    env,
+    encoding: 'utf8',
+    timeout: 60_000,
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  assert.ifError(result.error);
+  assert.equal(result.status, expectedStatus, `${command}: ${result.stdout}\n${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function writeFixture(name, contents) {
+  const filename = path.join(temporaryDir, name);
+  fs.writeFileSync(filename, contents);
+  return filename;
+}
+
+function request(route) {
+  const url = new URL(route, base);
+  assert.equal(url.origin, base, 'Smoke requests must stay on the local server');
+  // biome-ignore lint/style/noRestrictedGlobals: final-image test uses Node builtins and loopback only
+  return fetch(url, { signal: AbortSignal.timeout(5000) });
+}
+
+let server;
+let serverLog = '';
+try {
+  assert.notEqual(process.getuid(), 0, 'The final image must run as its non-root user');
+  const manifest = require('./package.json');
+  const { version } = manifest;
+  // npm's dev+optional overlap must not silently remove supported runtime SDKs.
+  for (const dependency of Object.keys(manifest.optionalDependencies).filter(
+    (name) => name in manifest.devDependencies,
+  )) {
+    assert(
+      fs.existsSync(path.join(app, 'node_modules', dependency, 'package.json')),
+      `Missing runtime dependency also declared for development: ${dependency}`,
+    );
+  }
+  for (const command of ['promptfoo', 'pf']) {
+    assert.equal(run(command, ['--version']), version);
+  }
+
+  // Exercise both public module formats from the final dependency tree.
+  run('node', [
+    '--input-type=module',
+    '-e',
+    `
+    import assert from 'node:assert/strict';
+    import { createRequire } from 'node:module';
+    import { evaluate } from 'promptfoo';
+    import { InputTypeValues } from 'promptfoo/contracts';
+    const require = createRequire(import.meta.url);
+    assert.equal(typeof evaluate, 'function');
+    assert.equal(typeof require('promptfoo').evaluate, 'function');
+    assert.deepEqual(InputTypeValues, require('promptfoo/contracts').InputTypeValues);
+  `,
+  ]);
+
+  // These optional platform packages must survive the production install.
+  const { createClient } = require('@libsql/client');
+  const database = createClient({ url: `file:${path.join(temporaryDir, 'native.db')}` });
+  try {
+    await database.execute('CREATE TABLE smoke (value TEXT)');
+    await database.execute({ sql: 'INSERT INTO smoke VALUES (?)', args: ['native roundtrip'] });
+    assert.equal(
+      (await database.execute('SELECT value FROM smoke')).rows[0].value,
+      'native roundtrip',
+    );
+  } finally {
+    database.close();
+  }
+  const sharp = require('sharp');
+  const png = await sharp({ create: { width: 2, height: 3, channels: 3, background: '#123456' } })
+    .png()
+    .toBuffer();
+  const metadata = await sharp(png).metadata();
+  assert.equal(metadata.width, 2);
+  assert.equal(metadata.height, 3);
+  assert.equal(metadata.format, 'png');
+  // Docker does not download Chromium; verify the remote-browser plugin can load.
+  assert.equal(require('puppeteer-extra-plugin-stealth')().name, 'stealth');
+
+  // An enum requires transpilation; do not preload tsx and mask a broken CLI loader.
+  writeFixture('helper.ts', 'export enum Prefix { Value = "fixture:" }\n');
+  const typescript = writeFixture(
+    'provider.ts',
+    `
+    import { Prefix } from './helper.ts';
+    export default class Provider {
+      id() { return 'docker-typescript'; }
+      async callApi(prompt: string) {
+        return prompt === 'error' ? { error: 'fixture provider failure' } : { output: Prefix.Value + prompt };
+      }
+    }
+  `,
+  );
+  const python = writeFixture(
+    'provider.py',
+    `
+def call_api(prompt, options, context):
+    if prompt == "error":
+        return {"error": "fixture provider failure"}
+    return {"output": "fixture:" + prompt}
+`,
+  );
+  const summaries = [];
+  for (const scenario of ['success', 'assertion-failure', 'provider-error']) {
+    const prompt = scenario === 'provider-error' ? 'error' : 'hello';
+    const config = writeFixture(
+      `${scenario}.json`,
+      JSON.stringify({
+        description: `Docker smoke ${scenario}`,
+        prompts: [prompt],
+        providers: [`file://${typescript}`, `file://${python}`],
+        tests: [
+          {
+            assert: [
+              {
+                type: 'equals',
+                value: scenario === 'assertion-failure' ? 'wrong' : 'fixture:hello',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+    const output = path.join(temporaryDir, `${scenario}-output.json`);
+    run(
+      'promptfoo',
+      [
+        'eval',
+        '-c',
+        config,
+        '-o',
+        output,
+        '--no-cache',
+        '--no-table',
+        '--no-progress-bar',
+        '--max-concurrency',
+        '1',
+        ...(scenario === 'success' ? [] : ['--no-write']),
+      ],
+      scenario === 'success' ? 0 : 100,
+    );
+    const {
+      results: { results },
+    } = JSON.parse(fs.readFileSync(output, 'utf8'));
+    assert.equal(results.length, 2);
+    for (const result of results) {
+      assert.equal(result.success, scenario === 'success', JSON.stringify(result));
+      assert.equal(result.score, scenario === 'success' ? 1 : 0, JSON.stringify(result));
+      if (scenario === 'provider-error') {
+        assert.match(result.error, /fixture provider failure/);
+        assert.equal(result.response.error, 'fixture provider failure');
+      } else {
+        assert.equal(result.response.output, 'fixture:hello');
+        assert.equal(result.response.error, undefined);
+        if (scenario === 'success') {
+          assert.equal(result.error, undefined);
+        } else {
+          assert.match(result.error, /Expected output/);
+        }
+      }
+    }
+    summaries.push({
+      scenario,
+      results: results.map(({ success, score, error, response }) => ({
+        success,
+        score,
+        error,
+        response,
+      })),
+    });
+  }
+
+  server = spawn('node', ['dist/src/server/index.js'], {
+    cwd: app,
+    env: { ...env, API_PORT: '3000', HOST: '127.0.0.1' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  server.stdout.on('data', (chunk) => {
+    serverLog += chunk;
+  });
+  server.stderr.on('data', (chunk) => {
+    serverLog += chunk;
+  });
+  let ready = false;
+  for (let attempt = 0; attempt < 60; attempt++) {
+    assert.equal(server.exitCode, null, serverLog);
+    try {
+      ready = (await request('/health')).ok;
+    } catch {
+      // The process may still be starting and applying migrations.
+    }
+    if (ready) {
+      break;
+    }
+    await delay(500);
+  }
+  assert(ready, `Server did not become healthy:\n${serverLog}`);
+  const page = await request('/');
+  assert(page.ok);
+  assert.match(page.headers.get('content-type'), /text\/html/);
+  const html = await page.text();
+  for (const extension of ['js', 'css']) {
+    const asset = html.match(new RegExp(`(?:src|href)="([^"]+\\.${extension})"`))?.[1];
+    assert(asset, `Missing built ${extension} asset in HTML`);
+    const response = await request(asset);
+    assert(response.ok, `Missing asset: ${asset}`);
+    assert.match(
+      response.headers.get('content-type'),
+      extension === 'js' ? /javascript/ : /text\/css/,
+    );
+    assert((await response.text()).length > 0);
+  }
+  const list = await request('/api/results');
+  assert(list.ok);
+  const { data } = await list.json();
+  assert.equal(
+    data.length,
+    1,
+    'Server must read the successful CLI eval from the isolated database',
+  );
+  assert.equal(data[0].description, 'Docker smoke success');
+  const detail = await request(`/api/results/${data[0].evalId}`);
+  assert(detail.ok);
+  assert.equal((await detail.json()).data.config.description, 'Docker smoke success');
+  assert.equal((await request('/api/results/missing-eval')).status, 404);
+
+  if (process.env.PROMPTFOO_TEST_PRODUCTION_DEPS === '1') {
+    for (const dependency of ['vitest', '@docusaurus/core', '@testing-library/react']) {
+      assert.throws(() => require.resolve(dependency), { code: 'MODULE_NOT_FOUND' });
+    }
+  }
+  console.log(
+    JSON.stringify(
+      {
+        version,
+        native: ['libsql', 'sharp'],
+        server: 'health, UI JS/CSS, persisted eval, missing eval',
+        evals: summaries,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  if (server && server.exitCode === null) {
+    const exited = once(server, 'exit');
+    server.kill('SIGTERM');
+    const forceKill = setTimeout(() => server.kill('SIGKILL'), 5000);
+    try {
+      await exited;
+    } finally {
+      clearTimeout(forceKill);
+    }
+  }
+  fs.rmSync(temporaryDir, { recursive: true, force: true });
+}

--- a/scripts/testDockerImage.js
+++ b/scripts/testDockerImage.js
@@ -253,7 +253,15 @@ def call_api(prompt, options, context):
   assert.equal(data[0].description, 'Docker smoke success');
   const detail = await request(`/api/results/${data[0].evalId}`);
   assert(detail.ok);
-  assert.equal((await detail.json()).data.config.description, 'Docker smoke success');
+  const persisted = (await detail.json()).data;
+  assert.equal(persisted.config.description, 'Docker smoke success');
+  assert.equal(persisted.results.results.length, 2);
+  for (const result of persisted.results.results) {
+    assert.equal(result.success, true);
+    assert.equal(result.score, 1);
+    assert.equal(result.response.output, 'fixture:hello');
+    assert.equal(result.error, undefined);
+  }
   assert.equal((await request('/api/results/missing-eval')).status, 404);
 
   if (process.env.PROMPTFOO_TEST_PRODUCTION_DEPS === '1') {

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { minVersion, satisfies, subset, validRange } from 'semver';
 import { describe, expect, it } from 'vitest';
-import { extractModuleSpecifiers } from '../scripts/architectureUtils';
+import { extractModuleSpecifiers, getPackageName } from '../scripts/architectureUtils';
 
 type PackageManifest = {
   dependencies?: Record<string, string>;
@@ -509,6 +509,34 @@ describe('package manifests', () => {
     expect(satisfies(packageLock.packages[`node_modules/${sdkName}`].version!, sdkRange!)).toBe(
       true,
     );
+  });
+
+  it('includes every browser loader in the optional production profile', () => {
+    const packageJson = readPackageJson<PackageManifest>('package.json');
+    const packageLock =
+      readPackageJson<PackageLockManifest<PackageManifest & { version?: string; dev?: boolean }>>(
+        'package-lock.json',
+      );
+    const browserSource = fs.readFileSync('src/providers/browser.ts', 'utf8');
+    const browserPackages = extractModuleSpecifiers(browserSource, 'src/providers/browser.ts')
+      .map(getPackageName)
+      .filter((name): name is string => name !== undefined);
+
+    expect(browserPackages).toContain('puppeteer-extra-plugin-stealth');
+    for (const dependency of new Set(browserPackages)) {
+      const range = packageJson.optionalDependencies?.[dependency];
+      expect(
+        range,
+        `${dependency} must be available to production browser consumers`,
+      ).toBeDefined();
+      // npm treats a same-root dev + optional declaration as dev-only during
+      // `npm ci --omit=dev`, even though packed consumers resolve it as optional.
+      expect(packageJson.devDependencies?.[dependency]).toBeUndefined();
+      expect(packageLock.packages[''].optionalDependencies?.[dependency]).toBe(range);
+      const installed = packageLock.packages[`node_modules/${dependency}`];
+      expect(installed?.dev, `${dependency} must survive --omit=dev`).not.toBe(true);
+      expect(satisfies(installed.version!, range!)).toBe(true);
+    }
   });
 
   it('keeps the Linux Rollup binary optional and aligned with the lockfile', () => {

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -535,6 +535,7 @@ describe('package manifests', () => {
       expect(packageLock.packages[''].optionalDependencies?.[dependency]).toBe(range);
       const installed = packageLock.packages[`node_modules/${dependency}`];
       expect(installed?.dev, `${dependency} must survive --omit=dev`).not.toBe(true);
+      expect(installed?.version, `${dependency} must have a locked version`).toBeDefined();
       expect(satisfies(installed.version!, range!)).toBe(true);
     }
   });


### PR DESCRIPTION
The runtime image currently copies the builder's full workspace dependency tree. Install a separate production tree from the existing lockfile while retaining optional native packages and runtime TypeScript support.

This PR is stacked on #10755, which fixes the browser runtime declarations. The Docker stage removes `devDependencies` from its temporary manifest before `npm ci`: npm otherwise drops SDKs declared in both development and optional dependencies. The shipped manifest still comes from the builder, unchanged.

Validation now runs inside the final image with networking disabled: CLI aliases, ESM/CJS entrypoints, TypeScript and Python providers (success, assertion failure, provider error), libSQL and sharp, browser plugin loading, persisted evals, server health, and UI JS/CSS. Docker CI also runs for manifest changes and stacked PRs.

## Validation

- Node 24.20.0 / npm 11.19.0; Alpine linux/amd64 builds.
- 44 manifest tests, TypeScript, architecture, Knip, changed-file lint/format passed.
- Baseline and candidate built from identical source/manifests on Alpine linux/amd64; both final-image smoke suites passed. Exported eval JSON verifies two passes (score 1), two assertion failures (score 0), and two provider errors (score 0); final-image API readback also preserves scores and outputs.
- Docker-reported image size (`docker image inspect .Size`): **977,707,508 → 770,157,170 bytes (21.2% smaller)**. Installed `node_modules` (`du -sk`): **3,470,284 → 2,274,508 KiB (34.5% smaller)**. Package instances: **2,658 → 806**.
- The original manifest and complete `dist` match by SHA-256. All **768 unique package versions** reachable through root runtime dependencies, optional dependencies, and required peers remain with unchanged resolution edges. Optional Babel macro/React type/browser hash peers are excluded from this Node runtime comparison.
- Offline npm fixture proves stage-only manifest normalization preserves dual-declared packages and their children without changing the lockfile; direct dual-dependency presence is checked in the image smoke test.

No browser binaries or local-model weights are downloaded by this smoke test. ARM64 execution remains unverified locally.

Exact-head [CI](https://github.com/promptfoo/promptfoo/actions/runs/34195208566) and [Docker acceptance](https://github.com/promptfoo/promptfoo/actions/runs/34195208573) passed on `b82f6e7d2079196370933edb4e6dacfd88556973`. Automated code review completed with no inline findings.
