### PR TITLE
ci(release): publish the exact validated npm artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,17 +212,25 @@ jobs:
             echo "PostHog key replacement verified successfully"
           fi
 
+      - name: Pack Package Artifact
+        id: package-artifact
+        run: |
+          tarball="$(npm run --silent package:pack -- --destination "$RUNNER_TEMP/package-artifact")"
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+
       - name: Test Package Artifact
         env:
+          PACKAGE_TARBALL: ${{ steps.package-artifact.outputs.tarball }}
           PROMPTFOO_DISABLE_TELEMETRY: 1
           npm_config_install_strategy: ${{ matrix.node == '22.22' && 'shallow' || 'hoisted' }}
-        run: npm run test:package-artifact
+        run: npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL"
 
       - name: Test Package Artifact Without Optional Dependencies
         if: matrix.node == '24.x'
         env:
+          PACKAGE_TARBALL: ${{ steps.package-artifact.outputs.tarball }}
           PROMPTFOO_DISABLE_TELEMETRY: 1
-        run: npm run test:package-artifact -- --profile omit-optional
+        run: npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL" --profile omit-optional
 
   style-check:
     name: Style Check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -112,17 +113,20 @@ jobs:
           path: node_modules
           key: node-modules-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('package-lock.json') }}
 
+      - name: Use npm 11
+        run: npm install -g npm@11.11.0 --registry=https://registry.npmjs.org/
+
       - name: Install Dependencies (Node 26)
         if: steps.cache-node-modules.outputs.cache-hit != 'true' && matrix.node == '26.x'
         # Node 26 hosted installs stall when lifecycle scripts run during npm ci.
         # Install the tree without scripts, then rebuild the native addon tests need.
         run: |
-          npm ci --ignore-scripts
+          npm ci --ignore-scripts --registry=https://registry.npmjs.org/
           npm rebuild better-sqlite3
 
       - name: Install Dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true' && matrix.node != '26.x'
-        run: npx -y npm@11.11.0 ci
+        run: npm ci --registry=https://registry.npmjs.org/
 
       - name: Test
         # Treat a post-run forks-worker crash (all tests already passed, then the
@@ -176,14 +180,17 @@ jobs:
           node-version: ${{ matrix.node == '22.22' && '22.22.0' || matrix.node }}
           cache: 'npm'
 
+      - name: Use npm 11
+        run: npm install -g npm@11.11.0 --registry=https://registry.npmjs.org/
+
       - name: Install Dependencies
         # The build does not need native dependency lifecycle scripts. Skipping them
         # keeps the Node 26 build lane out of the install stall seen on hosted runners.
         run: |
           if [ "${{ matrix.node }}" = "26.x" ]; then
-            npm ci --ignore-scripts
+            npm ci --ignore-scripts --registry=https://registry.npmjs.org/
           else
-            npx -y npm@11.11.0 ci
+            npm ci --registry=https://registry.npmjs.org/
           fi
 
       - name: Build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,61 +67,130 @@ jobs:
         )
       }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: release-please
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
       # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
-      - run: npm install -g npm@11.11.0
-      - run: npm ci
+      - run: npm install -g npm@11.11.0 --registry=https://registry.npmjs.org/
+      - run: npm ci --registry=https://registry.npmjs.org/
       - run: npm test
 
-  publish-npm:
+  build-npm:
     if: >-
       ${{
-        always() &&
-        !cancelled() &&
+        always() && !cancelled() &&
         needs.release-please.outputs.release_created == 'true' &&
         needs.build.result == 'success'
       }}
     needs: [build, release-please]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
+      - run: npm install -g npm@11.11.0 --registry=https://registry.npmjs.org/
+      - run: npm ci --registry=https://registry.npmjs.org/
+      # Publishing a tarball does not run prepublishOnly. Run its clean build and
+      # required telemetry-key guard here, before packing and validating the bytes.
+      - name: Build npm package
+        run: npm run prepublishOnly
+        env:
+          PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}
+      - name: Pack npm package
+        id: package-artifact
+        run: |
+          tarball="$(npm run --silent package:pack -- --destination "$RUNNER_TEMP/promptfoo-package")"
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+      - name: Validate npm package
+        env:
+          PACKAGE_TARBALL: ${{ steps.package-artifact.outputs.tarball }}
+          PROMPTFOO_DISABLE_TELEMETRY: 1
+        run: |
+          npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL"
+          npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL" --profile omit-optional
+      - name: Upload verified npm package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: promptfoo-npm-package
+          path: ${{ steps.package-artifact.outputs.tarball }}
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-npm:
+    # Keep trusted publishing in this workflow. This job executes no repository
+    # code or dependency install scripts; it only publishes the verified archive.
+    if: >-
+      ${{
+        always() && !cancelled() &&
+        needs.release-please.outputs.release_created == 'true' &&
+        needs.build-npm.result == 'success'
+      }}
+    needs: [build-npm, release-please]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          # Includes npm 11 with trusted publishing support; no tool installation here.
+          node-version: '24.20.0'
           registry-url: 'https://registry.npmjs.org'
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
-      - run: npm install -g npm@11.11.0
-      - run: npm ci
-      # Empty NODE_AUTH_TOKEN so npm uses OIDC trusted publishing instead of the
-      # placeholder token actions/setup-node writes into .npmrc (actions/setup-node#1440).
-      - run: npm publish --provenance --access public
+      - name: Download verified npm package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: promptfoo-npm-package
+          path: ${{ runner.temp }}/promptfoo-package
+      - name: Publish verified npm package
         env:
+          EXPECTED_VERSION: ${{ needs.release-please.outputs.tag_name }}
+          # Neutralize setup-node's token placeholder so npm uses OIDC.
           NODE_AUTH_TOKEN: ''
