### PR TITLE
fix(providers): recover gateway model discovery

### DIFF
--- a/src/providers/aimlapi.ts
+++ b/src/providers/aimlapi.ts
@@ -1,4 +1,4 @@
-import { fetchWithCache, getHeadersForCacheKey, getScopedCacheKey } from '../cache';
+import { fetchWithCache, getHeadersForCacheKey, getScopedCacheKey, isCacheEnabled } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import { createModelDiscoveryCache } from './modelDiscovery';
@@ -16,7 +16,7 @@ export interface AimlApiModel {
   aliases?: string[];
 }
 
-const modelCache = createModelDiscoveryCache<AimlApiModel>();
+const modelCache = createModelDiscoveryCache<AimlApiModel>(isCacheEnabled);
 
 export function clearAimlApiModelsCache() {
   modelCache.clear();

--- a/src/providers/aimlapi.ts
+++ b/src/providers/aimlapi.ts
@@ -1,6 +1,7 @@
-import { fetchWithCache } from '../cache';
+import { fetchWithCache, getHeadersForCacheKey, getScopedCacheKey } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
+import { createModelDiscoveryCache } from './modelDiscovery';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
@@ -12,19 +13,16 @@ import type { OpenAiCompletionOptions } from './openai/types';
 
 export interface AimlApiModel {
   id: string;
+  aliases?: string[];
 }
 
-let modelCache: AimlApiModel[] | null = null;
+const modelCache = createModelDiscoveryCache<AimlApiModel>();
 
 export function clearAimlApiModelsCache() {
-  modelCache = null;
+  modelCache.clear();
 }
 
 export async function fetchAimlApiModels(env?: EnvOverrides): Promise<AimlApiModel[]> {
-  if (modelCache) {
-    return modelCache;
-  }
-
   try {
     const apiKey = env?.AIML_API_KEY || getEnvString('AIML_API_KEY');
     const headers: Record<string, string> = {};
@@ -32,24 +30,54 @@ export async function fetchAimlApiModels(env?: EnvOverrides): Promise<AimlApiMod
       headers['Authorization'] = `Bearer ${apiKey}`;
     }
 
-    const { data } = await fetchWithCache<any>(
-      'https://api.aimlapi.com/models',
-      { headers },
-      getRequestTimeoutMs(),
-    );
-
-    const models = data?.data || data?.models || data;
-    if (Array.isArray(models)) {
-      modelCache = models.map((m: any) => ({ id: m.id || m.model || m.name || m }));
-    } else {
-      modelCache = [];
-    }
+    const url = 'https://api.aimlapi.com/v1/models';
+    // Reuse the process-salted header identity and caller namespace, never raw credentials.
+    const key = getScopedCacheKey(JSON.stringify(getHeadersForCacheKey(url, { headers })));
+    return await modelCache.get(key, async () => {
+      // This cache owns discovery expiry; do not replay a 14-day HTTP cache entry.
+      const { data, status } = await fetchWithCache<unknown>(
+        url,
+        { headers },
+        getRequestTimeoutMs(),
+        'json',
+        true,
+        2,
+      );
+      if (status < 200 || status >= 300) {
+        throw new Error(`HTTP ${status}`);
+      }
+      const body = data as { data?: unknown; models?: unknown } | null;
+      const models = body?.data ?? body?.models ?? data;
+      if (!Array.isArray(models)) {
+        throw new Error('Invalid AIML API model catalogue');
+      }
+      return models.map((model: unknown) => {
+        const item = model as {
+          id?: unknown;
+          model?: unknown;
+          name?: unknown;
+          aliases?: unknown;
+        } | null;
+        const id = typeof model === 'string' ? model : (item?.id ?? item?.model ?? item?.name);
+        if (typeof id !== 'string' || !id.trim()) {
+          throw new Error('Invalid AIML API model ID');
+        }
+        if (item?.aliases !== undefined) {
+          if (
+            !Array.isArray(item.aliases) ||
+            item.aliases.some((alias) => typeof alias !== 'string' || !alias.trim())
+          ) {
+            throw new Error('Invalid AIML API model aliases');
+          }
+          return { id, aliases: [...new Set(item.aliases as string[])] };
+        }
+        return { id };
+      });
+    });
   } catch (err) {
-    logger.warn(`Failed to fetch aimlapi models: ${String(err)}`);
-    modelCache = [];
+    logger.warn('Failed to fetch aimlapi models', { error: err });
+    return [];
   }
-
-  return modelCache;
 }
 
 /**

--- a/src/providers/cometapi.ts
+++ b/src/providers/cometapi.ts
@@ -1,4 +1,4 @@
-import { fetchWithCache, getHeadersForCacheKey, getScopedCacheKey } from '../cache';
+import { fetchWithCache, getHeadersForCacheKey, getScopedCacheKey, isCacheEnabled } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import { createModelDiscoveryCache } from './modelDiscovery';
@@ -18,7 +18,7 @@ export interface CometApiModel {
 
 // Note: We no longer filter models - users specify intent via provider syntax like :chat:, :image:, :embedding:
 
-const modelCache = createModelDiscoveryCache<CometApiModel>();
+const modelCache = createModelDiscoveryCache<CometApiModel>(isCacheEnabled);
 
 export function clearCometApiModelsCache() {
   modelCache.clear();

--- a/src/providers/cometapi.ts
+++ b/src/providers/cometapi.ts
@@ -1,6 +1,7 @@
-import { fetchWithCache } from '../cache';
+import { fetchWithCache, getHeadersForCacheKey, getScopedCacheKey } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
+import { createModelDiscoveryCache } from './modelDiscovery';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
@@ -17,17 +18,13 @@ export interface CometApiModel {
 
 // Note: We no longer filter models - users specify intent via provider syntax like :chat:, :image:, :embedding:
 
-let modelCache: CometApiModel[] | null = null;
+const modelCache = createModelDiscoveryCache<CometApiModel>();
 
 export function clearCometApiModelsCache() {
-  modelCache = null;
+  modelCache.clear();
 }
 
 export async function fetchCometApiModels(env?: EnvOverrides): Promise<CometApiModel[]> {
-  if (modelCache) {
-    return modelCache;
-  }
-
   try {
     const apiKey = env?.COMETAPI_KEY || getEnvString('COMETAPI_KEY');
     const headers: Record<string, string> = { Accept: 'application/json' };
@@ -35,28 +32,40 @@ export async function fetchCometApiModels(env?: EnvOverrides): Promise<CometApiM
       headers['Authorization'] = `Bearer ${apiKey}`;
     }
 
-    const { data } = await fetchWithCache<any>(
-      'https://api.cometapi.com/v1/models',
-      { headers },
-      getRequestTimeoutMs(),
-    );
-
-    const raw = data?.data || data?.models || data;
-    let models: CometApiModel[] = [];
-    if (Array.isArray(raw)) {
-      models = raw.map((m: any) => ({
-        id: m.id || m.model || m.name || (typeof m === 'string' ? m : ''),
-      }));
-    }
-
-    // Return all models - let users specify their intent with :chat:, :image:, :embedding: prefixes
-    modelCache = models;
+    const url = 'https://api.cometapi.com/v1/models';
+    const key = getScopedCacheKey(JSON.stringify(getHeadersForCacheKey(url, { headers })));
+    return await modelCache.get(key, async () => {
+      // Keep credentialed discovery out of the persistent HTTP cache.
+      const { data, status } = await fetchWithCache<unknown>(
+        url,
+        { headers },
+        getRequestTimeoutMs(),
+        'json',
+        true,
+        2,
+      );
+      if (status < 200 || status >= 300) {
+        throw new Error(`HTTP ${status}`);
+      }
+      const body = data as { data?: unknown; models?: unknown } | null;
+      const raw = body?.data ?? body?.models ?? data;
+      if (!Array.isArray(raw)) {
+        throw new Error('Invalid CometAPI model catalogue');
+      }
+      // Task selection remains the caller's choice, independent of model names.
+      return raw.map((model: unknown) => {
+        const item = model as { id?: unknown; model?: unknown; name?: unknown } | null;
+        const id = typeof model === 'string' ? model : (item?.id ?? item?.model ?? item?.name);
+        if (typeof id !== 'string' || !id.trim()) {
+          throw new Error('Invalid CometAPI model ID');
+        }
+        return { id };
+      });
+    });
   } catch (err) {
-    logger.warn(`Failed to fetch cometapi models: ${String(err)}`);
-    modelCache = [];
+    logger.warn('Failed to fetch cometapi models', { error: err });
+    return [];
   }
-
-  return modelCache;
 }
 
 /**

--- a/src/providers/modelDiscovery.ts
+++ b/src/providers/modelDiscovery.ts
@@ -1,0 +1,59 @@
+import { isCacheEnabled } from '../cache';
+
+const SUCCESS_TTL_MS = 5 * 60 * 1000;
+const ERROR_RETRY_MS = 5 * 1000;
+const MAX_ENTRIES = 100;
+
+interface DiscoveryEntry<T> {
+  models: T[];
+  expiresAt: number;
+  pending?: Promise<T[]>;
+}
+
+/** Short-lived discovery state only; inference responses use the normal provider cache. */
+export function createModelDiscoveryCache<T>() {
+  const entries = new Map<string, DiscoveryEntry<T>>();
+
+  return {
+    clear() {
+      entries.clear();
+    },
+    async get(key: string, load: () => Promise<T[]>): Promise<T[]> {
+      if (!isCacheEnabled()) {
+        return load();
+      }
+      const now = Date.now();
+      for (const [entryKey, entry] of entries) {
+        if (!entry.pending && entry.expiresAt <= now) {
+          entries.delete(entryKey);
+        }
+      }
+      const cached = entries.get(key);
+      if (cached) {
+        return cached.pending ?? cached.models;
+      }
+      // Bound retained account identities, including entries waiting for a response.
+      if (entries.size >= MAX_ENTRIES) {
+        entries.delete(entries.keys().next().value!);
+      }
+      const entry: DiscoveryEntry<T> = { models: [], expiresAt: 0 };
+      entries.set(key, entry);
+      entry.pending = Promise.resolve()
+        .then(load)
+        .then((models) => {
+          entry.models = models;
+          entry.expiresAt = Date.now() + SUCCESS_TTL_MS;
+          return models;
+        })
+        .catch((err) => {
+          // A failed request is not a successful empty catalogue. Retry shortly.
+          entry.expiresAt = Date.now() + ERROR_RETRY_MS;
+          throw err;
+        })
+        .finally(() => {
+          entry.pending = undefined;
+        });
+      return entry.pending;
+    },
+  };
+}

