### PR TITLE
docs(site): correct cloud and image provider onboarding

### DIFF
--- a/site/docs/providers/cloudflare-ai.md
+++ b/site/docs/providers/cloudflare-ai.md
@@ -1,11 +1,11 @@
 ---
 sidebar_label: Cloudflare Workers AI
-description: Configure Cloudflare Workers AI's edge-based inference platform with Mistral-7B for low-latency LLM testing and evaluation at the network edge using OpenAI-compatible APIs
+description: Configure Cloudflare Workers AI chat and embedding models for evals with account-scoped authentication, exact model IDs, and OpenAI-compatible requests.
 ---
 
 # Cloudflare Workers AI
 
-This provider supports the [models](https://developers.cloudflare.com/workers-ai/models/) provided by Cloudflare Workers AI, a serverless edge inference platform that runs AI models closer to users for low-latency responses.
+This provider connects to Cloudflare Workers AI [text-generation and embedding models](https://developers.cloudflare.com/workers-ai/models/) through its OpenAI-compatible API.
 
 The provider uses Cloudflare's OpenAI-compatible API endpoints, making it easy to migrate between OpenAI and Cloudflare AI or use them interchangeably.
 
@@ -53,17 +53,16 @@ providers:
 
 ## OpenAI Compatibility
 
-This provider leverages Cloudflare's OpenAI-compatible endpoints:
+Cloudflare documents these [OpenAI-compatible endpoints](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/):
 
 - **Chat completions**: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1/chat/completions`
-- **Text completions**: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1/completions`
 - **Embeddings**: `https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1/embeddings`
 
-All standard OpenAI parameters work with Cloudflare AI models: `temperature`, `max_tokens`, `top_p`, `frequency_penalty`, and `presence_penalty`. Many newer models also support advanced capabilities like function calling, batch processing, and multimodal inputs.
+Supported parameters and capabilities vary by model. Check the model's Cloudflare documentation before configuring sampling options, tools, or multimodal inputs.
 
 ## Provider Types
 
-The Cloudflare AI provider supports three different provider types:
+Use the `chat` or `embedding` provider type for the documented endpoints. The legacy `completion` type is described below.
 
 ### Chat Completion
 
@@ -78,13 +77,9 @@ providers:
 
 ### Text Completion
 
-For completion-style tasks:
+The legacy `cloudflare-ai:completion:<model>` selector sends requests to `/ai/v1/completions`. Cloudflare's current compatibility documentation does not establish support for this endpoint. Use a `cloudflare-ai:chat:<model>` selector for new text-generation configurations, including code generation.
 
-```yaml
-providers:
-  - cloudflare-ai:completion:@cf/qwen/qwen2.5-coder-32b-instruct
-  - cloudflare-ai:completion:@cf/microsoft/phi-2
-```
+[Phi-2](https://developers.cloudflare.com/workers-ai/models/phi-2/) was deprecated on May 30, 2026 and should no longer be used for onboarding.
 
 ### Embeddings
 
@@ -164,7 +159,7 @@ providers:
       frequency_penalty: 0.1
       presence_penalty: 0.1
 
-  - id: cloudflare-ai:completion:@cf/qwen/qwen2.5-coder-32b-instruct
+  - id: cloudflare-ai:chat:@cf/qwen/qwen2.5-coder-32b-instruct
     config:
       accountId: your_account_id_here
       temperature: 0.2

--- a/site/docs/providers/databricks.md
+++ b/site/docs/providers/databricks.md
@@ -5,7 +5,7 @@ description: Configure Databricks Foundation Model APIs with Llama-3, Claude, an
 
 # Databricks Foundation Model APIs
 
-The Databricks provider integrates with Databricks' Foundation Model APIs, offering access to state-of-the-art models through a unified OpenAI-compatible interface. It supports multiple deployment modes to match your specific use case and performance requirements.
+The `databricks:` provider sends chat requests through Databricks' OpenAI-compatible Foundation Model APIs. It supports pay-per-token, provisioned, and external chat endpoints. Use the exact serving endpoint name as the provider suffix; custom endpoint names are workspace-specific identities.
 
 ## Overview
 
@@ -42,12 +42,14 @@ providers:
       workspaceUrl: https://your-workspace.cloud.databricks.com
 ```
 
-Available pay-per-token models include:
+Example pay-per-token chat endpoints include:
 
-- `databricks-meta-llama-3-3-70b-instruct` - Meta's latest Llama model
-- `databricks-claude-3-7-sonnet` - Anthropic Claude with reasoning capabilities
-- `databricks-gte-large-en` - Text embeddings model
-- `databricks-dbrx-instruct` - Databricks' own foundation model
+- `databricks-meta-llama-3-3-70b-instruct` - Meta Llama 3.3 70B Instruct
+- `databricks-claude-sonnet-4-6` - Anthropic Claude Sonnet 4.6
+
+Check the [current model catalog](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models) and [retirement policy](https://docs.databricks.com/aws/en/machine-learning/retired-models-policy) for availability. The pay-per-token offerings for Claude 3.7 Sonnet and DBRX have retired; this does not rename custom endpoints in your workspace.
+
+Databricks also offers embedding models such as `databricks-gte-large-en`, but the `databricks:` provider is chat-only. Embedding requests require a separate integration with the [Databricks embeddings API](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference#embeddings-api).
 
 ### Provisioned Throughput Endpoints
 
@@ -88,7 +90,7 @@ The Databricks provider extends the [OpenAI configuration options](/docs/provide
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: databricks:databricks-claude-3-7-sonnet
+  - id: databricks:databricks-claude-sonnet-4-6
     config:
       isPayPerToken: true
       workspaceUrl: https://your-workspace.cloud.databricks.com
@@ -96,7 +98,6 @@ providers:
       # Standard OpenAI parameters
       temperature: 0.7
       max_tokens: 2000
-      top_p: 0.9
 
       # Usage tracking for cost attribution
       usageContext:
@@ -127,7 +128,7 @@ prompts:
   - file://vision-prompt.json
 
 providers:
-  - id: databricks:databricks-claude-3-7-sonnet
+  - id: databricks:databricks-claude-sonnet-4-6
     config:
       isPayPerToken: true
 

--- a/site/docs/providers/modelslab.md
+++ b/site/docs/providers/modelslab.md
@@ -1,13 +1,13 @@
 ---
 title: ModelsLab Provider
-description: Generate images with ModelsLab's text-to-image API including Flux, SDXL, and 200+ community models
+description: Generate images with ModelsLab's v6 text-to-image API using exact IDs for Flux, SDXL, and Seedream, with API key configuration and automatic async polling.
 sidebar_position: 63
 keywords: [modelslab, image generation, flux, sdxl, text-to-image, promptfoo provider]
 ---
 
 # ModelsLab
 
-The `modelslab` provider supports text-to-image generation via the [ModelsLab API](https://docs.modelslab.com), with access to first-party and community models.
+The `modelslab` provider supports text-to-image generation through ModelsLab's [v6 image API](https://docs.modelslab.com/quickstart), using `/api/v6/images/text2img`. The model name is sent unchanged as `model_id`, so use an exact ModelsLab ID supported by that endpoint.
 
 ## Setup
 
@@ -28,14 +28,13 @@ modelslab:image:<model_name>
 
 **Text to Image:**
 
-- `modelslab:image:nano-banana-2` - Google Nano Banana 2, fast 1024x1024 generation with natural language editing
-- `modelslab:image:seedream-5.0-lite` - Bytedance Seedream 5.0 Lite, fast and lightweight
+- `modelslab:image:seedream-5-lite-t2i` - ByteDance Seedream 5 Lite, documented in ModelsLab's [v6 integration guide](https://modelslab.com/blog/image-generation/seedream-5-0-api-bytedance-image-model-modelslab-2026)
 - `modelslab:image:flux` - Flux, high-quality image generation
 - `modelslab:image:sdxl` - Stable Diffusion XL
 
 :::info
 
-Browse the full [model catalog](https://modelslab.com/models) for community fine-tunes and additional models.
+Browse the [model catalog](https://modelslab.com/models) and check each model's API version. For example, [Nano Banana 2](https://modelslab.com/models/google/gemini-3.1-t2i) uses `gemini-3.1-t2i` in a v7 example; that does not establish support through this v6 provider.
 
 :::
 

--- a/site/docs/providers/snowflake.md
+++ b/site/docs/providers/snowflake.md
@@ -1,23 +1,28 @@
 ---
 sidebar_label: Snowflake Cortex
-description: "Connect to AI models through Snowflake Cortex's OpenAI-compatible REST API with access to Claude, GPT, Mistral, and Llama models"
+description: 'Configure Snowflake Cortex text generation through its REST API with native model IDs, bearer-token authentication, and account-specific model availability.'
 ---
 
 # Snowflake Cortex
 
-[Snowflake Cortex](https://docs.snowflake.com/en/user-guide/snowflake-cortex/overview) is Snowflake's AI and ML platform that provides access to various LLM models through an [OpenAI-compatible](/docs/providers/openai/) REST API. Cortex offers industry-leading LLMs including Claude, GPT, Mistral, and Llama models without requiring a dedicated warehouse.
+[Snowflake Cortex](https://docs.snowflake.com/en/user-guide/snowflake-cortex/overview) provides access to language models without requiring a dedicated warehouse. The `snowflake:` provider sends chat requests to `/api/v2/cortex/inference:complete`. This differs from Snowflake's newer OpenAI-compatible `/api/v2/cortex/v1/chat/completions` endpoint.
 
 ## Setup
 
 1. Obtain your Snowflake account identifier (format: `orgname-accountname`)
 2. Generate a bearer token (JWT, OAuth, or programmatic access token)
 3. Ensure you have the `SNOWFLAKE.CORTEX_USER` database role
+4. Check [model availability in your region](https://docs.snowflake.com/en/user-guide/snowflake-cortex/aisql-regional-availability) and your account's model access settings
 
 ## Provider Format
 
 The Snowflake Cortex provider uses this format:
 
 - `snowflake:<model_name>` - Connects to Snowflake Cortex using the specified model name
+
+Use the exact Snowflake model ID. The examples below use `claude-sonnet-4-6`, which Snowflake documents for the [existing REST endpoint](https://docs.snowflake.com/en/user-guide/snowflake-cortex/complete-structured-outputs#rest-api-example). Availability still depends on your account and region.
+
+For new configurations, avoid legacy models such as `mistral-large2` and `llama3.1-70b`: Snowflake restricts them to accounts with prior usage under its [August 2026 model lifecycle policy](https://docs.snowflake.com/en/release-notes/bcr-bundles/un-bundled/bcr-august-model-deprecations). Existing account-specific model selections must be checked against that policy before changing them.
 
 ## Configuration
 
@@ -26,7 +31,7 @@ The Snowflake Cortex provider uses this format:
 ```yaml title="promptfooconfig.yaml"
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 providers:
-  - id: snowflake:mistral-large2
+  - id: snowflake:claude-sonnet-4-6
     config:
       accountIdentifier: 'myorg-myaccount'
       apiKey: 'your-bearer-token'
@@ -45,22 +50,21 @@ Then use the provider without specifying credentials:
 
 ```yaml
 providers:
-  - id: snowflake:mistral-large2
+  - id: snowflake:claude-sonnet-4-6
 ```
 
 ### With Additional Parameters
 
-Snowflake Cortex supports OpenAI-compatible parameters:
+For text chat, configure generation parameters such as:
 
 ```yaml
 providers:
-  - id: snowflake:mistral-large2
+  - id: snowflake:claude-sonnet-4-6
     config:
       accountIdentifier: 'myorg-myaccount'
       apiKey: 'your-bearer-token'
       temperature: 0.7
       max_tokens: 1024
-      top_p: 0.9
 ```
 
 ### Custom Base URL
@@ -69,7 +73,7 @@ Override the default base URL if needed:
 
 ```yaml
 providers:
-  - id: snowflake:claude-3-5-sonnet
+  - id: snowflake:claude-sonnet-4-6
     config:
       apiBaseUrl: 'https://custom.snowflakecomputing.com'
       apiKey: 'your-bearer-token'
@@ -77,14 +81,9 @@ providers:
 
 ## Features
 
-Snowflake Cortex supports:
+These examples cover text chat through the existing REST endpoint. Cortex capabilities such as tools, vision, structured output, and cross-region inference depend on the model, endpoint, and account configuration; a platform capability does not imply support through every provider route.
 
-- **Tool Calling** - Function calling and tool use
-- **Structured Output** - JSON schema validation
-- **Streaming** - Real-time token streaming (via API)
-- **Image Input** - Vision capabilities for select models
-- **Content Filtering** - Built-in guardrails
-- **Cross-Region Inference** - Models available across Snowflake regions
+In particular, Snowflake's [structured-output REST example](https://docs.snowflake.com/en/user-guide/snowflake-cortex/complete-structured-outputs#rest-api-example) uses `response_format` with `type: json` and `schema`. Do not assume that the newer OpenAI-compatible endpoint's `json_schema` format works unchanged with the `snowflake:` provider.
 
 ## Authentication
 
@@ -98,21 +97,13 @@ Authentication is handled via Bearer tokens in the Authorization header. Snowfla
 
 ```yaml title="promptfooconfig.yaml"
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-description: 'Compare Snowflake Cortex models'
+description: 'Evaluate Snowflake Cortex text responses'
 
 prompts:
   - 'Explain {{topic}} in simple terms'
 
 providers:
-  - id: snowflake:claude-3-5-sonnet
-    config:
-      temperature: 0.7
-      max_tokens: 1024
-  - id: snowflake:mistral-large2
-    config:
-      temperature: 0.7
-      max_tokens: 1024
-  - id: snowflake:llama-3.1-70b
+  - id: snowflake:claude-sonnet-4-6
     config:
       temperature: 0.7
       max_tokens: 1024

--- a/src/providers/snowflake.ts
+++ b/src/providers/snowflake.ts
@@ -20,24 +20,21 @@ import type {
  *
  * Documentation: https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api
  *
- * The Snowflake Cortex REST API provides OpenAI-compatible endpoints but with
- * a different URL structure:
+ * Uses the existing REST COMPLETE endpoint, which is distinct from Snowflake's
+ * newer OpenAI-compatible /api/v2/cortex/v1/chat/completions endpoint:
  * - Endpoint: https://<account_identifier>.snowflakecomputing.com/api/v2/cortex/inference:complete
  * - Authentication: Bearer token (JWT, OAuth, or programmatic access token)
- * - Supports similar parameters to OpenAI (temperature, max_tokens, etc.)
- * - Supports tool calling, structured output, and streaming
+ * - Supports text generation parameters such as temperature and max_tokens
+ * - Model availability and capabilities depend on the account, region, and endpoint
  *
- * Available models include:
- * - Claude models (claude-3-5-sonnet, claude-4-sonnet)
- * - OpenAI GPT models
- * - Mistral models
- * - Llama models
- * - Custom fine-tuned models
+ * Use exact Snowflake model IDs. The example below uses a model documented on
+ * this REST endpoint; it does not imply all OpenAI request formats are supported.
+ * https://docs.snowflake.com/en/user-guide/snowflake-cortex/complete-structured-outputs#rest-api-example
  *
  * Example configuration:
  * ```yaml
  * providers:
- *   - id: snowflake:mistral-large2
+ *   - id: snowflake:claude-sonnet-4-6
  *     config:
  *       accountIdentifier: "myorg-myaccount"  # or set SNOWFLAKE_ACCOUNT_IDENTIFIER
  *       apiKey: "your-bearer-token"           # or set SNOWFLAKE_API_KEY


### PR DESCRIPTION
Replace stale cloud onboarding selectors with exact platform model IDs and explain adapter task/API limits. Snowflake examples use Sonnet 4.6 on the existing REST route; ModelsLab uses the documented v6 Seedream ID and separates Nano Banana v7 evidence; Databricks keeps embeddings outside its chat provider; Cloudflare code examples use chat and remove deprecated Phi-2. Custom endpoint names and existing supported defaults are preserved. Snowflake source changes are JSDoc only.

Validation: fresh `npm ci`, `npm run l`, `npm run f`, the full documentation build with `SKIP_OG_GENERATION=true`, and normal pre-commit hooks passed with Node 24.20.0/npm 11.19.0. Public primary sources were refreshed on September 8, 2026; no vendor inference was performed.

Primary sources: [Snowflake REST model example](https://docs.snowflake.com/en/user-guide/snowflake-cortex/complete-structured-outputs#rest-api-example), [ModelsLab v6 integration](https://modelslab.com/blog/image-generation/seedream-5-0-api-bytedance-image-model-modelslab-2026), [Databricks model catalog](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models), and [Cloudflare compatibility](https://developers.cloudflare.com/workers-ai/configuration/open-ai-compatibility/).
