### PR TITLE
test(package): exercise installed runtime assets across platforms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -298,7 +298,7 @@ jobs:
       - name: Install isolated artifact tooling
         working-directory: ${{ steps.prepare.outputs.tooling }}
         # TypeScript's native compiler needs its optional platform package.
-        run: npm install --ignore-scripts --include=optional --no-audit --no-fund --registry=https://registry.npmjs.org/
+        run: npm ci --ignore-scripts --include=optional --no-audit --no-fund --registry=https://registry.npmjs.org/
       - name: Test the downloaded package
         working-directory: ${{ steps.prepare.outputs.tooling }}
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,6 +205,12 @@ jobs:
         with:
           ruby-version: '4.0.1'
 
+      - name: Use Go for installed wrapper acceptance
+        if: matrix.node == '24.x'
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: src/golang/go.mod
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,6 +193,18 @@ jobs:
             npm ci --registry=https://registry.npmjs.org/
           fi
 
+      - name: Use Python for installed wrapper acceptance
+        if: matrix.node == '24.x'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Use Ruby for installed wrapper acceptance
+        if: matrix.node == '24.x'
+        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1
+        with:
+          ruby-version: '4.0.1'
+
       - name: Build
         run: npm run build
 
@@ -229,15 +241,70 @@ jobs:
         env:
           PACKAGE_TARBALL: ${{ steps.package-artifact.outputs.tarball }}
           PROMPTFOO_DISABLE_TELEMETRY: 1
+          RUNTIME_ASSETS: ${{ matrix.node == '24.x' && 'all' || 'none' }}
           npm_config_install_strategy: ${{ matrix.node == '22.22' && 'shallow' || 'hoisted' }}
-        run: npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL"
+        run: npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL" --runtime-assets "$RUNTIME_ASSETS"
 
       - name: Test Package Artifact Without Optional Dependencies
         if: matrix.node == '24.x'
         env:
           PACKAGE_TARBALL: ${{ steps.package-artifact.outputs.tarball }}
           PROMPTFOO_DISABLE_TELEMETRY: 1
-        run: npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL" --profile omit-optional
+        run: npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL" --profile omit-optional --runtime-assets all
+
+      - name: Upload package for platform acceptance
+        if: matrix.node == '24.x'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: promptfoo-platform-package
+          path: ${{ steps.package-artifact.outputs.tarball }}
+          if-no-files-found: error
+          retention-days: 7
+
+  artifact-consumer:
+    name: Installed package on ${{ matrix.os }}
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, windows-2025-vs2026]
+    defaults:
+      run:
+        shell: bash
+    env:
+      npm_config_cache: ${{ github.workspace }}/.artifact-npm-cache
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.22.0'
+      - name: Use npm 11
+        run: npm install -g npm@11.11.0 --registry=https://registry.npmjs.org/
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: promptfoo-platform-package
+          path: ${{ runner.temp }}/package-artifact
+      - name: Prepare isolated artifact tooling
+        id: prepare
+        env:
+          ARTIFACT_DIRECTORY: ${{ runner.temp }}/package-artifact
+        run: node scripts/preparePackageArtifactTest.mjs --artifact-directory "$ARTIFACT_DIRECTORY"
+      - name: Install isolated artifact tooling
+        working-directory: ${{ steps.prepare.outputs.tooling }}
+        # TypeScript's native compiler needs its optional platform package.
+        run: npm install --ignore-scripts --include=optional --no-audit --no-fund --registry=https://registry.npmjs.org/
+      - name: Test the downloaded package
+        working-directory: ${{ steps.prepare.outputs.tooling }}
+        env:
+          PACKAGE_TARBALL: ${{ steps.prepare.outputs.tarball }}
+          PROMPTFOO_DISABLE_TELEMETRY: 1
+        run: npm run test:artifact -- --tarball "$PACKAGE_TARBALL"
 
   style-check:
     name: Style Check

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "dist",
     "!dist/test",
     "!dist/src/__mocks__",
-    "!dist/**/*.map"
+    "!dist/**/*.map",
+    "!dist/**/*.tsbuildinfo"
   ],
   "engines": {
     "node": ">=22.22.0"

--- a/scripts/preparePackageArtifactTest.mjs
+++ b/scripts/preparePackageArtifactTest.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+// Bootstrap artifact acceptance with Node alone, before installing repository dependencies.
+const { values } = parseArgs({
+  options: {
+    'artifact-directory': { type: 'string' },
+    'temp-root': { type: 'string' },
+  },
+});
+assert(values['artifact-directory'], '--artifact-directory is required');
+const artifactDirectory = path.resolve(values['artifact-directory']);
+const archives = fs.readdirSync(artifactDirectory).filter((file) => file.endsWith('.tgz'));
+assert.equal(archives.length, 1, 'Expected exactly one downloaded package archive');
+const tarball = path.join(artifactDirectory, archives[0]);
+assert(fs.statSync(tarball).isFile(), 'Expected a package archive file');
+
+const repository = path.resolve(import.meta.dirname, '..');
+const lock = JSON.parse(fs.readFileSync(path.join(repository, 'package-lock.json'), 'utf8'));
+const dependencies = Object.fromEntries(
+  ['tsx', 'typescript', 'semver'].map((name) => {
+    const version = lock.packages[`node_modules/${name}`]?.version;
+    assert(
+      typeof version === 'string' && /^\d+\.\d+\.\d+(?:-[\w.-]+)?(?:\+[\w.-]+)?$/.test(version),
+      `Expected an exact locked tool version: ${name}`,
+    );
+    return [name, version];
+  }),
+);
+const tempRoot = path.resolve(values['temp-root'] ?? process.env.RUNNER_TEMP ?? os.tmpdir());
+const tooling = fs.mkdtempSync(path.join(tempRoot, 'promptfoo-artifact-tools-'));
+fs.mkdirSync(path.join(tooling, 'scripts'));
+fs.mkdirSync(path.join(tooling, 'test', 'fixtures'), { recursive: true });
+for (const filename of ['testPackageArtifact.ts', 'packPackageArtifact.ts', 'postbuild.ts']) {
+  fs.copyFileSync(
+    path.join(repository, 'scripts', filename),
+    path.join(tooling, 'scripts', filename),
+  );
+}
+fs.cpSync(
+  path.join(repository, 'test', 'fixtures', 'package-artifact'),
+  path.join(tooling, 'test', 'fixtures', 'package-artifact'),
+  { recursive: true },
+);
+fs.writeFileSync(
+  path.join(tooling, 'package.json'),
+  `${JSON.stringify(
+    {
+      name: 'promptfoo-artifact-tooling',
+      private: true,
+      type: 'module',
+      scripts: { 'test:artifact': 'tsx scripts/testPackageArtifact.ts' },
+      dependencies,
+    },
+    null,
+    2,
+  )}\n`,
+);
+if (process.env.GITHUB_OUTPUT) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `tooling=${tooling}\ntarball=${tarball}\n`);
+}
+console.log(JSON.stringify({ tooling, tarball }));

--- a/scripts/preparePackageArtifactTest.mjs
+++ b/scripts/preparePackageArtifactTest.mjs
@@ -30,6 +30,51 @@ const dependencies = Object.fromEntries(
     return [name, version];
   }),
 );
+// Retain the repository's exact transitive graph, including every native platform
+// package. Keep nested lock keys so npm resolves dependencies exactly as reviewed.
+const packages = {};
+function includeDependency(name, from = '') {
+  let parent = from;
+  let key;
+  while (true) {
+    const candidate = path.posix.join(parent, 'node_modules', name);
+    if (lock.packages[candidate]) {
+      key = candidate;
+      break;
+    }
+    assert(parent, `Missing locked artifact tool dependency: ${name} from ${from || 'root'}`);
+    parent = path.posix.dirname(parent);
+    if (parent === '.') {
+      parent = '';
+    }
+  }
+  if (packages[key]) {
+    return;
+  }
+  const entry = lock.packages[key];
+  assert(!entry.link && entry.resolved && entry.integrity, `Expected a registry tool: ${key}`);
+  // These tools are production dependencies of this private package, even when
+  // the repository classifies them as development-only dependencies.
+  const { dev, devOptional, ...installedEntry } = entry;
+  packages[key] = installedEntry;
+  for (const dependency of Object.keys({ ...entry.dependencies, ...entry.optionalDependencies })) {
+    includeDependency(dependency, key);
+  }
+  assert(
+    Object.keys(entry.peerDependencies ?? {}).length === 0,
+    `Artifact tooling peer dependencies require explicit lock support: ${key}`,
+  );
+}
+for (const name of Object.keys(dependencies)) {
+  includeDependency(name);
+}
+const manifest = {
+  name: 'promptfoo-artifact-tooling',
+  private: true,
+  type: 'module',
+  scripts: { 'test:artifact': 'tsx scripts/testPackageArtifact.ts' },
+  dependencies,
+};
 const tempRoot = path.resolve(values['temp-root'] ?? process.env.RUNNER_TEMP ?? os.tmpdir());
 const tooling = fs.mkdtempSync(path.join(tempRoot, 'promptfoo-artifact-tools-'));
 fs.mkdirSync(path.join(tooling, 'scripts'));
