### PR TITLE
test(package): verify installed browser capability

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -243,14 +243,19 @@ jobs:
           PROMPTFOO_DISABLE_TELEMETRY: 1
           RUNTIME_ASSETS: ${{ matrix.node == '24.x' && 'all' || 'none' }}
           npm_config_install_strategy: ${{ matrix.node == '22.22' && 'shallow' || 'hoisted' }}
-        run: npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL" --runtime-assets "$RUNTIME_ASSETS"
+        run: |
+          browser_args=()
+          if [ "$RUNTIME_ASSETS" = all ]; then
+            browser_args+=(--browser)
+          fi
+          npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL" --runtime-assets "$RUNTIME_ASSETS" "${browser_args[@]}"
 
       - name: Test Package Artifact Without Optional Dependencies
         if: matrix.node == '24.x'
         env:
           PACKAGE_TARBALL: ${{ steps.package-artifact.outputs.tarball }}
           PROMPTFOO_DISABLE_TELEMETRY: 1
-        run: npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL" --profile omit-optional --runtime-assets all
+        run: npm run test:package-artifact -- --tarball "$PACKAGE_TARBALL" --profile omit-optional --runtime-assets all --browser
 
       - name: Upload package for platform acceptance
         if: matrix.node == '24.x'

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,10 +139,7 @@
         "node-sql-parser": "^5.4.0",
         "oxc-parser": "^0.147.0",
         "pdf-parse": "^2.4.5",
-        "playwright": "^1.60.0",
-        "playwright-extra": "^4.3.6",
         "prettier": "^3.8.1",
-        "puppeteer-extra-plugin-stealth": "^2.11.2",
         "read-excel-file": "^9.3.9",
         "shx": "^0.4.0",
         "source-map-support": "^0.5.21",
@@ -199,6 +196,7 @@
         "pem": "~1.14.8",
         "playwright": "^1.60.0",
         "playwright-extra": "^4.3.6",
+        "puppeteer-extra-plugin-stealth": "^2.11.2",
         "read-excel-file": "^9.3.9",
         "sharp": "^0.35.4"
       }
@@ -18881,7 +18879,7 @@
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -19079,7 +19077,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -21010,8 +21008,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22542,8 +22540,8 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "for-own": "^0.1.3",
         "is-plain-object": "^2.0.1",
@@ -22780,7 +22778,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -24434,7 +24432,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -26436,8 +26434,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26446,8 +26444,8 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "for-in": "^1.0.1"
       },
@@ -26623,8 +26621,8 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -26638,14 +26636,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -27123,7 +27120,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/graphql": {
@@ -28312,8 +28309,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -28692,8 +28689,8 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-ci": {
       "version": "3.0.1",
@@ -28754,7 +28751,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28939,7 +28936,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -29057,7 +29054,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29507,7 +29504,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -29634,8 +29631,8 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-buffer": "^1.1.5"
       },
@@ -30514,8 +30511,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -31775,8 +31772,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
       "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "arr-union": "^3.1.0",
         "clone-deep": "^0.2.4",
@@ -33992,8 +33989,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "for-in": "^0.1.3",
         "is-extendable": "^0.1.1"
@@ -34006,8 +34003,8 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
       "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35457,8 +35454,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35800,7 +35797,7 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
       "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.62.1"
@@ -35832,8 +35829,8 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
       "integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -38315,8 +38312,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.3.tgz",
       "integrity": "sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/debug": "^4.1.0",
         "debug": "^4.1.1",
@@ -38342,8 +38339,8 @@
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.11.2.tgz",
       "integrity": "sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "puppeteer-extra-plugin": "^3.2.3",
@@ -38369,8 +38366,8 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
       "integrity": "sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "fs-extra": "^10.0.0",
@@ -38397,8 +38394,8 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.4.1.tgz",
       "integrity": "sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "deepmerge": "^4.2.2",
