### PR TITLE
fix(package): preserve CommonJS evaluation in packed consumers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,6 +215,7 @@ jobs:
       - name: Test Package Artifact
         env:
           PROMPTFOO_DISABLE_TELEMETRY: 1
+          npm_config_install_strategy: ${{ matrix.node == '22.22' && 'shallow' || 'hoisted' }}
         run: npm run test:package-artifact
 
       - name: Test Package Artifact Without Optional Dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,6 +165,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,6 +215,12 @@ jobs:
           PROMPTFOO_DISABLE_TELEMETRY: 1
         run: npm run test:package-artifact
 
+      - name: Test Package Artifact Without Optional Dependencies
+        if: matrix.node == '24.x'
+        env:
+          PROMPTFOO_DISABLE_TELEMETRY: 1
+        run: npm run test:package-artifact -- --profile omit-optional
+
   style-check:
     name: Style Check
     timeout-minutes: 10

--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -726,7 +726,13 @@ async function main(): Promise<void> {
       if (values.profile === 'omit-optional') {
         assert.throws(() => packageRequire.resolve(optionalPackage), { code: 'MODULE_NOT_FOUND' });
       } else {
-        assert(packageRequire.resolve(optionalPackage).startsWith(consumerDir));
+        const relative = path.relative(
+          fs.realpathSync(consumerDir),
+          fs.realpathSync(packageRequire.resolve(optionalPackage)),
+        );
+        assert(
+          relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative),
+        );
       }
     }
 

--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -718,15 +718,15 @@ async function main(): Promise<void> {
     assert.equal(installedPackageJson.version, packResult.version);
     assertExportsResolve(installedPackageDir, installedPackageJson);
     assertInstalledRefParserTransport(installedPackageDir);
-    const consumerRequire = createRequire(path.join(consumerDir, 'package.json'));
+    const packageRequire = createRequire(path.join(installedPackageDir, 'package.json'));
     for (const optionalPackage of [
       '@playwright/browser-chromium/package.json',
       '@anthropic-ai/claude-agent-sdk',
     ]) {
       if (values.profile === 'omit-optional') {
-        assert.throws(() => consumerRequire.resolve(optionalPackage), { code: 'MODULE_NOT_FOUND' });
+        assert.throws(() => packageRequire.resolve(optionalPackage), { code: 'MODULE_NOT_FOUND' });
       } else {
-        assert(consumerRequire.resolve(optionalPackage).startsWith(consumerDir));
+        assert(packageRequire.resolve(optionalPackage).startsWith(consumerDir));
       }
     }
 

--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -5,6 +5,7 @@ import { createServer } from 'node:http';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
+import { parseArgs } from 'node:util';
 import { brotliCompressSync, gzipSync } from 'node:zlib';
 
 import { satisfies } from 'semver';
@@ -32,6 +33,7 @@ type ArtifactEvalOutput = {
         output?: unknown;
       };
       success?: boolean;
+      score?: number;
     }>;
   };
 };
@@ -52,6 +54,7 @@ const requiredPackagedPaths = [
   'dist/src/contracts.js',
   'dist/src/index.cjs',
   'dist/src/index.d.ts',
+  'dist/src/index.d.cts',
   'dist/src/index.js',
   'dist/src/main.js',
   'dist/src/package.json',
@@ -394,6 +397,64 @@ function writeConsumerScripts(consumerDir: string): void {
       '',
     ].join('\n'),
   );