@@ -45,15 +90,15 @@ fs.cpSync(
   path.join(tooling, 'test', 'fixtures', 'package-artifact'),
   { recursive: true },
 );
+fs.writeFileSync(path.join(tooling, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
 fs.writeFileSync(
-  path.join(tooling, 'package.json'),
+  path.join(tooling, 'package-lock.json'),
   `${JSON.stringify(
     {
-      name: 'promptfoo-artifact-tooling',
-      private: true,
-      type: 'module',
-      scripts: { 'test:artifact': 'tsx scripts/testPackageArtifact.ts' },
-      dependencies,
+      name: manifest.name,
+      lockfileVersion: 3,
+      requires: true,
+      packages: { '': { name: manifest.name, dependencies }, ...packages },
     },
     null,
     2,

--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -78,6 +78,7 @@ function run(
   args: string[],
   cwd: string,
   envOverrides: NodeJS.ProcessEnv = {},
+  options: { shell?: string } = {},
 ): string {
   try {
     return execFileSync(command, args, {
@@ -91,6 +92,7 @@ function run(
       },
       maxBuffer: 128 * 1024 * 1024,
       stdio: ['ignore', 'pipe', 'pipe'],
+      shell: options.shell,
     });
   } catch (error) {
     if (error instanceof Error) {
@@ -165,6 +167,10 @@ function assertPackagedFiles(packResult: PackResult, compareSource: boolean): vo
   if (compareSource) {
     assertBuiltAssetsPackaged(ROOT, packResult.files);
   }
+  assert(
+    packResult.files.every((file) => !file.path.endsWith('.tsbuildinfo')),
+    'TypeScript incremental build state should be excluded from the package',
+  );
   assert(
     packResult.files.every((file) => !file.path.endsWith('.map')),
     'Source maps should be excluded from the package',
@@ -302,12 +308,11 @@ function runInstalledBinVersion(consumerDir: string, configDir: string, binName:
   };
 
   if (process.platform === 'win32') {
-    return run(
-      process.env.ComSpec || 'cmd.exe',
-      ['/d', '/s', '/c', `"${binPath}" --version`],
-      consumerDir,
-      envOverrides,
-    );
+    // Let Node construct cmd.exe's outer quotes and verbatim arguments. The
+    // executable path is quoted here because the owned temp directory may have spaces.
+    return run(`"${binPath}"`, ['--version'], consumerDir, envOverrides, {
+      shell: process.env.ComSpec || 'cmd.exe',
+    });
   }
 
   return run(binPath, ['--version'], consumerDir, envOverrides);
@@ -616,8 +621,13 @@ async function main(): Promise<void> {
       profile: { type: 'string', default: 'default' },
       registry: { type: 'string', default: 'https://registry.npmjs.org/' },
       tarball: { type: 'string' },
+      'runtime-assets': { type: 'string', default: 'none' },
     },
   });
+  assert(
+    ['none', 'python-go', 'all'].includes(values['runtime-assets']),
+    `Unknown runtime asset profile: ${values['runtime-assets']}`,
+  );
   const suppliedTarball = values.tarball === undefined ? undefined : path.resolve(values.tarball);
   if (suppliedTarball) {
     assert(suppliedTarball.endsWith('.tgz'), '--tarball must be a local .tgz file');
@@ -773,7 +783,19 @@ async function main(): Promise<void> {
       }
     }
     if (values.profile === 'default') {
+      console.log(await runAsync(process.execPath, ['migrations.mjs'], consumerDir, consumerEnv));
       await runInstalledCompressionEval(consumerDir, configDir);
+    }
+
+    if (values['runtime-assets'] !== 'none') {
+      console.log(
+        await runAsync(
+          process.execPath,
+          ['runtime-assets.mjs', ...(values['runtime-assets'] === 'all' ? ['--ruby'] : [])],
+          consumerDir,
+          consumerEnv,
+        ),
+      );
     }
 
     if (suppliedTarball) {

--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -640,7 +640,10 @@ async function main(): Promise<void> {
     ['default', 'omit-optional'].includes(values.profile),
     `Unknown install profile: ${values.profile}`,
   );
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-package-artifact-'));
+  // Module resolution canonicalizes paths (for example /var to /private/var on macOS).
+  const tempDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-package-artifact-')),
+  );
   const artifactsDir = path.join(tempDir, 'artifacts');
   const configDir = path.join(tempDir, 'config');
   const consumerDir = path.join(tempDir, 'consumer');
@@ -718,7 +721,7 @@ async function main(): Promise<void> {
       if (values.profile === 'omit-optional') {
         assert.throws(() => packageRequire.resolve(optionalPackage), { code: 'MODULE_NOT_FOUND' });
       } else {
-        assert(packageRequire.resolve(optionalPackage).startsWith(consumerDir));
+        assert(packageRequire.resolve(optionalPackage).startsWith(`${consumerDir}${path.sep}`));
       }
     }
 

--- a/test/fixtures/package-artifact/README.md
+++ b/test/fixtures/package-artifact/README.md
@@ -50,3 +50,37 @@ to an isolated publisher. Publication cannot invoke another build.
 Historical backfills keep their tagged build. Tags with an exact-artifact harness
 use it; older tags receive an explicitly limited installed CLI/JSON echo check.
 They still publish the same archive that passed that compatibility check.
+
+## Runtime assets and platforms
+
+Default consumers migrate an isolated database from the first packaged migration,
+retain a nonempty legacy result/table/config byte-for-byte, export it through the
+installed CLI, and persist a new passing and failing evaluation. A second process
+reopens the database and verifies migration idempotency and stored results.
+
+Select interpreter checks explicitly; missing interpreters fail the selected gate:
+
+```sh
+npm run test:package-artifact -- --runtime-assets python-go
+npm run test:package-artifact -- --profile omit-optional --runtime-assets all
+```
+
+`python-go` tests Python and Go; `all` additionally requires Ruby. Each provider
+runs success, deliberate error, and recovery cases with scores 1/0/1. The Python
+fixture uses both the prompt wrapper and a persistent provider worker. The same
+gate roundtrips a nonempty trace using the installed protobuf definitions and
+rejects malformed bytes; it does not start an OTLP receiver.
+
+| CI consumer                  | Install layout                        | Additional checks                                            |
+| ---------------------------- | ------------------------------------- | ------------------------------------------------------------ |
+| Linux Node 22.22             | Shallow                               | Historical database upgrade                                  |
+| Linux Node 24                | Hoisted, default and optional-omitted | Python, Go, Ruby, protobuf; upgrade in default profile       |
+| Linux Node 26                | Hoisted                               | Historical database upgrade                                  |
+| macOS and Windows Node 22.22 | Hoisted                               | Linux-produced archive, native SQLite and historical upgrade |
+
+The macOS/Windows jobs use `scripts/preparePackageArtifactTest.mjs` to copy only
+the acceptance scripts/fixtures into a temporary tool package. Its three tools
+use exact versions from the repository lockfile; the installed Promptfoo consumer
+resolves dependencies independently. No repository dependency install or build is
+required on those platforms. Incremental TypeScript compiler state is excluded
+from the published archive.

--- a/test/fixtures/package-artifact/README.md
+++ b/test/fixtures/package-artifact/README.md
@@ -80,7 +80,9 @@ rejects malformed bytes; it does not start an OTLP receiver.
 
 The macOS/Windows jobs use `scripts/preparePackageArtifactTest.mjs` to copy only
 the acceptance scripts/fixtures into a temporary tool package. Its three tools
-use exact versions from the repository lockfile; the installed Promptfoo consumer
+and their complete dependency graph are copied from the repository lockfile,
+including integrity hashes and optional native packages, then installed with `npm ci`.
+The installed Promptfoo consumer
 resolves dependencies independently. No repository dependency install or build is
 required on those platforms. Incremental TypeScript compiler state is excluded
 from the published archive.

--- a/test/fixtures/package-artifact/migrations.mjs
+++ b/test/fixtures/package-artifact/migrations.mjs
@@ -52,8 +52,7 @@ async function runPersistedEvaluation() {
   );
 }
 
-async function checkMigrations() {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-artifact-migrations-'));
+async function checkMigrations(tempDir) {
   const configDir = path.join(tempDir, 'config');
   const oldMigrationsDir = path.join(tempDir, 'old-migrations');
   const outputPath = path.join(tempDir, 'evaluation.json');
@@ -163,8 +162,8 @@ async function checkMigrations() {
     client.close();
     client = undefined;
 
-    // The child exercises public migration selection and persistence, then releases all
-    // native handles before this process inspects and removes its own temporary database.
+    // Each evaluation process releases its native handles before the checking process
+    // inspects the database. The outer supervisor owns cleanup after all of them exit.
     const runNode = (args) =>
       execFileSync(process.execPath, args, {
         cwd: path.dirname(fileURLToPath(import.meta.url)),
@@ -283,13 +282,27 @@ async function checkMigrations() {
     );
   } finally {
     client?.close();
-    fs.rmSync(tempDir, { recursive: true, force: true });
   }
 }
 
 if (process.argv[2] === '--evaluate') {
   await runPersistedEvaluation();
+} else if (process.argv[2] === '--check') {
+  assert.equal(process.argv.length, 4, 'Expected the owned migration directory');
+  await checkMigrations(process.argv[3]);
 } else {
   assert.equal(process.argv.length, 2, 'Unexpected migration fixture arguments');
-  await checkMigrations();
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-artifact-migrations-'));
+  try {
+    // libSQL transactions can retain native connections after client.close(). Keep every
+    // database handle in a child so Windows permits deletion when that process exits.
+    execFileSync(process.execPath, [fileURLToPath(import.meta.url), '--check', tempDir], {
+      cwd: path.dirname(fileURLToPath(import.meta.url)),
+      env: { ...platformEnv, NODE_PATH: '' },
+      stdio: 'inherit',
+      timeout: 60_000,
+    });
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  }
 }

--- a/test/fixtures/package-artifact/migrations.mjs
+++ b/test/fixtures/package-artifact/migrations.mjs
@@ -83,6 +83,13 @@ async function runNativeCheck(tempDir, timeoutMs) {
           } catch (secondError) {
             // If the OS refuses both attempts, do not unlink a database that may still
             // be open. Report the PID and retain state for diagnosis instead of hiding it.
+            // Settle first: the best-effort kill can synchronously emit an error event.
+            reject(
+              new NativeCheckTerminationError(
+                child.pid,
+                new AggregateError([firstError, secondError], 'Migration tree termination failed'),
+              ),
+            );
             try {
               child.kill('SIGKILL');
             } catch {
@@ -91,12 +98,6 @@ async function runNativeCheck(tempDir, timeoutMs) {
             child.stdout.destroy();
             child.stderr.destroy();
             child.unref();
-            reject(
-              new NativeCheckTerminationError(
-                child.pid,
-                new AggregateError([firstError, secondError], 'Migration tree termination failed'),
-              ),
-            );
           }
         }
       }, timeoutMs);

--- a/test/fixtures/package-artifact/migrations.mjs
+++ b/test/fixtures/package-artifact/migrations.mjs
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
 
 // Copy this fixture into an isolated installed consumer before running it. Every runtime
 // dependency and migration must resolve from that consumer's promptfoo installation.
@@ -18,6 +19,92 @@ const platformEnv = Object.fromEntries(
     .filter((key) => process.env[key] !== undefined)
     .map((key) => [key, process.env[key]]),
 );
+
+class NativeCheckTerminationError extends Error {
+  constructor(pid, cause) {
+    super(`Could not confirm termination of migration process tree ${pid}`, { cause });
+  }
+}
+
+function killNativeTree(pid, fallback = false) {
+  const options = { stdio: 'pipe', timeout: 5_000, env: platformEnv };
+  if (process.platform === 'win32') {
+    execFileSync(
+      path.join(process.env.SystemRoot || process.env.WINDIR, 'System32', 'taskkill.exe'),
+      ['/pid', String(pid), '/t', '/f'],
+      options,
+    );
+  } else if (fallback) {
+    // Retry from a separate process if the first signal attempt failed.
+    execFileSync(
+      process.execPath,
+      ['-e', 'process.kill(-Number(process.argv[1]), "SIGKILL")', String(pid)],
+      options,
+    );
+  } else {
+    process.kill(-pid, 'SIGKILL');
+  }
+}
+
+async function runNativeCheck(tempDir, timeoutMs) {
+  const child = spawn(process.execPath, [fileURLToPath(import.meta.url), '--check', tempDir], {
+    cwd: path.dirname(fileURLToPath(import.meta.url)),
+    env: { ...platformEnv, NODE_PATH: '' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: process.platform !== 'win32',
+  });
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+  let timedOut = false;
+  let timer;
+  try {
+    await new Promise((resolve, reject) => {
+      child.once('error', reject);
+      child.once('close', (code, signal) => {
+        if (timedOut) {
+          reject(new Error(`Installed migration check timed out after ${timeoutMs}ms`));
+        } else if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`Installed migration check failed (${signal ?? code})`));
+        }
+      });
+      timer = setTimeout(() => {
+        timedOut = true;
+        try {
+          // Terminate the complete owned tree, including any stalled evaluation process.
+          killNativeTree(child.pid);
+        } catch (firstError) {
+          if (firstError.code === 'ESRCH') {
+            return;
+          }
+          try {
+            killNativeTree(child.pid, true);
+          } catch (secondError) {
+            // If the OS refuses both attempts, do not unlink a database that may still
+            // be open. Report the PID and retain state for diagnosis instead of hiding it.
+            try {
+              child.kill('SIGKILL');
+            } catch {
+              /* Best effort direct-child fallback. */
+            }
+            child.stdout.destroy();
+            child.stderr.destroy();
+            child.unref();
+            reject(
+              new NativeCheckTerminationError(
+                child.pid,
+                new AggregateError([firstError, secondError], 'Migration tree termination failed'),
+              ),
+            );
+          }
+        }
+      }, timeoutMs);
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 async function runPersistedEvaluation() {
   const { evaluate } = await import('promptfoo');
@@ -291,18 +378,35 @@ if (process.argv[2] === '--evaluate') {
   assert.equal(process.argv.length, 4, 'Expected the owned migration directory');
   await checkMigrations(process.argv[3]);
 } else {
-  assert.equal(process.argv.length, 2, 'Unexpected migration fixture arguments');
+  const { values } = parseArgs({
+    options: { 'timeout-ms': { type: 'string', default: '45000' } },
+  });
+  const timeoutMs = Number(values['timeout-ms']);
+  assert(
+    Number.isInteger(timeoutMs) && timeoutMs > 0 && timeoutMs <= 45_000,
+    'Migration timeout must be an integer from 1 to 45000ms',
+  );
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-artifact-migrations-'));
+  const startedAt = performance.now();
+  let safeToRemove = true;
   try {
     // libSQL transactions can retain native connections after client.close(). Keep every
     // database handle in a child so Windows permits deletion when that process exits.
-    execFileSync(process.execPath, [fileURLToPath(import.meta.url), '--check', tempDir], {
-      cwd: path.dirname(fileURLToPath(import.meta.url)),
-      env: { ...platformEnv, NODE_PATH: '' },
-      stdio: 'inherit',
-      timeout: 60_000,
-    });
+    // Leave time to terminate descendants, wait for exit, and remove state before the
+    // harness's 60 second deadline. Tests may select a smaller deadline with --timeout-ms.
+    await runNativeCheck(tempDir, timeoutMs);
+  } catch (error) {
+    if (error instanceof NativeCheckTerminationError) {
+      safeToRemove = false;
+      console.error(`Retained migration state after termination failure: ${tempDir}`);
+    }
+    throw error;
   } finally {
-    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    if (safeToRemove) {
+      fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
   }
+  console.log(
+    `Verified installed migration cleanup after child exit (${Math.round(performance.now() - startedAt)}ms)`,
+  );
 }

--- a/test/fixtures/package-artifact/migrations.mjs
+++ b/test/fixtures/package-artifact/migrations.mjs
@@ -1,0 +1,295 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// Copy this fixture into an isolated installed consumer before running it. Every runtime
+// dependency and migration must resolve from that consumer's promptfoo installation.
+const consumerRequire = createRequire(import.meta.url);
+const packageEntry = consumerRequire.resolve('promptfoo');
+const packageRequire = createRequire(packageEntry);
+const installedPackageDir = path.resolve(path.dirname(packageEntry), '..', '..');
+const platformEnv = Object.fromEntries(
+  ['PATH', 'Path', 'SystemRoot', 'WINDIR', 'COMSPEC', 'PATHEXT', 'LANG', 'LC_ALL']
+    .filter((key) => process.env[key] !== undefined)
+    .map((key) => [key, process.env[key]]),
+);
+
+async function runPersistedEvaluation() {
+  const { evaluate } = await import('promptfoo');
+  const outputPath = process.argv[3];
+  const summaryPath = process.argv[4];
+  assert(outputPath && summaryPath, 'Expected evaluation output and summary paths');
+  const record = await evaluate(
+    {
+      description: 'Installed artifact migration acceptance',
+      author: 'package-artifact-fixture',
+      prompts: ['Hello {{name}}'],
+      providers: ['echo'],
+      tests: [
+        {
+          vars: { name: 'migrated artifact' },
+          assert: [{ type: 'equals', value: 'Hello migrated artifact' }],
+        },
+        {
+          vars: { name: 'deliberate failure' },
+          assert: [{ type: 'equals', value: 'different output' }],
+        },
+      ],
+      writeLatestResults: true,
+      sharing: false,
+      outputPath,
+    },
+    { cache: false, maxConcurrency: 1 },
+  );
+  fs.writeFileSync(
+    summaryPath,
+    JSON.stringify({ id: record.id, summary: await record.toEvaluateSummary() }),
+  );
+}
+
+async function checkMigrations() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-artifact-migrations-'));
+  const configDir = path.join(tempDir, 'config');
+  const oldMigrationsDir = path.join(tempDir, 'old-migrations');
+  const outputPath = path.join(tempDir, 'evaluation.json');
+  const summaryPath = path.join(tempDir, 'summary.json');
+  let client;
+
+  try {
+    fs.mkdirSync(configDir);
+    fs.mkdirSync(path.join(oldMigrationsDir, 'meta'), { recursive: true });
+    const migrationsDir = path.join(installedPackageDir, 'dist', 'drizzle');
+    const journal = JSON.parse(
+      fs.readFileSync(path.join(migrationsDir, 'meta', '_journal.json'), 'utf8'),
+    );
+    assert(journal.entries.length > 1, 'Expected an initial schema and later migrations');
+    const firstMigration = journal.entries[0];
+    assert.equal(firstMigration.tag, '0000_lush_hellion');
+    fs.copyFileSync(
+      path.join(migrationsDir, `${firstMigration.tag}.sql`),
+      path.join(oldMigrationsDir, `${firstMigration.tag}.sql`),
+    );
+    fs.writeFileSync(
+      path.join(oldMigrationsDir, 'meta', '_journal.json'),
+      JSON.stringify({ ...journal, entries: [firstMigration] }),
+    );
+
+    const { createClient } = packageRequire('@libsql/client');
+    const { drizzle } = packageRequire('drizzle-orm/libsql');
+    const { migrate } = packageRequire('drizzle-orm/libsql/migrator');
+    const dbUrl = pathToFileURL(path.join(configDir, 'promptfoo.db')).href;
+    client = createClient({ url: dbUrl });
+    await migrate(drizzle(client), { migrationsFolder: oldMigrationsDir });
+    const historicalValue = 'café / 日本語 / 🚀\n"quoted" \\ unchanged';
+    const historicalOutput = `Legacy ${historicalValue}`;
+    const historicalPrompt = {
+      id: 'prompt-package-artifact-historical',
+      raw: 'Legacy {{value}}',
+      label: 'Historical echo',
+      provider: 'echo',
+    };
+    const historicalTest = {
+      vars: { value: historicalValue },
+      assert: [{ type: 'equals', value: historicalOutput }],
+    };
+    const historicalTokens = { total: 7, prompt: 3, completion: 4, cached: 0, numRequests: 1 };
+    const historicalResult = {
+      id: 'result-package-artifact-historical',
+      promptIdx: 0,
+      testIdx: 0,
+      promptId: historicalPrompt.id,
+      prompt: { raw: historicalOutput, label: historicalPrompt.label },
+      provider: { id: 'echo' },
+      testCase: historicalTest,
+      vars: historicalTest.vars,
+      response: { output: historicalOutput, tokenUsage: historicalTokens },
+      success: true,
+      score: 1,
+      failureReason: 0,
+      latencyMs: 17,
+      cost: 0.125,
+      namedScores: { historical: 1 },
+      gradingResult: { pass: true, score: 1, reason: 'Historical exact match' },
+    };
+    const historicalSummary = {
+      version: 2,
+      timestamp: new Date(1710348564000).toISOString(),
+      results: [historicalResult],
+      table: {
+        head: { prompts: [historicalPrompt], vars: ['value'] },
+        body: [
+          {
+            test: historicalTest,
+            testIdx: 0,
+            vars: [historicalValue],
+            outputs: [
+              {
+                ...historicalResult,
+                pass: historicalResult.success,
+                text: historicalOutput,
+                prompt: historicalOutput,
+                provider: 'echo',
+                tokenUsage: historicalTokens,
+              },
+            ],
+          },
+        ],
+      },
+      stats: { successes: 1, failures: 0, errors: 0, tokenUsage: historicalTokens },
+    };
+    const historical = {
+      id: 'eval-package-artifact-historical',
+      created_at: 1710348564000,
+      description: 'Preserve café / 日本語 / 🚀',
+      results: JSON.stringify(historicalSummary),
+      config: JSON.stringify({
+        description: 'Historical configuration',
+        prompts: ['Legacy {{value}}'],
+        providers: ['echo'],
+        tests: [historicalTest],
+      }),
+    };
+    await client.execute({
+      sql: 'INSERT INTO evals (id, created_at, description, results, config) VALUES (?, ?, ?, ?, ?)',
+      args: Object.values(historical),
+    });
+    const before = await client.execute('SELECT count(*) AS count FROM __drizzle_migrations');
+    assert.equal(Number(before.rows[0].count), 1, 'Fixture must start on the original schema');
+    client.close();
+    client = undefined;
+
+    // The child exercises public migration selection and persistence, then releases all
+    // native handles before this process inspects and removes its own temporary database.
+    const runNode = (args) =>
+      execFileSync(process.execPath, args, {
+        cwd: path.dirname(fileURLToPath(import.meta.url)),
+        env: {
+          ...platformEnv,
+          NODE_PATH: '',
+          IS_TESTING: 'false',
+          PROMPTFOO_CONFIG_DIR: configDir,
+          PROMPTFOO_CACHE_PATH: path.join(tempDir, 'cache'),
+          PROMPTFOO_DISABLE_REMOTE_GENERATION: 'true',
+          PROMPTFOO_DISABLE_TELEMETRY: '1',
+          PROMPTFOO_DISABLE_UPDATE: 'true',
+          PROMPTFOO_TRACING_ENABLED: 'false',
+          PROMPTFOO_ENABLE_OTEL: 'false',
+        },
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 60_000,
+      });
+    const runEvaluation = () =>
+      runNode([fileURLToPath(import.meta.url), '--evaluate', outputPath, summaryPath]);
+    runEvaluation();
+    const firstId = JSON.parse(fs.readFileSync(summaryPath, 'utf8')).id;
+    // A fresh process reopening the upgraded database must not rerun migrations.
+    runEvaluation();
+    const { id, summary } = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+    assert.notEqual(id, firstId, 'The second evaluation must create its own persisted row');
+    const exported = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    for (const results of [summary.results, exported.results.results]) {
+      assert.equal(results.length, 2);
+      assert.equal(results[0].success, true);
+      assert.equal(results[0].score, 1);
+      assert.equal(results[0].error, undefined);
+      assert.equal(results[0].response.error, undefined);
+      assert.equal(results[0].response.output, 'Hello migrated artifact');
+      assert.equal(results[0].provider.id, 'echo');
+      assert.equal(results[1].success, false);
+      assert.equal(results[1].score, 0);
+      assert.match(results[1].error, /different output/);
+      assert.equal(results[1].response.error, undefined);
+      assert.equal(results[1].response.output, 'Hello deliberate failure');
+      assert.equal(results[1].provider.id, 'echo');
+    }
+    assert.equal(summary.stats.successes, 1);
+    assert.equal(summary.stats.failures, 1);
+    assert.equal(summary.stats.errors, 0);
+
+    // The package root does not export a persisted-eval lookup API. Exercise the
+    // supported CLI reader instead of reaching into a private bundled module.
+    const manifest = JSON.parse(fs.readFileSync(path.join(installedPackageDir, 'package.json')));
+    const historicalExportPath = path.join(tempDir, 'historical-export.json');
+    runNode([
+      path.join(installedPackageDir, manifest.bin.promptfoo),
+      'export',
+      'eval',
+      historical.id,
+      '--output',
+      historicalExportPath,
+    ]);
+    const historicalExport = JSON.parse(fs.readFileSync(historicalExportPath, 'utf8'));
+    assert.equal(historicalExport.evalId, historical.id);
+    assert.deepEqual(
+      historicalExport.results,
+      historicalSummary,
+      'The public CLI must read the complete historical result and table after migration',
+    );
+    assert.deepEqual(historicalExport.config, JSON.parse(historical.config));
+
+    client = createClient({ url: dbUrl });
+    const preserved = await client.execute({
+      sql: 'SELECT id, created_at, description, results, config FROM evals WHERE id = ?',
+      args: [historical.id],
+    });
+    assert.equal(preserved.rows.length, 1, 'Historical eval must survive the upgrade');
+    for (const [key, value] of Object.entries(historical)) {
+      assert.equal(preserved.rows[0][key], value, `Migration changed historical ${key}`);
+    }
+    const saved = await client.execute({
+      sql: 'SELECT success, score, error, response FROM eval_results WHERE eval_id = ? ORDER BY test_idx',
+      args: [id],
+    });
+    assert.equal(saved.rows.length, 2, 'The installed API must persist both new results');
+    assert.equal(saved.rows[0].success, 1);
+    assert.equal(saved.rows[0].score, 1);
+    assert.equal(saved.rows[0].error, null);
+    assert.equal(JSON.parse(saved.rows[0].response).output, 'Hello migrated artifact');
+    assert.equal(saved.rows[1].success, 0);
+    assert.equal(saved.rows[1].score, 0);
+    assert.match(saved.rows[1].error, /different output/);
+    assert.equal(JSON.parse(saved.rows[1].response).output, 'Hello deliberate failure');
+    const previousResults = await client.execute({
+      sql: 'SELECT count(*) AS count FROM eval_results WHERE eval_id = ?',
+      args: [firstId],
+    });
+    assert.equal(
+      Number(previousResults.rows[0].count),
+      2,
+      'Reopening must preserve previous results',
+    );
+
+    const applied = await client.execute(
+      'SELECT hash, created_at FROM __drizzle_migrations ORDER BY created_at',
+    );
+    assert.deepEqual(
+      applied.rows.map((row) => ({ hash: row.hash, when: Number(row.created_at) })),
+      journal.entries.map((entry) => ({
+        hash: createHash('sha256')
+          .update(fs.readFileSync(path.join(migrationsDir, `${entry.tag}.sql`)))
+          .digest('hex'),
+        when: entry.when,
+      })),
+      'The installed API must apply each packaged migration exactly once',
+    );
+    console.log(
+      `Verified installed migrations: 1 -> ${applied.rows.length}, stable after reopening; nonempty historical result/table retained exactly and read by CLI; pass=1 failure=1 scores=1/0 errors=0`,
+    );
+  } finally {
+    client?.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[2] === '--evaluate') {
+  await runPersistedEvaluation();
+} else {
+  assert.equal(process.argv.length, 2, 'Unexpected migration fixture arguments');
+  await checkMigrations();
+}

--- a/test/fixtures/package-artifact/runtime-assets.mjs
+++ b/test/fixtures/package-artifact/runtime-assets.mjs
@@ -1,0 +1,255 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+// Copy beside an installed consumer's package.json. Python and Go are required;
+// --ruby additionally requires Ruby and never silently skips an unavailable interpreter.
+const fixturePath = fileURLToPath(import.meta.url);
+const consumerRequire = createRequire(import.meta.url);
+const packageEntry = consumerRequire.resolve('promptfoo');
+const packageRequire = createRequire(packageEntry);
+const installedPackageDir = path.resolve(path.dirname(packageEntry), '..', '..');
+const platformEnv = Object.fromEntries(
+  ['PATH', 'Path', 'SystemRoot', 'WINDIR', 'COMSPEC', 'PATHEXT', 'LANG', 'LC_ALL']
+    .filter((key) => process.env[key] !== undefined)
+    .map((key) => [key, process.env[key]]),
+);
+
+async function checkProtobuf() {
+  const protobuf = packageRequire('protobufjs');
+  const protoDir = path.join(installedPackageDir, 'dist', 'src', 'tracing', 'proto');
+  const root = new protobuf.Root();
+  root.resolvePath = (_origin, target) => path.join(protoDir, target);
+  await root.load('opentelemetry/proto/collector/trace/v1/trace_service.proto');
+  const requestType = root.lookupType(
+    'opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest',
+  );
+  const traceId = Buffer.from('0123456789abcdef0123456789abcdef', 'hex');
+  const spanId = Buffer.from('0123456789abcdef', 'hex');
+  const message = requestType.fromObject({
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [{ key: 'service.name', value: { stringValue: 'artifact-fixture' } }],
+        },
+        scopeSpans: [
+          {
+            scope: { name: 'artifact-assets' },
+            spans: [
+              {
+                traceId,
+                spanId,
+                name: 'Local protobuf café 🚀',
+                kind: 1,
+                startTimeUnixNano: '1700000000000000000',
+                endTimeUnixNano: '1700000000001000000',
+                attributes: [{ key: 'fixture.value', value: { intValue: 7 } }],
+                status: { code: 1 },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+  assert.equal(requestType.verify(message), null);
+  const encoded = requestType.encode(message).finish();
+  assert(encoded.length > 0);
+  const decoded = requestType.toObject(requestType.decode(encoded), { longs: String });
+  const resource = decoded.resourceSpans[0];
+  const span = resource.scopeSpans[0].spans[0];
+  assert.equal(resource.resource.attributes[0].value.stringValue, 'artifact-fixture');
+  assert.equal(resource.scopeSpans[0].scope.name, 'artifact-assets');
+  assert.deepEqual(Buffer.from(span.traceId), traceId);
+  assert.deepEqual(Buffer.from(span.spanId), spanId);
+  assert.equal(span.name, 'Local protobuf café 🚀');
+  assert.equal(span.startTimeUnixNano, '1700000000000000000');
+  assert.equal(span.endTimeUnixNano, '1700000000001000000');
+  assert.equal(span.attributes[0].value.intValue, '7');
+  assert.equal(span.status.code, 1);
+  assert.throws(() => requestType.decode(Uint8Array.of(0xff)), /range|buffer|varint/i);
+  console.log('Verified installed protobuf definitions: nonempty trace roundtrip and invalid data');
+}
+
+function writeProvider(stateDir, language) {
+  const providerDir = path.join(stateDir, 'local providers', language);
+  fs.mkdirSync(providerDir, { recursive: true });
+  let scriptPath;
+  if (language === 'python') {
+    scriptPath = path.join(providerDir, 'provider.py');
+    fs.writeFileSync(
+      scriptPath,
+      `calls = 0
+
+def make_prompt(context):
+    return "Asset " + context["vars"]["value"]
+
+def call_api(prompt, options, context):
+    global calls
+    calls += 1
+    if context["vars"]["fail"]:
+        raise ValueError("artifact-python-failure")
+    return {"output": "python:" + prompt, "metadata": {"calls": calls}}
+`,
+    );
+  } else if (language === 'go') {
+    // The Go provider copies its module tree. Keep go.mod below the consumer so
+    // that this operation never copies node_modules or the repository.
+    fs.writeFileSync(
+      path.join(providerDir, 'go.mod'),
+      'module artifact.local/fixture\n\ngo 1.22\n',
+    );
+    scriptPath = path.join(providerDir, 'provider.go');
+    fs.writeFileSync(
+      scriptPath,
+      `package main
+
+func CallApi(prompt string, options map[string]interface{}, context map[string]interface{}) (map[string]interface{}, error) {
+    if context["vars"].(map[string]interface{})["fail"] == true {
+        return map[string]interface{}{"error": "artifact-go-failure"}, nil
+    }
+    return map[string]interface{}{"output": "go:" + prompt}, nil
+}
+`,
+    );
+  } else {
+    scriptPath = path.join(providerDir, 'provider.rb');
+    fs.writeFileSync(
+      scriptPath,
+      `def call_api(prompt, options, context)
+  raise "artifact-ruby-failure" if context["vars"]["fail"]
+  { output: "ruby:" + prompt }
+end
+`,
+    );
+  }
+  return { providerDir, scriptPath };
+}
+
+async function checkProvider(stateDir, language) {
+  const { evaluate, loadApiProvider } = await import('promptfoo');
+  const { providerDir, scriptPath } = writeProvider(stateDir, language);
+  const providerId = `artifact-${language}`;
+  const provider = await loadApiProvider(`file://${scriptPath}`, {
+    basePath: providerDir,
+    options: {
+      id: providerId,
+      config: language === 'python' ? { workers: 1, timeout: 10_000 } : {},
+    },
+  });
+  assert.equal(provider.id(), providerId);
+  try {
+    const record = await evaluate(
+      {
+        // A named Python prompt exercises wrapper.py as well as the provider's
+        // persistent_wrapper.py; the other languages use an ordinary template.
+        prompts: [language === 'python' ? `file://${scriptPath}:make_prompt` : 'Asset {{value}}'],
+        providers: [provider],
+        tests: ['café 日本語 🚀', 'deliberate error', 'recovered'].map((value, index) => ({
+          vars: { value, fail: index === 1 },
+          assert: [{ type: 'equals', value: `${language}:Asset ${value}` }],
+        })),
+        writeLatestResults: false,
+        sharing: false,
+      },
+      { cache: false, maxConcurrency: 1 },
+    );
+    const summaryPath = path.join(stateDir, `${language}-results.json`);
+    fs.writeFileSync(summaryPath, JSON.stringify(await record.toEvaluateSummary()));
+    const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+    assert.equal(summary.results.length, 3);
+    for (const [index, result] of summary.results.entries()) {
+      assert.equal(result.provider.id, providerId);
+      assert.equal(result.success, index !== 1, `${language} test ${index}: ${result.error}`);
+      assert.equal(result.score, index === 1 ? 0 : 1);
+      if (index === 1) {
+        assert.match(result.error, new RegExp(`artifact-${language}-failure`));
+      } else {
+        assert.equal(result.error, undefined);
+        assert.equal(result.response.error, undefined);
+        assert.equal(
+          result.response.output,
+          `${language}:Asset ${index === 0 ? 'café 日本語 🚀' : 'recovered'}`,
+        );
+        if (language === 'python') {
+          assert.equal(
+            result.response.metadata.calls,
+            index + 1,
+            'Python worker must survive errors',
+          );
+        }
+      }
+    }
+    assert.equal(summary.stats.successes, 2);
+    assert.equal(summary.stats.errors, 1);
+    console.log(`Verified installed ${language} wrapper: pass=2 score=1 each, deliberate errors=1`);
+  } finally {
+    await provider.shutdown?.();
+  }
+}
+
+if (process.argv[2] === '--child') {
+  const stateDir = process.argv[3];
+  assert(stateDir, 'Expected an owned state directory');
+  await checkProtobuf();
+  for (const language of ['python', 'go', ...(process.argv[4] === '--ruby' ? ['ruby'] : [])]) {
+    await checkProvider(stateDir, language);
+  }
+} else {
+  const { values } = parseArgs({ options: { ruby: { type: 'boolean', default: false } } });
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-runtime-assets-'));
+  try {
+    for (const directory of ['config', 'cache', 'go-cache', 'go-mod-cache', 'tmp']) {
+      fs.mkdirSync(path.join(stateDir, directory));
+    }
+    execFileSync(
+      process.execPath,
+      [fixturePath, '--child', stateDir, ...(values.ruby ? ['--ruby'] : [])],
+      {
+        cwd: path.dirname(fixturePath),
+        env: {
+          ...platformEnv,
+          NODE_PATH: '',
+          IS_TESTING: 'false',
+          PROMPTFOO_CONFIG_DIR: path.join(stateDir, 'config'),
+          PROMPTFOO_CACHE_PATH: path.join(stateDir, 'cache'),
+          PROMPTFOO_DISABLE_REMOTE_GENERATION: 'true',
+          PROMPTFOO_DISABLE_TELEMETRY: '1',
+          PROMPTFOO_DISABLE_UPDATE: 'true',
+          PROMPTFOO_TRACING_ENABLED: 'false',
+          PROMPTFOO_ENABLE_OTEL: 'false',
+          PROMPTFOO_PYTHON: 'python3',
+          PYTHONDONTWRITEBYTECODE: '1',
+          PYTHONNOUSERSITE: '1',
+          PYTHONPATH: '',
+          PYTHONIOENCODING: 'utf-8',
+          PYTHONUTF8: '1',
+          GOCACHE: path.join(stateDir, 'go-cache'),
+          GOMODCACHE: path.join(stateDir, 'go-mod-cache'),
+          GOPATH: path.join(stateDir, 'go-path'),
+          GOPROXY: 'off',
+          GOSUMDB: 'off',
+          GOTOOLCHAIN: 'local',
+          GOTELEMETRY: 'off',
+          GOENV: 'off',
+          GOFLAGS: '-buildvcs=false',
+          GOWORK: 'off',
+          TMPDIR: path.join(stateDir, 'tmp'),
+          TEMP: path.join(stateDir, 'tmp'),
+          TMP: path.join(stateDir, 'tmp'),
+        },
+        encoding: 'utf8',
+        stdio: 'inherit',
+        timeout: 60_000,
+        maxBuffer: 8 * 1024 * 1024,
+      },
+    );
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+}

--- a/test/scripts/packageArtifact.test.ts
+++ b/test/scripts/packageArtifact.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -98,5 +98,49 @@ describe('package artifact packing', () => {
     const destination = path.join(root, 'output');
     expect(() => packPackageArtifact(root, destination)).toThrow('Expected the promptfoo package');
     expect(fs.existsSync(destination)).toBe(false);
+  });
+});
+
+describe('standalone artifact tooling', () => {
+  const script = path.resolve(__dirname, '../../scripts/preparePackageArtifactTest.mjs');
+
+  it.each([0, 2])('rejects %i archives before creating a tooling directory', (count) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-tool-prepare-'));
+    directories.push(root);
+    for (let index = 0; index < count; index++) {
+      fs.writeFileSync(path.join(root, `${index}.tgz`), 'fixture');
+    }
+    const result = spawnSync(
+      process.execPath,
+      [script, '--artifact-directory', root, '--temp-root', root],
+      { encoding: 'utf8' },
+    );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Expected exactly one downloaded package archive');
+    expect(fs.readdirSync(root)).toHaveLength(count);
+  });
+
+  it('prepares only the pinned test tools and preserves a selected archive with spaces', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact tools with spaces '));
+    directories.push(root);
+    const tarball = path.join(root, 'selected archive.tgz');
+    fs.writeFileSync(tarball, 'selected bytes');
+    const output = JSON.parse(
+      execFileSync(process.execPath, [script, '--artifact-directory', root, '--temp-root', root], {
+        encoding: 'utf8',
+        env: { ...process.env, GITHUB_OUTPUT: '' },
+      }),
+    );
+    expect(output.tarball).toBe(tarball);
+    expect(fs.readFileSync(tarball, 'utf8')).toBe('selected bytes');
+    const manifest = JSON.parse(fs.readFileSync(path.join(output.tooling, 'package.json'), 'utf8'));
+    expect(manifest.private).toBe(true);
+    expect(Object.keys(manifest.dependencies).sort()).toEqual(['semver', 'tsx', 'typescript']);
+    for (const version of Object.values(manifest.dependencies)) {
+      expect(version).toMatch(/^\d+\.\d+\.\d+/);
+    }
+    for (const excluded of ['src', 'dist', 'drizzle', 'node_modules', 'package-lock.json']) {
+      expect(fs.existsSync(path.join(output.tooling, excluded))).toBe(false);
+    }
   });
 });