@@ -39832,8 +39829,8 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -39848,15 +39845,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -39867,8 +39864,8 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -39888,8 +39885,8 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -40716,8 +40713,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-extendable": "^0.1.1",
         "kind-of": "^2.0.1",
@@ -40732,8 +40729,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
       "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-buffer": "^1.0.2"
       },
@@ -40745,8 +40742,8 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
       "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -43668,7 +43665,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -261,10 +261,7 @@
     "node-sql-parser": "^5.4.0",
     "oxc-parser": "^0.147.0",
     "pdf-parse": "^2.4.5",
-    "playwright": "^1.60.0",
-    "playwright-extra": "^4.3.6",
     "prettier": "^3.8.1",
-    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "read-excel-file": "^9.3.9",
     "shx": "^0.4.0",
     "source-map-support": "^0.5.21",
@@ -318,6 +315,7 @@
     "pem": "~1.14.8",
     "playwright": "^1.60.0",
     "playwright-extra": "^4.3.6",
+    "puppeteer-extra-plugin-stealth": "^2.11.2",
     "read-excel-file": "^9.3.9",
     "sharp": "^0.35.4"
   },

--- a/scripts/testPackageArtifact.ts
+++ b/scripts/testPackageArtifact.ts
@@ -622,6 +622,7 @@ async function main(): Promise<void> {
       registry: { type: 'string', default: 'https://registry.npmjs.org/' },
       tarball: { type: 'string' },
       'runtime-assets': { type: 'string', default: 'none' },
+      browser: { type: 'boolean', default: false },
     },
   });
   assert(
@@ -799,6 +800,36 @@ async function main(): Promise<void> {
           consumerEnv,
         ),
       );