+  // The root API exposes Eval's ORM methods. Drizzle's declarations pull unrelated optional
+  // database drivers and have upstream type errors; check caller code with skipLibCheck while
+  // keeping the portable contracts checks above fully strict.
+  for (const [mode, module] of [
+    ['esm', 'NodeNext'],
+    ['cjs', 'Node16'],
+  ]) {
+    fs.writeFileSync(
+      path.join(consumerDir, `tsconfig.api-${mode}.json`),
+      JSON.stringify({
+        compilerOptions: {
+          module,
+          moduleResolution: module,
+          noEmit: true,
+          strict: true,
+          skipLibCheck: true,
+        },
+        include: [mode === 'esm' ? 'import-api.ts' : 'require-api.cts'],
+      }),
+    );
+  }
+  const apiTypesBody = [
+    "const provider: ApiProvider = { id: () => 'local', callApi: async (prompt) => ({ output: prompt }) };",
+    "const suite: EvaluateTestSuite = { prompts: ['hello'], providers: [provider], tests: [{ assert: [{ type: 'equals', value: 'hello' }] }], writeLatestResults: false };",
+    'async function consume() {',
+    '  const record = await evaluate(suite, { cache: false });',
+    '  const summary = await record.toEvaluateSummary();',
+    '  const successes: number = summary.stats.successes;',
+    '  const id: string = record.id;',
+    '  void successes; void id;',
+    '  // @ts-expect-error Eval keeps its typed result surface',
+    '  await record.nonexistentMethod();',
+    '  // @ts-expect-error success counts remain numeric',
+    "  const invalid: typeof summary.stats.successes = 'wrong';",
+    '  void invalid;',
+    '}',
+    'void consume;',
+    '// @ts-expect-error providers are a required part of the public eval input',
+    "void evaluate({ prompts: ['hello'] });",
+  ].join('\n');
+  fs.writeFileSync(
+    path.join(consumerDir, 'import-api.ts'),
+    [
+      "import { evaluate } from 'promptfoo';",
+      "import type { ApiProvider, EvaluateTestSuite } from 'promptfoo';",
+      apiTypesBody,
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(consumerDir, 'require-api.cts'),
+    [
+      "import api = require('promptfoo');",
+      'const { evaluate } = api;',
+      'type ApiProvider = api.ApiProvider;',
+      'type EvaluateTestSuite = api.EvaluateTestSuite;',
+      apiTypesBody,
+    ].join('\n'),
+  );
   fs.writeFileSync(
     path.join(consumerDir, 'tsconfig.json'),
     JSON.stringify({
@@ -552,6 +613,7 @@ async function runInstalledCompressionEval(consumerDir: string, configDir: strin
     assert(Array.isArray(results), 'Installed promptfoo output is missing evaluation results');
     assert.equal(results.length, 2, 'Expected one result for each compressed provider');
     for (const result of results) {
+      assert.equal(result.score, 1);
       assert.equal(result.success, true, `Compressed provider failed: ${JSON.stringify(result)}`);
       assert.equal(
         result.error,
@@ -576,6 +638,11 @@ async function runInstalledCompressionEval(consumerDir: string, configDir: strin
 }
 
 async function main(): Promise<void> {
+  const { values } = parseArgs({ options: { profile: { type: 'string', default: 'default' } } });
+  assert(
+    ['default', 'omit-optional'].includes(values.profile),
+    `Unknown install profile: ${values.profile}`,
+  );
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-package-artifact-'));
   const artifactsDir = path.join(tempDir, 'artifacts');
   const configDir = path.join(tempDir, 'config');
@@ -615,14 +682,17 @@ async function main(): Promise<void> {
         type: 'module',
       }),
     );
+    console.log(`Installing packed consumer (${values.profile})...`);
     runNpm(
       [
         'install',
+        ...(values.profile === 'omit-optional' ? ['--omit=optional'] : ['--include=optional']),
         '--ignore-scripts',
+        '--omit=dev',
         '--no-audit',
         '--no-fund',
         '--no-package-lock',
-        '--registry=https://registry.npmjs.org/',
+        `--registry=${runNpm(['config', 'get', 'registry'], ROOT).trim()}`,
         tarballPath,
       ],
       consumerDir,
@@ -643,25 +713,72 @@ async function main(): Promise<void> {
     assert.equal(installedPackageJson.version, packResult.version);
     assertExportsResolve(installedPackageDir, installedPackageJson);
     assertInstalledRefParserTransport(installedPackageDir);
+    const consumerRequire = createRequire(path.join(consumerDir, 'package.json'));
+    for (const optionalPackage of [
+      '@playwright/browser-chromium/package.json',
+      '@anthropic-ai/claude-agent-sdk',
+    ]) {
+      if (values.profile === 'omit-optional') {
+        assert.throws(() => consumerRequire.resolve(optionalPackage), { code: 'MODULE_NOT_FOUND' });
+      } else {
+        assert(consumerRequire.resolve(optionalPackage).startsWith(consumerDir));
+      }
+    }
 
+    // Consumer files live outside the repository so neither workspaces nor devDependencies
+    // can satisfy undeclared package imports. Keep all user state local to this fixture.
+    const consumerEnv = {
+      NODE_PATH: '',
+      PROMPTFOO_CONFIG_DIR: configDir,
+      PROMPTFOO_CACHE_PATH: path.join(tempDir, 'cache'),
+      PROMPTFOO_DISABLE_TELEMETRY: '1',
+      PROMPTFOO_DISABLE_UPDATE: 'true',
+      PROMPTFOO_DISABLE_REMOTE_GENERATION: 'true',
+    };
     writeConsumerScripts(consumerDir);
-    run(process.execPath, ['import-package.mjs'], consumerDir);
-    run(process.execPath, ['require-package.cjs'], consumerDir);
+    fs.cpSync(path.join(ROOT, 'test', 'fixtures', 'package-artifact'), consumerDir, {
+      recursive: true,
+    });
+    run(process.execPath, ['import-package.mjs'], consumerDir, consumerEnv);
+    run(process.execPath, ['require-package.cjs'], consumerDir, consumerEnv);
     const tscPath = path.join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc');
-    for (const tsconfig of ['tsconfig.json', 'tsconfig.node16-cjs.json']) {
+    for (const tsconfig of [
+      'tsconfig.json',
+      'tsconfig.node16-cjs.json',
+      'tsconfig.api-esm.json',
+      'tsconfig.api-cjs.json',
+    ]) {
       run(process.execPath, [tscPath, '--project', tsconfig], consumerDir);
+    }
+    for (const script of ['import-api.mjs', 'require-api.cjs']) {
+      console.log(await runAsync(process.execPath, [script], consumerDir, consumerEnv));
     }
     assertInstalledWebApp(installedPackageDir);
 
     for (const binName of ['promptfoo', 'pf']) {
-      assert.equal(
-        runInstalledBinVersion(consumerDir, configDir, binName).trim(),
-        packResult.version,
-      );
+      if (values.profile === 'omit-optional') {
+        // The CLI currently initializes SQLite before handling --version. Omission removes
+        // libsql's native platform package: verify its actionable failure, not a crash.
+        assert.throws(
+          () => runInstalledBinVersion(consumerDir, configDir, binName),
+          (error: unknown) =>
+            error instanceof Error &&
+            (error.cause as { status?: number })?.status === 1 &&
+            error.message.includes('could not load its SQLite dependency') &&
+            error.message.includes('Required package: @libsql/'),
+        );
+      } else {
+        assert.equal(
+          runInstalledBinVersion(consumerDir, configDir, binName).trim(),
+          packResult.version,
+        );
+      }
     }
-    await runInstalledCompressionEval(consumerDir, configDir);
+    if (values.profile === 'default') {
+      await runInstalledCompressionEval(consumerDir, configDir);
+    }
 
-    console.log(`Verified installed package artifact: ${packResult.filename}`);
+    console.log(`Verified installed package artifact (${values.profile}): ${packResult.filename}`);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -638,7 +638,12 @@ async function runInstalledCompressionEval(consumerDir: string, configDir: strin
 }
 
 async function main(): Promise<void> {
-  const { values } = parseArgs({ options: { profile: { type: 'string', default: 'default' } } });
+  const { values } = parseArgs({
+    options: {
+      profile: { type: 'string', default: 'default' },
+      registry: { type: 'string', default: 'https://registry.npmjs.org/' },
+    },
+  });
   assert(
     ['default', 'omit-optional'].includes(values.profile),
     `Unknown install profile: ${values.profile}`,
@@ -692,7 +697,7 @@ async function main(): Promise<void> {
         '--no-audit',
         '--no-fund',
         '--no-package-lock',
-        `--registry=${runNpm(['config', 'get', 'registry'], ROOT).trim()}`,
+        `--registry=${values.registry}`,
         tarballPath,
       ],
       consumerDir,

--- a/test/fixtures/package-artifact/README.md
+++ b/test/fixtures/package-artifact/README.md
@@ -1,0 +1,31 @@
+# Installed package fixtures
+
+`scripts/testPackageArtifact.ts` copies these scripts into a temporary consumer
+outside the repository, installs a packed `promptfoo`, and runs its public API.
+The consumer inherits the configured npm registry but not the repository's
+workspaces, lockfile, overrides, or development dependencies.
+
+After `npm run build`, run from the repository root:
+
+```sh
+npm run test:package-artifact
+npm run test:package-artifact -- --profile omit-optional
+```
+
+Both dependency profiles disable install scripts. They verify ESM/CommonJS root
+API evaluations, root and contracts declarations, and web asset references.
+The CommonJS fixture checks writable exports and the identity of its native Zod
+constructors. API fixtures check a pass, an assertion failure, and a provider
+error with caching disabled and isolated configuration paths. Default dependency
+resolution also runs the installed CLI against a local compressed HTTP server.
+Default CLI version aliases must report the installed version. The
+optional-omitted profile intentionally lacks native SQLite platform packages and
+checks the existing actionable CLI failure (even `--version` initializes SQLite).
+It cannot run persistence-dependent CLI evaluations.
+
+The TypeScript compiler is a test tool from the repository; its consumer projects
+resolve all package declarations from the isolated installation with strict
+checking enabled for consumer code. Contracts also check dependency declarations;
+root API consumers use `skipLibCheck` because the public `Eval` surface currently
+exposes Drizzle declarations with upstream errors and unrelated optional driver
+imports. This does not claim a clean root declaration closure.

--- a/test/fixtures/package-artifact/README.md
+++ b/test/fixtures/package-artifact/README.md
@@ -2,8 +2,9 @@
 
 `scripts/testPackageArtifact.ts` copies these scripts into a temporary consumer
 outside the repository, installs a packed `promptfoo`, and runs its public API.
-The consumer inherits the configured npm registry but not the repository's
-workspaces, lockfile, overrides, or development dependencies.
+The consumer uses the public npm registry and is isolated from the repository's
+workspaces, lockfile, overrides, and development dependencies. To select a trusted
+local mirror explicitly, pass `--registry https://your-registry.example/`.
 
 After `npm run build`, run from the repository root:
 

--- a/test/fixtures/package-artifact/evaluate.mjs
+++ b/test/fixtures/package-artifact/evaluate.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+// Shared assertions, but each caller loads its own public ESM or CJS entrypoint.
+export async function checkEvaluate(api, mode) {
+  assert.equal(api.default.evaluate, api.evaluate);
+  assert.equal(api.default.loadApiProvider, api.loadApiProvider);
+  const provider = await api.loadApiProvider('echo');
+  assert.equal(provider.id(), 'echo');
+  assert.equal((await provider.callApi('local artifact')).output, 'local artifact');
+
+  const outputPath = `${mode}-results.json`;
+  const record = await api.evaluate(
+    {
+      prompts: ['Hello {{name}}'],
+      providers: ['echo'],
+      tests: [
+        { vars: { name: 'artifact' }, assert: [{ type: 'equals', value: 'Hello artifact' }] },
+        { vars: { name: 'failure' }, assert: [{ type: 'equals', value: 'deliberate mismatch' }] },
+      ],
+      writeLatestResults: false,
+      sharing: false,
+      outputPath,
+    },
+    { cache: false, maxConcurrency: 1 },
+  );
+  assert.equal(typeof record.id, 'string');
+  assert.equal(typeof record.toEvaluateSummary, 'function');
+  const summary = await record.toEvaluateSummary();
+  const exported = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  for (const results of [summary.results, exported.results.results]) {
+    assert.equal(results.length, 2);
+    for (const [index, result] of results.entries()) {
+      assert.equal(result.success, index === 0);
+      assert.equal(result.score, index === 0 ? 1 : 0);
+      assert.equal(result.response.output, index === 0 ? 'Hello artifact' : 'Hello failure');
+      assert.equal(result.response.error, undefined);
+      assert.equal(result.provider.id, 'echo');
+    }
+  }
+  assert.equal(summary.stats.successes, 1);
+  assert.equal(summary.stats.failures, 1);
+
+  // A custom provider error must remain an error result rather than a passing assertion.
+  const failed = await api.evaluate(
+    {
+      prompts: ['local error'],
+      providers: [
+        {
+          id: () => 'artifact-error',
+          callApi: async () => ({ error: 'artifact provider failure' }),
+        },
+      ],
+      tests: [{ vars: {} }],
+      writeLatestResults: false,
+      sharing: false,
+    },
+    { cache: false },
+  );
+  const errors = (await failed.toEvaluateSummary()).results;
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].success, false);
+  assert.equal(errors[0].score, 0);
+  assert.match(errors[0].error, /artifact provider failure/);
+  assert.equal(errors[0].response.error, 'artifact provider failure');
+
+  console.log(`Verified ${mode} root API: pass=1 fail=1 provider-error=1`);
+}

--- a/test/fixtures/package-artifact/import-api.mjs
+++ b/test/fixtures/package-artifact/import-api.mjs
@@ -1,0 +1,4 @@
+import * as api from 'promptfoo';
+import { checkEvaluate } from './evaluate.mjs';
+
+await checkEvaluate(api, 'esm');

--- a/test/fixtures/package-artifact/require-api.cjs
+++ b/test/fixtures/package-artifact/require-api.cjs
@@ -1,0 +1,17 @@
+const assert = require('node:assert/strict');
+const { createRequire } = require('node:module');
+const api = require('promptfoo');
+const packageRequire = createRequire(require.resolve('promptfoo'));
+const { ZodType } = packageRequire('zod');
+
+async function main() {
+  assert(api.AssertionSchema instanceof ZodType, 'Keep CommonJS dependency export conditions');
+  assert.equal(Object.isExtensible(api), true);
+  assert.equal(Object.getOwnPropertyDescriptor(api, 'evaluate').writable, true);
+  const { checkEvaluate } = await import('./evaluate.mjs');
+  await checkEvaluate(api, 'cjs');
+}
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/fixtures/package-artifact/require-api.cjs
+++ b/test/fixtures/package-artifact/require-api.cjs
@@ -7,7 +7,9 @@ const { ZodType } = packageRequire('zod');
 async function main() {
   assert(api.AssertionSchema instanceof ZodType, 'Keep CommonJS dependency export conditions');
   assert.equal(Object.isExtensible(api), true);
-  assert.equal(Object.getOwnPropertyDescriptor(api, 'evaluate').writable, true);
+  const evaluateDescriptor = Object.getOwnPropertyDescriptor(api, 'evaluate');
+  assert(evaluateDescriptor, 'Keep the CommonJS evaluate export');
+  assert.equal(evaluateDescriptor.writable, true);
   const { checkEvaluate } = await import('./evaluate.mjs');
   await checkEvaluate(api, 'cjs');
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -101,6 +101,14 @@ export default defineConfig([
   // Library CJS build for compatibility
   {
     ...sharedBuildOptions,
+    // Native require(ESM) returns Chalk's namespace, while the CJS interop wrapper
+    // expects its default function. Bundle this ESM-only dependency so logging works
+    // without changing the require conditions of other dependencies (notably Zod).
+    deps: {
+      ...sharedBuildOptions.deps,
+      neverBundle: /^(?!chalk(?:\/|$))[a-z@][^:]*/,
+      alwaysBundle: ['chalk'],
+    },
     entry: {
       contracts: 'src/contracts.ts',
       index: 'src/index.ts',


### PR DESCRIPTION
CommonJS consumers can import `promptfoo`, but exporting an evaluation to JSON can throw `chalk.default.yellow is not a function` when logging a trace lookup warning. Bundle Chalk in the CJS output, preserving the normal `require` branches and schema constructors of other dependencies.

Extend packed-consumer acceptance to call the root API through ESM and CJS, check passing/failing assertions and provider errors, inspect exported JSON, and compile root API callers. Add an explicit optional-omitted profile that checks working library behavior and the CLI's existing actionable missing-SQLite diagnostic.

## Validation

- Clean build, root TypeScript, architecture check, and changed-file lint/format
- 65 focused package/postbuild/release tests; 12 built-library integration tests
- CommonJS evaluation on minimum Node 22.22.0
- Fresh installed default and optional-omitted consumers on Node 24.20.0 (npm 11.19.0, explicit trusted mirror); deterministic local echo/HTTP providers only

Install scripts remain disabled in the consumer harness. Contracts declarations retain full checking; root caller tests use `skipLibCheck` because the existing public Eval surface exposes Drizzle's upstream declaration/optional-driver errors. This change does not claim to repair that declaration closure or add CLI support without native SQLite.

Consumer installs default to the public npm registry; local mirrors require an explicit `--registry` override. The build checkout does not persist GitHub credentials.

The Node 22.22 artifact lane uses npm's shallow layout to cover nested dependency resolution; Node 24 and 26 retain hoisted installs. Optional capability checks resolve from the installed package.
