### PR TITLE
docs(site): correct gateway example protocols

### DIFF
--- a/examples/provider-litellm/README.md
+++ b/examples/provider-litellm/README.md
@@ -32,7 +32,7 @@ LiteLLM provides a unified interface to 400+ LLMs. Instead of managing different
 
    # Or manually:
    pip install litellm[proxy]
-   litellm --model gpt-4.1 --model claude-sonnet-4-6 --model gemini-2.5-pro --model text-embedding-3-large
+   litellm --config litellm_config.yaml --port 4000
    ```
 
 3. **Run the evaluation**:
@@ -63,6 +63,8 @@ The LiteLLM provider in promptfoo connects to a LiteLLM proxy server (default po
 - `promptfooconfig.yaml` - Main evaluation configuration
 - `litellm_config.yaml` - LiteLLM proxy server configuration
 - `start-proxy.sh` - Helper script to start the proxy
+
+The proxy keeps client-facing `model_name` aliases separate from backend routes. For Google AI Studio, the [LiteLLM Gemini backend](https://docs.litellm.ai/docs/providers/gemini) uses `gemini/gemini-2.5-pro`; promptfoo continues to select `litellm:gemini-2.5-pro`. API keys in the proxy YAML use LiteLLM's `os.environ/VARIABLE_NAME` syntax.
 
 ## Example Configuration
 

--- a/examples/provider-litellm/litellm_config.yaml
+++ b/examples/provider-litellm/litellm_config.yaml
@@ -5,22 +5,22 @@ model_list:
   - model_name: gpt-4.1
     litellm_params:
       model: openai/gpt-4.1
-      api_key: ${OPENAI_API_KEY}
+      api_key: os.environ/OPENAI_API_KEY
 
   - model_name: claude-sonnet-4-6
     litellm_params:
       model: anthropic/claude-sonnet-4-6
-      api_key: ${ANTHROPIC_API_KEY}
+      api_key: os.environ/ANTHROPIC_API_KEY
 
   - model_name: gemini-2.5-pro
     litellm_params:
-      model: google/gemini-2.5-pro
-      api_key: ${GOOGLE_AI_API_KEY}
+      model: gemini/gemini-2.5-pro
+      api_key: os.environ/GOOGLE_AI_API_KEY
 
   - model_name: text-embedding-3-large
     litellm_params:
       model: openai/text-embedding-3-large
-      api_key: ${OPENAI_API_KEY}
+      api_key: os.environ/OPENAI_API_KEY
 
 litellm_settings:
   drop_params: true

--- a/examples/provider-litellm/start-proxy.sh
+++ b/examples/provider-litellm/start-proxy.sh
@@ -19,7 +19,7 @@ if ! command -v litellm &>/dev/null; then
 fi
 
 # Check for at least one API key
-if [ -z "$OPENAI_API_KEY" ] && [ -z "$ANTHROPIC_API_KEY" ] && [ -z "$GOOGLE_AI_API_KEY" ]; then
+if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${GOOGLE_AI_API_KEY:-}" ]; then
   echo "ERROR: No API keys found. Set at least one of the environment variables above."
   exit 1
 fi
@@ -27,10 +27,6 @@ fi
 echo "Starting proxy on http://localhost:4000..."
 echo ""
 
-# Start the proxy with models used in the example
-litellm \
-  --model gpt-4.1 \
-  --model claude-sonnet-4-6 \
-  --model gemini-2.5-pro \
-  --model text-embedding-3-large \
-  --port 4000
+# Load the backend routes and public model aliases from the example config.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+litellm --config "$SCRIPT_DIR/litellm_config.yaml" --port 4000

--- a/examples/redteam-harmbench/promptfooconfig.yaml
+++ b/examples/redteam-harmbench/promptfooconfig.yaml
@@ -11,7 +11,7 @@ providers:
   # Ablated model, which should fail all of the Harmbench tests
   - 'ollama:mannix/llama3.1-8b-abliterated'
   # Vanilla model from Meta, which should refuse to comply with most of the Harmbench prompts
-  - 'ollama:chat:llama3.3:8b'
+  - 'ollama:chat:llama3.1:8b'
 
 defaultTest:
   assert:

--- a/site/docs/providers/cloudflare-gateway.md
+++ b/site/docs/providers/cloudflare-gateway.md
@@ -14,7 +14,7 @@ description: Route AI requests through Cloudflare AI Gateway for caching, rate l
 - **Logging** - Monitor requests and responses
 - **Fallback** - Configure fallback providers for reliability
 
-The `cloudflare-gateway` provider lets you route your promptfoo evaluations through Cloudflare AI Gateway to any supported AI provider.
+The `cloudflare-gateway` provider routes promptfoo evals through Cloudflare AI Gateway using the chat protocols listed below. Cloudflare also offers an OpenAI-compatible account API for supported models.
 
 ## Provider Format
 
@@ -26,7 +26,7 @@ cloudflare-gateway:{provider}:{model}
 
 - `cloudflare-gateway:openai:gpt-5.2`
 - `cloudflare-gateway:anthropic:claude-sonnet-4-5-20250929`
-- `cloudflare-gateway:groq:llama-3.3-70b-versatile`
+- `cloudflare-gateway:groq:openai/gpt-oss-120b`
 
 ## Required Configuration
 
@@ -98,25 +98,22 @@ tests:
 
 ## Supported Providers
 
-Cloudflare AI Gateway supports routing to these providers:
+The `cloudflare-gateway` adapter supports these provider-specific chat routes:
 
-| Provider         | Gateway Name       | API Key Environment Variable |
-| ---------------- | ------------------ | ---------------------------- |
-| OpenAI           | `openai`           | `OPENAI_API_KEY`             |
-| Anthropic        | `anthropic`        | `ANTHROPIC_API_KEY`          |
-| Groq             | `groq`             | `GROQ_API_KEY`               |
-| Perplexity       | `perplexity-ai`    | `PERPLEXITY_API_KEY`         |
-| Google AI Studio | `google-ai-studio` | `GOOGLE_API_KEY`             |
-| Mistral          | `mistral`          | `MISTRAL_API_KEY`            |
-| Cohere           | `cohere`           | `COHERE_API_KEY`             |
-| Azure OpenAI     | `azure-openai`     | `AZURE_OPENAI_API_KEY`       |
-| Workers AI       | `workers-ai`       | `CLOUDFLARE_API_KEY`         |
-| Hugging Face     | `huggingface`      | `HUGGINGFACE_API_KEY`        |
-| Replicate        | `replicate`        | `REPLICATE_API_KEY`          |
-| Grok (xAI)       | `grok`             | `XAI_API_KEY`                |
+| Provider     | Gateway Name    | API Key Environment Variable |
+| ------------ | --------------- | ---------------------------- |
+| OpenAI       | `openai`        | `OPENAI_API_KEY`             |
+| Anthropic    | `anthropic`     | `ANTHROPIC_API_KEY`          |
+| Groq         | `groq`          | `GROQ_API_KEY`               |
+| Perplexity   | `perplexity-ai` | `PERPLEXITY_API_KEY`         |
+| Mistral      | `mistral`       | `MISTRAL_API_KEY`            |
+| Azure OpenAI | `azure-openai`  | `AZURE_OPENAI_API_KEY`       |
+| Grok (xAI)   | `grok`          | `XAI_API_KEY`                |
 
 :::note
-AWS Bedrock is not supported through Cloudflare AI Gateway because it requires AWS request signing, which is incompatible with the gateway proxy approach.
+The provider-specific `cloudflare-gateway:` routes for Workers AI, Google AI Studio, Cohere, Hugging Face, and Replicate currently send OpenAI Chat Completions requests to incompatible native endpoints. Use Cloudflare's [OpenAI-compatible REST API](https://developers.cloudflare.com/ai-gateway/usage/rest-api/) for models it supports, as shown below for Workers AI. Other native endpoints require a [custom provider](/docs/providers/custom-api).
+
+AWS Bedrock request signing is not implemented by the `cloudflare-gateway` adapter.
 :::
 
 ## Configuration Options
@@ -155,15 +152,21 @@ providers:
 
 ### Workers AI Configuration
 
-Workers AI routes requests to Cloudflare's edge-deployed models. The model name is included in the URL path:
+Use the generic OpenAI provider with Cloudflare's [OpenAI-compatible Workers AI endpoint](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/) and a supported chat model such as [Llama 3.3 70B](https://developers.cloudflare.com/workers-ai/models/llama-3.3-70b-instruct-fp8-fast/). Keep the Workers AI model ID in the request body and select the gateway with `cf-aig-gateway-id`:
 
 ```yaml
 providers:
-  - id: cloudflare-gateway:workers-ai:@cf/meta/llama-3.1-8b-instruct
+  - id: openai:chat:@cf/meta/llama-3.3-70b-instruct-fp8-fast
     config:
-      accountId: '{{env.CLOUDFLARE_ACCOUNT_ID}}'
-      gatewayId: '{{env.CLOUDFLARE_GATEWAY_ID}}'
+      apiBaseUrl: https://api.cloudflare.com/client/v4/accounts/{{env.CLOUDFLARE_ACCOUNT_ID}}/ai/v1
+      apiKeyEnvar: CLOUDFLARE_API_TOKEN
+      headers:
+        cf-aig-gateway-id: '{{env.CLOUDFLARE_GATEWAY_ID}}'
 ```
+
+This account API uses a Cloudflare API token with **Account → Workers AI → Read** permission as the bearer credential; a gateway-only token is insufficient. Set `CLOUDFLARE_API_TOKEN` to that token. The `cfAigToken` option above belongs to the provider-specific gateway routes and is not used in this configuration. See [Cloudflare REST authentication](https://developers.cloudflare.com/ai-gateway/usage/rest-api/#authentication).
+
+For third-party models on the same account API, choose a supported model from Cloudflare's provider documentation: [Google AI Studio](https://developers.cloudflare.com/ai-gateway/usage/providers/google-ai-studio/) uses `openai:chat:google-ai-studio/<model>`, and [Cohere](https://developers.cloudflare.com/ai-gateway/usage/providers/cohere/) uses `openai:chat:cohere/<model>`. Cloudflare uses the stored BYOK key under the `default` alias when present and otherwise uses Unified Billing; this route does not send your upstream API key. Review [credential precedence](https://developers.cloudflare.com/ai-gateway/features/unified-billing/#credential-precedence) before switching an existing gateway configuration. The older gateway `/compat` endpoint is [deprecated for single-model calls](https://developers.cloudflare.com/ai-gateway/usage/chat-completion/) and has different authentication options.
 
 ### Provider-Specific Options
 
@@ -201,7 +204,7 @@ providers:
       accountId: '{{env.CLOUDFLARE_ACCOUNT_ID}}'
       gatewayId: '{{env.CLOUDFLARE_GATEWAY_ID}}'
 
-  - id: cloudflare-gateway:groq:llama-3.3-70b-versatile
+  - id: cloudflare-gateway:groq:openai/gpt-oss-120b
     config:
       accountId: '{{env.CLOUDFLARE_ACCOUNT_ID}}'
       gatewayId: '{{env.CLOUDFLARE_GATEWAY_ID}}'


### PR DESCRIPTION
Cloudflare gateway docs advertised native routes that send incompatible OpenAI chat requests. Limit the support table to implemented chat protocols and show Workers AI through the documented compatible account API, with its token permissions and third-party BYOK/billing rules. Update the Workers AI and Groq starters to current public chat models.

The LiteLLM example now starts from its checked-in config, uses the Gemini backend namespace and documented environment lookups, and preserves client-facing aliases. The HarmBench YAML now selects the published `llama3.1:8b` model its README already provisions.

Validation: `npm ci`, `npm run l && npm run f`, shell syntax, five launcher stub cases, three YAML checks, two actual adapter request-body checks with network calls forbidden, normal commit hooks, and the production docs build with `SKIP_OG_GENERATION=true` all passed. No vendor inference or HarmBench workflow ran.

Primary sources checked September 8, 2026: [Cloudflare account REST API](https://developers.cloudflare.com/ai-gateway/usage/rest-api/), [Cloudflare Workers AI compatibility](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/), and [LiteLLM Gemini backend](https://docs.litellm.ai/docs/providers/gemini).