--- a/src/providers/modelDiscovery.ts
+++ b/src/providers/modelDiscovery.ts
@@ -1,5 +1,3 @@
-import { isCacheEnabled } from '../cache';
-
 const SUCCESS_TTL_MS = 5 * 60 * 1000;
 const ERROR_RETRY_MS = 5 * 1000;
 const MAX_ENTRIES = 100;
@@ -11,7 +9,7 @@ interface DiscoveryEntry<T> {
 }
 
 /** Short-lived discovery state only; inference responses use the normal provider cache. */
-export function createModelDiscoveryCache<T>() {
+export function createModelDiscoveryCache<T>(isCacheEnabled: () => boolean) {
   const entries = new Map<string, DiscoveryEntry<T>>();
 
   return {

--- a/test/providers/aimlapi.test.ts
+++ b/test/providers/aimlapi.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../src/cache';
 import {
   clearAimlApiModelsCache,
@@ -10,7 +10,15 @@ import { OpenAiCompletionProvider } from '../../src/providers/openai/completion'
 import { OpenAiEmbeddingProvider } from '../../src/providers/openai/embedding';
 
 vi.mock('../../src/providers/openai');
-vi.mock('../../src/cache');
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.resetAllMocks();
+  clearAimlApiModelsCache();
+});
 
 describe('createAimlApiProvider', () => {
   beforeEach(() => {
@@ -59,9 +67,12 @@ describe('fetchAimlApiModels', () => {
     const models = await fetchAimlApiModels();
 
     expect(fetchWithCache).toHaveBeenCalledWith(
-      'https://api.aimlapi.com/models',
+      'https://api.aimlapi.com/v1/models',
       { headers: {} },
       expect.any(Number),
+      'json',
+      true,
+      2,
     );
     expect(models).toEqual([{ id: 'model-a' }, { id: 'model-b' }]);
   });

--- a/test/providers/cometapi.test.ts
+++ b/test/providers/cometapi.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache } from '../../src/cache';
 import {
   CometApiImageProvider,
@@ -28,7 +28,15 @@ vi.mock('../../src/providers/openai/embedding', async (importOriginal) => {
     OpenAiEmbeddingProvider: vi.fn(),
   };
 });
-vi.mock('../../src/cache');
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.resetAllMocks();
+  clearCometApiModelsCache();
+});
 
 describe('createCometApiProvider', () => {
   beforeEach(() => {
@@ -110,6 +118,9 @@ describe('fetchCometApiModels', () => {
       'https://api.cometapi.com/v1/models',
       { headers: { Accept: 'application/json', Authorization: 'Bearer sk-test' } },
       expect.any(Number),
+      'json',
+      true,
+      2,
     );
     // All models should be included - no filtering based on model names
     expect(models).toEqual([

--- a/test/providers/modelDiscovery.test.ts
+++ b/test/providers/modelDiscovery.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache, withCacheEnabled, withCacheNamespace } from '../../src/cache';
+import { clearAimlApiModelsCache, fetchAimlApiModels } from '../../src/providers/aimlapi';
+import { clearCometApiModelsCache, fetchCometApiModels } from '../../src/providers/cometapi';
+
+import type { EnvOverrides } from '../../src/types/env';
+
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchWithCache: vi.fn(),
+}));
+
+function response(data: unknown, status = 200) {
+  return {
+    data,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    cached: false,
+    headers: {},
+    deleteFromCache: vi.fn(async () => {}),
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(fetchWithCache).mockReset();
+  vi.stubEnv('AIML_API_KEY', '');
+  vi.stubEnv('COMETAPI_KEY', '');
+  clearAimlApiModelsCache();
+  clearCometApiModelsCache();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.resetAllMocks();
+  clearAimlApiModelsCache();
+  clearCometApiModelsCache();
+});
+
+describe.each([
+  {
+    name: 'AIML API',
+    fetch: fetchAimlApiModels,
+    clear: clearAimlApiModelsCache,
+    key: 'AIML_API_KEY',
+  },
+  {
+    name: 'CometAPI',
+    fetch: fetchCometApiModels,
+    clear: clearCometApiModelsCache,
+    key: 'COMETAPI_KEY',
+  },
+])('$name discovery', ({ fetch, clear, key }) => {
+  const env = (value: string): EnvOverrides => ({ [key]: value });
+
+  it('refreshes successful and empty catalogues after five minutes', async () => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce(response({ data: [{ id: 'old-model' }] }))
+      .mockResolvedValueOnce(response({ data: [] }))
+      .mockResolvedValueOnce(response({ data: [{ id: 'new-model' }] }));
+    expect(await fetch()).toEqual([{ id: 'old-model' }]);
+    await vi.advanceTimersByTimeAsync(299_999);
+    expect(await fetch()).toEqual([{ id: 'old-model' }]);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await fetch()).toEqual([]);
+    expect(await fetch()).toEqual([]);
+    expect(fetchWithCache).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(await fetch()).toEqual([{ id: 'new-model' }]);
+  });
+
+  it.each([401, 429, 500, 503])('retries HTTP %i after a short cooldown', async (status) => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce(response({ data: [{ id: 'not-a-success' }] }, status))
+      .mockResolvedValueOnce(response({ data: [{ id: 'recovered-model' }] }));
+    expect(await fetch()).toEqual([]);
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(await fetch()).toEqual([]);
+    expect(fetchWithCache).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await fetch()).toEqual([{ id: 'recovered-model' }]);
+  });
+
+  it.each([
+    null,
+    { error: 'temporarily unavailable' },
+    { data: 'not an array' },
+    { data: [null] },
+    { data: [{ id: '' }] },
+    { data: [{ id: 42 }] },
+  ])('does not retain malformed responses: %j', async (data) => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce(response(data))
+      .mockResolvedValueOnce(response({ data: [{ id: 'recovered-model' }] }));
+    expect(await fetch()).toEqual([]);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(await fetch()).toEqual([{ id: 'recovered-model' }]);
+  });
+
+  it('recovers from a rejected request', async () => {
+    vi.mocked(fetchWithCache)
+      .mockRejectedValueOnce(new Error('Request timed out'))
+      .mockResolvedValueOnce(response({ data: [{ id: 'recovered-model' }] }));
+    expect(await fetch()).toEqual([]);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(await fetch()).toEqual([{ id: 'recovered-model' }]);
+  });
+
+  it('isolates anonymous, process, and scoped credentials', async () => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce(response({ data: [{ id: 'anonymous' }] }))
+      .mockResolvedValueOnce(response({ data: [{ id: 'process' }] }))
+      .mockResolvedValueOnce(response({ data: [{ id: 'scoped' }] }));
+    expect(await fetch()).toEqual([{ id: 'anonymous' }]);
+    vi.stubEnv(key, 'process-key');
+    expect(await fetch()).toEqual([{ id: 'process' }]);
+    expect(await fetch(env('scoped-key'))).toEqual([{ id: 'scoped' }]);
+    expect(await fetch()).toEqual([{ id: 'process' }]);
+    expect(await fetch(env('scoped-key'))).toEqual([{ id: 'scoped' }]);
+    expect(fetchWithCache).toHaveBeenCalledTimes(3);
+  });
+
+  it('isolates failures from other accounts', async () => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce(response({ error: 'unauthorized' }, 401))
+      .mockResolvedValueOnce(response({ data: [{ id: 'other-account' }] }));
+    expect(await fetch(env('invalid-key'))).toEqual([]);
+    expect(await fetch(env('valid-key'))).toEqual([{ id: 'other-account' }]);
+    expect(await fetch(env('invalid-key'))).toEqual([]);
+    expect(fetchWithCache).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates caller cache namespaces', async () => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce(response({ data: [{ id: 'first' }] }))
+      .mockResolvedValueOnce(response({ data: [{ id: 'second' }] }));
+    expect(await withCacheNamespace('first', () => fetch())).toEqual([{ id: 'first' }]);
+    expect(await withCacheNamespace('second', () => fetch())).toEqual([{ id: 'second' }]);
+    expect(await withCacheNamespace('first', () => fetch())).toEqual([{ id: 'first' }]);
+  });
+
+  it('coalesces concurrent requests only for the same account', async () => {
+    vi.mocked(fetchWithCache).mockImplementation(async (_url, options) =>
+      response({ data: [{ id: new Headers(options?.headers).get('Authorization') }] }),
+    );
+    const results = await Promise.all([fetch(env('one')), fetch(env('one')), fetch(env('two'))]);
+    expect(results).toEqual([
+      [{ id: 'Bearer one' }],
+      [{ id: 'Bearer one' }],
+      [{ id: 'Bearer two' }],
+    ]);
+    expect(fetchWithCache).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds retained account entries', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue(response({ data: [{ id: 'model' }] }));
+    for (let i = 0; i <= 100; i++) {
+      await fetch(env(`account-${i}`));
+    }
+    await fetch(env('account-100'));
+    expect(fetchWithCache).toHaveBeenCalledTimes(101);
+    await fetch(env('account-0'));
+    expect(fetchWithCache).toHaveBeenCalledTimes(102);
+  });
+
+  it('honors disabled caching without replacing an existing entry', async () => {
+    vi.mocked(fetchWithCache)
+      .mockResolvedValueOnce(response({ data: [{ id: 'cached-model' }] }))
+      .mockResolvedValue(response({ data: [{ id: 'fresh-model' }] }));
+    expect(await fetch()).toEqual([{ id: 'cached-model' }]);
+    await withCacheEnabled(false, async () => {
+      expect(await fetch()).toEqual([{ id: 'fresh-model' }]);
+      expect(await fetch()).toEqual([{ id: 'fresh-model' }]);
+    });
+    expect(await fetch()).toEqual([{ id: 'cached-model' }]);
+    expect(fetchWithCache).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not repopulate a cleared cache from an older in-flight request', async () => {
+    let resolve!: (value: ReturnType<typeof response>) => void;
+    vi.mocked(fetchWithCache)
+      .mockImplementationOnce(
+        () =>
+          new Promise((done) => {
+            resolve = done;
+          }),
+      )
+      .mockResolvedValueOnce(response({ data: [{ id: 'new-model' }] }));
+    const pending = fetch();
+    await vi.advanceTimersByTimeAsync(0);
+    clear();
+    expect(await fetch()).toEqual([{ id: 'new-model' }]);
+    resolve(response({ data: [{ id: 'old-model' }] }));
+    expect(await pending).toEqual([{ id: 'old-model' }]);
+    expect(await fetch()).toEqual([{ id: 'new-model' }]);
+  });
+
+  it.each([
+    { payload: { data: [{ id: 'model-a' }] } },
+    { payload: { models: [{ model: 'model-a' }] } },
+    { payload: [{ name: 'model-a' }] },
+    { payload: ['model-a'] },
+  ])('preserves supported response envelopes: %j', async ({ payload }) => {
+    vi.mocked(fetchWithCache).mockResolvedValue(response(payload));
+    expect(await fetch()).toEqual([{ id: 'model-a' }]);
+  });
+});
+
+describe('provider-specific model identity', () => {
+  it('preserves AIML aliases under the canonical ID without inventing duplicate models', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue(
+      response({
+        data: [{ id: 'vendor/canonical', aliases: ['alias', 'other-alias', 'alias'] }],
+      }),
+    );
+    expect(await fetchAimlApiModels()).toEqual([
+      { id: 'vendor/canonical', aliases: ['alias', 'other-alias'] },
+    ]);
+  });
+
+  it.each([{ aliases: 'alias' }, { aliases: [null] }, { aliases: [''] }])(
+    'retries malformed AIML aliases: %j',
+    async ({ aliases }) => {
+      vi.mocked(fetchWithCache)
+        .mockResolvedValueOnce(response({ data: [{ id: 'canonical', aliases }] }))
+        .mockResolvedValueOnce(response({ data: [{ id: 'canonical', aliases: ['alias'] }] }));
+      expect(await fetchAimlApiModels()).toEqual([]);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(await fetchAimlApiModels()).toEqual([{ id: 'canonical', aliases: ['alias'] }]);
+    },
+  );
+
+  it('does not impose AIML alias fields on Comet models', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValue(
+      response({ data: [{ id: 'comet-model', aliases: 42 }] }),
+    );
+    expect(await fetchCometApiModels()).toEqual([{ id: 'comet-model' }]);
+  });
+});


### PR DESCRIPTION
A failed AIML API or CometAPI model-list request leaves an empty catalog cached until the process restarts. Expire successful discovery results after five minutes and retry errors after five seconds, with bounded account- and namespace-isolated entries and concurrent request coalescing. Preserve AIML aliases alongside canonical IDs and reject malformed catalog responses.

Validation: 65 focused provider tests, architecture check, root type check, backend/app builds, and normal pre-commit hooks passed. An actual built CLI evaluation exercised both compiled discovery helpers using synthetic HTTP responses; both exported cases passed with zero token usage.