--- a/test/scripts/packageArtifact.test.ts
+++ b/test/scripts/packageArtifact.test.ts
@@ -3,8 +3,9 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { packPackageArtifact } from '../../scripts/packPackageArtifact';
 
 const directories: string[] = [];
@@ -246,11 +247,10 @@ setInterval(() => {}, 1000);`;
         for (const pid of pids) {
           expect(Number.isInteger(pid) && pid > 0 && pid !== process.pid).toBe(true);
         }
-        const deadline = Date.now() + 1_000;
-        while (pids.some(processIsRunning) && Date.now() < deadline) {
-          await new Promise((resolve) => setTimeout(resolve, 20));
-        }
-        expect(pids.filter(processIsRunning)).toEqual([]);
+        await vi.waitFor(() => expect(pids.filter(processIsRunning)).toEqual([]), {
+          timeout: 1_000,
+          interval: 20,
+        });
         expect(fs.readdirSync(temporary)).toEqual([]);
       } finally {
         fs.closeSync(descriptor);
@@ -273,4 +273,80 @@ setInterval(() => {}, 1000);`;
       }
     },
   );
+
+  it('retains owned state when best-effort kill emits a synchronous error after tree termination fails', async () => {
+    const { root, temporary, nativeDir, fixture } = prepareConsumer(
+      'Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);',
+    );
+    const preload = path.join(root, 'kill-failure.mjs');
+    fs.writeFileSync(
+      preload,
+      `import childProcess from 'node:child_process';
+import { syncBuiltinESMExports } from 'node:module';
+const failure = () => Object.assign(new Error('injected-tree-kill-failure'), { code: 'EPERM' });
+const originalProcessKill = process.kill;
+process.kill = function (pid, signal) {
+  if (pid < 0) throw failure();
+  return originalProcessKill.call(process, pid, signal);
+};
+childProcess.execFileSync = () => { throw failure(); };
+syncBuiltinESMExports();
+const originalChildKill = childProcess.ChildProcess.prototype.kill;
+childProcess.ChildProcess.prototype.kill = function (signal) {
+  const result = originalChildKill.call(this, signal);
+  console.error('injected-synchronous-child-kill-error');
+  this.emit('error', Object.assign(new Error('injected-child-kill-EPERM'), { code: 'EPERM' }));
+  return result;
+};`,
+    );
+    const output = path.join(root, 'supervisor.log');
+    const descriptor = fs.openSync(output, 'w');
+    const pidFile = path.join(nativeDir, 'native-pid');
+    try {
+      // --import applies only to this supervisor; its child receives no preload arguments.
+      const result = spawnSync(
+        process.execPath,
+        ['--import', pathToFileURL(preload).href, fixture, '--timeout-ms', '1500'],
+        {
+          stdio: ['ignore', descriptor, descriptor],
+          timeout: 8_000,
+          killSignal: 'SIGKILL',
+          env: { ...process.env, TMPDIR: temporary, TMP: temporary, TEMP: temporary },
+        },
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.status).not.toBeNull();
+      expect(result.status).not.toBe(0);
+      const diagnostic = fs.readFileSync(output, 'utf8');
+      expect(diagnostic).toContain('injected-synchronous-child-kill-error');
+      expect(diagnostic).toContain('Could not confirm termination of migration process tree');
+      expect(diagnostic).toContain('Retained migration state after termination failure');
+      const pid = Number(fs.readFileSync(pidFile, 'utf8'));
+      expect(Number.isInteger(pid) && pid > 0 && pid !== process.pid && pid !== result.pid).toBe(
+        true,
+      );
+      await vi.waitFor(() => expect(processIsRunning(pid)).toBe(false), {
+        timeout: 1_000,
+        interval: 20,
+      });
+      const retained = fs.readdirSync(temporary);
+      expect(retained).toHaveLength(1);
+      expect(retained[0]).toMatch(/^promptfoo-artifact-migrations-/);
+      expect(fs.statSync(path.join(temporary, retained[0])).isDirectory()).toBe(true);
+    } finally {
+      fs.closeSync(descriptor);
+      if (fs.existsSync(pidFile)) {
+        const pid = Number(fs.readFileSync(pidFile, 'utf8'));
+        if (Number.isInteger(pid) && pid > 0 && pid !== process.pid && processIsRunning(pid)) {
+          try {
+            process.kill(pid, 'SIGKILL');
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+              throw error;
+            }
+          }
+        }
+      }
+    }
+  });
 });