-          PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}
+          PACKAGE_DIR: ${{ runner.temp }}/promptfoo-package
+          REGISTRY_URL: https://registry.npmjs.org/
+        run: |
+          shopt -s nullglob
+          tarballs=("$PACKAGE_DIR"/*.tgz)
+          if [[ "${#tarballs[@]}" -ne 1 ]]; then
+            echo "::error::Expected exactly one verified npm tarball"
+            exit 1
+          fi
+          manifest_path="$RUNNER_TEMP/promptfoo-publish-manifest.json"
+          tar -xOf "${tarballs[0]}" package/package.json > "$manifest_path"
+          node - "$manifest_path" "$EXPECTED_VERSION" <<'NODE'
+          const fs = require('node:fs');
+          const [manifestPath, expectedVersion] = process.argv.slice(2);
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+          if (manifest.name !== 'promptfoo' || manifest.version !== expectedVersion || manifest.publishConfig !== undefined) {
+            throw new Error('Downloaded artifact has unexpected publish metadata');
+          }
+          NODE
+          npm publish "${tarballs[0]}" --ignore-scripts --provenance --access public --registry="$REGISTRY_URL"
 
-  publish-npm-backfill:
-    # npm trusted publishing is bound to this workflow filename on npmjs.com,
-    # so manual backfills must stay inside release-please.yml.
+  build-npm-backfill:
     if: github.event_name == 'workflow_dispatch' && inputs.tag_name != ''
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
-      id-token: write
     env:
       TAG_NAME: ${{ inputs.tag_name }}
     steps:
@@ -131,11 +200,14 @@ jobs:
             echo "::error::TAG_NAME '$TAG_NAME' is empty or invalid"
             exit 1
           fi
-
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: refs/tags/${{ inputs.tag_name }}
-
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
       - name: Verify package version matches tag
         run: |
           package_version="$(node -p "require('./package.json').version")"
@@ -143,21 +215,116 @@ jobs:
             echo "::error::package.json version '$package_version' does not match tag '$TAG_NAME'"
             exit 1
           fi
+      - run: npm install -g npm@11.11.0 --registry=https://registry.npmjs.org/
+      - run: npm ci --registry=https://registry.npmjs.org/
+      - name: Build npm package
+        run: npm run prepublishOnly
+        env:
+          PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}
+      - name: Pack npm package
+        id: package-artifact
+        # Older tags do not contain package:pack. Pack their prebuilt output directly.
+        run: |
+          artifact_dir="$RUNNER_TEMP/promptfoo-package"
+          mkdir -p "$artifact_dir"
+          npm pack --ignore-scripts --json --pack-destination "$artifact_dir" > "$RUNNER_TEMP/npm-pack.json"
+          filename="$(node -p "const r = require(process.env.RUNNER_TEMP + '/npm-pack.json'); if (r.length !== 1 || r[0].name !== 'promptfoo' || r[0].version !== process.env.TAG_NAME) throw new Error('Unexpected packed metadata'); r[0].filename")"
+          echo "tarball=$artifact_dir/$filename" >> "$GITHUB_OUTPUT"
+      - name: Validate historical npm package
+        env:
+          PACKAGE_TARBALL: ${{ steps.package-artifact.outputs.tarball }}
+          PROMPTFOO_DISABLE_TELEMETRY: 1
+        run: |
+          if [[ -f scripts/testPackageArtifact.ts ]] && grep -q -- '--tarball' scripts/testPackageArtifact.ts; then
+            npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL"
+          else
+            # Compatibility gate for tags predating exact-artifact acceptance. This tests
+            # the selected archive's CLI and JSON output, without rebuilding or repacking it.
+            consumer_dir="$(mktemp -d "$RUNNER_TEMP/promptfoo-backfill-consumer.XXXXXX")"
+            trap 'rm -rf "$consumer_dir"' EXIT
+            export PROMPTFOO_CONFIG_DIR="$consumer_dir/config"
+            export PROMPTFOO_CACHE_PATH="$consumer_dir/cache"
+            export PROMPTFOO_DISABLE_UPDATE=true
+            export PROMPTFOO_DISABLE_REMOTE_GENERATION=true
+            export npm_config_userconfig="$consumer_dir/.npmrc"
+            touch "$npm_config_userconfig"
+            printf '{"private":true}' > "$consumer_dir/package.json"
+            npm install --prefix "$consumer_dir" --ignore-scripts --no-audit --no-fund --no-package-lock --registry=https://registry.npmjs.org/ "$PACKAGE_TARBALL"
+            printf '{"prompts":["artifact"],"providers":["echo"],"tests":[{"assert":[{"type":"equals","value":"artifact"}]}]}' > "$consumer_dir/config.json"
+            "$consumer_dir/node_modules/.bin/promptfoo" --version
+            "$consumer_dir/node_modules/.bin/promptfoo" eval --config "$consumer_dir/config.json" --output "$consumer_dir/results.json" --no-cache --no-write
+            node - "$consumer_dir/results.json" <<'NODE'
+          const assert = require('node:assert/strict');
+          const fs = require('node:fs');
+          const output = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+          const results = output.results.results;
+          assert.equal(results.length, 1);
+          assert.equal(results[0].success, true);
+          assert.equal(results[0].score, 1);
+          assert.equal(results[0].error, undefined);
+          assert.equal(results[0].response.error, undefined);
+          assert.equal(results[0].response.output, 'artifact');
+          NODE
+          fi
+      - name: Upload verified npm package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: promptfoo-npm-backfill-package
+          path: ${{ steps.package-artifact.outputs.tarball }}
+          if-no-files-found: error
+          retention-days: 7
 
+  publish-npm-backfill:
+    # Keep trusted publishing in this workflow. This job executes no repository
+    # code or dependency install scripts; it only publishes the verified archive.
+    if: >-
+      ${{
+        always() && !cancelled() &&
+        github.event_name == 'workflow_dispatch' && inputs.tag_name != '' &&
+        needs.build-npm-backfill.result == 'success'
+      }}
+    needs: build-npm-backfill
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
+          # Includes npm 11 with trusted publishing support; no tool installation here.
+          node-version: '24.20.0'
           registry-url: 'https://registry.npmjs.org'
-
-      # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
-      - run: npm install -g npm@11.11.0
-      - run: npm ci
-      - name: Publish package
-        run: npm publish --provenance --access public
+      - name: Download verified npm package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: promptfoo-npm-backfill-package
+          path: ${{ runner.temp }}/promptfoo-package
+      - name: Publish verified npm package
         env:
+          EXPECTED_VERSION: ${{ inputs.tag_name }}
+          # Neutralize setup-node's token placeholder so npm uses OIDC.
           NODE_AUTH_TOKEN: ''
-          PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}
+          PACKAGE_DIR: ${{ runner.temp }}/promptfoo-package
+          REGISTRY_URL: https://registry.npmjs.org/
+        run: |
+          shopt -s nullglob
+          tarballs=("$PACKAGE_DIR"/*.tgz)
+          if [[ "${#tarballs[@]}" -ne 1 ]]; then
+            echo "::error::Expected exactly one verified npm tarball"
+            exit 1
+          fi
+          manifest_path="$RUNNER_TEMP/promptfoo-publish-manifest.json"
+          tar -xOf "${tarballs[0]}" package/package.json > "$manifest_path"
+          node - "$manifest_path" "$EXPECTED_VERSION" <<'NODE'
+          const fs = require('node:fs');
+          const [manifestPath, expectedVersion] = process.argv.slice(2);
+          const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+          if (manifest.name !== 'promptfoo' || manifest.version !== expectedVersion || manifest.publishConfig !== undefined) {
+            throw new Error('Downloaded artifact has unexpected publish metadata');
+          }
+          NODE
+          npm publish "${tarballs[0]}" --ignore-scripts --provenance --access public --registry="$REGISTRY_URL"
 
   docker:
     if: >-
@@ -224,7 +391,7 @@ jobs:
           cache: 'npm'
 
       # Node 24 ships with npm 11.6.2 which has a lockfile compatibility bug (npm/cli#8669)
-      - run: npm install -g npm@11.11.0
+      - run: npm install -g npm@11.11.0 --registry=https://registry.npmjs.org/
 
       # The action's runtime install is pinned to this commit's root package.json
       # version, inlined into dist/ at build time. Refuse to mirror a release whose

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -223,13 +223,18 @@ jobs:
           PROMPTFOO_POSTHOG_KEY: ${{ secrets.PROMPTFOO_POSTHOG_KEY }}
       - name: Pack npm package
         id: package-artifact
-        # Older tags do not contain package:pack. Pack their prebuilt output directly.
+        # Preserve inventory checks on capable tags; older tags pack prebuilt output directly.
         run: |
           artifact_dir="$RUNNER_TEMP/promptfoo-package"
           mkdir -p "$artifact_dir"
-          npm pack --ignore-scripts --json --pack-destination "$artifact_dir" > "$RUNNER_TEMP/npm-pack.json"
-          filename="$(node -p "const r = require(process.env.RUNNER_TEMP + '/npm-pack.json'); if (r.length !== 1 || r[0].name !== 'promptfoo' || r[0].version !== process.env.TAG_NAME) throw new Error('Unexpected packed metadata'); r[0].filename")"
-          echo "tarball=$artifact_dir/$filename" >> "$GITHUB_OUTPUT"
+          if node -e "process.exit(require('./package.json').scripts?.['package:pack'] ? 0 : 1)"; then
+            tarball="$(npm run --silent package:pack -- --destination "$artifact_dir")"
+          else
+            npm pack --ignore-scripts --json --pack-destination "$artifact_dir" > "$RUNNER_TEMP/npm-pack.json"
+            filename="$(node -p "const r = require(process.env.RUNNER_TEMP + '/npm-pack.json'); if (r.length !== 1 || r[0].name !== 'promptfoo' || r[0].version !== process.env.TAG_NAME) throw new Error('Unexpected packed metadata'); r[0].filename")"
+            tarball="$artifact_dir/$filename"
+          fi
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
       - name: Validate historical npm package
         env:
           PACKAGE_TARBALL: ${{ steps.package-artifact.outputs.tarball }}
@@ -247,12 +252,19 @@ jobs:
             export PROMPTFOO_DISABLE_UPDATE=true
             export PROMPTFOO_DISABLE_REMOTE_GENERATION=true
             export npm_config_userconfig="$consumer_dir/.npmrc"
+            export npm_config_cache="$consumer_dir/npm-cache"
+            export npm_config_devdir="$consumer_dir/node-gyp"
             touch "$npm_config_userconfig"
             printf '{"private":true}' > "$consumer_dir/package.json"
             npm install --prefix "$consumer_dir" --ignore-scripts --no-audit --no-fund --no-package-lock --registry=https://registry.npmjs.org/ "$PACKAGE_TARBALL"
+            # Before libSQL, the CLI needs better-sqlite3's native binding even for
+            # --version. Build only that dependency, in this tokenless consumer job.
+            if node -e "process.exit(require(process.argv[1]).dependencies?.['better-sqlite3'] ? 0 : 1)" "$consumer_dir/node_modules/promptfoo/package.json"; then
+              npm rebuild --prefix "$consumer_dir" --ignore-scripts=false --registry=https://registry.npmjs.org/ better-sqlite3
+            fi
             printf '{"prompts":["artifact"],"providers":["echo"],"tests":[{"assert":[{"type":"equals","value":"artifact"}]}]}' > "$consumer_dir/config.json"
             "$consumer_dir/node_modules/.bin/promptfoo" --version
-            "$consumer_dir/node_modules/.bin/promptfoo" eval --config "$consumer_dir/config.json" --output "$consumer_dir/results.json" --no-cache --no-write
+            "$consumer_dir/node_modules/.bin/promptfoo" eval --config "$consumer_dir/config.json" --output "$consumer_dir/results.json" --no-cache
             node - "$consumer_dir/results.json" <<'NODE'
           const assert = require('node:assert/strict');
           const fs = require('node:fs');

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "preversion": "command -v gh >/dev/null 2>&1 || (echo \"Error: GitHub CLI required.\" && exit 1) && [ \"$(git rev-parse --abbrev-ref HEAD)\" = \"main\" ] || (echo \"Error: Must be on main branch to version\" && exit 1) && git pull origin main && git checkout -b \"chore/bump-version-$(date +%s)\"",
     "changelog:release": "node scripts/update-changelog-version.cjs",
     "postversion": "npm run changelog:release && npm run citation:generate && git add CHANGELOG.md CITATION.cff && git commit --amend --no-edit && gh pr create --repo promptfoo/promptfoo --title \"chore: bump version $npm_package_version\" --body \"\"",
+    "package:pack": "tsx scripts/packPackageArtifact.ts",
     "prepublishOnly": "node -e \"if (!process.env.PROMPTFOO_POSTHOG_KEY) { console.error('Error: PROMPTFOO_POSTHOG_KEY must be set'); process.exit(1); }\" && npm run build:clean && npm run build",
     "test:app": "npm --prefix src/app run test --",
     "test:app:browser": "npm --prefix src/app run test:browser --",

--- a/scripts/packPackageArtifact.ts
+++ b/scripts/packPackageArtifact.ts
@@ -8,6 +8,10 @@ import { parseArgs } from 'node:util';
 import { shouldCopyDrizzlePath } from './postbuild';
 
 function listFiles(packageDir: string, rootDir: string): string[] {
+  assert(
+    fs.existsSync(rootDir),
+    `Missing built asset directory: ${path.relative(packageDir, rootDir)}`,
+  );
   return fs.readdirSync(rootDir, { withFileTypes: true }).flatMap((entry) => {
     const fullPath = path.join(rootDir, entry.name);
     return entry.isDirectory()
@@ -55,12 +59,17 @@ export function packPackageArtifact(packageDir: string, destination: string): st
     ],
     { cwd: packageDir, encoding: 'utf8', maxBuffer: 128 * 1024 * 1024 },
   );
-  const results = JSON.parse(output) as Array<{
+  let results: Array<{
     name: string;
     version: string;
     filename: string;
     files: Array<{ path: string }>;
   }>;
+  try {
+    results = JSON.parse(output);
+  } catch {
+    assert.fail(`npm pack --json returned invalid JSON: ${output}`);
+  }
   assert.equal(results.length, 1, 'Expected exactly one package artifact');
   const [result] = results;
   assert.equal(result.name, manifest.name);

--- a/scripts/packPackageArtifact.ts
+++ b/scripts/packPackageArtifact.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+import { shouldCopyDrizzlePath } from './postbuild';
+
+function listFiles(packageDir: string, rootDir: string): string[] {
+  return fs.readdirSync(rootDir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(rootDir, entry.name);
+    return entry.isDirectory()
+      ? listFiles(packageDir, fullPath)
+      : [path.relative(packageDir, fullPath).split(path.sep).join('/')];
+  });
+}
+
+// Validate the complete build inventory here, including lazy-loaded UI chunks.
+// Existing-archive consumers can then run without the original source/build tree.
+export function assertBuiltAssetsPackaged(
+  packageDir: string,
+  files: Array<{ path: string }>,
+): void {
+  const packagedPaths = new Set(files.map((file) => file.path));
+  const expectedPaths = [
+    ...listFiles(packageDir, path.join(packageDir, 'drizzle'))
+      .filter(shouldCopyDrizzlePath)
+      .map((file) => `dist/${file}`),
+    ...listFiles(packageDir, path.join(packageDir, 'dist', 'src', 'app')).filter(
+      (file) => !file.endsWith('.map'),
+    ),
+  ];
+  const missing = expectedPaths.filter((file) => !packagedPaths.has(file));
+  assert.deepEqual(missing, [], `Missing packaged build assets: ${missing.join(', ')}`);
+}
+
+// Pack prebuilt output once. The release workflow runs prepublishOnly explicitly before
+// this step, then passes this exact file to consumer acceptance and npm publish.
+export function packPackageArtifact(packageDir: string, destination: string): string {
+  assert(process.env.npm_execpath, 'Run the artifact packer through npm');
+  const manifest = JSON.parse(fs.readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
+  assert.equal(manifest.name, 'promptfoo', 'Expected the promptfoo package');
+  const artifactDirectory = path.resolve(destination);
+  fs.mkdirSync(artifactDirectory, { recursive: true });
+  const output = execFileSync(
+    process.execPath,
+    [
+      process.env.npm_execpath,
+      'pack',
+      '--ignore-scripts',
+      '--json',
+      '--pack-destination',
+      artifactDirectory,
+    ],
+    { cwd: packageDir, encoding: 'utf8', maxBuffer: 128 * 1024 * 1024 },
+  );
+  const results = JSON.parse(output) as Array<{
+    name: string;
+    version: string;
+    filename: string;
+    files: Array<{ path: string }>;
+  }>;
+  assert.equal(results.length, 1, 'Expected exactly one package artifact');
+  const [result] = results;
+  assert.equal(result.name, manifest.name);
+  assert.equal(result.version, manifest.version);
+  assert.equal(typeof result.filename, 'string');
+  assert.equal(
+    path.basename(result.filename),
+    result.filename,
+    'Expected a plain artifact filename',
+  );
+  const artifactPath = path.join(artifactDirectory, result.filename);
+  assert(fs.statSync(artifactPath).isFile(), `Missing package artifact: ${artifactPath}`);
+  assertBuiltAssetsPackaged(packageDir, result.files);
+  return artifactPath;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const { values } = parseArgs({ options: { destination: { type: 'string' } } });
+  assert(values.destination, '--destination requires an artifact directory');
+  console.log(packPackageArtifact(path.resolve(import.meta.dirname, '..'), values.destination));
+}

--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFile, execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import { createServer } from 'node:http';
 import { createRequire } from 'node:module';
@@ -9,7 +10,7 @@ import { parseArgs } from 'node:util';
 import { brotliCompressSync, gzipSync } from 'node:zlib';
 
 import { satisfies } from 'semver';
-import { shouldCopyDrizzlePath } from './postbuild';
+import { assertBuiltAssetsPackaged } from './packPackageArtifact';
 
 type PackFile = {
   mode: number;
@@ -39,7 +40,6 @@ type ArtifactEvalOutput = {
 };
 
 const ROOT = path.resolve(import.meta.dirname, '..');
-const drizzleDir = path.join(ROOT, 'drizzle');
 // The August 2026 undici advisories were fixed in 6.28.0, 7.29.0 and 8.9.0. Keep this in sync
 // with PATCHED_UNDICI_RANGE in test/package-manifests.test.ts.
 const PATCHED_UNDICI_RANGE = '^6.28.0 || ^7.29.0 || >=8.9.0';
@@ -72,18 +72,6 @@ const requiredPackagedPaths = [
   'dist/src/tracing/proto/opentelemetry/proto/resource/v1/resource.proto',
   'dist/src/tracing/proto/opentelemetry/proto/trace/v1/trace.proto',
 ];
-
-function listFiles(rootDir: string): string[] {
-  return fs.readdirSync(rootDir, { withFileTypes: true }).flatMap((entry) => {
-    const fullPath = path.join(rootDir, entry.name);
-
-    if (entry.isDirectory()) {
-      return listFiles(fullPath);
-    }
-
-    return [path.relative(ROOT, fullPath).split(path.sep).join('/')];
-  });
-}
 
 function run(
   command: string,
@@ -170,28 +158,13 @@ function runNpm(args: string[], cwd: string, envOverrides: NodeJS.ProcessEnv = {
   return run(process.execPath, [process.env.npm_execpath, ...args], cwd, envOverrides);
 }
 
-function assertPackagedFiles(packResult: PackResult): void {
+function assertPackagedFiles(packResult: PackResult, compareSource: boolean): void {
   const packagedPaths = new Set(packResult.files.map((file) => file.path));
   const missingPaths = requiredPackagedPaths.filter((file) => !packagedPaths.has(file));
-  const missingDrizzleFiles = listFiles(drizzleDir)
-    .filter(shouldCopyDrizzlePath)
-    .map((file) => `dist/${file}`)
-    .filter((file) => !packagedPaths.has(file));
-  const missingWebAppFiles = listFiles(path.join(ROOT, 'dist', 'src', 'app'))
-    .filter((file) => !file.endsWith('.map'))
-    .filter((file) => !packagedPaths.has(file));
-
   assert.deepEqual(missingPaths, [], `Missing packaged runtime assets: ${missingPaths.join(', ')}`);
-  assert.deepEqual(
-    missingDrizzleFiles,
-    [],
-    `Missing packaged Drizzle files: ${missingDrizzleFiles.join(', ')}`,
-  );
-  assert.deepEqual(
-    missingWebAppFiles,
-    [],
-    `Missing packaged web app files: ${missingWebAppFiles.join(', ')}`,
-  );
+  if (compareSource) {
+    assertBuiltAssetsPackaged(ROOT, packResult.files);
+  }
   assert(
     packResult.files.every((file) => !file.path.endsWith('.map')),
     'Source maps should be excluded from the package',
@@ -642,8 +615,17 @@ async function main(): Promise<void> {
     options: {
       profile: { type: 'string', default: 'default' },
       registry: { type: 'string', default: 'https://registry.npmjs.org/' },
+      tarball: { type: 'string' },
     },
   });
+  const suppliedTarball = values.tarball === undefined ? undefined : path.resolve(values.tarball);
+  if (suppliedTarball) {
+    assert(suppliedTarball.endsWith('.tgz'), '--tarball must be a local .tgz file');
+    assert(fs.statSync(suppliedTarball).isFile(), '--tarball must be an existing file');
+  }
+  const originalHash = suppliedTarball
+    ? createHash('sha512').update(fs.readFileSync(suppliedTarball)).digest('hex')
+    : undefined;
   assert(
     ['default', 'omit-optional'].includes(values.profile),
     `Unknown install profile: ${values.profile}`,
@@ -660,10 +642,10 @@ async function main(): Promise<void> {
     fs.mkdirSync(consumerDir);
     fs.writeFileSync(consumerNpmrc, '');
 
-    const packOutput = runNpm(
-      ['pack', '--ignore-scripts', '--json', '--pack-destination', artifactsDir],
-      ROOT,
-    );
+    // npm's dry-run inspects the supplied archive without repacking it or running hooks.
+    const packOutput = suppliedTarball
+      ? runNpm(['pack', suppliedTarball, '--dry-run', '--ignore-scripts', '--json'], ROOT)
+      : runNpm(['pack', '--ignore-scripts', '--json', '--pack-destination', artifactsDir], ROOT);
     let packResults: PackResult[];
     try {
       packResults = JSON.parse(packOutput) as PackResult[];
@@ -674,9 +656,9 @@ async function main(): Promise<void> {
 
     const [packResult] = packResults;
     assert.equal(packResult.name, 'promptfoo');
-    assertPackagedFiles(packResult);
+    assertPackagedFiles(packResult, !suppliedTarball);
 
-    const tarballPath = path.join(artifactsDir, packResult.filename);
+    const tarballPath = suppliedTarball ?? path.join(artifactsDir, packResult.filename);
     assert(fs.existsSync(tarballPath), `Missing tarball: ${tarballPath}`);
 
     fs.writeFileSync(
@@ -759,6 +741,17 @@ async function main(): Promise<void> {
       console.log(await runAsync(process.execPath, [script], consumerDir, consumerEnv));
     }
     assertInstalledWebApp(installedPackageDir);
+    const installedMigrations = path.join(installedPackageDir, 'dist', 'drizzle');
+    const journal = JSON.parse(
+      fs.readFileSync(path.join(installedMigrations, 'meta', '_journal.json'), 'utf8'),
+    ) as { entries: Array<{ tag: string }> };
+    assert(journal.entries.length > 0, 'Expected installed migration journal entries');
+    for (const { tag } of journal.entries) {
+      assert(
+        fs.statSync(path.join(installedMigrations, `${tag}.sql`)).isFile(),
+        `Missing installed migration: ${tag}`,
+      );
+    }
 
     for (const binName of ['promptfoo', 'pf']) {
       if (values.profile === 'omit-optional') {
@@ -783,7 +776,16 @@ async function main(): Promise<void> {
       await runInstalledCompressionEval(consumerDir, configDir);
     }
 
-    console.log(`Verified installed package artifact (${values.profile}): ${packResult.filename}`);
+    if (suppliedTarball) {
+      assert.equal(
+        createHash('sha512').update(fs.readFileSync(suppliedTarball)).digest('hex'),
+        originalHash,
+        'The tested tarball changed during validation',
+      );
+    }
+    console.log(
+      `Verified installed package artifact (${values.profile}): ${path.basename(tarballPath)}`,
+    );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/fixtures/package-artifact/README.md
+++ b/test/fixtures/package-artifact/README.md
@@ -30,3 +30,21 @@ checking enabled for consumer code. Contracts also check dependency declarations
 root API consumers use `skipLibCheck` because the public `Eval` surface currently
 exposes Drizzle declarations with upstream errors and unrelated optional driver
 imports. This does not claim a clean root declaration closure.
+
+## Validate an existing artifact
+
+```sh
+npm run package:pack -- --destination /tmp/promptfoo-artifacts
+npm run test:package-artifact -- --tarball /tmp/promptfoo-artifacts/promptfoo-VERSION.tgz
+npm run test:package-artifact -- --tarball /tmp/promptfoo-artifacts/promptfoo-VERSION.tgz --profile omit-optional
+```
+
+The supplied archive is inspected and installed without repacking. Validation
+checks its own migration journal and UI references, works without a local `dist`,
+and verifies that its bytes remain unchanged. Current release jobs run
+`prepublishOnly` first, then pack, validate both profiles, and upload that archive
+to an isolated publisher. Publication cannot invoke another build.
+
+Historical backfills keep their tagged build. Tags with an exact-artifact harness
+use it; older tags receive an explicitly limited installed CLI/JSON echo check.
+They still publish the same archive that passed that compatibility check.

--- a/test/fixtures/package-artifact/README.md
+++ b/test/fixtures/package-artifact/README.md
@@ -6,7 +6,9 @@ The consumer uses the public npm registry and is isolated from the repository's
 workspaces, lockfile, overrides, and development dependencies. To select a trusted
 local mirror explicitly, pass `--registry https://your-registry.example/`.
 
-After `npm run build`, run from the repository root:
+Use npm 11 as required by the repository. Older npm 10 pack implementations can
+run `prepare` despite `--ignore-scripts`. After `npm run build`, run from the
+repository root:
 
 ```sh
 npm run test:package-artifact

--- a/test/release-artifact.test.ts
+++ b/test/release-artifact.test.ts
@@ -1,0 +1,122 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import * as yaml from 'js-yaml';
+import { afterEach, describe, expect, it } from 'vitest';
+
+type Step = {
+  name?: string;
+  uses?: string;
+  run?: string;
+  env?: Record<string, string>;
+  with?: Record<string, unknown>;
+};
+type Job = {
+  needs?: string | string[];
+  if?: string;
+  permissions: Record<string, string>;
+  steps: Step[];
+};
+const workflow = yaml.load(
+  fs.readFileSync(path.resolve(__dirname, '../.github/workflows/release-please.yml'), 'utf8'),
+) as {
+  concurrency: { 'cancel-in-progress': boolean };
+  jobs: Record<string, Job>;
+};
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('exact artifact release', () => {
+  it('builds and validates before an OIDC-only publisher, retaining release controls', () => {
+    expect(workflow.concurrency['cancel-in-progress']).toBe(false);
+    for (const [buildName, publishName] of [
+      ['build-npm', 'publish-npm'],
+      ['build-npm-backfill', 'publish-npm-backfill'],
+    ]) {
+      const build = workflow.jobs[buildName];
+      const publisher = workflow.jobs[publishName];
+      expect(build.permissions['id-token']).toBeUndefined();
+      expect(
+        build.steps.find((s) => s.uses?.startsWith('actions/checkout@'))?.with?.[
+          'persist-credentials'
+        ],
+      ).toBe(false);
+      const buildIndex = build.steps.findIndex((s) => s.run === 'npm run prepublishOnly');
+      const validateIndex = build.steps.findIndex(
+        (s) => s.name?.startsWith('Validate ') && s.env?.PACKAGE_TARBALL,
+      );
+      const uploadIndex = build.steps.findIndex((s) =>
+        s.uses?.startsWith('actions/upload-artifact@'),
+      );
+      expect(buildIndex).toBeGreaterThan(-1);
+      expect(validateIndex).toBeGreaterThan(buildIndex);
+      expect(uploadIndex).toBeGreaterThan(validateIndex);
+      expect(build.steps[buildIndex].env?.PROMPTFOO_POSTHOG_KEY).toBeDefined();
+      expect(publisher.permissions['id-token']).toBe('write');
+      expect([publisher.needs].flat()).toContain(buildName);
+      expect(publisher.if).toContain(`needs.${buildName}.result == 'success'`);
+      expect(publisher.steps.some((s) => s.uses?.startsWith('actions/checkout@'))).toBe(false);
+      expect(publisher.steps.map((s) => s.run ?? '').join('\n')).not.toMatch(
+        /npm (?:ci|install|run)/,
+      );
+      const publish = publisher.steps.find((s) => s.name === 'Publish verified npm package')!;
+      expect(publish.env?.NODE_AUTH_TOKEN).toBe('');
+      expect(publish.run).toContain(
+        'npm publish "${tarballs[0]}" --ignore-scripts --provenance --access public',
+      );
+    }
+  });
+
+  it('keeps npm artifact acceptance separate from the shared code-scan test gate', () => {
+    expect(workflow.jobs.build.steps.some((step) => step.run === 'npm test')).toBe(true);
+    expect(workflow.jobs.build.steps.some((step) => step.run?.includes('package-artifact'))).toBe(
+      false,
+    );
+    const mirror = workflow.jobs['publish-code-scan-action'];
+    expect(mirror.if).toContain("needs.build.result == 'success'");
+    expect(mirror.if).not.toContain('needs.build-npm');
+    expect(mirror.if).not.toContain('needs.publish-npm.result');
+  });
+
+  for (const jobName of ['publish-npm', 'publish-npm-backfill']) {
+    it(`${jobName} rejects wrong identity, version, and publish configuration before publishing`, () => {
+      const run = workflow.jobs[jobName].steps.find(
+        (s) => s.name === 'Publish verified npm package',
+      )!.run!;
+      const script = run.match(/<<'NODE'\n([\s\S]*?)\nNODE\n/)?.[1];
+      expect(script).toBeDefined();
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'release-artifact-'));
+      directories.push(root);
+      const manifestPath = path.join(root, 'package.json');
+      for (const [manifest, valid] of [
+        [{ name: 'promptfoo', version: '1.2.3' }, true],
+        [{ name: 'other', version: '1.2.3' }, false],
+        [{ name: 'promptfoo', version: '9.9.9' }, false],
+        [
+          {
+            name: 'promptfoo',
+            version: '1.2.3',
+            publishConfig: { registry: 'https://example.invalid' },
+          },
+          false,
+        ],
+      ] as const) {
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+        const result = spawnSync(process.execPath, ['-', manifestPath, '1.2.3'], {
+          input: script,
+          encoding: 'utf8',
+        });
+        expect(result.status === 0).toBe(valid);
+        if (!valid) {
+          expect(result.stderr).toContain('Downloaded artifact has unexpected publish metadata');
+        }
+      }
+    });
+  }
+});

--- a/test/release-artifact.test.ts
+++ b/test/release-artifact.test.ts
@@ -63,7 +63,7 @@ describe('exact artifact release', () => {
       expect(publisher.if).toContain(`needs.${buildName}.result == 'success'`);
       expect(publisher.steps.some((s) => s.uses?.startsWith('actions/checkout@'))).toBe(false);
       expect(publisher.steps.map((s) => s.run ?? '').join('\n')).not.toMatch(
-        /npm (?:ci|install|run)/,
+        /npm (?:ci|install|run|rebuild)/,
       );
       const publish = publisher.steps.find((s) => s.name === 'Publish verified npm package')!;
       expect(publish.env?.NODE_AUTH_TOKEN).toBe('');
@@ -82,6 +82,51 @@ describe('exact artifact release', () => {
     expect(mirror.if).toContain("needs.build.result == 'success'");
     expect(mirror.if).not.toContain('needs.build-npm');
     expect(mirror.if).not.toContain('needs.publish-npm.result');
+  });
+
+  it('detects current packers and legacy native SQLite from tag manifests', () => {
+    const steps = workflow.jobs['build-npm-backfill'].steps;
+    const pack = steps.find((step) => step.name === 'Pack npm package')!.run!;
+    const validate = steps.find((step) => step.name === 'Validate historical npm package')!.run!;
+    const packProbe = pack.match(/if node -e "([^"]+)"/)?.[1];
+    const nativeProbe = validate.match(/if node -e "([^"]+)"/)?.[1];
+    expect(packProbe).toBeDefined();
+    expect(nativeProbe).toBeDefined();
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'backfill-capabilities-'));
+    directories.push(root);
+    const manifestPath = path.join(root, 'package.json');
+    for (const [manifest, hasPacker, needsNativeBuild] of [
+      [
+        {
+          scripts: { 'package:pack': 'tsx scripts/packPackageArtifact.ts' },
+          dependencies: { '@libsql/client': '^0.17.0' },
+        },
+        true,
+        false,
+      ],
+      [{ dependencies: { 'better-sqlite3': '^12.8.0' } }, false, true],
+      [
+        {
+          dependencies: { '@libsql/client': '^0.17.0' },
+          devDependencies: { 'better-sqlite3': '^12.8.0' },
+        },
+        false,
+        false,
+      ],
+    ] as const) {
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+      expect(spawnSync(process.execPath, ['-e', packProbe!], { cwd: root }).status === 0).toBe(
+        hasPacker,
+      );
+      expect(
+        spawnSync(process.execPath, ['-e', nativeProbe!, manifestPath], { cwd: root }).status === 0,
+      ).toBe(needsNativeBuild);
+    }
+    expect(pack).toContain('npm run --silent package:pack -- --destination');
+    expect(validate).toContain('npm rebuild --prefix "$consumer_dir" --ignore-scripts=false');
+    // Older releases only export per-test rows when their isolated database is written.
+    expect(validate).not.toContain('--no-write');
+    expect(validate).toContain('PROMPTFOO_CONFIG_DIR="$consumer_dir/config"');
   });
 
   for (const jobName of ['publish-npm', 'publish-npm-backfill']) {

--- a/test/scripts/packageArtifact.test.ts
+++ b/test/scripts/packageArtifact.test.ts
@@ -28,6 +28,8 @@ function writeBuildAssets(source: string): void {
 
 describe('package artifact packing', () => {
   it('packs prebuilt bytes without hooks and inspects an unchanged archive with spaces in its path', () => {
+    const npmExecPath = process.env.npm_execpath;
+    expect(npmExecPath).toBeTruthy();
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-packer-'));
     directories.push(root);
     const source = path.join(root, 'source');
@@ -51,7 +53,7 @@ describe('package artifact packing', () => {
     const metadata = JSON.parse(
       execFileSync(
         process.execPath,
-        [process.env.npm_execpath!, 'pack', renamed, '--dry-run', '--ignore-scripts', '--json'],
+        [npmExecPath!, 'pack', renamed, '--dry-run', '--ignore-scripts', '--json'],
         { cwd: source, encoding: 'utf8' },
       ),
     );

--- a/test/scripts/packageArtifact.test.ts
+++ b/test/scripts/packageArtifact.test.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { packPackageArtifact } from '../../scripts/packPackageArtifact';
+
+const directories: string[] = [];
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function writeBuildAssets(source: string): void {
+  for (const relativePath of [
+    'drizzle/0000.sql',
+    'dist/drizzle/0000.sql',
+    'dist/src/app/index.html',
+    'dist/src/app/assets/lazy.js',
+  ]) {
+    fs.mkdirSync(path.dirname(path.join(source, relativePath)), { recursive: true });
+    fs.writeFileSync(path.join(source, relativePath), 'fixture');
+  }
+}
+
+describe('package artifact packing', () => {
+  it('packs prebuilt bytes without hooks and inspects an unchanged archive with spaces in its path', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-packer-'));
+    directories.push(root);
+    const source = path.join(root, 'source');
+    fs.mkdirSync(source);
+    writeBuildAssets(source);
+    fs.writeFileSync(
+      path.join(source, 'package.json'),
+      JSON.stringify({
+        name: 'promptfoo',
+        version: '1.2.3',
+        files: ['index.js', 'dist'],
+        scripts: { prepack: 'node -e "process.exit(99)"', prepare: 'node -e "process.exit(99)"' },
+      }),
+    );
+    fs.writeFileSync(path.join(source, 'index.js'), 'module.exports = "prebuilt";\n');
+    const packed = packPackageArtifact(source, path.join(root, 'artifacts with spaces'));
+    const renamed = path.join(path.dirname(packed), 'renamed archive.tgz');
+    fs.renameSync(packed, renamed);
+    const hash = () => createHash('sha512').update(fs.readFileSync(renamed)).digest('hex');
+    const before = hash();
+    const metadata = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [process.env.npm_execpath!, 'pack', renamed, '--dry-run', '--ignore-scripts', '--json'],
+        { cwd: source, encoding: 'utf8' },
+      ),
+    );
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0]).toMatchObject({ name: 'promptfoo', version: '1.2.3' });
+    expect(metadata[0].files).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: 'index.js' })]),
+    );
+    expect(hash()).toBe(before);
+    expect(fs.readdirSync(path.dirname(renamed))).toEqual(['renamed archive.tgz']);
+  });
+
+  it.each(['dist/drizzle/0000.sql', 'dist/src/app/assets/lazy.js'])(
+    'rejects packing when the archive omits built asset %s',
+    (omittedAsset) => {
+      const source = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-missing-asset-'));
+      directories.push(source);
+      writeBuildAssets(source);
+      fs.writeFileSync(
+        path.join(source, 'package.json'),
+        JSON.stringify({
+          name: 'promptfoo',
+          version: '1.2.3',
+          files: [
+            'dist/drizzle/0000.sql',
+            'dist/src/app/index.html',
+            'dist/src/app/assets/lazy.js',
+          ].filter((file) => file !== omittedAsset),
+        }),
+      );
+      expect(() => packPackageArtifact(source, path.join(source, 'artifacts'))).toThrow(
+        `Missing packaged build assets: ${omittedAsset}`,
+      );
+    },
+  );
+
+  it('rejects a different package before emitting an artifact', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-packer-'));
+    directories.push(root);
+    fs.writeFileSync(
+      path.join(root, 'package.json'),
+      JSON.stringify({ name: 'other', version: '1.2.3' }),
+    );
+    const destination = path.join(root, 'output');
+    expect(() => packPackageArtifact(root, destination)).toThrow('Expected the promptfoo package');
+    expect(fs.existsSync(destination)).toBe(false);
+  });
+});


### PR DESCRIPTION
The npm release jobs currently rebuild while publishing, so installed-consumer acceptance does not cover the bytes sent to npm. Pack once after the existing `prepublishOnly` build/telemetry guard, validate that archive, and pass it through an immutable workflow artifact to an isolated OIDC publisher with lifecycle scripts disabled.

- Preserve complete migration and UI build inventory checks in the packer, including lazy-loaded chunks. Existing-archive acceptance verifies the selected file without rebuilding or repacking it.
- Keep root test, Docker, code-scan ordering, backfill tag/version, concurrency, provenance, and trusted-publishing controls. Separate npm artifact acceptance from the shared code-scan test gate.
- Current releases validate both dependency profiles. Historical backfills use their exact-artifact harness when available, with inventory-aware packing when available and a limited installed CLI/JSON compatibility gate for older tags. Legacy SQLite bindings are rebuilt selectively in the tokenless consumer job; isolated persistence preserves historical JSON export behavior.

This is the focused current-source replacement for the **release portion of #9608**; its unrelated registry/readiness stack remains unchanged. Depends on #10765.

## Validation

- 14 focused package/release regressions: skipped pack hooks, renamed archives, missing migration/lazy UI assets, publisher identity/version/config rejection, and preserved release gates
- Root TypeScript, Knip, changed-file lint/format, and Actionlint passed
- Default and optional-omitted installed consumers exercised the same retained archive with source `dist` unavailable; SHA-512 unchanged. Root ESM/CJS pass/fail/provider-error outputs and local HTTP CLI JSON were inspected
- Published `0.121.10` archive: missing native binding reproduced, selective SQLite rebuild restored CLI, isolated echo export inspected (`success=true`, `score=1`, no errors). Scratch SDK resolution used a policy-allowed version within its declared range; this was archive acceptance, not a historical source rebuild
- Independent release review completed; no live publication or OIDC exchange performed

CI pins npm 11 for the full test/build job, including cache hits. The lifecycle-hook sentinel reproduces npm 10.9.4's ignored `--ignore-scripts` behavior and passes with the exact CI npm 11.11.0 pin.
