### PR TITLE
fix(providers): preserve Replicate creation sharing on cancellation

### DIFF
--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'crypto';
 
-import { fetchWithCache, getCache, isCacheEnabled } from '../cache';
+import { fetchWithCache, getCache, getScopedCacheKey, isCacheEnabled } from '../cache';
 import { getEnvFloat, getEnvInt, getEnvString } from '../envars';
 import logger from '../logger';
 import { getRequestTimeoutMs } from '../providers/shared';
@@ -63,6 +63,10 @@ interface ReplicatePrediction {
 }
 
 const REPLICATE_CACHE_KEY_HMAC_KEY = 'promptfoo:replicate:cache-key:v1';
+const pendingPredictions = new Map<
+  string,
+  { promise: ReturnType<typeof fetchWithCache>; controller: AbortController; subscribers: number }
+>();
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && (error.name === 'AbortError' || error.name === 'AbortException');
@@ -79,6 +83,23 @@ function throwIfAborted(signal?: AbortSignal) {
   const error = new Error(reason instanceof Error ? reason.message : 'Request was aborted');
   error.name = 'AbortError';
   throw error;
+}
+
+function awaitPrediction<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener('abort', onAbort);
+      reject(signal.reason);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort));
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
 }
 
 function normalizeReplicateCacheValue(value: unknown): unknown {
@@ -278,23 +299,51 @@ export class ReplicateProvider implements ApiProvider {
     let cached = false;
     try {
       // Create prediction with sync mode (wait up to 60 seconds)
-      const createResponse = await fetchWithCache(
-        this.modelName.includes(':')
-          ? 'https://api.replicate.com/v1/predictions'
-          : `https://api.replicate.com/v1/models/${this.modelName}/predictions`,
-        {
-          method: 'POST',
-          signal: options?.abortSignal,
-          headers: {
-            Authorization: `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-            Prefer: 'wait=60',
-          },
-          body: JSON.stringify(data),
+      const url = this.modelName.includes(':')
+        ? 'https://api.replicate.com/v1/predictions'
+        : `https://api.replicate.com/v1/models/${this.modelName}/predictions`;
+      const request = {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+          Prefer: 'wait=60',
         },
-        getRequestTimeoutMs(),
-        'json',
-      );
+        body: JSON.stringify(data),
+      };
+      const signal = options?.abortSignal;
+      const key = cacheKey && getScopedCacheKey(cacheKey);
+      let pending = key ? pendingPredictions.get(key) : undefined;
+      if (!pending) {
+        const controller = new AbortController();
+        const promise = fetchWithCache(
+          url,
+          { ...request, signal: key ? controller.signal : signal },
+          getRequestTimeoutMs(),
+          'json',
+        );
+        pending = { promise, controller, subscribers: 0 };
+        if (key) {
+          pendingPredictions.set(key, pending);
+          void promise
+            .finally(() => {
+              if (pendingPredictions.get(key) === pending) {
+                pendingPredictions.delete(key);
+              }
+            })
+            .catch(() => {});
+        }
+      }
+      pending.subscribers++;
+      let createResponse;
+      try {
+        createResponse = await awaitPrediction(pending.promise, signal);
+      } finally {
+        if (--pending.subscribers === 0 && key && pendingPredictions.get(key) === pending) {
+          pendingPredictions.delete(key);
+          pending.controller.abort();
+        }
+      }
 
       cached = createResponse.cached;
       response = createResponse.data as ReplicatePrediction;

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -169,6 +169,7 @@ async function createPrediction(
     body: JSON.stringify(data),
   };
   const key = cacheKey && `${getCacheClearGeneration()}:${getScopedCacheKey(cacheKey)}`;
+  throwIfAborted(signal);
   let pending = key ? pendingPredictions.get(key) : undefined;
   const shared = pending !== undefined;
   if (!pending) {
@@ -182,30 +183,11 @@ async function createPrediction(
     pending = { promise, controller, subscribers: 0, claimed: false };
     if (key) {
       pendingPredictions.set(key, pending);
-      void promise
-        .finally(() => {
-          if (pendingPredictions.get(key) === pending) {
-            pendingPredictions.delete(key);
-          }
-        })
-        .catch(() => {});
     }
   }
   const pendingRequest = pending;
   pendingRequest.subscribers++;
-  try {
-    return {
-      creation: await awaitPrediction(pendingRequest.promise, signal),
-      shared,
-      claim: () => {
-        if (pendingRequest.claimed) {
-          return false;
-        }
-        pendingRequest.claimed = true;
-        return true;
-      },
-    };
-  } finally {
+  const release = () => {
     if (
       --pendingRequest.subscribers === 0 &&
       key &&
@@ -214,6 +196,36 @@ async function createPrediction(
       pendingPredictions.delete(key);
       pendingRequest.controller.abort();
     }
+  };
+  try {
+    return {
+      creation: await awaitPrediction(pendingRequest.promise, signal),
+      shared,
+      release,
+      claim: () => {
+        if (pendingRequest.claimed) {
+          return false;
+        }
+        pendingRequest.claimed = true;
+        return true;
+      },
+    };
+  } catch (error) {
+    release();
+    throw error;
+  }
+}
+
+async function withPredictionLease<T>(
+  run: (retain: (release: () => void) => void) => Promise<T>,
+): Promise<T> {
+  let release: (() => void) | undefined;
+  try {
+    return await run((value) => {
+      release = value;
+    });
+  } finally {
+    release?.();
   }
 }
 
@@ -298,12 +310,19 @@ export class ReplicateProvider implements ApiProvider {
       return result;
     };
 
-    return withGenAISpan(spanContext, () => this.callApiInternal(prompt, options), resultExtractor);
+    return withPredictionLease((retain) =>
+      withGenAISpan(
+        spanContext,
+        () => this.callApiInternal(prompt, options, retain),
+        resultExtractor,
+      ),
+    );
   }
 
   protected async callApiInternal(
     prompt: string,
     options?: CallApiOptionsParams,
+    retainPrediction?: (release: () => void) => void,
   ): Promise<ProviderResponse> {
     if (!this.apiKey) {
       throw new Error(
@@ -378,13 +397,14 @@ export class ReplicateProvider implements ApiProvider {
     let cached = false;
     try {
       // Create prediction with sync mode (wait up to 60 seconds)
-      const { creation, shared, claim } = await createPrediction(
+      const { creation, shared, claim, release } = await createPrediction(
         this.modelName,
         this.apiKey,
         data,
         cacheKey,
         options?.abortSignal,
       );
+      retainPrediction?.(release);
       cached = creation.cached || shared;
       response = creation.data as ReplicatePrediction;
 
@@ -629,18 +649,21 @@ export class ReplicateImageProvider extends ReplicateProvider {
     options?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
     throwIfAborted(options?.abortSignal);
-    try {
-      return await this.callImageApiInternal(prompt, options);
-    } catch (err) {
-      // Body reads can wrap a custom abort reason in a plain Error after headers arrive.
-      throwIfAborted(options?.abortSignal);
-      throw err;
-    }
+    return withPredictionLease(async (retain) => {
+      try {
+        return await this.callImageApiInternal(prompt, options, retain);
+      } catch (err) {
+        // Body reads can wrap a custom abort reason in a plain Error after headers arrive.
+        throwIfAborted(options?.abortSignal);
+        throw err;
+      }
+    });
   }
 
   private async callImageApiInternal(
     prompt: string,
     options?: CallApiOptionsParams,
+    retainPrediction?: (release: () => void) => void,
   ): Promise<ProviderResponse> {
     if (!this.apiKey) {
       throw new Error(
@@ -689,13 +712,14 @@ export class ReplicateImageProvider extends ReplicateProvider {
       }
 
       // Create prediction with sync mode
-      const { creation, shared, claim } = await createPrediction(
+      const { creation, shared, claim, release } = await createPrediction(
         this.modelName,
         this.apiKey,
         data,
         isCacheEnabled() ? cacheKey : undefined,
         options?.abortSignal,
       );
+      retainPrediction?.(release);
       cached = creation.cached || shared;
       let prediction = creation.data as ReplicatePrediction;
 

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -1,6 +1,12 @@
 import { createHmac } from 'crypto';
 
-import { fetchWithCache, getCache, getScopedCacheKey, isCacheEnabled } from '../cache';
+import {
+  fetchWithCache,
+  getCache,
+  getCacheClearGeneration,
+  getScopedCacheKey,
+  isCacheEnabled,
+} from '../cache';
 import { getEnvFloat, getEnvInt, getEnvString } from '../envars';
 import logger from '../logger';
 import { getRequestTimeoutMs } from '../providers/shared';
@@ -136,6 +142,59 @@ function getReplicateAuthCacheNamespace(apiKey: string | undefined) {
   }
 
   return createHmac('sha256', apiKey).update(REPLICATE_CACHE_KEY_HMAC_KEY).digest('hex');
+}
+
+async function createPrediction(
+  modelName: string,
+  apiKey: string,
+  data: unknown,
+  cacheKey: string | undefined,
+  signal?: AbortSignal,
+) {
+  const url = modelName.includes(':')
+    ? 'https://api.replicate.com/v1/predictions'
+    : `https://api.replicate.com/v1/models/${modelName}/predictions`;
+  const request = {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'wait=60',
+    },
+    body: JSON.stringify(data),
+  };
+  const key = cacheKey && `${getCacheClearGeneration()}:${getScopedCacheKey(cacheKey)}`;
+  let pending = key ? pendingPredictions.get(key) : undefined;
+  const shared = pending !== undefined;
+  if (!pending) {
+    const controller = new AbortController();
+    const promise = fetchWithCache(
+      url,
+      { ...request, signal: key ? controller.signal : signal },
+      getRequestTimeoutMs(),
+      'json',
+    );
+    pending = { promise, controller, subscribers: 0 };
+    if (key) {
+      pendingPredictions.set(key, pending);
+      void promise
+        .finally(() => {
+          if (pendingPredictions.get(key) === pending) {
+            pendingPredictions.delete(key);
+          }
+        })
+        .catch(() => {});
+    }
+  }
+  pending.subscribers++;
+  try {
+    return { creation: await awaitPrediction(pending.promise, signal), shared };
+  } finally {
+    if (--pending.subscribers === 0 && key && pendingPredictions.get(key) === pending) {
+      pendingPredictions.delete(key);
+      pending.controller.abort();
+    }
+  }
 }
 
 function getReplicateValueSummary(prefix: string, value: unknown): Record<string, unknown> {
@@ -299,58 +358,19 @@ export class ReplicateProvider implements ApiProvider {
     let cached = false;
     try {
       // Create prediction with sync mode (wait up to 60 seconds)
-      const url = this.modelName.includes(':')
-        ? 'https://api.replicate.com/v1/predictions'
-        : `https://api.replicate.com/v1/models/${this.modelName}/predictions`;
-      const request = {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json',
-          Prefer: 'wait=60',
-        },
-        body: JSON.stringify(data),
-      };
-      const signal = options?.abortSignal;
-      const key = cacheKey && getScopedCacheKey(cacheKey);
-      let pending = key ? pendingPredictions.get(key) : undefined;
-      if (!pending) {
-        const controller = new AbortController();
-        const promise = fetchWithCache(
-          url,
-          { ...request, signal: key ? controller.signal : signal },
-          getRequestTimeoutMs(),
-          'json',
-        );
-        pending = { promise, controller, subscribers: 0 };
-        if (key) {
-          pendingPredictions.set(key, pending);
-          void promise
-            .finally(() => {
-              if (pendingPredictions.get(key) === pending) {
-                pendingPredictions.delete(key);
-              }
-            })
-            .catch(() => {});
-        }
-      }
-      pending.subscribers++;
-      let createResponse;
-      try {
-        createResponse = await awaitPrediction(pending.promise, signal);
-      } finally {
-        if (--pending.subscribers === 0 && key && pendingPredictions.get(key) === pending) {
-          pendingPredictions.delete(key);
-          pending.controller.abort();
-        }
-      }
-
-      cached = createResponse.cached;
-      response = createResponse.data as ReplicatePrediction;
+      const { creation, shared } = await createPrediction(
+        this.modelName,
+        this.apiKey,
+        data,
+        cacheKey,
+        options?.abortSignal,
+      );
+      cached = creation.cached || shared;
+      response = creation.data as ReplicatePrediction;
 
       // If still processing, poll for completion
       if (response.status === 'starting' || response.status === 'processing') {
-        cached = false;
+        cached = shared;
         response = await this.pollForCompletion(response.id, options?.abortSignal);
       }
 
@@ -642,25 +662,15 @@ export class ReplicateImageProvider extends ReplicateProvider {
       }
 
       // Create prediction with sync mode
-      const createResponse = await fetchWithCache(
-        this.modelName.includes(':')
-          ? 'https://api.replicate.com/v1/predictions'
-          : `https://api.replicate.com/v1/models/${this.modelName}/predictions`,
-        {
-          method: 'POST',
-          signal: options?.abortSignal,
-          headers: {
-            Authorization: `Bearer ${this.apiKey}`,
-            'Content-Type': 'application/json',
-            Prefer: 'wait=60',
-          },
-          body: JSON.stringify(data),
-        },
-        getRequestTimeoutMs(),
-        'json',
+      const { creation, shared } = await createPrediction(
+        this.modelName,
+        this.apiKey,
+        data,
+        isCacheEnabled() ? cacheKey : undefined,
+        options?.abortSignal,
       );
-
-      let prediction = createResponse.data as ReplicatePrediction;
+      cached = creation.cached || shared;
+      let prediction = creation.data as ReplicatePrediction;
 
       logger.debug(`Initial prediction status: ${prediction.status}, ID: ${prediction.id}`);
 

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -446,8 +446,10 @@ export class ReplicateProvider implements ApiProvider {
       tokenUsage: { ...createEmptyTokenUsage(), numRequests: Number(!cached) },
     };
 
+    if (Array.isArray(response) && response.every((item) => typeof item === 'string')) {
+      response = response.join('');
+    }
     if (typeof response === 'string') {
-      // It's text
       const ret = {
         output: response,
         ...responseMetadata,
@@ -460,23 +462,6 @@ export class ReplicateProvider implements ApiProvider {
         }
       }
       return ret;
-    } else if (Array.isArray(response)) {
-      // It's a list of generative outputs
-      if (response.every((item) => typeof item === 'string')) {
-        const output = response.join('');
-        const ret = {
-          output,
-          ...responseMetadata,
-        };
-        if (cache && cacheKey) {
-          try {
-            await cache.set(cacheKey, JSON.stringify(ret));
-          } catch (err) {
-            logger.error(`Failed to cache response: ${String(err)}`);
-          }
-        }
-        return ret;
-      }
     }
 
     logger.error('Unsupported response from Replicate: ' + JSON.stringify(response));

--- a/src/providers/replicate.ts
+++ b/src/providers/replicate.ts
@@ -71,7 +71,12 @@ interface ReplicatePrediction {
 const REPLICATE_CACHE_KEY_HMAC_KEY = 'promptfoo:replicate:cache-key:v1';
 const pendingPredictions = new Map<
   string,
-  { promise: ReturnType<typeof fetchWithCache>; controller: AbortController; subscribers: number }
+  {
+    promise: ReturnType<typeof fetchWithCache>;
+    controller: AbortController;
+    subscribers: number;
+    claimed: boolean;
+  }
 >();
 
 function isAbortError(error: unknown): boolean {
@@ -174,7 +179,7 @@ async function createPrediction(
       getRequestTimeoutMs(),
       'json',
     );
-    pending = { promise, controller, subscribers: 0 };
+    pending = { promise, controller, subscribers: 0, claimed: false };
     if (key) {
       pendingPredictions.set(key, pending);
       void promise
@@ -186,13 +191,28 @@ async function createPrediction(
         .catch(() => {});
     }
   }
-  pending.subscribers++;
+  const pendingRequest = pending;
+  pendingRequest.subscribers++;
   try {
-    return { creation: await awaitPrediction(pending.promise, signal), shared };
+    return {
+      creation: await awaitPrediction(pendingRequest.promise, signal),
+      shared,
+      claim: () => {
+        if (pendingRequest.claimed) {
+          return false;
+        }
+        pendingRequest.claimed = true;
+        return true;
+      },
+    };
   } finally {
-    if (--pending.subscribers === 0 && key && pendingPredictions.get(key) === pending) {
+    if (
+      --pendingRequest.subscribers === 0 &&
+      key &&
+      pendingPredictions.get(key) === pendingRequest
+    ) {
       pendingPredictions.delete(key);
-      pending.controller.abort();
+      pendingRequest.controller.abort();
     }
   }
 }
@@ -358,7 +378,7 @@ export class ReplicateProvider implements ApiProvider {
     let cached = false;
     try {
       // Create prediction with sync mode (wait up to 60 seconds)
-      const { creation, shared } = await createPrediction(
+      const { creation, shared, claim } = await createPrediction(
         this.modelName,
         this.apiKey,
         data,
@@ -369,7 +389,8 @@ export class ReplicateProvider implements ApiProvider {
       response = creation.data as ReplicatePrediction;
 
       // If still processing, poll for completion
-      if (response.status === 'starting' || response.status === 'processing') {
+      const polled = response.status === 'starting' || response.status === 'processing';
+      if (polled) {
         cached = shared;
         response = await this.pollForCompletion(response.id, options?.abortSignal);
       }
@@ -379,6 +400,12 @@ export class ReplicateProvider implements ApiProvider {
       }
 
       response = response.output;
+      if (
+        typeof response === 'string' ||
+        (Array.isArray(response) && response.every((item) => typeof item === 'string'))
+      ) {
+        cached = (!polled && creation.cached) || !claim();
+      }
     } catch (err) {
       throwIfAborted(options?.abortSignal);
       if (isAbortError(err)) {
@@ -662,7 +689,7 @@ export class ReplicateImageProvider extends ReplicateProvider {
       }
 
       // Create prediction with sync mode
-      const { creation, shared } = await createPrediction(
+      const { creation, shared, claim } = await createPrediction(
         this.modelName,
         this.apiKey,
         data,
@@ -675,7 +702,8 @@ export class ReplicateImageProvider extends ReplicateProvider {
       logger.debug(`Initial prediction status: ${prediction.status}, ID: ${prediction.id}`);
 
       // If still processing, poll for completion
-      if (prediction.status === 'starting' || prediction.status === 'processing') {
+      const polled = prediction.status === 'starting' || prediction.status === 'processing';
+      if (polled) {
         prediction = await this.pollForCompletion(prediction.id, options?.abortSignal);
       }
 
@@ -692,6 +720,12 @@ export class ReplicateImageProvider extends ReplicateProvider {
       }
 
       response = prediction.output;
+      if (
+        typeof response === 'string' ||
+        (Array.isArray(response) && typeof response[0] === 'string')
+      ) {
+        cached = (!polled && creation.cached) || !claim();
+      }
     }
 
     // Handle various response formats

--- a/test/providers/replicate-cancellation.test.ts
+++ b/test/providers/replicate-cancellation.test.ts
@@ -31,6 +31,64 @@ function reply(status: string, output?: unknown) {
   };
 }
 
+it('shares a cached prediction across row signals while cancelling only its caller', async () => {
+  vi.mocked(isCacheEnabled).mockReturnValue(true);
+  vi.mocked(getCache).mockResolvedValue({ get: vi.fn(), set: vi.fn() } as any);
+  let finish!: (value: ReturnType<typeof reply>) => void;
+  vi.mocked(fetchWithCache).mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+  );
+  const provider = new ReplicateProvider('owner/model', { config: { apiKey: 'fixture' } });
+  const first = new AbortController();
+  const second = new AbortController();
+  const result1 = provider.callApi('Hello', undefined, { abortSignal: first.signal });
+  const result2 = provider.callApi('Hello', undefined, { abortSignal: second.signal });
+  await vi.advanceTimersByTimeAsync(0);
+  expect(fetchWithCache).toHaveBeenCalledTimes(1);
+  const sharedSignal = vi.mocked(fetchWithCache).mock.calls[0][1]?.signal;
+  expect(sharedSignal).toBeInstanceOf(AbortSignal);
+  first.abort();
+  await expect(result1).rejects.toMatchObject({ name: 'AbortError' });
+  expect(sharedSignal?.aborted).toBe(false);
+  finish(reply('succeeded', 'shared output'));
+  await expect(result2).resolves.toMatchObject({ output: 'shared output' });
+});
+
+it('aborts an unneeded shared prediction and allows a fresh creation', async () => {
+  vi.mocked(isCacheEnabled).mockReturnValue(true);
+  vi.mocked(getCache).mockResolvedValue({ get: vi.fn(), set: vi.fn() } as any);
+  vi.mocked(fetchWithCache).mockImplementation(
+    (_url, request) =>
+      new Promise((_resolve, reject) => {
+        request?.signal?.addEventListener('abort', () => reject(request.signal?.reason), {
+          once: true,
+        });
+      }),
+  );
+  const provider = new ReplicateProvider('owner/model', { config: { apiKey: 'fixture' } });
+  const first = new AbortController();
+  const second = new AbortController();
+  const result1 = provider.callApi('Hello', undefined, { abortSignal: first.signal });
+  const result2 = provider.callApi('Hello', undefined, { abortSignal: second.signal });
+  await vi.advanceTimersByTimeAsync(0);
+  const sharedSignal = vi.mocked(fetchWithCache).mock.calls[0][1]?.signal;
+  first.abort();
+  await expect(result1).rejects.toMatchObject({ name: 'AbortError' });
+  expect(sharedSignal?.aborted).toBe(false);
+  second.abort();
+  await expect(result2).rejects.toMatchObject({ name: 'AbortError' });
+  expect(sharedSignal?.aborted).toBe(true);
+  const third = new AbortController();
+  const result3 = provider.callApi('Hello', undefined, { abortSignal: third.signal });
+  await vi.advanceTimersByTimeAsync(0);
+  expect(fetchWithCache).toHaveBeenCalledTimes(2);
+  third.abort();
+  await expect(result3).rejects.toMatchObject({ name: 'AbortError' });
+});
+
 describe.each([ReplicateProvider, ReplicateImageProvider])('%s local cancellation', (Provider) => {
   it('rejects an already-aborted call before cache or network access', async () => {
     const controller = new AbortController();

--- a/test/providers/replicate-cancellation.test.ts
+++ b/test/providers/replicate-cancellation.test.ts
@@ -93,6 +93,85 @@ it('counts only the creator when concurrent rows share a prediction', async () =
   expect((await second).tokenUsage?.numRequests).toBe(0);
 });
 
+it.each(['both-succeed', 'creator-aborts', 'all-abort'] as const)(
+  'keeps prediction ownership and cleanup across a late joiner: %s',
+  async (scenario) => {
+    vi.mocked(isCacheEnabled).mockReturnValue(true);
+    vi.mocked(getCache).mockReturnValue({ get: vi.fn(), set: vi.fn() } as any);
+    const polls: Array<(response: ReturnType<typeof reply>) => void> = [];
+    vi.mocked(fetchWithCache).mockImplementation((_url, request) =>
+      request?.method === 'POST'
+        ? Promise.resolve(reply('processing'))
+        : new Promise((resolve, reject) => {
+            request?.signal?.addEventListener('abort', () => reject(request.signal?.reason));
+            polls.push(resolve);
+          }),
+    );
+    const provider = new ReplicateProvider('owner/model', { config: { apiKey: 'fixture' } });
+    const controller = new AbortController();
+    const first = provider.callApi('Hello', undefined, { abortSignal: controller.signal });
+    await vi.advanceTimersByTimeAsync(0);
+    const lateController = new AbortController();
+    const late = provider.callApi('Hello', undefined, { abortSignal: lateController.signal });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(polls).toHaveLength(2);
+    if (scenario === 'both-succeed') {
+      polls.forEach((resolve) => resolve(reply('succeeded', 'shared output')));
+      const results = await Promise.all([first, late]);
+      expect(results.map((result) => result.tokenUsage?.numRequests).sort()).toEqual([0, 1]);
+    } else {
+      controller.abort();
+      await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+      if (scenario === 'all-abort') {
+        lateController.abort();
+        await expect(late).rejects.toMatchObject({ name: 'AbortError' });
+        const nextController = new AbortController();
+        const next = provider.callApi('Hello', undefined, { abortSignal: nextController.signal });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(
+          vi.mocked(fetchWithCache).mock.calls.filter(([, request]) => request?.method === 'POST'),
+        ).toHaveLength(2);
+        nextController.abort();
+        await expect(next).rejects.toMatchObject({ name: 'AbortError' });
+        return;
+      }
+      polls[1](reply('succeeded', 'shared output'));
+      expect((await late).tokenUsage?.numRequests).toBe(1);
+    }
+    expect(
+      vi.mocked(fetchWithCache).mock.calls.filter(([, request]) => request?.method === 'POST'),
+    ).toHaveLength(1);
+  },
+);
+
+it.each([ReplicateProvider, ReplicateImageProvider])(
+  '%s avoids creating a prediction when cancelled during cache lookup',
+  async (Provider) => {
+    vi.mocked(isCacheEnabled).mockReturnValue(true);
+    let finishCache!: (value: undefined) => void;
+    vi.mocked(getCache).mockReturnValue({
+      get: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finishCache = resolve;
+          }),
+      ),
+      set: vi.fn(),
+    } as any);
+    const controller = new AbortController();
+    const result = new Provider('owner/model', { config: { apiKey: 'fixture' } }).callApi(
+      'Hello',
+      undefined,
+      { abortSignal: controller.signal },
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+    finishCache(undefined);
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchWithCache).not.toHaveBeenCalled();
+  },
+);
+
 it('caches an image completed by polling after replaying an incomplete creation', async () => {
   vi.mocked(isCacheEnabled).mockReturnValue(true);
   const cache = { get: vi.fn(), set: vi.fn() };

--- a/test/providers/replicate-cancellation.test.ts
+++ b/test/providers/replicate-cancellation.test.ts
@@ -61,7 +61,13 @@ it.each([
     await expect(result1).rejects.toMatchObject({ name: 'AbortError' });
     expect(sharedSignal?.aborted).toBe(false);
     finish(reply('succeeded', output));
-    await expect(result2).resolves.toMatchObject({ output: expect.stringContaining(output) });
+    const surviving = await result2;
+    expect(surviving).toMatchObject({ output: expect.stringContaining(output) });
+    if (Provider === ReplicateProvider) {
+      expect(surviving.tokenUsage?.numRequests).toBe(1);
+    } else {
+      expect(surviving.cached).toBe(false);
+    }
   },
 );
 
@@ -85,6 +91,25 @@ it('counts only the creator when concurrent rows share a prediction', async () =
   finish(reply('succeeded', 'shared output'));
   expect((await first).tokenUsage?.numRequests).toBe(1);
   expect((await second).tokenUsage?.numRequests).toBe(0);
+});
+
+it('caches an image completed by polling after replaying an incomplete creation', async () => {
+  vi.mocked(isCacheEnabled).mockReturnValue(true);
+  const cache = { get: vi.fn(), set: vi.fn() };
+  vi.mocked(getCache).mockReturnValue(cache as any);
+  vi.mocked(fetchWithCache)
+    .mockResolvedValueOnce({ ...reply('processing'), cached: true })
+    .mockResolvedValueOnce(reply('succeeded', ['https://example.invalid/complete.png']));
+  const provider = new ReplicateImageProvider('owner/model', { config: { apiKey: 'fixture' } });
+  const result = await provider.callApi('Hello');
+  expect(result).toMatchObject({ cached: false, output: expect.stringContaining('complete.png') });
+  expect(cache.set).toHaveBeenCalledWith(
+    expect.any(String),
+    JSON.stringify(['https://example.invalid/complete.png']),
+  );
+  cache.get.mockResolvedValueOnce(cache.set.mock.calls[0][1]);
+  expect(await provider.callApi('Hello')).toMatchObject({ cached: true });
+  expect(fetchWithCache).toHaveBeenCalledTimes(2);
 });
 
 it('starts a new prediction after the cache is cleared', async () => {

--- a/test/providers/replicate-cancellation.test.ts
+++ b/test/providers/replicate-cancellation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchWithCache, getCache, isCacheEnabled } from '../../src/cache';
+import { fetchWithCache, getCache, getCacheClearGeneration, isCacheEnabled } from '../../src/cache';
 import {
   ReplicateImageProvider,
   ReplicateModerationProvider,
@@ -10,11 +10,13 @@ vi.mock('../../src/cache', async (importOriginal) => ({
   ...(await importOriginal()),
   fetchWithCache: vi.fn(),
   getCache: vi.fn(),
+  getCacheClearGeneration: vi.fn(),
   isCacheEnabled: vi.fn(),
 }));
 beforeEach(() => {
   vi.mocked(fetchWithCache).mockReset();
   vi.mocked(getCache).mockReset();
+  vi.mocked(getCacheClearGeneration).mockReset().mockReturnValue(0);
   vi.mocked(isCacheEnabled).mockReset().mockReturnValue(false);
   vi.useFakeTimers();
 });
@@ -31,9 +33,41 @@ function reply(status: string, output?: unknown) {
   };
 }
 
-it('shares a cached prediction across row signals while cancelling only its caller', async () => {
+it.each([
+  [ReplicateProvider, 'shared output'],
+  [ReplicateImageProvider, 'https://example.invalid/shared.png'],
+])(
+  'shares a cached %s prediction across row signals while cancelling only its caller',
+  async (Provider, output) => {
+    vi.mocked(isCacheEnabled).mockReturnValue(true);
+    vi.mocked(getCache).mockReturnValue({ get: vi.fn(), set: vi.fn() } as any);
+    let finish!: (value: ReturnType<typeof reply>) => void;
+    vi.mocked(fetchWithCache).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const provider = new Provider('owner/model', { config: { apiKey: 'fixture' } });
+    const first = new AbortController();
+    const second = new AbortController();
+    const result1 = provider.callApi('Hello', undefined, { abortSignal: first.signal });
+    const result2 = provider.callApi('Hello', undefined, { abortSignal: second.signal });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchWithCache).toHaveBeenCalledTimes(1);
+    const sharedSignal = vi.mocked(fetchWithCache).mock.calls[0][1]?.signal;
+    expect(sharedSignal).toBeInstanceOf(AbortSignal);
+    first.abort();
+    await expect(result1).rejects.toMatchObject({ name: 'AbortError' });
+    expect(sharedSignal?.aborted).toBe(false);
+    finish(reply('succeeded', output));
+    await expect(result2).resolves.toMatchObject({ output: expect.stringContaining(output) });
+  },
+);
+
+it('counts only the creator when concurrent rows share a prediction', async () => {
   vi.mocked(isCacheEnabled).mockReturnValue(true);
-  vi.mocked(getCache).mockResolvedValue({ get: vi.fn(), set: vi.fn() } as any);
+  vi.mocked(getCache).mockReturnValue({ get: vi.fn(), set: vi.fn() } as any);
   let finish!: (value: ReturnType<typeof reply>) => void;
   vi.mocked(fetchWithCache).mockImplementation(
     () =>
@@ -42,24 +76,39 @@ it('shares a cached prediction across row signals while cancelling only its call
       }),
   );
   const provider = new ReplicateProvider('owner/model', { config: { apiKey: 'fixture' } });
-  const first = new AbortController();
-  const second = new AbortController();
-  const result1 = provider.callApi('Hello', undefined, { abortSignal: first.signal });
-  const result2 = provider.callApi('Hello', undefined, { abortSignal: second.signal });
+  const first = provider.callApi('Hello', undefined, { abortSignal: new AbortController().signal });
+  const second = provider.callApi('Hello', undefined, {
+    abortSignal: new AbortController().signal,
+  });
   await vi.advanceTimersByTimeAsync(0);
   expect(fetchWithCache).toHaveBeenCalledTimes(1);
-  const sharedSignal = vi.mocked(fetchWithCache).mock.calls[0][1]?.signal;
-  expect(sharedSignal).toBeInstanceOf(AbortSignal);
-  first.abort();
-  await expect(result1).rejects.toMatchObject({ name: 'AbortError' });
-  expect(sharedSignal?.aborted).toBe(false);
   finish(reply('succeeded', 'shared output'));
-  await expect(result2).resolves.toMatchObject({ output: 'shared output' });
+  expect((await first).tokenUsage?.numRequests).toBe(1);
+  expect((await second).tokenUsage?.numRequests).toBe(0);
+});
+
+it('starts a new prediction after the cache is cleared', async () => {
+  vi.mocked(isCacheEnabled).mockReturnValue(true);
+  vi.mocked(getCache).mockReturnValue({ get: vi.fn(), set: vi.fn() } as any);
+  vi.mocked(fetchWithCache).mockImplementation(() => new Promise(() => {}));
+  const provider = new ReplicateProvider('owner/model', { config: { apiKey: 'fixture' } });
+  const firstSignal = new AbortController();
+  const first = provider.callApi('Hello', undefined, { abortSignal: firstSignal.signal });
+  await vi.advanceTimersByTimeAsync(0);
+  vi.mocked(getCacheClearGeneration).mockReturnValue(1);
+  const secondSignal = new AbortController();
+  const second = provider.callApi('Hello', undefined, { abortSignal: secondSignal.signal });
+  await vi.advanceTimersByTimeAsync(0);
+  expect(fetchWithCache).toHaveBeenCalledTimes(2);
+  firstSignal.abort();
+  secondSignal.abort();
+  await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+  await expect(second).rejects.toMatchObject({ name: 'AbortError' });
 });
 
 it('aborts an unneeded shared prediction and allows a fresh creation', async () => {
   vi.mocked(isCacheEnabled).mockReturnValue(true);
-  vi.mocked(getCache).mockResolvedValue({ get: vi.fn(), set: vi.fn() } as any);
+  vi.mocked(getCache).mockReturnValue({ get: vi.fn(), set: vi.fn() } as any);
   vi.mocked(fetchWithCache).mockImplementation(
     (_url, request) =>
       new Promise((_resolve, reject) => {


### PR DESCRIPTION
## Summary

Follow-up to merged #10740. When concurrent evaluation rows use distinct abort signals, the cache no longer shares identical Replicate prediction creation requests. This can submit and bill separate predictions for the same prompt.

Share creation while caching is enabled and preserve independent per-row cancellation. If all callers cancel, abort the creation transport; later calls may start a fresh request. Cache-disabled requests continue to pass their caller's signal directly.

The moderation signal comment on #10740 is already satisfied on current main: `callGradingProvider` forwards the execution signal into the moderation adapter.

## Validation

- Focused Replicate and moderation tests: 38 passed.
- Full backend: 24,165 passed; TypeScript, architecture, lint, format and root build passed.
- Built CLI with an in-process deterministic Replicate transport fixture and `--no-cache`: success true, score 1, no error. No vendor network calls.