+    }
+
+    if (values.browser) {
+      const browserArgs = ['browser.mjs', '--profile', values.profile];
+      if (values.profile === 'default') {
+        // Resolve from Promptfoo so shallow installs cannot borrow checkout dependencies.
+        // Fail undeclared capabilities before downloading the consumer's matching browser.
+        packageRequire.resolve('puppeteer-extra-plugin-stealth');
+        const playwrightManifest = packageRequire.resolve('playwright/package.json');
+        const playwright = JSON.parse(fs.readFileSync(playwrightManifest, 'utf8')) as {
+          bin: { playwright: string };
+        };
+        assert.equal(typeof playwright.bin.playwright, 'string');
+        const browsersPath = path.join(tempDir, 'browsers');
+        console.log(
+          await runAsync(
+            process.execPath,
+            [
+              path.resolve(path.dirname(playwrightManifest), playwright.bin.playwright),
+              'install',
+              'chromium',
+              '--only-shell',
+            ],
+            consumerDir,
+            { ...consumerEnv, PLAYWRIGHT_BROWSERS_PATH: browsersPath },
+          ),
+        );
+        browserArgs.push('--browsers-path', browsersPath);
+      }
+      console.log(await runAsync(process.execPath, browserArgs, consumerDir, consumerEnv));
     }
 
     if (suppliedTarball) {

--- a/test/fixtures/package-artifact/README.md
+++ b/test/fixtures/package-artifact/README.md
@@ -84,3 +84,25 @@ use exact versions from the repository lockfile; the installed Promptfoo consume
 resolves dependencies independently. No repository dependency install or build is
 required on those platforms. Incremental TypeScript compiler state is excluded
 from the published archive.
+
+## Browser capability
+
+Add `--browser` to verify the installed browser provider:
+
+```sh
+npm run test:package-artifact -- --browser
+npm run test:package-artifact -- --profile omit-optional --browser
+```
+
+The default gate requires production browser and stealth dependencies. It uses
+the consumer's Playwright CLI to download matching Chromium into a temporary
+directory owned by the harness. It never installs missing capability packages or
+uses a shared browser cache. Local HTML tests check Unicode input, clicking,
+extraction, stealth at launch, a missing-selector error, and recovery. Exported
+results must have scores 1/0/1 and exactly one deliberate error. The omitted gate
+downloads nothing and verifies the public provider's actionable missing-module
+error.
+
+CI enables this gate for Linux Node 24 default and optional-omitted consumers.
+Release/backfill and native platform jobs retain their existing coverage; browser
+downloads are only performed when this flag is selected.

--- a/test/fixtures/package-artifact/browser.mjs
+++ b/test/fixtures/package-artifact/browser.mjs
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parseArgs } from 'node:util';
+
+// Copy beside the installed consumer's package.json. The default profile requires
+// a caller-owned Chromium installation via --browsers-path; this fixture never downloads.
+// Enable that profile only after production browser/stealth dependencies are present.
+const fixturePath = fileURLToPath(import.meta.url);
+
+async function checkBrowser(stateDir, profile) {
+  const consumerRequire = createRequire(import.meta.url);
+  const packageRequire = createRequire(consumerRequire.resolve('promptfoo'));
+  const { evaluate, loadApiProvider } = await import('promptfoo');
+  if (profile === 'omit-optional') {
+    assert.throws(() => packageRequire.resolve('@playwright/browser-chromium/package.json'), {
+      code: 'MODULE_NOT_FOUND',
+    });
+    const provider = await loadApiProvider('browser', { options: { config: { steps: [] } } });
+    assert.equal(provider.id(), 'browser-provider');
+    const response = await provider.callApi('local capability probe');
+    assert.match(response.error, /Failed to import required modules/);
+    assert.match(response.error, /playwright-extra/);
+    assert.match(response.error, /puppeteer-extra-plugin-stealth/);
+    assert.equal(response.output, undefined);
+    console.log('Verified omitted browser capability: actionable missing-module error');
+    return;
+  }
+
+  packageRequire.resolve('@playwright/browser-chromium/package.json');
+  packageRequire.resolve('puppeteer-extra-plugin-stealth/evasions/navigator.webdriver');
+  const htmlPath = path.join(stateDir, 'local browser.html');
+  fs.writeFileSync(
+    htmlPath,
+    `<!doctype html>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'">
+<title>Installed browser fixture</title>
+<label>Message <input id="message"></label><button id="submit">Send</button>
+<output id="answer"></output>
+<script>
+  document.querySelector('#submit').addEventListener('click', () => {
+    document.querySelector('#answer').textContent = 'browser:' + document.querySelector('#message').value;
+  });
+</script>
+`,
+  );
+  const provider = await loadApiProvider('browser', {
+    options: {
+      config: {
+        headless: true,
+        timeoutMs: 500,
+        steps: [
+          { action: 'navigate', args: { url: pathToFileURL(htmlPath).href } },
+          { action: 'type', args: { selector: '#message', text: '{{prompt}}' } },
+          { action: 'click', args: { selector: '#submit' } },
+          { action: 'extract', args: { selector: '{{selector}}' }, name: 'answer' },
+          {
+            action: 'extract',
+            args: { script: "return navigator.webdriver === true ? 'enabled' : 'hidden';" },
+            name: 'webdriver',
+          },
+        ],
+        transformResponse: (extracted) => ({
+          output: extracted.answer,
+          metadata: { webdriver: extracted.webdriver },
+        }),
+      },
+    },
+  });
+  assert.equal(provider.id(), 'browser-provider');
+  const record = await evaluate(
+    {
+      prompts: ['{{value}}'],
+      providers: [provider],
+      tests: ['café 日本語 🚀', 'deliberate failure', 'recovered'].map((value, index) => ({
+        vars: { value, selector: index === 1 ? '#missing' : '#answer' },
+        assert: [{ type: 'equals', value: `browser:${value}` }],
+      })),
+      writeLatestResults: false,
+      sharing: false,
+    },
+    { cache: false, maxConcurrency: 1 },
+  );
+  const summaryPath = path.join(stateDir, 'browser-results.json');
+  fs.writeFileSync(summaryPath, JSON.stringify(await record.toEvaluateSummary()));
+  const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+  assert.equal(summary.results.length, 3);
+  for (const [index, result] of summary.results.entries()) {
+    assert.equal(result.provider.id, 'browser-provider');
+    assert.equal(result.success, index !== 1, result.error);
+    assert.equal(result.score, index === 1 ? 0 : 1);
+    if (index === 1) {
+      assert.match(result.error, /Browser execution error/);
+      assert.match(result.error, /#missing/);
+    } else {
+      assert.equal(result.error, undefined);
+      assert.equal(result.response.error, undefined);
+      assert.equal(
+        result.response.output,
+        `browser:${index === 0 ? 'café 日本語 🚀' : 'recovered'}`,
+      );
+      assert.equal(
+        result.response.metadata.webdriver,
+        'hidden',
+        'Stealth must load at browser launch',
+      );
+    }
+  }
+  assert.equal(summary.stats.successes, 2);
+  assert.equal(summary.stats.errors, 1);
+  console.log('Verified installed browser and stealth: local HTML, pass=2, scores=1/0/1, errors=1');
+}
+
+if (process.argv[2] === '--child') {
+  // Exit before the outer timeout: Playwright handles SIGTERM, so relying only on
+  // that signal can leave a stuck fixture waiting for graceful browser shutdown.
+  setTimeout(() => {
+    console.error('Installed browser fixture exceeded its 45 second budget');
+    process.exit(1);
+  }, 45_000).unref();
+  await checkBrowser(process.argv[3], process.argv[4]);
+} else {
+  const { values } = parseArgs({
+    options: {
+      profile: { type: 'string', default: 'default' },
+      'browsers-path': { type: 'string' },
+    },
+  });
+  assert(['default', 'omit-optional'].includes(values.profile), 'Unexpected browser profile');
+  if (values.profile === 'default') {
+    assert(
+      values['browsers-path'],
+      '--browsers-path must select a caller-owned Chromium installation',
+    );
+    assert(
+      fs.statSync(values['browsers-path']).isDirectory(),
+      'Expected an existing browser directory',
+    );
+  }
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-browser-artifact-'));
+  try {
+    for (const directory of ['config', 'cache', 'tmp', 'browsers']) {
+      fs.mkdirSync(path.join(stateDir, directory));
+    }
+    const platformEnv = Object.fromEntries(
+      ['PATH', 'Path', 'SystemRoot', 'WINDIR', 'COMSPEC', 'PATHEXT', 'LANG', 'LC_ALL']
+        .filter((key) => process.env[key] !== undefined)
+        .map((key) => [key, process.env[key]]),
+    );
+    execFileSync(process.execPath, [fixturePath, '--child', stateDir, values.profile], {
+      cwd: path.dirname(fixturePath),
+      env: {
+        ...platformEnv,
+        NODE_PATH: '',
+        IS_TESTING: 'false',
+        PROMPTFOO_CONFIG_DIR: path.join(stateDir, 'config'),
+        PROMPTFOO_CACHE_PATH: path.join(stateDir, 'cache'),
+        PROMPTFOO_DISABLE_REMOTE_GENERATION: 'true',
+        PROMPTFOO_DISABLE_TELEMETRY: '1',
+        PROMPTFOO_DISABLE_UPDATE: 'true',
+        PROMPTFOO_TRACING_ENABLED: 'false',
+        PROMPTFOO_ENABLE_OTEL: 'false',
+        PLAYWRIGHT_BROWSERS_PATH: values['browsers-path']
+          ? path.resolve(values['browsers-path'])
+          : path.join(stateDir, 'browsers'),
+        TMPDIR: path.join(stateDir, 'tmp'),
+        TEMP: path.join(stateDir, 'tmp'),
+        TMP: path.join(stateDir, 'tmp'),
+      },
+      stdio: 'inherit',
+      timeout: 60_000,
+    });
+  } finally {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+}

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { minVersion, satisfies, subset, validRange } from 'semver';
 import { describe, expect, it } from 'vitest';
-import { extractModuleSpecifiers } from '../scripts/architectureUtils';
+import { extractModuleSpecifiers, getPackageName } from '../scripts/architectureUtils';
 
 type PackageManifest = {
   dependencies?: Record<string, string>;
@@ -509,6 +509,34 @@ describe('package manifests', () => {
     expect(satisfies(packageLock.packages[`node_modules/${sdkName}`].version!, sdkRange!)).toBe(
       true,
     );
+  });
+
+  it('includes every browser loader in the optional production profile', () => {
+    const packageJson = readPackageJson<PackageManifest>('package.json');
+    const packageLock =
+      readPackageJson<PackageLockManifest<PackageManifest & { version?: string; dev?: boolean }>>(
+        'package-lock.json',
+      );
+    const browserSource = fs.readFileSync('src/providers/browser.ts', 'utf8');
+    const browserPackages = extractModuleSpecifiers(browserSource, 'src/providers/browser.ts')
+      .map(getPackageName)
+      .filter((name): name is string => name !== undefined);
+
+    expect(browserPackages).toContain('puppeteer-extra-plugin-stealth');
+    for (const dependency of new Set(browserPackages)) {
+      const range = packageJson.optionalDependencies?.[dependency];
+      expect(
+        range,
+        `${dependency} must be available to production browser consumers`,
+      ).toBeDefined();
+      // npm treats a same-root dev + optional declaration as dev-only during
+      // `npm ci --omit=dev`, even though packed consumers resolve it as optional.
+      expect(packageJson.devDependencies?.[dependency]).toBeUndefined();
+      expect(packageLock.packages[''].optionalDependencies?.[dependency]).toBe(range);
+      const installed = packageLock.packages[`node_modules/${dependency}`];
+      expect(installed?.dev, `${dependency} must survive --omit=dev`).not.toBe(true);
+      expect(satisfies(installed.version!, range!)).toBe(true);
+    }
   });
 
   it('keeps the Linux Rollup binary optional and aligned with the lockfile', () => {

--- a/test/package-manifests.test.ts
+++ b/test/package-manifests.test.ts
@@ -535,6 +535,7 @@ describe('package manifests', () => {
       expect(packageLock.packages[''].optionalDependencies?.[dependency]).toBe(range);
       const installed = packageLock.packages[`node_modules/${dependency}`];
       expect(installed?.dev, `${dependency} must survive --omit=dev`).not.toBe(true);
+      expect(installed?.version, `${dependency} must have a locked version`).toBeDefined();
       expect(satisfies(installed.version!, range!)).toBe(true);
     }
   });


### PR DESCRIPTION
Repository development dependencies can hide missing production browser modules. Add an installed-package browser check that resolves dependencies from Promptfoo and downloads matching Chromium into a temporary directory owned by the harness.

Verify Unicode input, clicking, extraction, navigator.webdriver evasion, an intentional missing-selector error, and a later successful call with a fresh browser. The optional-omitted profile downloads nothing and checks the provider's actionable missing-module error. Enable both profiles in the Linux Node 24 artifact job; other artifact jobs retain their existing checks.

Depends on #10772. The production browser dependencies from #10755 are already merged.

## Validation

- 180 package, release, manifest, and hygiene tests passed against current main. TypeScript, full build, Actionlint, and changed-file lint/format passed.
- Fresh default and optional-omitted consumers passed using the same unchanged archive through the configured registry. The default consumer also preserved historical migration data and passed installed CLI/compressed-response checks.
- Real Chromium on macOS passed local HTML interaction, stealth, and recovery with scores 1/0/1 and exactly one expected error. The omitted profile returned the expected missing-module error.
- Preserved main's locked-browser-version assertion; the feature branch merges cleanly with main.

Browser checks remain opt-in for release/backfill and native platform jobs. Forced cleanup of a stalled real Chromium tree was not independently exercised. No publication was performed.
