### PR TITLE
fix(examples): honor framework model selection

### DIFF
--- a/examples/integration-crewai/README.md
+++ b/examples/integration-crewai/README.md
@@ -64,6 +64,10 @@ npm install -g promptfoo
 - `agent.py`: Contains the CrewAI agent setup and promptfoo provider interface
 - `promptfooconfig.yaml`: Configures prompts, providers, and tests for evaluation
 
+Set `providers[0].config.model` to a CrewAI model ID such as `openai/gpt-4.1`.
+The provider passes it to `LLM(model=...)` through the agent's `llm` field. CrewAI
+uses a slash between provider and model names.
+
 ### Note on Reliability
 
 When using a real LLM, you may notice that the agent's output is not always reliable, especially for more complex queries. For example, the agent may fail to return valid JSON or may not return a response at all. This is a common challenge when working with LLMs.

--- a/examples/integration-crewai/agent.py
+++ b/examples/integration-crewai/agent.py
@@ -5,13 +5,13 @@ import re
 import textwrap
 from typing import Any, Dict
 
-from crewai import Agent, Crew, Task
+from crewai import LLM, Agent, Crew, Task
 
 # ✅ Load the OpenAI API key from the environment
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 
-def get_recruitment_agent(model: str = "openai:gpt-4.1") -> Crew:
+def get_recruitment_agent(model: str = "openai/gpt-4.1") -> Crew:
     """
     Creates a CrewAI recruitment agent setup.
     This agent's goal: find the best Ruby on Rails + React candidates.
@@ -25,8 +25,7 @@ def get_recruitment_agent(model: str = "openai:gpt-4.1") -> Crew:
             You never fail to return a valid JSON object as your final answer.
         """).strip(),
         verbose=False,
