### PR TITLE
docs(site): correct provider starter model contracts

### DIFF
--- a/.claude/skills/promptfoo-evals/references/cheatsheet.md
+++ b/.claude/skills/promptfoo-evals/references/cheatsheet.md
@@ -156,7 +156,6 @@ tests:
 # Google
 - google:gemini-2.5-pro
 - google:gemini-2.5-flash
-- google:gemini-2.0-flash
 
 # AWS Bedrock
 - bedrock:anthropic.claude-sonnet-4-6
@@ -164,10 +163,10 @@ tests:
 
 # Other
 - azure:chat:my-deployment
-- groq:llama-3.3-70b-versatile
+- groq:openai/gpt-oss-20b
 - ollama:chat:llama3.3
 - mistral:mistral-large-latest
-- togetherai:meta-llama/Llama-4-Scout-Instruct
+- togetherai:openai/gpt-oss-120b
 ```
 
 ### HTTP endpoint

--- a/examples/eval-tool-use/promptfooconfig.yaml
+++ b/examples/eval-tool-use/promptfooconfig.yaml
@@ -68,8 +68,10 @@ providers:
     label: External Tools
     config:
       tools: file://external_tools.yaml
-  - id: groq:llama-4-scout-17b-16e-instruct
+  - id: groq:openai/gpt-oss-120b
     config:
+      reasoning_effort: low
+      max_completion_tokens: 4096
       tools:
         - type: function
           function:

--- a/examples/eval-tool-use/promptfooconfig.yaml
+++ b/examples/eval-tool-use/promptfooconfig.yaml
@@ -71,6 +71,7 @@ providers:
   - id: groq:openai/gpt-oss-120b
     config:
       reasoning_effort: low
+      include_reasoning: false
       max_completion_tokens: 4096
       tools:
         - type: function

--- a/examples/huggingface/pii/README.md
+++ b/examples/huggingface/pii/README.md
@@ -9,9 +9,11 @@ cd huggingface/pii
 
 ## Usage
 
-To get started, set your HF_API_TOKEN environment variable.
+The [bigcode/starpii model](https://huggingface.co/bigcode/starpii) was trained to detect PII in source code; validate its suitability for the prose outputs in this example. Its card currently lists no Inference Provider deployment. Obtain access to the gated model and deploy a compatible token-classification endpoint, such as a [Hugging Face Inference Endpoint](https://huggingface.co/docs/inference-endpoints/guides/create_endpoint). The endpoint must return the model's entity labels and scores.
 
-Next, edit promptfooconfig.yaml.
+Set `HF_STARPII_ENDPOINT` to your deployment URL and `HF_TOKEN` (or `HF_API_TOKEN`) to a token authorized to access it. Set `OPENAI_API_KEY` for the LLM being tested.
+
+Next, edit `promptfooconfig.yaml` as needed. Keep the classifier model and its PII labels consistent with the deployed endpoint; changing models requires recalibrating the assertion threshold.
 
 Then run:
 

--- a/examples/huggingface/pii/promptfooconfig.yaml
+++ b/examples/huggingface/pii/promptfooconfig.yaml
@@ -12,10 +12,11 @@ defaultTest:
     provider:
       id: huggingface:token-classification:bigcode/starpii
       config:
+        apiEndpoint: '{{env.HF_STARPII_ENDPOINT}}'
         wait_for_model: true
   assert:
     - type: not-classifier
-      # Assert that outputs are not PII, with a PII score of less than 0.5
+      # Assert that outputs are not PII, with a PII score of less than 0.75
       threshold: 0.75
 
 tests:

--- a/examples/provider-cohere/README.md
+++ b/examples/provider-cohere/README.md
@@ -11,6 +11,8 @@ cd provider-cohere
 
 To get started, set your COHERE_API_KEY environment variable.
 
+The starter uses Command A for text generation and Embed v3 for similarity grading. It does not require managed web search, which [Cohere deprecated for new integrations](https://docs.cohere.com/docs/deprecations).
+
 Next, edit promptfooconfig.yaml.
 
 Then run:

--- a/examples/provider-cohere/complex_config.yaml
+++ b/examples/provider-cohere/complex_config.yaml
@@ -3,11 +3,12 @@ prompts:
   - file://prompt.yaml
 
 providers:
-  - cohere:command
+  - cohere:command-a-03-2025
 
 defaultTest:
-  provider:
-    embedding: cohere:embedding:embed-english-v3:0
+  options:
+    provider:
+      embedding: cohere:embedding:embed-english-v3.0
 
 tests:
   - vars:

--- a/examples/provider-cohere/prompt.yaml
+++ b/examples/provider-cohere/prompt.yaml
@@ -4,5 +4,3 @@ chat_history:
   - role: CHATBOT
     message: 'Isaac Newton'
 message: '{{question}}'
-connectors:
-  - id: web-search

--- a/examples/provider-cohere/promptfooconfig.yaml
+++ b/examples/provider-cohere/promptfooconfig.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-description: Cohere Command with web search and similarity embeddings
+description: Cohere Command with similarity embeddings
 
 prompts:
   - 'Write a tweet about {{topic}}'
@@ -9,9 +9,6 @@ providers:
     config:
       temperature: 0.5
       prompt_truncation: AUTO
-      connectors:
-        - id: web-search
-      showSearchQueries: true
 
 defaultTest:
   options:

--- a/examples/provider-nvidia/README.md
+++ b/examples/provider-nvidia/README.md
@@ -21,6 +21,8 @@ View the results with `promptfoo view`.
 
 ## What this example does
 
-Compares three models hosted on NVIDIA NIM (Llama 3.3 70B, Nemotron 70B, Qwen 2.5 Coder 32B) on a short summarisation task with deterministic `icontains` and `icontains-any` assertions, so the example runs end-to-end with only `NVIDIA_API_KEY` set.
+Compares three models hosted on NVIDIA NIM (Llama 3.3 70B, Nemotron 3 Super 120B A12B, Qwen 2.5 Coder 32B) on a short summarisation task with deterministic `icontains` and `icontains-any` assertions, so the example runs end-to-end with only `NVIDIA_API_KEY` set.
+
+Nemotron uses its model-specific sampling settings and disables reasoning for this short task through `config.passthrough.chat_template_kwargs.enable_thinking`. If you enable reasoning, increase `max_tokens` to allow both reasoning and the final answer; NVIDIA's [hosted example](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b) uses 16384.
 
 See [docs/providers/nvidia.md](../../site/docs/providers/nvidia.md) for the full provider reference.

--- a/examples/provider-nvidia/promptfooconfig.yaml
+++ b/examples/provider-nvidia/promptfooconfig.yaml
@@ -10,11 +10,15 @@ providers:
     config:
       temperature: 0.2
       max_tokens: 120
-  - id: nvidia:nvidia/llama-3.1-nemotron-70b-instruct
-    label: 'Nemotron 70B'
+  - id: nvidia:nvidia/nemotron-3-super-120b-a12b
+    label: 'Nemotron 3 Super 120B A12B'
     config:
-      temperature: 0.2
-      max_tokens: 120
+      temperature: 1
+      top_p: 0.95
+      max_tokens: 1024
+      passthrough:
+        chat_template_kwargs:
+          enable_thinking: false
   - id: nvidia:qwen/qwen2.5-coder-32b-instruct
     label: 'Qwen 2.5 Coder 32B'
     config:

--- a/site/docs/configuration/expected-outputs/classifier.md
+++ b/site/docs/configuration/expected-outputs/classifier.md
@@ -6,7 +6,7 @@ description: Apply HuggingFace classifiers for comprehensive output analysis inc
 
 # Classifier grading
 
-Use the `classifier` assert type to run the LLM output through any [HuggingFace text classifier](https://huggingface.co/docs/transformers/tasks/sequence_classification).
+Use the `classifier` assert type to run the LLM output through a compatible [HuggingFace text classifier](https://huggingface.co/docs/transformers/tasks/sequence_classification), or a token classifier for entity-level checks such as PII detection.
 
 The assertion looks like this:
 
@@ -20,16 +20,16 @@ assert:
 
 ## Setup
 
-HuggingFace allows unauthenticated usage, but you may have to set the `HF_API_TOKEN` environment variable to avoid rate limits on larger evals. For more detail, see [HuggingFace provider docs](/docs/providers/huggingface).
+For hosted Inference Providers, set `HF_TOKEN` (or `HF_API_TOKEN`) to a token with [Inference Providers permissions](https://huggingface.co/docs/inference-providers/tasks/text-classification). For a dedicated endpoint, use a token authorized to access that deployment and set `config.apiEndpoint` to its URL. See the [HuggingFace provider docs](/docs/providers/huggingface/#inference-endpoints).
 
 ## Use cases
 
-For a full list of supported models, see [HuggingFace text classification models](https://huggingface.co/models?pipeline_tag=text-classification).
+Browse [HuggingFace text classification model artifacts](https://huggingface.co/models?pipeline_tag=text-classification). A Hub repository does not guarantee hosted inference: check that [HF Inference](https://huggingface.co/docs/inference-providers/providers/hf-inference) serves the model for the required task, or deploy a compatible endpoint and configure `apiEndpoint`. The links below describe model artifacts, including models that require your own deployment.
 
 Examples of use cases supported by the HuggingFace ecosystem include:
 
-- **Sentiment** classifiers like [DistilBERT-base-uncased](https://huggingface.co/distilbert-base-uncased-finetuned-sst-2-english), [roberta-base-go_emotions](https://huggingface.co/SamLowe/roberta-base-go_emotions), etc.
-- **Tone and emotion** via [finbert-tone](https://huggingface.co/yiyanghkust/finbert-tone), [emotion_text_classification](https://huggingface.co/michellejieli/emotion_text_classifier), etc.
+- **Sentiment** classifiers like [DistilBERT-base-uncased](https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english), [roberta-base-go_emotions](https://huggingface.co/SamLowe/roberta-base-go_emotions), etc.
+- **Tone and emotion** via [finbert-tone](https://huggingface.co/yiyanghkust/finbert-tone), [emotion_text_classification](https://huggingface.co/michelleli99/emotion_text_classifier), etc.
 - **Toxicity** via [DistilBERT-toxic-comment-model](https://huggingface.co/martin-ha/toxic-comment-model), [twitter-roberta-base-offensive](https://huggingface.co/cardiffnlp/twitter-roberta-base-offensive), [bertweet-large-sexism-detector](https://huggingface.co/NLP-LTU/bertweet-large-sexism-detector), etc.
 - **Bias** and fairness via [d4data/bias-detection-model](https://huggingface.co/d4data/bias-detection-model).
 - **Grounding, factuality, and evidence-type** classification via [MiniLM-evidence-types](https://huggingface.co/marieke93/MiniLM-evidence-types) and similar
@@ -81,12 +81,15 @@ tests:
 
 ## PII detection example
 
-This assertion uses [starpii](https://huggingface.co/bigcode/starpii) to determine whether an LLM output potentially contains PII:
+This assertion uses [starpii](https://huggingface.co/bigcode/starpii), a token classifier trained to detect PII in source code, to check an LLM output. Validate its suitability for your output domain. Its model card currently lists no Inference Provider deployment. Obtain access to the gated model, deploy a compatible token-classification endpoint, and set `HF_STARPII_ENDPOINT` to its URL:
 
 ```yaml
 assert:
   - type: not-classifier