--- a/test/scripts/packageArtifact.test.ts
+++ b/test/scripts/packageArtifact.test.ts
@@ -144,3 +144,44 @@ describe('standalone artifact tooling', () => {
     }
   });
 });
+
+describe('installed migration fixture lifetime', () => {
+  it('loads native bindings in a child and cleans owned state when that child fails', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-lifetime-'));
+    directories.push(root);
+    const temporary = path.join(root, 'temporary');
+    const packageDir = path.join(root, 'node_modules', 'promptfoo');
+    const nativeDir = path.join(root, 'node_modules', '@libsql', 'client');
+    fs.mkdirSync(temporary);
+    fs.mkdirSync(path.join(packageDir, 'dist', 'src'), { recursive: true });
+    fs.mkdirSync(nativeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({ name: 'promptfoo', exports: './dist/src/index.cjs' }),
+    );
+    fs.writeFileSync(path.join(packageDir, 'dist', 'src', 'index.cjs'), 'module.exports = {};');
+    fs.cpSync(path.resolve(__dirname, '../../drizzle'), path.join(packageDir, 'dist', 'drizzle'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(nativeDir, 'index.js'),
+      `require('node:fs').writeFileSync(__dirname + '/native-pid', String(process.pid));
+throw new Error('artifact-native-binding-sentinel');`,
+    );
+    const fixture = path.join(root, 'migrations.mjs');
+    fs.copyFileSync(
+      path.resolve(__dirname, '../fixtures/package-artifact/migrations.mjs'),
+      fixture,
+    );
+    const result = spawnSync(process.execPath, [fixture], {
+      encoding: 'utf8',
+      env: { ...process.env, TMPDIR: temporary, TMP: temporary, TEMP: temporary },
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('artifact-native-binding-sentinel');
+    expect(Number(fs.readFileSync(path.join(nativeDir, 'native-pid'), 'utf8'))).not.toBe(
+      result.pid,
+    );
+    expect(fs.readdirSync(temporary)).toEqual([]);
+  });
+});

--- a/test/scripts/packageArtifact.test.ts
+++ b/test/scripts/packageArtifact.test.ts
@@ -146,7 +146,7 @@ describe('standalone artifact tooling', () => {
 });
 
 describe('installed migration fixture lifetime', () => {
-  it('loads native bindings in a child and cleans owned state when that child fails', () => {
+  function prepareConsumer(nativeSource: string) {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-lifetime-'));
     directories.push(root);
     const temporary = path.join(root, 'temporary');
@@ -166,15 +166,40 @@ describe('installed migration fixture lifetime', () => {
     fs.writeFileSync(
       path.join(nativeDir, 'index.js'),
       `require('node:fs').writeFileSync(__dirname + '/native-pid', String(process.pid));
-throw new Error('artifact-native-binding-sentinel');`,
+${nativeSource}`,
     );
     const fixture = path.join(root, 'migrations.mjs');
     fs.copyFileSync(
       path.resolve(__dirname, '../fixtures/package-artifact/migrations.mjs'),
       fixture,
     );
+    return { root, temporary, nativeDir, fixture };
+  }
+
+  function processIsRunning(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      if (process.platform === 'linux') {
+        // A killed grandchild may await reaping by init; a zombie cannot hold the database open.
+        const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+        return stat.slice(stat.lastIndexOf(')') + 2, stat.lastIndexOf(')') + 3) !== 'Z';
+      }
+      return true;
+    } catch (error) {
+      if (['ESRCH', 'ENOENT'].includes((error as NodeJS.ErrnoException).code ?? '')) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  it('loads native bindings in a child and cleans owned state when that child fails', () => {
+    const { temporary, nativeDir, fixture } = prepareConsumer(
+      "throw new Error('artifact-native-binding-sentinel');",
+    );
     const result = spawnSync(process.execPath, [fixture], {
       encoding: 'utf8',
+      timeout: 8_000,
       env: { ...process.env, TMPDIR: temporary, TMP: temporary, TEMP: temporary },
     });
     expect(result.status).not.toBe(0);
@@ -184,4 +209,68 @@ throw new Error('artifact-native-binding-sentinel');`,
     );
     expect(fs.readdirSync(temporary)).toEqual([]);
   });
+
+  it.each([false, true])(
+    'terminates a stalled native check and cleans owned state (descendant: %s)',
+    async (withDescendant) => {
+      const timeoutMs = 1_500;
+      const descendant = `require('node:fs').writeFileSync(process.argv[1], String(process.pid));
+setInterval(() => {}, 1000);`;
+      const { root, temporary, nativeDir, fixture } = prepareConsumer(
+        withDescendant
+          ? `require('node:child_process').spawnSync(process.execPath,
+['-e', ${JSON.stringify(descendant)}, __dirname + '/descendant-pid'], { stdio: 'inherit' });`
+          : 'Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);',
+      );
+      const pidFiles = ['native-pid', ...(withDescendant ? ['descendant-pid'] : [])].map((name) =>
+        path.join(nativeDir, name),
+      );
+      const output = path.join(root, 'supervisor.log');
+      const descriptor = fs.openSync(output, 'w');
+      try {
+        // File descriptors prevent orphaned inherited pipes from hanging the outer watchdog.
+        const result = spawnSync(process.execPath, [fixture, '--timeout-ms', String(timeoutMs)], {
+          stdio: ['ignore', descriptor, descriptor],
+          timeout: 8_000,
+          killSignal: 'SIGKILL',
+          env: { ...process.env, TMPDIR: temporary, TMP: temporary, TEMP: temporary },
+        });
+        expect(result.error).toBeUndefined();
+        expect(result.status).not.toBeNull();
+        expect(result.status).not.toBe(0);
+        expect(fs.readFileSync(output, 'utf8')).toContain(
+          `Installed migration check timed out after ${timeoutMs}ms`,
+        );
+        const pids = pidFiles.map((file) => Number(fs.readFileSync(file, 'utf8')));
+        expect(new Set([result.pid, ...pids]).size).toBe(pids.length + 1);
+        for (const pid of pids) {
+          expect(Number.isInteger(pid) && pid > 0 && pid !== process.pid).toBe(true);
+        }
+        const deadline = Date.now() + 1_000;
+        while (pids.some(processIsRunning) && Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        expect(pids.filter(processIsRunning)).toEqual([]);
+        expect(fs.readdirSync(temporary)).toEqual([]);
+      } finally {
+        fs.closeSync(descriptor);
+        // Clean only PIDs recorded by these owned fixtures, even if the supervisor regresses.
+        for (const file of pidFiles) {
+          if (!fs.existsSync(file)) {
+            continue;
+          }
+          const pid = Number(fs.readFileSync(file, 'utf8'));
+          if (Number.isInteger(pid) && pid > 0 && pid !== process.pid && processIsRunning(pid)) {
+            try {
+              process.kill(pid, 'SIGKILL');
+            } catch (error) {
+              if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+                throw error;
+              }
+            }
+          }
+        }
+      }
+    },
+  );
 });

--- a/test/scripts/packageArtifact.test.ts
+++ b/test/scripts/packageArtifact.test.ts
@@ -121,7 +121,7 @@ describe('standalone artifact tooling', () => {
     expect(fs.readdirSync(root)).toHaveLength(count);
   });
 
-  it('prepares only the pinned test tools and preserves a selected archive with spaces', () => {
+  it('locks the complete test-tool dependency tree and preserves a selected archive with spaces', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact tools with spaces '));
     directories.push(root);
     const tarball = path.join(root, 'selected archive.tgz');
@@ -136,13 +136,96 @@ describe('standalone artifact tooling', () => {
     expect(fs.readFileSync(tarball, 'utf8')).toBe('selected bytes');
     const manifest = JSON.parse(fs.readFileSync(path.join(output.tooling, 'package.json'), 'utf8'));
     expect(manifest.private).toBe(true);
-    expect(Object.keys(manifest.dependencies).sort()).toEqual(['semver', 'tsx', 'typescript']);
-    for (const version of Object.values(manifest.dependencies)) {
-      expect(version).toMatch(/^\d+\.\d+\.\d+/);
+    const repositoryLock = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '../../package-lock.json'), 'utf8'),
+    );
+    expect(manifest.dependencies).toEqual(
+      Object.fromEntries(
+        ['tsx', 'typescript', 'semver'].map((name) => [
+          name,
+          repositoryLock.packages[`node_modules/${name}`].version,
+        ]),
+      ),
+    );
+    expect(manifest).not.toHaveProperty('devDependencies');
+    expect(manifest).not.toHaveProperty('workspaces');
+    const toolingLock = JSON.parse(
+      fs.readFileSync(path.join(output.tooling, 'package-lock.json'), 'utf8'),
+    );
+    expect(toolingLock.lockfileVersion).toBe(3);
+    expect(toolingLock.packages[''].dependencies).toEqual(manifest.dependencies);
+    expect(toolingLock.packages['']).not.toHaveProperty('devDependencies');
+    expect(toolingLock.packages['']).not.toHaveProperty('workspaces');
+    const nativePackages = ['esbuild', 'typescript'].flatMap((name) =>
+      Object.keys(repositoryLock.packages[`node_modules/${name}`].optionalDependencies).map(
+        (dependency) => `node_modules/${dependency}`,
+      ),
+    );
+    const expectedPackages = [
+      'node_modules/tsx',
+      'node_modules/typescript',
+      'node_modules/semver',
+      'node_modules/esbuild',
+      'node_modules/tsx/node_modules/fsevents',
+      ...nativePackages,
+    ];
+    expect(Object.keys(toolingLock.packages).sort()).toEqual(['', ...expectedPackages].sort());
+    for (const packagePath of expectedPackages) {
+      const expected = { ...repositoryLock.packages[packagePath] };
+      delete expected.dev;
+      delete expected.devOptional;
+      expect(toolingLock.packages[packagePath]).toMatchObject(expected);
+      expect(toolingLock.packages[packagePath]).not.toHaveProperty('dev');
+      expect(toolingLock.packages[packagePath]).not.toHaveProperty('devOptional');
     }
-    for (const excluded of ['src', 'dist', 'drizzle', 'node_modules', 'package-lock.json']) {
+    for (const excluded of ['src', 'dist', 'drizzle', 'node_modules']) {
       expect(fs.existsSync(path.join(output.tooling, excluded))).toBe(false);
     }
+  });
+
+  it('rejects a missing transitive tool dependency before creating an installable bootstrap', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-missing-lock-edge-'));
+    directories.push(root);
+    const scripts = path.join(root, 'scripts');
+    const temporary = path.join(root, 'temporary');
+    const artifacts = path.join(root, 'artifacts');
+    const fixtures = path.join(root, 'test', 'fixtures', 'package-artifact');
+    for (const directory of [scripts, temporary, artifacts, fixtures]) {
+      fs.mkdirSync(directory, { recursive: true });
+    }
+    for (const filename of [
+      'preparePackageArtifactTest.mjs',
+      'testPackageArtifact.ts',
+      'packPackageArtifact.ts',
+      'postbuild.ts',
+    ]) {
+      fs.copyFileSync(
+        path.resolve(__dirname, '../../scripts', filename),
+        path.join(scripts, filename),
+      );
+    }
+    const lock = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, '../../package-lock.json'), 'utf8'),
+    );
+    delete lock.packages['node_modules/esbuild'];
+    fs.writeFileSync(path.join(root, 'package-lock.json'), JSON.stringify(lock));
+    fs.writeFileSync(path.join(artifacts, 'selected.tgz'), 'selected bytes');
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(scripts, 'preparePackageArtifactTest.mjs'),
+        '--artifact-directory',
+        artifacts,
+        '--temp-root',
+        temporary,
+      ],
+      { encoding: 'utf8', timeout: 5_000, env: { ...process.env, GITHUB_OUTPUT: '' } },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('esbuild');
+    expect(fs.readdirSync(temporary)).toEqual([]);
+    expect(fs.readFileSync(path.join(artifacts, 'selected.tgz'), 'utf8')).toBe('selected bytes');
   });
 });
 