-        model=model,
-        api_key=OPENAI_API_KEY,  # ✅ Make sure to pass the API key
+        llm=LLM(model=model, api_key=OPENAI_API_KEY),
     )
 
     task = Task(
@@ -58,7 +57,7 @@ def get_recruitment_agent(model: str = "openai:gpt-4.1") -> Crew:
     return crew
 
 
-async def run_recruitment_agent(prompt, model="openai:gpt-4.1"):
+async def run_recruitment_agent(prompt, model="openai/gpt-4.1"):
     """
     Runs the recruitment agent with a given job requirements prompt.
     Returns a structured JSON-like dictionary with candidate info.
@@ -72,7 +71,7 @@ async def run_recruitment_agent(prompt, model="openai:gpt-4.1"):
     crew = get_recruitment_agent(model)
     try:
         # ⚡ Trigger the agent to start working
-        crew.kickoff(inputs={"job_requirements": prompt})
+        result = crew.kickoff(inputs={"job_requirements": prompt})
 
         # The result might be a string, or an object with a 'raw' attribute.
         output_text = ""
@@ -118,7 +117,7 @@ def call_api(
     try:
         # ✅ Run the async recruitment agent synchronously
         config = options.get("config", {})
-        model = config.get("model", "openai:gpt-4.1")
+        model = config.get("model", "openai/gpt-4.1")
         result = asyncio.run(run_recruitment_agent(prompt, model=model))
 
         if "error" in result:

--- a/examples/integration-crewai/promptfooconfig.yaml
+++ b/examples/integration-crewai/promptfooconfig.yaml
@@ -8,7 +8,7 @@ providers:
   - id: 'file://./agent.py'
     label: 'CrewAI Recruitment Agent'
     config:
-      model: 'openai:gpt-4.1'
+      model: 'openai/gpt-4.1'
 
 # It's a good practice to have a defaultTest that applies to all test cases.
 defaultTest:

--- a/examples/integration-langchain/README.md
+++ b/examples/integration-langchain/README.md
@@ -9,7 +9,7 @@ cd integration-langchain
 
 ## Usage
 
-This example shows how to run a Python LangChain Expression Language (LCEL) chain with Promptfoo. It compares GPT-5 with a math-focused LangChain prompt-and-output-parser pipeline.
+This example shows how to run a Python LangChain Expression Language (LCEL) chain with Promptfoo. It compares GPT-5.4 with a math-focused LangChain prompt-and-output-parser pipeline using `ChatOpenAI(model="gpt-4.1-mini")` and the Chat Completions API.
 
 This example requires Python 3.10 or newer. Create and activate a virtual environment, then
 install the requirements:

--- a/examples/integration-langchain/langchain_example.py
+++ b/examples/integration-langchain/langchain_example.py
@@ -16,9 +16,9 @@ def main() -> int:
     # configuration errors stay concise even before the example is installed.
     from langchain_core.output_parsers import StrOutputParser
     from langchain_core.prompts import PromptTemplate
-    from langchain_openai import OpenAI
+    from langchain_openai import ChatOpenAI
 
-    llm = OpenAI(temperature=0, api_key=api_key)
+    llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0, api_key=api_key)
     math_chain = (
         PromptTemplate.from_template(
             "Solve the following math problem carefully. Return only the final answer.\n\n{question}"

--- a/examples/integration-langgraph/README.md
+++ b/examples/integration-langgraph/README.md
@@ -21,7 +21,7 @@ You can set this in a `.env` file or directly in your environment.
 
 - Python 3.9-3.12 tested
 - Node.js >=22.22.0 (Node.js 24 LTS recommended)
-- OpenAI API access (for GPT-4o, GPT-4o-mini, and OpenAI's forthcoming o3 mini once released)
+- OpenAI API access for GPT-4o, the model selected by this example
 - An OpenAI API key
 
 Install Python packages:

--- a/examples/provider-golang/core/openai_test.go
+++ b/examples/provider-golang/core/openai_test.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+func TestCreateCompletion(t *testing.T) {
+	for _, effort := range []string{"low", "medium", "high"} {
+		t.Run(effort, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body openai.ChatCompletionRequest
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				if r.Method != http.MethodPost || r.URL.Path != "/chat/completions" || body.Model != "gpt-5-mini" || body.ReasoningEffort != effort {
+					t.Errorf("unexpected chat request: %s %s model=%q effort=%q", r.Method, r.URL.Path, body.Model, body.ReasoningEffort)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"Hello"}}]}`))
+			}))
+			defer server.Close()
+			config := openai.DefaultConfig("offline-test-key")
+			config.BaseURL = server.URL
+			client := &Client{api: openai.NewClientWithConfig(config)}
+			output, err := client.CreateCompletion("Say hello", effort)
+			if err != nil || output != "Hello" {
+				t.Fatalf("output=%q error=%v", output, err)
+			}
+		})
+	}
+}
+
+func TestCreateCompletionError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"Unsupported reasoning effort","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+	config := openai.DefaultConfig("offline-test-key")
+	config.BaseURL = server.URL
+	client := &Client{api: openai.NewClientWithConfig(config)}
+	output, err := client.CreateCompletion("Say hello", "invalid")
+	if err == nil || !strings.Contains(err.Error(), "Unsupported reasoning effort") || output != "" {
+		t.Fatalf("output=%q error=%v", output, err)
+	}
+}

--- a/examples/provider-golang/pkg1/utils.go
+++ b/examples/provider-golang/pkg1/utils.go
@@ -9,7 +9,7 @@ func GetDefaultReasoningEffort() string {
 }
 
 // GetModel returns the model identifier to use for API calls.
-// Currently uses o3-mini, which is optimized for reasoning tasks.
+// Uses GPT-5 mini with configurable reasoning effort.
 func GetModel() string {
-	return "o3-mini"
+	return "gpt-5-mini"
 }

--- a/site/docs/guides/evaluate-crewai.md
+++ b/site/docs/guides/evaluate-crewai.md
@@ -44,7 +44,7 @@ Before starting, make sure you have:
 
 - Python 3.10+
 - Node.js `>=22.22.0`
-- OpenAI API access (for GPT-5, GPT-5-mini, or other models)
+- OpenAI API access for GPT-4.1, the model selected by this example
 - An OpenAI API key
 
 ## Step 1: Initial Setup
@@ -197,12 +197,12 @@ import re
 import textwrap
 from typing import Any, Dict
 
-from crewai import Agent, Crew, Task
+from crewai import LLM, Agent, Crew, Task
 
 # ✅ Load the OpenAI API key from the environment
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
-def get_recruitment_agent(model: str = "openai:gpt-5") -> Crew:
+def get_recruitment_agent(model: str = "openai/gpt-4.1") -> Crew:
     """
     Creates a CrewAI recruitment agent setup.
     This agent’s goal: find the best Ruby on Rails + React candidates.
@@ -216,8 +216,7 @@ def get_recruitment_agent(model: str = "openai:gpt-5") -> Crew:
             You never fail to return a valid JSON object as your final answer.
         """).strip(),
         verbose=False,
-        model=model,
-        api_key=OPENAI_API_KEY  # ✅ Make sure to pass the API key
+        llm=LLM(model=model, api_key=OPENAI_API_KEY)
     )
 
     task = Task(
@@ -248,7 +247,7 @@ def get_recruitment_agent(model: str = "openai:gpt-5") -> Crew:
     crew = Crew(agents=[agent], tasks=[task])
     return crew
 
-async def run_recruitment_agent(prompt, model='openai:gpt-5'):
+async def run_recruitment_agent(prompt, model='openai/gpt-4.1'):
     """
     Runs the recruitment agent with a given job requirements prompt.
     Returns a structured JSON-like dictionary with candidate info.
@@ -309,7 +308,7 @@ def call_api(prompt: str, options: Dict[str, Any], context: Dict[str, Any]) -> D
     try:
         # ✅ Run the async recruitment agent synchronously
         config = options.get("config", {})
-        model = config.get("model", "openai:gpt-5")
+        model = config.get("model", "openai/gpt-4.1")
         result = asyncio.run(run_recruitment_agent(prompt, model=model))
 
         if "error" in result:
@@ -334,26 +333,31 @@ if __name__ == "__main__":
     print("Provider result:", json.dumps(result, indent=2))
 ```
 
+CrewAI receives the model through `Agent(llm=LLM(...))`. Use its `provider/model`
+format, such as `openai/gpt-4.1`, for the custom provider’s `config.model` field.
+
 ### Edit `promptfooconfig.yaml`
 
 Open the generated `promptfooconfig.yaml` and update it like this:
 
-```python
-description: "CrewAI Recruitment Agent Evaluation"
+```yaml
+description: 'CrewAI Recruitment Agent Evaluation'
 
 # 📝 Define the input prompts (using variable placeholder)
 prompts:
-  - "{{job_requirements}}"
+  - '{{job_requirements}}'
 
 # ⚙️ Define the provider — here we point to our local agent.py
 providers:
-  - id: file://./agent.py  # Local file provider (make sure path is correct!)
+  - id: file://./agent.py # Local file provider (make sure path is correct!)
     label: CrewAI Recruitment Agent
+    config:
+      model: openai/gpt-4.1
 
 # ✅ Define default tests to check the agent output shape and content
 defaultTest:
   assert:
-    - type: is-json  # Ensure output is valid JSON
+    - type: is-json # Ensure output is valid JSON
       value:
         type: object
         properties:
@@ -366,18 +370,16 @@ defaultTest:
                   type: string
                 experience:
                   type: string
-          summary:
-            type: string
-        required: ['candidates', 'summary']  # Both fields must be present
+        required: ['candidates']
 
 # 🧪 Specific test case to validate basic output behavior
 tests:
-  - description: "Basic test for RoR and React candidates"
+  - description: 'Basic test for RoR and React candidates'
     vars:
-      job_requirements: "List top candidates with RoR and React"
+      job_requirements: 'List top candidates with RoR and React'
     assert:
-      - type: python  # Custom Python check
-        value: "'candidates' in output and isinstance(output['candidates'], list) and 'summary' in output"
+      - type: python # Custom Python check
+        value: "'candidates' in output and isinstance(output['candidates'], list)"
 ```
 
 **What did we just do?**

--- a/site/docs/guides/evaluate-langgraph.md
+++ b/site/docs/guides/evaluate-langgraph.md
@@ -172,7 +172,7 @@ class ResearchState(BaseModel):
     summary: str = ""     # Final summarized result
 
 # Function to create and return the research agent graph
-def get_research_agent(model="gpt-5-mini"):
+def get_research_agent(model="gpt-4o"):
     # Initialize the OpenAI LLM with the specified model and API key
     llm = ChatOpenAI(model=model, api_key=OPENAI_API_KEY)
 

--- a/site/docs/providers/opencode-sdk.md
+++ b/site/docs/providers/opencode-sdk.md
@@ -13,7 +13,7 @@ This provider integrates [OpenCode](https://opencode.ai/), an open-source AI cod
 - `opencode:sdk` - Uses OpenCode's configured model
 - `opencode` - Same as `opencode:sdk`
 
-The model is configured via the OpenCode CLI or `~/.opencode/config.yaml`.
+When you omit `provider_id` and `model`, OpenCode selects the model using its own configuration and defaults. Set a global model in `~/.config/opencode/opencode.json`; see [OpenCode configuration](https://opencode.ai/docs/config/). Additional suffixes on the promptfoo provider ID identify provider instances; they do not select a model.
 
 ## Installation
 
@@ -77,26 +77,26 @@ prompts:
   - 'Write a Python function that validates email addresses'
 ```
 
-Configure your model via the OpenCode CLI: `opencode config set model openai/gpt-4o`
+Select a model with `/models` in OpenCode, or set `model` in your OpenCode configuration.
 
 By default, OpenCode SDK runs in a temporary directory with no tools enabled. When your test cases finish, the temporary directory is deleted.
 
 ### With Inline Model Configuration
 
-Specify the provider and model directly in your config:
+Set `provider_id` to the OpenCode provider key and `model` to the model ID within that provider:
 
 ```yaml title="promptfooconfig.yaml"
 providers:
   - id: opencode:sdk
     config:
       provider_id: anthropic
-      model: claude-sonnet-4-20250514
+      model: claude-sonnet-4-6
 
 prompts:
   - 'Write a Python function that validates email addresses'
 ```
 
-This overrides the model configured via the OpenCode CLI for this specific eval.
+This overrides OpenCode's model selection for this specific eval. Keep `provider_id` separate from `model`; for example, a custom provider with a model ID of `team/model-name` uses `provider_id: my-provider` and `model: team/model-name`.
 
 ### With Working Directory
 
@@ -199,7 +199,7 @@ When enabling write/edit/bash tools, consider how you will reset files after eac
 | `working_dir`       | string  | Directory for file operations and read-only default tools                  | Temporary directory                    |
 | `workspace`         | string  | Workspace identifier for workspace-aware OpenCode requests                 | None                                   |
 | `provider_id`       | string  | LLM provider (`anthropic`, `openai`, `google`, `ollama`, etc.)             | OpenCode default                       |
-| `model`             | string  | Model to use for this request                                              | OpenCode default                       |
+| `model`             | string  | Model ID within `provider_id`; set both for an explicit selection          | OpenCode default                       |
 | `format`            | object  | Output format, including JSON Schema structured output                     | Text                                   |
 | `variant`           | string  | Provider/model variant defined in OpenCode config                          | Default variant                        |
 | `tools`             | object  | Tool configuration                                                         | None; read-only with `working_dir`     |
@@ -238,18 +238,16 @@ OpenCode supports 75+ LLM providers through [Models.dev](https://models.dev/):
 - LM Studio
 - llama.cpp
 
-Configure your preferred model using the OpenCode CLI:
+Configure your preferred default model in OpenCode's global configuration:
 
-```bash
-# Set your default model
-opencode config set model anthropic/claude-sonnet-4-20250514
-
-# Or for OpenAI
-opencode config set model openai/gpt-4o
-
-# Or for local models
-opencode config set model ollama/llama3
+```json title="~/.config/opencode/opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-sonnet-4-6"
+}
 ```
+
+OpenCode's `model` setting uses the full `provider/model-id` format, such as `openai/gpt-4o` or `ollama/llama3`. Use the provider key and model ID configured on your OpenCode server, including any model path segments.
 
 ## Tools and Permissions
 
@@ -505,7 +503,7 @@ providers:
       custom_agent:
         description: Security-focused code reviewer
         mode: primary # 'primary', 'subagent', or 'all'
-        model: claude-sonnet-4-20250514
+        model: anthropic/claude-sonnet-4-6
         temperature: 0.3
         top_p: 0.9 # Nucleus sampling parameter
         steps: 10 # Max iterations before text-only response
@@ -525,11 +523,13 @@ providers:
 
 `custom_agent` is applied when promptfoo starts the OpenCode server itself. If you use `baseUrl`, define that agent on the target server and use `agent` to select it.
 
+`custom_agent.model` uses OpenCode's full [`provider/model-id` format](https://opencode.ai/docs/agents/#model). For example, `anthropic/claude-sonnet-4-6` selects the Anthropic provider. Unlike the top-level `model` field, it includes the provider key; promptfoo passes this string unchanged. Omit it to use OpenCode's agent model defaults.
+
 | Parameter     | Type    | Description                               |
 | ------------- | ------- | ----------------------------------------- |
 | `description` | string  | Required. Explains the agent's purpose    |
 | `mode`        | string  | 'primary', 'subagent', or 'all'           |
-| `model`       | string  | Model ID (overrides global)               |
+| `model`       | string  | Full OpenCode `provider/model-id`         |
 | `temperature` | number  | Response randomness (0.0-1.0)             |
 | `top_p`       | number  | Nucleus sampling (0.0-1.0)                |
 | `steps`       | number  | Max iterations before text-only response  |

--- a/site/docs/providers/python.md
+++ b/site/docs/providers/python.md
@@ -167,7 +167,7 @@ Contains your provider configuration and metadata:
     "id": "file://my_provider.py",
     "config": {
         # Your custom configuration from promptfooconfig.yaml
-        "model_name": "gpt-3.5-turbo",
+        "model": "gpt-4.1-mini",
         "temperature": 0.7,
         "max_tokens": 100,
 
@@ -321,7 +321,7 @@ def call_api(prompt, options, context):
     # Make API call
     try:
         response = client.chat.completions.create(
-            model=config.get('model', 'gpt-3.5-turbo'),
+            model=config.get('model', 'gpt-4.1-mini'),
             messages=messages,
             temperature=config.get('temperature', 0.7),
             max_tokens=config.get('max_tokens', 150)

--- a/site/docs/providers/ruby.md
+++ b/site/docs/providers/ruby.md
@@ -145,7 +145,7 @@ Contains your provider configuration and metadata:
   'id' => 'file://my_provider.rb',
   'config' => {
     # Your custom configuration from promptfooconfig.yaml
-    'model_name' => 'gpt-3.5-turbo',
+    'model' => 'gpt-4.1-mini',
     'temperature' => 0.7,
     'max_tokens' => 100,
 
@@ -306,7 +306,7 @@ def call_api(prompt, options, context)
   request['Authorization'] = "Bearer #{ENV['OPENAI_API_KEY']}"
 
   request.body = JSON.generate({
-    model: config['model'] || 'gpt-3.5-turbo',
+    model: config['model'] || 'gpt-4.1-mini',
     messages: messages,
     temperature: config['temperature'] || 0.7,
     max_tokens: config['max_tokens'] || 150

--- a/src/providers/opencode-sdk.ts
+++ b/src/providers/opencode-sdk.ts
@@ -166,7 +166,7 @@ export interface OpenCodeAgentConfig {
   description: string;
   /** Agent mode: 'primary' for main assistants, 'subagent' for specialized tasks, 'all' for both */
   mode?: 'primary' | 'subagent' | 'all';
-  /** Model ID to use for this agent (overrides global model) */
+  /** Full OpenCode provider/model-id for this agent (e.g., 'anthropic/claude-sonnet-4-6') */
   model?: string;
   /** Temperature for response randomness (0.0-1.0) */
   temperature?: number;
@@ -263,8 +263,8 @@ export interface OpenCodeSDKConfig {
   provider_id?: string;
 
   /**
-   * Model ID to use (e.g., 'claude-sonnet-4-6', 'gpt-4o')
-   * Combined with provider_id to specify the exact model
+   * Model ID within provider_id (e.g., 'claude-sonnet-4-6', 'gpt-4o').
+   * Set provider_id separately; custom_agent.model uses the full provider/model-id instead.
    */
   model?: string;
 

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -207,7 +207,7 @@ export const providerMap: ProviderFactory[] = [
       const { OpenCodeSDKProvider } = await import('./opencode-sdk');
 
       // opencode:sdk or opencode - uses OpenCode's configured default model
-      // Model selection is configured via OpenCode CLI: opencode config set model <provider/model>
+      // Model selection uses OpenCode configuration or explicit provider_id/model options.
       return new OpenCodeSDKProvider({
         ...providerOptions,
         id: providerPath,

--- a/test/examples/integrationCrewai.test.ts
+++ b/test/examples/integrationCrewai.test.ts
@@ -1,0 +1,121 @@
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { getConfiguredPythonPath, validatePythonPath } from '../../src/python/pythonUtils';
+
+const EXAMPLE_PATH = path.join(process.cwd(), 'examples', 'integration-crewai', 'agent.py');
+const CANDIDATES = {
+  candidates: [{ name: 'Sample Candidate', experience: '8 years', skills: ['Ruby'] }],
+};
+
+// Import the real example with an offline CrewAI boundary. Agent ignores unknown fields,
+// like CrewAI does, so passing model= instead of llm= cannot satisfy these assertions.
+const CHECK_EXAMPLE = String.raw`
+import importlib.util
+import json
+import sys
+from types import ModuleType, SimpleNamespace
+
+settings = json.loads(sys.argv[2])
+observed = {}
+
+class LLM:
+    def __init__(self, model, api_key=None):
+        if settings.get("error") == "llm":
+            raise RuntimeError("fixture LLM initialization failed")
+        self.model = model
+        self.api_key = api_key
+
+class Agent:
+    def __init__(self, llm=None, **kwargs):
+        self.llm = llm
+
+class Task:
+    def __init__(self, **kwargs):
+        pass
+
+class Crew:
+    def __init__(self, agents, tasks):
+        self.agent = agents[0]
+
+    def kickoff(self, inputs):
+        observed["model"] = self.agent.llm.model if self.agent.llm else None
+        observed["api_key"] = self.agent.llm.api_key if self.agent.llm else None
+        observed["inputs"] = inputs
+        if settings.get("error") == "kickoff":
+            raise RuntimeError("fixture kickoff failed")
+        text = json.dumps(settings["output"])
+        if settings.get("result_type") == "string":
+            return "\x60\x60\x60json\n" + text + "\n\x60\x60\x60"
+        return SimpleNamespace(raw=text)
+
+crewai = ModuleType("crewai")
+crewai.LLM, crewai.Agent, crewai.Task, crewai.Crew = LLM, Agent, Task, Crew
+sys.modules["crewai"] = crewai
+spec = importlib.util.spec_from_file_location("recruitment_example", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+response = module.call_api("Find a Ruby engineer", {"config": settings.get("config", {})}, {})
+print(json.dumps({"response": response, "observed": observed}))
+`;
+
+describe('integration-crewai example', () => {
+  let pythonPath: string;
+
+  beforeAll(async () => {
+    const configured = getConfiguredPythonPath();
+    pythonPath = await validatePythonPath(configured ?? 'python', Boolean(configured));
+  });
+
+  function runExample(settings: Record<string, unknown>) {
+    const result = spawnSync(
+      pythonPath,
+      ['-c', CHECK_EXAMPLE, EXAMPLE_PATH, JSON.stringify(settings)],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, OPENAI_API_KEY: 'fixture-key', PYTHONDONTWRITEBYTECODE: '1' },
+        timeout: 5000,
+      },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toBe('');
+    return JSON.parse(result.stdout);
+  }
+
+  it('uses the default LLM and parses the crew output', () => {
+    const result = runExample({ output: CANDIDATES });
+    expect(result.response).toEqual({ output: CANDIDATES });
+    expect(result.observed).toEqual({
+      model: 'openai/gpt-4.1',
+      api_key: 'fixture-key',
+      inputs: { job_requirements: 'Find a Ruby engineer' },
+    });
+  });
+
+  it.each(['openai/gpt-4.1-mini', 'custom-provider/team/model:release'])(
+    'forwards the configured model %s unchanged and parses a markdown string',
+    (model) => {
+      const result = runExample({ config: { model }, output: CANDIDATES, result_type: 'string' });
+      expect(result.response).toEqual({ output: CANDIDATES });
+      expect(result.observed.model).toBe(model);
+    },
+  );
+
+  it('surfaces a kickoff failure as a provider error', () => {
+    const result = runExample({ error: 'kickoff' });
+    expect(result.response).toEqual({
+      error: 'An unexpected error occurred: fixture kickoff failed',
+      raw: '',
+    });
+  });
+
+  it('surfaces LLM initialization failures as provider errors', () => {
+    const result = runExample({ error: 'llm' });
+    expect(result.response).toEqual({
+      error: 'An error occurred in call_api: fixture LLM initialization failed',
+    });
+    expect(result.observed).toEqual({});
+  });
+});

--- a/test/examples/integrationLangchain.test.ts
+++ b/test/examples/integrationLangchain.test.ts
@@ -75,7 +75,7 @@ class PromptTemplate:
     );
     fs.writeFileSync(
       path.join(stubRoot, 'langchain_openai.py'),
-      'class OpenAI:\n    def __init__(self, **_kwargs):\n        pass\n',
+      'class ChatOpenAI:\n    def __init__(self, *, model, temperature, api_key):\n        pass\n',
     );
   });
 


### PR DESCRIPTION
CrewAI examples passed an undeclared `model` field, so configured models never reached the agent. Pass an explicit `LLM` through `Agent.llm`, align the guide and YAML namespace, retain the returned crew output, and add offline regression coverage. Move the LangChain example from its implicit legacy Completions model to `ChatOpenAI(model="gpt-4.1-mini")`.

Refresh retiring Python/Ruby chat and Go reasoning example models while preserving request parameters, custom IDs, and endpoints. Align the LangGraph guide and prerequisite with its bundled example. Correct OpenCode examples to use Sonnet 4.6 and explain its separate top-level provider/model fields, full custom-agent namespace, and global JSON configuration.

Validation: 258 focused example/provider/hygiene Vitest tests, including five CrewAI regressions; 11 installed Python framework/SDK cases, three Ruby snippet cases, four Go SDK loopback cases, and six built OpenCode SDK cases. TypeScript, CLI build/postbuild, production documentation build, final LangGraph MDX/Python-snippet checks, and lint/format passed. All protocol checks use intercepted or local fixture responses; no vendor inference was run.

Primary sources checked September 8, 2026: [CrewAI LLM configuration](https://docs.crewai.com/en/concepts/llms), [LangChain ChatOpenAI](https://docs.langchain.com/oss/python/integrations/chat/openai), and [native OpenAI lifecycle](https://developers.openai.com/api/docs/deprecations).
