### PR TITLE
docs(site): correct Google example model routes

### DIFF
--- a/examples/google-aistudio-tools/promptfooconfig.yaml
+++ b/examples/google-aistudio-tools/promptfooconfig.yaml
@@ -14,10 +14,13 @@ providers:
 
 defaultTest:
   options:
-    # This overrides the default grading providers with Vertex AI models
-    providers:
-      embedding: 'google:embedding:text-embedding-005'
-      text: 'google:gemini-2.5-flash'
+    # This overrides the default grading providers with native Gemini API models
+    provider:
+      embedding: 'google:embedding:gemini-embedding-001'
+      text:
+        id: 'google:gemini-2.5-flash'
+        config:
+          tools: [] # Keep grading separate from the target's weather tool.
 
 tests:
   # Function calling tests

--- a/examples/google-imagen/README.md
+++ b/examples/google-imagen/README.md
@@ -1,8 +1,6 @@
-# google-imagen (Google Imagen)
+# google-imagen (Google Image Generation)
 
-This example demonstrates Google image generation models, including both Imagen and Gemini native image generation.
-
-You can run this example with:
+This example generates images with Gemini. The directory keeps its existing name so `init --example google-imagen` continues to work.
 
 ```bash
 npx promptfoo@latest init --example google-imagen
@@ -11,123 +9,102 @@ cd google-imagen
 
 ## Prerequisites
 
-You can use Imagen models through either Google AI Studio or Vertex AI:
+Choose Google AI Studio for the native Gemini API or Vertex AI for Google Cloud authentication.
 
-### Option 1: Google AI Studio (Quick Start, Limited Features)
+### Option 1: Google AI Studio (Quick Start)
 
-- Get an API key from [Google AI Studio](https://aistudio.google.com/apikey)
-- **Supports**: Imagen 4 models only
-- **Limitations**: No `seed` or `addWatermark` parameters
+- Get an API key from [Google AI Studio](https://aistudio.google.com/apikey).
+- Use a billing-enabled project with access to the selected image model.
 
-### Option 2: Vertex AI (Full Features)
+### Option 2: Vertex AI
 
-- Google Cloud project with billing enabled
-- Vertex AI API enabled
-- Authentication via `gcloud auth application-default login`
-- **Supports**: All Imagen models and all parameters
+- Use a Google Cloud project with billing and the Vertex AI API enabled.
+- Authenticate with `gcloud auth application-default login`.
+- Check the [Vertex Gemini 3.1 Flash Image model card](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/gemini/3-1-flash-image) for model availability. The example uses the global endpoint.
 
 ## Setup
 
 ### For Google AI Studio:
 
 ```bash
-# Set your API key (Unix/Linux/macOS)
 export GOOGLE_API_KEY=your-api-key
 
-# For Windows Command Prompt:
+# Windows Command Prompt:
 # set GOOGLE_API_KEY=your-api-key
-
-# For Windows PowerShell:
+# Windows PowerShell:
 # $env:GOOGLE_API_KEY="your-api-key"
 ```
+
+Run without `GOOGLE_PROJECT_ID` or `GOOGLE_CLOUD_PROJECT` set: a configured project selects Vertex AI in this adapter.
 
 ### For Vertex AI:
 
 ```bash
-# Enable Vertex AI API
 gcloud services enable aiplatform.googleapis.com
-
-# Authenticate
 gcloud auth application-default login
-
-# Set project ID (Unix/Linux/macOS)
 export GOOGLE_PROJECT_ID=your-project-id
 
-# For Windows Command Prompt:
+# Windows Command Prompt:
 # set GOOGLE_PROJECT_ID=your-project-id
