### PR TITLE
fix(providers): omit unset Bedrock generation settings

### DIFF
--- a/src/providers/bedrock/agents.ts
+++ b/src/providers/bedrock/agents.ts
@@ -448,7 +448,7 @@ export class AwsBedrockAgentsProvider extends AwsBedrockGenericProvider implemen
       const filter = configuration.retrievalConfiguration?.vectorSearchConfiguration?.filter;
       if (filter !== undefined && !this.hasRetrievalFilterShape(filter)) {
         return {
-          error: `Invalid knowledgeBaseConfigurations[${index}].retrievalConfiguration.vectorSearchConfiguration.filter: use an AWS RetrievalFilter with one operator, such as equals or andAll. Flat metadata maps are not supported.`,
+          error: `Invalid knowledgeBaseConfigurations[${index}].retrievalConfiguration.vectorSearchConfiguration.filter: use an AWS RetrievalFilter with one operator, such as equals, or andAll/orAll with at least two operands. Flat metadata maps are not supported.`,
         };
       }
     }

--- a/src/providers/bedrock/knowledgeBase.ts
+++ b/src/providers/bedrock/knowledgeBase.ts
@@ -193,10 +193,11 @@ export class AwsBedrockKnowledgeBaseProvider
       }
     }
 
+    const generationConfiguration = this.buildGenerationConfiguration(modelArn);
     const knowledgeBaseConfiguration: any = {
       knowledgeBaseId: this.kbConfig.knowledgeBaseId,
       modelArn,
-      generationConfiguration: this.buildGenerationConfiguration(modelArn),
+      ...(generationConfiguration && { generationConfiguration }),
     };
 
     // Only add retrieval configuration when numberOfResults is explicitly configured

--- a/test/providers/bedrock/agents.test.ts
+++ b/test/providers/bedrock/agents.test.ts
@@ -235,7 +235,7 @@ describe('AwsBedrockAgentsProvider', () => {
 
       expect(result).toEqual({
         error:
-          'Invalid knowledgeBaseConfigurations[0].retrievalConfiguration.vectorSearchConfiguration.filter: use an AWS RetrievalFilter with one operator, such as equals or andAll. Flat metadata maps are not supported.',
+          'Invalid knowledgeBaseConfigurations[0].retrievalConfiguration.vectorSearchConfiguration.filter: use an AWS RetrievalFilter with one operator, such as equals, or andAll/orAll with at least two operands. Flat metadata maps are not supported.',
       });
       expect(getClient).not.toHaveBeenCalled();
       expect(mockGet).not.toHaveBeenCalled();

--- a/test/providers/bedrock/knowledgeBase.test.ts
+++ b/test/providers/bedrock/knowledgeBase.test.ts
@@ -439,6 +439,9 @@ describe('AwsBedrockKnowledgeBaseProvider', () => {
     };
 
     expect(RetrieveAndGenerateCommand).toHaveBeenCalledWith(expectedCommand);
+    expect(vi.mocked(RetrieveAndGenerateCommand).mock.calls[0][0]).not.toHaveProperty(
+      'retrieveAndGenerateConfiguration.knowledgeBaseConfiguration.generationConfiguration',
+    );
   });
 
   it('serializes configured generation settings, including zero values', async () => {


### PR DESCRIPTION
## Summary

Follow-up to merged #10751. Omit `generationConfiguration` from Bedrock Knowledge Base command inputs when no generation settings are configured. The existing equality assertion accepted an explicitly `undefined` property, so the test now checks that the property is absent.

Clarify the Bedrock Agent filter validation error: `andAll` and `orAll` need at least two operands.

## Validation

- Focused Bedrock tests: 44 passed. TypeScript, architecture, lint, format and root build passed.
- Full backend: 24,163 passed.
- Built local CLI Knowledge Base fixture: success true, score 1, no error; the fixture asserts the command input omits the field. Built agent error path asserts the two-operand message. No AWS requests.