### PR DESCRIPTION
Installed package checks verified asset presence but did not execute language wrappers, upgrade historical databases, or test the Linux-built archive on native macOS and Windows. Extend acceptance using isolated installed consumers and deterministic local providers.

- Upgrade packaged migration 1 to 26, preserve nonempty historical result/table/config values, export through the installed CLI, persist pass/fail results, and verify reopening is idempotent.
- Execute Python prompt/persistent-provider wrappers, Go, Ruby, and packaged protobuf definitions in normal and optional-omitted Node 24 consumers.
- Run the same archive on macOS ARM64 and Windows x64 at minimum Node 22.22 using three exactly pinned test tools, without repository dependencies or a rebuild. Canonicalize temporary paths and support Windows CLI aliases.
- Keep native database work in a supervised child. Terminate stalled owned process trees before the outer deadline; preserve state and diagnostics if termination cannot be confirmed. Exclude incremental compiler state from the package.

Depends on #10769. Browser acceptance follows in #10775 with production prerequisite #10755.

## Validation

- Actual installed default/omitted consumers passed on Linux; Python/Go/Ruby success/error/recovery scores 1/0/1, protobuf roundtrip/error, historical upgrade/export and new persisted scores 1/0 with no provider errors
- Isolated acceptance tooling installs its complete repository-derived lock with `npm ci`; native platform metadata and integrity hashes are preserved. Actual locked installation, pinned tools, and full installed-consumer checks passed with unchanged lock and archive
- Standalone minimum-Node tooling bootstrap, full build, TypeScript, Knip, Actionlint, and changed-file lint/format passed
- Final focused checks: 22 package/release tests and 115 test-hygiene tests passed; regressions cover ordinary native failure, stalled child/descendant cleanup, and synchronous termination-error state retention, with independently reproduced red/green evidence
- Final exact-head CI passed on Linux, macOS ARM64, and Windows x64, including locked tooling installation, historical migration preservation, native cleanup, and compressed CLI evaluation

Root API caller type checks retain the pre-existing Drizzle dependency-declaration limitation. Generic optional omission supports nonpersisting API checks and actionable capability errors; SQLite CLI is unsupported. Local Ruby QA uses isolated Ruby 3.2; CI selects Ruby 4.0.1. No publication or release performed.
