### PR TITLE
fix(providers): separate Azure chat and embedding defaults

### DIFF
--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -542,6 +542,8 @@ Then Azure OpenAI will be used as the default provider for all operations includ
 
 Because embedding models are distinct from text generation models, to set a default embedding provider you must specify `AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME`.
 
+When Azure is selected for chat and this variable is absent, promptfoo uses configured Gemini API, Mistral, or Voyage embedding credentials, then Google Application Default Credentials. It keeps Azure for chat and never sends embedding requests to the chat deployment. Without another embedding credential, the existing OpenAI embedding fallback requires its own API key. An explicit embedding provider override takes precedence; keep that override when comparing against an existing vector index.
+
 Set this environment variable to the deployment name of your embedding model:
 
 ```bash

--- a/src/providers/defaults.ts
+++ b/src/providers/defaults.ts
@@ -4,9 +4,10 @@ import { getAnthropicProviders } from './anthropic/defaults';
 import { AzureChatCompletionProvider } from './azure/chat';
 import { AzureEmbeddingProvider } from './azure/embedding';
 import { AzureModerationProvider } from './azure/moderation';
-import { getGoogleAiStudioProviders } from './google/ai.studio';
+import { AIStudioEmbeddingProvider, getGoogleAiStudioProviders } from './google/ai.studio';
 import { hasGoogleDefaultCredentials } from './google/util';
 import { getGoogleVertexEmbeddingProvider, getGoogleVertexProviders } from './google/vertex';
+import { MistralEmbeddingProvider as MistralEmbeddingApiProvider } from './mistral';
 import {
   DefaultEmbeddingProvider as MistralEmbeddingProvider,
   DefaultGradingJsonProvider as MistralGradingJsonProvider,
@@ -23,6 +24,7 @@ import {
   DefaultSuggestionsProvider as OpenAiSuggestionsProvider,
   DefaultWebSearchProvider as OpenAiWebSearchProvider,
 } from './openai/defaults';
+import { VoyageEmbeddingProvider } from './voyage';
 import { getXAIProviders } from './xai/defaults';
 
 import type { EnvOverrides } from '../types/env';
@@ -40,6 +42,42 @@ const EMBEDDING_PROVIDERS: (keyof DefaultProviders)[] = ['embeddingProvider'];
 
 let defaultCompletionProvider: ApiProvider;
 let defaultEmbeddingProvider: ApiProvider;
+
+async function getEmbeddingProviderForAzureDefaults(env?: EnvOverrides): Promise<ApiProvider> {
+  if (defaultEmbeddingProvider) {
+    return defaultEmbeddingProvider;
+  }
+
+  const embeddingDeploymentName =
+    getEnvString('AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME') ||
+    env?.AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME;
+  if (embeddingDeploymentName) {
+    return new AzureEmbeddingProvider(embeddingDeploymentName, { env });
+  }
+
+  // A chat deployment is not an embedding deployment. Prefer configured embedding
+  // API credentials before probing ADC, without changing Azure's chat selection.
+  if (
+    env?.GEMINI_API_KEY ||
+    getEnvString('GEMINI_API_KEY') ||
+    env?.GOOGLE_API_KEY ||
+    getEnvString('GOOGLE_API_KEY') ||
+    env?.PALM_API_KEY ||
+    getEnvString('PALM_API_KEY')
+  ) {
+    return new AIStudioEmbeddingProvider('gemini-embedding-001', { env });
+  }
+  if (env?.MISTRAL_API_KEY || getEnvString('MISTRAL_API_KEY')) {
+    return new MistralEmbeddingApiProvider({ env });
+  }
+  if (env?.VOYAGE_API_KEY || getEnvString('VOYAGE_API_KEY')) {
+    return new VoyageEmbeddingProvider('voyage-3.5', {}, env);
+  }
+  if (await hasGoogleDefaultCredentials()) {
+    return getGoogleVertexEmbeddingProvider(env);
+  }
+  return OpenAiEmbeddingProvider;
+}
 
 interface DefaultProviderPreferences {
   preferAnthropic: boolean;
@@ -145,18 +183,10 @@ export async function getDefaultProviders(env?: EnvOverrides): Promise<DefaultPr
       throw new Error('AZURE_OPENAI_DEPLOYMENT_NAME must be set when using Azure OpenAI');
     }
 
-    const embeddingDeploymentName =
-      getEnvString('AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME') ||
-      env?.AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME ||
-      deploymentName;
-
     const azureProvider = new AzureChatCompletionProvider(deploymentName, { env });
-    const azureEmbeddingProvider = new AzureEmbeddingProvider(embeddingDeploymentName, {
-      env,
-    });
 
     providers = {
-      embeddingProvider: azureEmbeddingProvider,
+      embeddingProvider: await getEmbeddingProviderForAzureDefaults(env),
       gradingJsonProvider: azureProvider,
       gradingProvider: azureProvider,
       moderationProvider: OpenAiModerationProvider,

--- a/test/providers/defaults.test.ts
+++ b/test/providers/defaults.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AzureChatCompletionProvider } from '../../src/providers/azure/chat';
+import { AzureEmbeddingProvider } from '../../src/providers/azure/embedding';
 import { AzureModerationProvider } from '../../src/providers/azure/moderation';
 import {
   getDefaultProviders,
   setDefaultCompletionProviders,
   setDefaultEmbeddingProviders,
 } from '../../src/providers/defaults';
-import { AIStudioChatProvider } from '../../src/providers/google/ai.studio';
+import {
+  AIStudioChatProvider,
+  AIStudioEmbeddingProvider,
+} from '../../src/providers/google/ai.studio';
 import { hasGoogleDefaultCredentials } from '../../src/providers/google/util';
 import { VertexEmbeddingProvider } from '../../src/providers/google/vertex';
 import {
@@ -83,6 +88,8 @@ describe('Provider override tests', () => {
     mockProcessEnv({ AZURE_API_KEY: undefined });
     mockProcessEnv({ AZURE_DEPLOYMENT_NAME: undefined });
     mockProcessEnv({ AZURE_OPENAI_DEPLOYMENT_NAME: undefined });
+    mockProcessEnv({ AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: undefined });
+    mockProcessEnv({ VOYAGE_API_KEY: undefined });
   });
 
   afterEach(async () => {
@@ -289,14 +296,122 @@ describe('Provider override tests', () => {
     expect(hasGoogleDefaultCredentials).toHaveBeenCalledTimes(1);
   });
 
-  it('should not probe Google default credentials when Azure is preferred', async () => {
+  it('should not probe Google default credentials when Azure has an embedding deployment', async () => {
     mockProcessEnv({ AZURE_OPENAI_API_KEY: 'azure-key' });
     mockProcessEnv({ AZURE_DEPLOYMENT_NAME: 'azure-chat' });
     mockProcessEnv({ AZURE_OPENAI_DEPLOYMENT_NAME: 'azure-chat' });
+    mockProcessEnv({ AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: 'azure-vectors' });
 
     await getDefaultProviders();
 
     expect(hasGoogleDefaultCredentials).not.toHaveBeenCalled();
+  });
+
+  describe('embeddings with Azure chat defaults', () => {
+    const azureEnv: EnvOverrides = {
+      AZURE_OPENAI_API_KEY: 'fixture-azure-key',
+      AZURE_DEPLOYMENT_NAME: 'tenant-chat',
+      AZURE_OPENAI_DEPLOYMENT_NAME: 'tenant-chat',
+    };
+
+    it.each(['process', 'scoped'])(
+      'uses an explicit Azure embedding deployment from %s unchanged',
+      async (source) => {
+        const env = { ...azureEnv, AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: 'tenant-vectors-v1' };
+        if (source === 'process') {
+          mockProcessEnv(env);
+        }
+        const providers = await getDefaultProviders(source === 'scoped' ? env : undefined);
+        expect(providers.embeddingProvider).toBeInstanceOf(AzureEmbeddingProvider);
+        expect(providers.embeddingProvider).toHaveProperty('deploymentName', 'tenant-vectors-v1');
+        expect(providers.gradingProvider).toBeInstanceOf(AzureChatCompletionProvider);
+        expect(providers.gradingProvider).toHaveProperty('deploymentName', 'tenant-chat');
+        expect(hasGoogleDefaultCredentials).not.toHaveBeenCalled();
+      },
+    );
+
+    it('preserves process precedence for the Azure embedding deployment', async () => {
+      mockProcessEnv({ AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: 'process-vectors' });
+      const providers = await getDefaultProviders({
+        ...azureEnv,
+        AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: 'scoped-vectors',
+      });
+      expect(providers.embeddingProvider).toHaveProperty('deploymentName', 'process-vectors');
+    });
+
+    it.each([
+      ['GEMINI_API_KEY', 'google:embedding:gemini-embedding-001'],
+      ['GOOGLE_API_KEY', 'google:embedding:gemini-embedding-001'],
+      ['PALM_API_KEY', 'google:embedding:gemini-embedding-001'],
+      ['MISTRAL_API_KEY', 'mistral:embedding:mistral-embed'],
+      ['VOYAGE_API_KEY', 'voyage:voyage-3.5'],
+    ])('uses scoped %s for embeddings while keeping Azure chat', async (key, id) => {
+      const env = {
+        ...azureEnv,
+        GOOGLE_GENAI_USE_VERTEXAI: 'true',
+        [key]: 'fixture-embedding-key',
+      };
+      const providers = await getDefaultProviders(env);
+      expect(providers.embeddingProvider.id()).toBe(id);
+      expect(providers.embeddingProvider).not.toBeInstanceOf(AzureEmbeddingProvider);
+      expect(providers.embeddingProvider).toHaveProperty('env', env);
+      expect(providers.gradingProvider).toBeInstanceOf(AzureChatCompletionProvider);
+      expect(providers.gradingProvider).toHaveProperty('deploymentName', 'tenant-chat');
+      expect(hasGoogleDefaultCredentials).not.toHaveBeenCalled();
+      if (key !== 'MISTRAL_API_KEY' && key !== 'VOYAGE_API_KEY') {
+        expect(providers.embeddingProvider).toBeInstanceOf(AIStudioEmbeddingProvider);
+        expect(providers.embeddingProvider).toHaveProperty('config.vertexai', false);
+        expect((providers.embeddingProvider as AIStudioEmbeddingProvider).getApiKey()).toBe(
+          'fixture-embedding-key',
+        );
+      }
+    });
+
+    it('uses process embedding credentials without reusing the chat deployment', async () => {
+      mockProcessEnv({ ...azureEnv, MISTRAL_API_KEY: 'fixture-mistral-key' });
+      const providers = await getDefaultProviders();
+      expect(providers.embeddingProvider.id()).toBe('mistral:embedding:mistral-embed');
+      expect(providers.gradingProvider).toHaveProperty('deploymentName', 'tenant-chat');
+      expect(hasGoogleDefaultCredentials).not.toHaveBeenCalled();
+    });
+
+    it('uses Vertex embeddings when only ADC is available beside Azure chat', async () => {
+      vi.mocked(hasGoogleDefaultCredentials).mockResolvedValue(true);
+      const providers = await getDefaultProviders(azureEnv);
+      expect(providers.embeddingProvider).toBeInstanceOf(VertexEmbeddingProvider);
+      expect(providers.embeddingProvider.id()).toBe('vertex:gemini-embedding-001');
+      expect(providers.gradingProvider).toBeInstanceOf(AzureChatCompletionProvider);
+      expect(hasGoogleDefaultCredentials).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the existing OpenAI fallback when no embedding credentials are available', async () => {
+      const providers = await getDefaultProviders(azureEnv);
+      expect(providers.embeddingProvider).toBe(OpenAiEmbeddingProvider);
+      expect(providers.embeddingProvider).not.toBeInstanceOf(AzureEmbeddingProvider);
+      expect(hasGoogleDefaultCredentials).toHaveBeenCalledTimes(1);
+      const response = await OpenAiEmbeddingProvider.callEmbeddingApi('hello');
+      expect(response.error).toMatch(/API key/i);
+      expect(response.embedding).toBeUndefined();
+    });
+
+    it('preserves explicit embedding overrides without probing ADC', async () => {
+      const override = new MockProvider('custom:existing-vector-space');
+      await setDefaultEmbeddingProviders(override);
+      const providers = await getDefaultProviders(azureEnv);
+      expect(providers.embeddingProvider).toBe(override);
+      expect(providers.gradingProvider).toBeInstanceOf(AzureChatCompletionProvider);
+      expect(hasGoogleDefaultCredentials).not.toHaveBeenCalled();
+    });
+
+    it('preserves an explicit embedding override over an Azure embedding deployment', async () => {
+      const override = new MockProvider('custom:existing-vector-space');
+      await setDefaultEmbeddingProviders(override);
+      const providers = await getDefaultProviders({
+        ...azureEnv,
+        AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME: 'tenant-vectors',
+      });
+      expect(providers.embeddingProvider).toBe(override);
+    });
   });
 
   it('should use Mistral providers when provided via env overrides', async () => {


### PR DESCRIPTION
When Azure is selected for chat, an embedding request now requires `AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME` before using Azure. Without it, promptfoo selects configured Gemini API, Mistral, or Voyage embeddings, then Vertex with Application Default Credentials, and finally the existing OpenAI embedding fallback.

Explicit embedding overrides and deployment names stay intact. Chat provider selection, process precedence for Azure deployment variables, existing embedding model pins, and GitHub Models retirement are preserved.

Validation: 43 default-selection tests, TypeScript, backend/app builds, normal hooks, and four built CLI cases against local fixtures passed. The CLI cases cover Mistral fallback, explicit Azure deployment, an existing vector-space override, and an embedding error. The production documentation build and architecture boundary check also passed.