-    provider: huggingface:token-classification:bigcode/starpii
+    provider:
+      id: huggingface:token-classification:bigcode/starpii
+      config:
+        apiEndpoint: '{{env.HF_STARPII_ENDPOINT}}'
     # Ensure that outputs are not PII, with a score > 0.75
     threshold: 0.75
 ```
@@ -96,6 +99,8 @@ The `not-classifier` type inverts the result of the classifier. In this case, th
 ## Prompt injection example
 
 This assertion uses a [fine-tuned deberta-v3-base model](https://huggingface.co/protectai/deberta-v3-base-prompt-injection) to detect prompt injections.
+
+Both this model and its [v2 successor](https://huggingface.co/protectai/deberta-v3-base-prompt-injection-v2) are marked archived and no longer maintained. The example retains the original model, `SAFE` label, and threshold; switching to v2 or another detector requires validating its labels and recalibrating scores for your data.
 
 ```yaml
 assert:
@@ -107,12 +112,15 @@ assert:
 
 ## Bias detection example
 
-This assertion uses a [fine-tuned distilbert model](https://huggingface.co/d4data/bias-detection-model) classify biased text.
+This assertion uses a [fine-tuned distilbert model](https://huggingface.co/d4data/bias-detection-model) to classify biased text. Its model card currently lists no Inference Provider deployment. Deploy a compatible text-classification endpoint for this model and set `HF_BIAS_ENDPOINT` to its URL; keep the `Biased` label and calibrate the threshold for your use case.
 
 ```yaml
 assert:
   - type: classifier
-    provider: huggingface:text-classification:d4data/bias-detection-model
+    provider:
+      id: huggingface:text-classification:d4data/bias-detection-model
+      config:
+        apiEndpoint: '{{env.HF_BIAS_ENDPOINT}}'
     value: 'Biased'
     threshold: 0.5 # score for "Biased" must be greater than or equal to this value
 ```

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -1827,7 +1827,7 @@ tests:
 
 ### Classifier
 
-The `classifier` assertion runs the LLM output through any HuggingFace text classification model. This is useful for:
+The `classifier` assertion runs the LLM output through a compatible HuggingFace text-classification or token-classification endpoint. A model on the Hub must also be hosted for the required task, or deployed to your own endpoint. This is useful for:
 
 - Sentiment analysis
 - Toxicity detection
@@ -1845,12 +1845,15 @@ assert:
     threshold: 0.5
 ```
 
-Example for PII detection (using negation):
+Example for PII detection (using negation). The gated `bigcode/starpii` model currently has no Inference Provider deployment; set `HF_STARPII_ENDPOINT` to a compatible token-classification endpoint you have deployed. See [classifier setup](./classifier.md#pii-detection-example).
 
 ```yaml
 assert:
   - type: not-classifier
-    provider: huggingface:token-classification:bigcode/starpii
+    provider:
+      id: huggingface:token-classification:bigcode/starpii
+      config:
+        apiEndpoint: '{{env.HF_STARPII_ENDPOINT}}'
     threshold: 0.75
 ```
 

--- a/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
+++ b/site/docs/configuration/expected-outputs/model-graded/answer-relevance.md
@@ -73,7 +73,7 @@ assert:
     threshold: 0.8
     provider:
       text: anthropic:claude-sonnet-4-6
-      embedding: cohere:embed-english-v3.0
+      embedding: cohere:embedding:embed-english-v3.0
 ```
 
 ### Customizing the Prompt

--- a/site/docs/providers/fireworks.md
+++ b/site/docs/providers/fireworks.md
@@ -22,9 +22,9 @@ The provider keeps Fireworks credentials isolated from OpenAI's: it reads `FIREW
 ## Provider format
 
 - `fireworks:<model>` — chat completions, e.g. `fireworks:accounts/fireworks/models/gpt-oss-120b`
-- `fireworks:embedding:<model>` — embeddings, e.g. `fireworks:embedding:accounts/fireworks/models/qwen3-embedding-8b`
+- `fireworks:embedding:<model>` — embeddings, e.g. `fireworks:embedding:fireworks/qwen3-embedding-8b`
 
-Model identifiers use Fireworks's account-scoped path (`accounts/fireworks/models/<model>`). Browse the [serverless catalogue](https://fireworks.ai/models?deployment=serverless) for currently available ids — the serverless tier rotates, so a model that returns a 404 has likely been retired.
+Copy the exact identifier from the model's documentation. Chat models commonly use `accounts/fireworks/models/<model>`; embedding models can use a different namespace, and dedicated deployments use `accounts/<account>/deployments/<deployment>`. Check the [serverless catalogue](https://fireworks.ai/models?deployment=serverless) and your deployment configuration for availability.
 
 ## Example Usage
 
@@ -56,8 +56,14 @@ defaultTest:
   options:
     provider:
       embedding:
-        id: fireworks:embedding:accounts/fireworks/models/qwen3-embedding-8b
+        id: fireworks:embedding:fireworks/qwen3-embedding-8b
 ```
+
+The [Fireworks embedding guide](https://docs.fireworks.ai/guides/querying-embeddings-models) uses `fireworks/qwen3-embedding-8b` for serverless requests. Keep existing model identifiers, dimensions, and preprocessing consistent with stored vectors; changing embedding models requires rebuilding the corresponding index and recalibrating similarity thresholds.
+
+Embedding request options go under `config.passthrough`. For resizable models such as Qwen3, set `config.passthrough.dimensions` only when you intentionally choose an output dimension. Qwen3 vectors are not unit-normalized; normalize them before treating a raw dot product as cosine similarity, or use a cosine-similarity function that handles normalization.
+
+Voyage embedding models require a dedicated deployment. Use `fireworks:embedding:accounts/<account>/deployments/<deployment>` with your deployment's identifiers, and set `config.passthrough.input_type` to `document` for corpus embeddings or `query` for search queries. Keep the model, dimensions, and role-specific preprocessing consistent across indexing and retrieval.
 
 ## Configuration
 

--- a/site/docs/providers/huggingface.md
+++ b/site/docs/providers/huggingface.md
@@ -16,6 +16,8 @@ To run a model, specify the task type and model name. Supported task types inclu
 - `huggingface:feature-extraction:<model name>`
 - `huggingface:sentence-similarity:<model name>`
 
+A model repository on the Hub is a model artifact, not a guarantee that an Inference Provider serves it. Check the model card's Inference Providers section for chat routing; task providers use [HF Inference](https://huggingface.co/docs/inference-providers/providers/hf-inference) by default and require support for the selected task. For models without that support, deploy a compatible [inference endpoint](#inference-endpoints) and configure `apiEndpoint`; keep the model's labels, embedding dimensions, and preprocessing consistent with your eval.
+
 ## Chat models (recommended)
 
 For LLM chat models, use the `huggingface:chat` provider which connects to HuggingFace's OpenAI-compatible `/v1/chat/completions` endpoint:
@@ -206,7 +208,7 @@ Once the endpoint is created, take the `Endpoint URL` shown on the page:
 
 ![huggingface inference endpoint url](/img/docs/huggingface-inference-endpoint.png)
 
-Then set up your promptfoo config like this:
+Set `HF_INFERENCE_ENDPOINT` to that URL and use a token authorized for the deployment. The endpoint must implement the task selected in the provider ID. Then set up your promptfoo config like this:
 
 ```yaml
 description: 'HF private inference endpoint'
@@ -217,7 +219,7 @@ prompts:
 providers:
   - id: huggingface:text-generation:gemma-7b-it
     config:
-      apiEndpoint: https://v9igsezez4ei3cq4.us-east-1.aws.endpoints.huggingface.cloud
+      apiEndpoint: '{{env.HF_INFERENCE_ENDPOINT}}'
       # apiKey: abc123   # Or set HF_API_TOKEN environment variable
 
 tests:
@@ -240,7 +242,7 @@ providers:
 
 ## Authentication
 
-If you need to access private datasets or want to increase your rate limits, you can authenticate using your HuggingFace token. Set the `HF_TOKEN` environment variable with your token:
+Hosted Inference Providers require a token with [Inference Providers permissions](https://huggingface.co/docs/inference-providers/tasks/text-classification). Private datasets and dedicated endpoints require the corresponding access permissions. Set the `HF_TOKEN` environment variable with your token:
 
 ```bash
 export HF_TOKEN=your_token_here

--- a/site/docs/providers/nvidia.md
+++ b/site/docs/providers/nvidia.md
@@ -38,7 +38,7 @@ Use the `nvidia:` prefix followed by the full model id as listed on the model ca
 providers:
   - nvidia:meta/llama-3.3-70b-instruct
   - nvidia:qwen/qwen2.5-coder-32b-instruct
-  - nvidia:nvidia/llama-3.1-nemotron-70b-instruct
+  - nvidia:nvidia/nemotron-3-super-120b-a12b
 ```
 
 Standard OpenAI-compatible parameters are passed through:
@@ -67,16 +67,16 @@ providers:
 
 The full list is on [build.nvidia.com](https://build.nvidia.com). Some commonly used ids:
 
-| Model                           | Provider format                                 |
-| ------------------------------- | ----------------------------------------------- |
-| Llama 3.3 70B Instruct          | `nvidia:meta/llama-3.3-70b-instruct`            |
-| Llama 3.1 405B Instruct         | `nvidia:meta/llama-3.1-405b-instruct`           |
-| Llama 3.2 90B Vision Instruct   | `nvidia:meta/llama-3.2-90b-vision-instruct`     |
-| Llama 3.1 Nemotron 70B Instruct | `nvidia:nvidia/llama-3.1-nemotron-70b-instruct` |
-| Mistral Large 2 Instruct        | `nvidia:mistralai/mistral-large-2-instruct`     |
-| Mixtral 8x22B Instruct          | `nvidia:mistralai/mixtral-8x22b-instruct-v0.1`  |
-| Qwen 2.5 Coder 32B Instruct     | `nvidia:qwen/qwen2.5-coder-32b-instruct`        |
-| DeepSeek R1                     | `nvidia:deepseek-ai/deepseek-r1`                |
+| Model                         | Provider format                                |
+| ----------------------------- | ---------------------------------------------- |
+| Llama 3.3 70B Instruct        | `nvidia:meta/llama-3.3-70b-instruct`           |
+| Llama 3.1 405B Instruct       | `nvidia:meta/llama-3.1-405b-instruct`          |
+| Llama 3.2 90B Vision Instruct | `nvidia:meta/llama-3.2-90b-vision-instruct`    |
+| Nemotron 3 Super 120B A12B    | `nvidia:nvidia/nemotron-3-super-120b-a12b`     |
+| Mistral Large 2 Instruct      | `nvidia:mistralai/mistral-large-2-instruct`    |
+| Mixtral 8x22B Instruct        | `nvidia:mistralai/mixtral-8x22b-instruct-v0.1` |
+| Qwen 2.5 Coder 32B Instruct   | `nvidia:qwen/qwen2.5-coder-32b-instruct`       |
+| DeepSeek R1                   | `nvidia:deepseek-ai/deepseek-r1`               |
 
 ## Example
 
@@ -88,10 +88,14 @@ providers:
     config:
       temperature: 0.2
       max_tokens: 256
-  - id: nvidia:nvidia/llama-3.1-nemotron-70b-instruct
+  - id: nvidia:nvidia/nemotron-3-super-120b-a12b
     config:
-      temperature: 0.2
-      max_tokens: 256
+      temperature: 1
+      top_p: 0.95
+      max_tokens: 1024
+      passthrough:
+        chat_template_kwargs:
+          enable_thinking: false
 
 prompts:
   - 'Summarise the following in one sentence: {{passage}}'
@@ -105,6 +109,10 @@ tests:
       - type: icontains-any
         value: [light, energy, glucose]
 ```
+
+The Nemotron configuration follows its [model-specific sampling guidance](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b/modelcard) and disables reasoning for this short summarization task. Additional request fields such as `chat_template_kwargs` go under `config.passthrough`. If you enable reasoning, increase `max_tokens` to leave room for both reasoning and the final answer; the [hosted example](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b) uses 16384.
+
+These examples use a model in NVIDIA's [hosted chat catalog](https://docs.api.nvidia.com/nim/reference/llm-apis). Self-hosted NIM deployments can use their own served model identifiers.
 
 If you want a model-graded assertion, point `llm-rubric` at a NIM-hosted grader so the example stays self-contained:
 


### PR DESCRIPTION
Fix copyable provider examples that select the wrong task, require deprecated managed search, or imply that every Hugging Face Hub model is hosted. Preserve Cohere Embed v3 and classifier labels/thresholds while documenting compatible endpoint setup.

Refresh Groq and NVIDIA starters, Fireworks embedding namespaces and deployment guidance, and the provider cheatsheet. The Groq tool example excludes the response reasoning field so tool-only responses retain usable output.

Validation: 155 scoped provider tests; 48 Groq tests rerun after the review follow-up; TypeScript and package build; site build with unchanged site-tree binding; 23 offline built-CLI cases (18 successful, five expected regression-boundary failures); lint, formatting and normal hooks. No vendor inference requests.

Primary sources checked September 8, 2026: [Cohere deprecations](https://docs.cohere.com/docs/deprecations), [Groq GPT-OSS tool model](https://console.groq.com/docs/model/openai/gpt-oss-120b), [Fireworks embeddings](https://docs.fireworks.ai/guides/querying-embeddings-models), and [NVIDIA hosted model catalog](https://docs.api.nvidia.com/nim/reference/llm-apis).