-
-# For Windows PowerShell:
+# Windows PowerShell:
 # $env:GOOGLE_PROJECT_ID="your-project-id"
 ```
 
 ## Environment Variables
 
-- `GOOGLE_API_KEY` - Google AI Studio API key (Option 1)
-- `GOOGLE_PROJECT_ID` - Your Google Cloud project ID (Option 2)
+- `GOOGLE_API_KEY` - Native Gemini API key.
+- `GOOGLE_PROJECT_ID` - Google Cloud project used by the Vertex example.
 
 ## Available Models
 
-### Imagen Models (use `google:image:` prefix)
+### Imagen Models (legacy `google:image:` prefix)
 
-- `imagen-4.0-ultra-generate-001` - Ultra quality ($0.06/image)
-- `imagen-4.0-generate-001` - Standard quality ($0.04/image)
-- `imagen-4.0-fast-generate-001` - Fast generation ($0.02/image)
-- `imagen-3.0-generate-002` - Imagen 3.0 ($0.04/image)
+The old Imagen configurations have been migrated to Gemini image generation. Native Imagen 4 reached its [August 17, 2026 shutdown](https://ai.google.dev/gemini-api/docs/imagen). Google Cloud separately [discontinued Imagen 3 and 4 models on June 30, 2026](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/release-notes).
 
-Google has deprecated the Imagen 4 models with an August 17, 2026 shutdown and recommends `gemini-3.1-flash-image` as the replacement. The older `imagen-4.0-*-preview-06-06` ids are already shut down.
+Use `google:gemini-3.1-flash-image` for the replacement. The `google:image:` prefix selects Imagen's `predict` adapter; putting a Gemini model after that prefix does not migrate the protocol.
 
 ### Gemini Native Image Generation
 
-- `google:gemini-3.1-flash-lite-image` - Gemini 3.1 Flash-Lite (Nano Banana 2 Lite) for the fastest, lowest-cost image generation (~$0.034/image at 1K; 1K only)
-- `google:gemini-3.1-flash-image` - Gemini 3.1 Flash (Nano Banana 2) with native image generation (~$0.067/image at 1K)
-- `google:gemini-3-pro-image` - Gemini 3 Pro (Nano Banana Pro) with native image generation (~$0.134/image at 1K/2K)
-- `google:gemini-2.5-flash-image` - Gemini 2.5 Flash (Nano Banana) with image generation (~$0.039/image)
+The default config uses `google:gemini-3.1-flash-image` at 1K resolution. `promptfooconfig-gemini.yaml` compares these native Gemini API models:
 
-Use the GA ids above; Google shut down the `gemini-3.1-flash-image-preview` and `gemini-3-pro-image-preview` aliases on June 25, 2026. Nano Banana 2 Lite never had a `-preview` alias.
+- `google:gemini-3.1-flash-lite-image` - 1K only; no Google Search grounding.
+- `google:gemini-3.1-flash-image` - Supports 1K, 2K, and 4K output.
+- `google:gemini-3-pro-image` - Supports 1K, 2K, and 4K output.
+- `google:gemini-2.5-flash-image` - Legacy comparison until its [October 2, 2026 native shutdown](https://ai.google.dev/gemini-api/docs/deprecations); use 3.1 Flash Image for new configs. Does not support `imageSize`.
+
+Use the stable IDs above. Google shut down the `gemini-3.1-flash-image-preview` and `gemini-3-pro-image-preview` aliases on [June 25, 2026](https://ai.google.dev/gemini-api/docs/deprecations). Check [current native pricing](https://ai.google.dev/gemini-api/docs/pricing) for the model and resolution you select; Vertex has separate pricing and availability.
 
 ## Running the Example
+
+For Google AI Studio:
 
 ```bash
 npx promptfoo@latest eval
 ```
 
+For Vertex AI, use the OAuth configuration:
+
+```bash
+npx promptfoo@latest eval -c promptfooconfig-advanced.yaml
+```
+
 ## Notes
 
-- Imagen models are available through both **Google AI Studio** and **Vertex AI**
-- **Google AI Studio**:
-  - Uses API key authentication (quick start)
-  - Only supports Imagen 4 models (4.0 preview models)
-  - Limited parameter support:
-    - No `seed` or `addWatermark` parameters
-    - Only `block_low_and_above` safety filter level
-- **Vertex AI**:
-  - Requires authentication via `gcloud auth application-default login`
-  - Supports all Imagen models (both 3.0 and 4.0)
-  - Full parameter support:
-    - All safety filter levels (`block_most`, `block_some`, `block_few`, `block_fewest`)
-    - `seed` for deterministic generation
-    - `addWatermark` control
-  - You must provide a Google Cloud project ID either via:
-    - `GOOGLE_PROJECT_ID` environment variable
-    - `projectId` in the provider config
-- Seed and watermark parameters are mutually exclusive (Vertex AI only)
+- Gemini image generation uses `generateContent` with `TEXT` and `IMAGE` response modalities.
+- Configure `imageAspectRatio` and `imageSize`. Imagen's `aspectRatio`, `safetyFilterLevel`, `seed`, `personGeneration`, and `addWatermark` options are not interchangeable with this adapter's settings.
+- Responses can contain both text and images. The assertions inspect `context.providerResponse.images` so a valid text-and-image response passes and a text-only response fails.
 
 ## Advanced Configuration
 
-See `promptfooconfig-advanced.yaml` for examples of platform-specific configurations that take advantage of each platform's unique capabilities.
+`promptfooconfig-advanced.yaml` demonstrates Vertex AI with an explicit project and 2K image generation. It sets `apiKeyRequired: false` because Google Cloud OAuth supplies authentication.
 
 ## Gemini Native Image Generation
 
-Gemini models can generate images natively using the `generateContent` API with `responseModalities` set to include images. This is different from Imagen which uses a dedicated image generation endpoint.
+For a comparison of native image models or a Google Search-grounded image, run:
 
-See `promptfooconfig-gemini.yaml` for Gemini native image generation examples.
-See `promptfooconfig-gemini-grounding.yaml` for Google Search-grounded Gemini image generation.
+```bash
+npx promptfoo@latest eval -c promptfooconfig-gemini.yaml
+npx promptfoo@latest eval -c promptfooconfig-gemini-grounding.yaml
+```
 
-Key differences from Imagen:
-
-- Uses the same `google:` provider namespace as Gemini chat (models with `-image` in the name automatically enable image generation)
-- Supports additional aspect ratios: `1:4`, `1:8`, `2:3`, `3:2`, `4:1`, `4:5`, `5:4`, `8:1`, `21:9`
-- Supports image resolution: `512px` (Gemini 3.1), `1K`, `2K`, `4K`
-- Can return both text and images in the same response
-- Uses the same authentication as Gemini chat models
-- Supports Google Search grounding via `tools: [{ googleSearch: {} }]`
+The grounding config uses `google:gemini-3.1-flash-image` with `tools: [{ googleSearch: {} }]`. See Google's [GenerateContent image guide](https://ai.google.dev/gemini-api/docs/generate-content/image-generation) for supported input, output, and grounding options.

--- a/examples/google-imagen/promptfooconfig-advanced.yaml
+++ b/examples/google-imagen/promptfooconfig-advanced.yaml
@@ -1,44 +1,25 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-description: Advanced Imagen configuration showing platform-specific settings
+description: Gemini image generation with Vertex AI
 
 prompts:
   - 'Create a {{quality}} image of {{subject}} with {{style}} aesthetic'
 
 providers:
-  # Google AI Studio configuration (API key authentication)
-  - id: google:image:imagen-4.0-generate-001
-    label: Imagen 4.0 (Google AI Studio)
+  # Vertex AI uses Google Cloud authentication and the global endpoint for this model.
+  - id: google:gemini-3.1-flash-image
     config:
-      aspectRatio: '16:9'
-      safetyFilterLevel: 'block_low_and_above' # Only value supported by Google AI Studio
-      # Note: seed and addWatermark are not supported in Google AI Studio
+      projectId: '{{env.GOOGLE_PROJECT_ID}}'
+      apiKeyRequired: false # This example uses Google Cloud OAuth, not a native API key.
+      imageAspectRatio: '16:9'
+      imageSize: '2K'
 
-  # Vertex AI configuration (OAuth authentication)
-  - id: google:image:imagen-4.0-generate-001
-    label: Imagen 4.0 (Vertex AI)
-    config:
-      projectId: 'your-project-id' # Forces Vertex AI usage
-      aspectRatio: '16:9'
-      safetyFilterLevel: 'block_some' # Vertex AI supports all safety levels
-      seed: 42 # Deterministic generation
-      addWatermark: false # Disable watermark (incompatible with seed)
-
-  # Imagen 3.0 - Only available through Vertex AI
-  - id: google:image:imagen-3.0-generate-002
-    label: Imagen 3.0 (Vertex AI only)
-    config:
-      projectId: 'your-project-id'
-      aspectRatio: '1:1'
-      safetyFilterLevel: 'block_fewest'
-      personGeneration: 'allow_adult'
+defaultTest:
+  assert:
+    - type: javascript
+      value: '(context.providerResponse?.images?.length ?? 0) > 0'
 
 tests:
   - vars:
       quality: 'photorealistic'
       subject: 'a serene mountain landscape'
       style: 'golden hour photography'
-    assert:
-      - type: javascript
-        value: |
-          // Check if the output contains a valid image data URL
-          return output.includes('![Generated Image](data:image/')

--- a/examples/google-imagen/promptfooconfig-gemini-grounding.yaml
+++ b/examples/google-imagen/promptfooconfig-gemini-grounding.yaml
@@ -5,7 +5,7 @@ prompts:
   - 'Create a travel poster for {{city}} using real landmarks and current points of interest'
 
 providers:
-  - id: google:gemini-3.1-flash-image-preview
+  - id: google:gemini-3.1-flash-image
     config:
       imageAspectRatio: '16:9'
       imageSize: '1K'
@@ -15,7 +15,7 @@ providers:
 defaultTest:
   assert:
     - type: javascript
-      value: output.length > 0 && (output.startsWith('data:image/') || output.startsWith('promptfoo://blob/'))
+      value: '(context.providerResponse?.images?.length ?? 0) > 0'
 
 tests:
   - vars:

--- a/examples/google-imagen/promptfooconfig-gemini.yaml
+++ b/examples/google-imagen/promptfooconfig-gemini.yaml
@@ -5,7 +5,8 @@ prompts:
   - 'Create a {{quality}} image of {{subject}} with {{style}} aesthetic'
 
 providers:
-  # Gemini 2.5 Flash - Fast image generation (generally available)
+  # Legacy comparison: native Gemini 2.5 Flash Image shuts down October 2, 2026.
+  # Use gemini-3.1-flash-image (below) for new configurations.
   # Note: imageSize is not supported for Gemini 2.5 models
   - id: google:gemini-2.5-flash-image
     config:

--- a/examples/google-imagen/promptfooconfig.yaml
+++ b/examples/google-imagen/promptfooconfig.yaml
@@ -1,42 +1,20 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-description: Google Imagen image generation comparison
+description: Google Gemini image generation
 
 prompts:
   - 'Create a {{quality}} image of {{subject}} with {{style}} aesthetic'
 
 providers:
-  # Ultra quality - highest detail and quality
-  - id: google:image:imagen-4.0-ultra-generate-001
+  - id: google:gemini-3.1-flash-image
     config:
-      # projectId: 'your-project-id'  # Optional: Can be set here or via GOOGLE_PROJECT_ID env var
-      aspectRatio: '16:9'
-      # seed: 42  # Note: seed is only supported in Vertex AI, not Google AI Studio
-      # safetyFilterLevel: 'block_some'  # Note: Google AI Studio only supports 'block_low_and_above'
-      # addWatermark: false  # Note: addWatermark is only supported in Vertex AI
+      imageAspectRatio: '16:9'
+      imageSize: '1K'
 
-  # Standard quality - balanced quality and speed
-  - id: google:image:imagen-4.0-generate-001
-    config:
-      aspectRatio: '16:9'
-      # seed: 42  # Note: seed is only supported in Vertex AI
-      # safetyFilterLevel: 'block_some'  # Note: Google AI Studio only supports 'block_low_and_above'
-      # addWatermark: false  # Note: addWatermark is only supported in Vertex AI
-
-  # Fast generation - optimized for speed
-  - id: google:image:imagen-4.0-fast-generate-001
-    config:
-      aspectRatio: '16:9'
-      # seed: 42  # Note: seed is only supported in Vertex AI
-      # safetyFilterLevel: 'block_some'  # Note: Google AI Studio only supports 'block_low_and_above'
-      # addWatermark: false  # Note: addWatermark is only supported in Vertex AI
-
-  # Previous generation for comparison
-  - id: google:image:imagen-3.0-generate-002
-    config:
-      aspectRatio: '16:9'
-      # seed: 42  # Note: seed is only supported in Vertex AI
-      # safetyFilterLevel: 'block_some'  # Note: Google AI Studio only supports 'block_low_and_above'
-      # addWatermark: false  # Note: addWatermark is only supported in Vertex AI
+defaultTest:
+  assert:
+    # Images can accompany text, so inspect the structured image response.
+    - type: javascript
+      value: '(context.providerResponse?.images?.length ?? 0) > 0'
 
 tests:
   - vars:

--- a/examples/google-vertex-tools/README.md
+++ b/examples/google-vertex-tools/README.md
@@ -60,6 +60,8 @@ Uses external tool definitions and validates function calls without execution:
 - `promptfooconfig.yaml` - YAML configuration with external tools
 - `tools.json` - Function definitions for weather lookup
 
+The basic config selects `gemini-3.5-flash` on the `global` endpoint for the target and text grader. Its semantic assertion uses Vertex `text-embedding-005`; this cloud model is separate from the native Gemini embedding namespace.
+
 ### Function Callbacks (`promptfooconfig-callback.js`)
 
 Demonstrates actual function execution with local callbacks:

--- a/examples/google-vertex-tools/promptfooconfig.yaml
+++ b/examples/google-vertex-tools/promptfooconfig.yaml
@@ -9,8 +9,9 @@ prompts:
 
 providers:
   # See https://www.promptfoo.dev/docs/providers/vertex/
-  - id: 'vertex:gemini-2.5-flash-002'
+  - id: 'vertex:gemini-3.5-flash'
     config:
+      region: global
       tools: file://tools.json
 
 defaultTest:
@@ -29,9 +30,12 @@ defaultTest:
 
   options:
     # This overrides the default grading providers with Vertex AI models.
-    providers:
+    provider:
       embedding: 'vertex:embedding:text-embedding-005'
-      text: 'vertex:gemini-2.5-flash-002'
+      text:
+        id: 'vertex:gemini-3.5-flash'
+        config:
+          region: global
 
 tests:
   - vars:

--- a/site/docs/configuration/tools.md
+++ b/site/docs/configuration/tools.md
@@ -71,7 +71,7 @@ providers:
     config:
       tools: *tools # Alias: reuse the same tools
 
-  - id: google:gemini-2.0-flash
+  - id: google:gemini-2.5-flash
     config:
       tools: *tools # Alias: works here too
 ```

--- a/site/docs/guides/factuality-eval.md
+++ b/site/docs/guides/factuality-eval.md
@@ -140,7 +140,7 @@ providers:
   - openai:gpt-5-mini
   - openai:gpt-5
   - anthropic:claude-sonnet-4-6
-  - google:gemini-2.0-flash
+  - google:gemini-2.5-flash
 prompts:
   - |
     Question: What is the capital of {{location}}?

--- a/site/docs/integrations/mcp.md
+++ b/site/docs/integrations/mcp.md
@@ -26,7 +26,7 @@ To enable MCP for a provider, add the `mcp` block to your provider's `config` in
 ```yaml title="promptfooconfig.yaml"
 description: Testing MCP memory server integration with Google AI Studio
 providers:
-  - id: google:gemini-2.0-flash
+  - id: google:gemini-2.5-flash
     config:
       mcp:
         enabled: true
@@ -148,7 +148,7 @@ You can configure multiple MCP servers by assigning different MCP server configu
 ```yaml title="promptfooconfig.yaml"
 description: Using multiple MCP servers
 providers:
-  - id: google:gemini-2.0-flash
+  - id: google:gemini-2.5-flash
     config:
       mcp:
         enabled: true


### PR DESCRIPTION
## Summary

Migrate retired Imagen examples to the Gemini image route, supported image options, and assertions that accept images alongside text. The Vertex example uses an explicit project and OAuth configuration; the existing `google-imagen` init name is preserved.

Correct the native embedding namespace and grading override key, keep text graders separate from the target's weather tools, and replace retired native tutorial IDs and invalid Vertex tool IDs. Preserve the supported Vertex embedding model and clearly date the optional legacy native image comparison.

## Validation

- 276 focused Google provider tests, type check, and CLI/library build pass.
- Seven built CLI fixture runs: 13 successful cases and two expected text-only/blocked image failures. Inspected exported outputs, scores, errors, usage, request routes, and grading overrides. All provider responses were mocked locally.
- Documentation build (`SKIP_OG_GENERATION=true`), `npm run l`, `npm run f`, and normal commit hooks pass.

Sources checked September 8, 2026: [native Gemini lifecycle](https://ai.google.dev/gemini-api/docs/deprecations), [Imagen migration](https://ai.google.dev/gemini-api/docs/imagen), [Gemini image generation](https://ai.google.dev/gemini-api/docs/generate-content/image-generation), and [Google Cloud Flash 3.5](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/guides/gemini-3-5-flash).
