### PR TITLE
fix(assertions): parse multiline tool calls and clarify guides

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -27,12 +27,11 @@ keywords:
 
 # Deterministic metrics
 
-These metrics are created by logical tests that are run on LLM output.
+These assertions can check LLM output or provider metadata directly. Configured scripts, webhooks, and grouped assertions may still depend on external services.
 
 | Assertion Type                                                  | Returns true if...                                                 |
 | --------------------------------------------------------------- | ------------------------------------------------------------------ |
 | [assert-set](#assert-set)                                       | A configurable threshold of grouped assertions pass                |
-| [classifier](#classifier)                                       | HuggingFace classifier returns expected class above threshold      |
 | [contains](#contains)                                           | output contains substring                                          |
 | [contains-all](#contains-all)                                   | output contains all list of substrings                             |
 | [contains-any](#contains-any)                                   | output contains any of the listed substrings                       |
@@ -42,7 +41,6 @@ These metrics are created by logical tests that are run on LLM output.
 | [contains-xml](#contains-xml)                                   | output contains valid xml fragment(s)                              |
 | [cost](#cost)                                                   | Inference cost is below a threshold                                |
 | [equals](#equality)                                             | output matches exactly                                             |
-| [f-score](#f-score)                                             | F-score is above a threshold                                       |
 | [finish-reason](#finish-reason)                                 | model stopped for the expected reason                              |
 | [icontains](#contains)                                          | output contains substring, case insensitive                        |
 | [icontains-all](#contains-all)                                  | output contains all list of substrings, case insensitive           |
@@ -65,18 +63,26 @@ These metrics are created by logical tests that are run on LLM output.
 | [levenshtein](#levenshtein-distance)                            | Levenshtein distance is below a threshold                          |
 | [perplexity-score](#perplexity-score)                           | Normalized perplexity                                              |
 | [perplexity](#perplexity)                                       | Perplexity is below a threshold                                    |
-| [pi](#pi)                                                       | Pi Labs scorer returns score above threshold                       |
 | [python](/docs/configuration/expected-outputs/python)           | provided Python function validates the output                      |
 | [regex](#regex)                                                 | output matches regex                                               |
 | [rouge-n](#rouge-n)                                             | Rouge-N score is above a given threshold                           |
-| [select-best](#select-best)                                     | Output is selected as best among multiple outputs                  |
-| [similar](#similar)                                             | Embedding similarity is above threshold                            |
 | [starts-with](#starts-with)                                     | output starts with string                                          |
 | [trace-span-count](#trace-span-count)                           | Count spans matching patterns with min/max thresholds              |
 | [trace-span-duration](#trace-span-duration)                     | Check span durations with percentile support                       |
 | [trace-error-spans](#trace-error-spans)                         | Detect errors in traces by status codes, attributes, and messages  |
 | [webhook](#webhook)                                             | provided webhook returns \{pass: true\}                            |
 | [word-count](#word-count)                                       | output has a specific number of words or falls within a range      |
+
+The [F-score](#f-score) section describes a derived metric built from named JavaScript assertions, not an assertion type.
+
+These checks use an additional model or external inference service. Their sections remain here for existing links:
+
+| Check                       | Requires                           |
+| --------------------------- | ---------------------------------- |
+| [classifier](#classifier)   | A HuggingFace classifier           |
+| [pi](#pi)                   | A Pi Labs scorer                   |
+| [select-best](#select-best) | A grading model to compare outputs |
+| [similar](#similar)         | An embedding model                 |
 
 :::tip
 Every test type can be negated by prepending `not-`. For example, `not-equals` or `not-regex`.
@@ -1591,7 +1597,7 @@ The F-score will be calculated automatically after the eval completes. A score c
 
 This is particularly useful for evaluating classification tasks like sentiment analysis, where you want to measure both the precision (accuracy of positive predictions) and recall (ability to find all positive cases).
 
-See [Github](https://github.com/promptfoo/promptfoo/tree/main/examples/eval-f-score) for a complete example.
+See [GitHub](https://github.com/promptfoo/promptfoo/tree/main/examples/eval-f-score) for a complete example.
 
 ### Finish Reason
 

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -439,12 +439,12 @@ For more advanced test cases, we recommend using a testing framework like [Jest 
 If you have a set of common assertions that you want to apply to multiple test cases, you can create assertion templates and reuse them across your configuration.
 
 ```yaml
-// highlight-start
+# highlight-start
 assertionTemplates:
   containsMentalHealth:
     type: javascript
     value: output.toLowerCase().includes('mental health')
-// highlight-end
+# highlight-end
 
 prompts:
   - file://prompt1.txt
@@ -456,13 +456,13 @@ tests:
   - vars:
       input: Tell me about the benefits of exercise.
     assert:
-      // highlight-next-line
-      - $ref: "#/assertionTemplates/containsMentalHealth"
+      # highlight-next-line
+      - $ref: '#/assertionTemplates/containsMentalHealth'
   - vars:
       input: How can I improve my well-being?
     assert:
-      // highlight-next-line
-      - $ref: "#/assertionTemplates/containsMentalHealth"
+      # highlight-next-line
+      - $ref: '#/assertionTemplates/containsMentalHealth'
 ```
 
 In this example, the `containsMentalHealth` assertion template is defined at the top of the configuration file and then reused in two test cases. This approach helps maintain consistency and reduces duplication in your configuration.

--- a/site/docs/providers/azure.md
+++ b/site/docs/providers/azure.md
@@ -564,7 +564,7 @@ defaultTest:
 
 For `text-embedding-3` deployments, set `config.dimensions` to request shorter vectors. Omit it to use the model's default vector size. Use the same embedding model and dimensions for indexed documents and queries; changing either requires rebuilding existing vectors. Azure deployment names are user-defined and remain unchanged by this option.
 
-Note that any moderation tasks will still use the OpenAI API.
+By default, moderation tasks use the OpenAI API. If you configure `AZURE_CONTENT_SAFETY_ENDPOINT`, they use Azure Content Safety instead.
 
 ## Configuration
 
@@ -654,7 +654,7 @@ The `azureAuthorityHost` defaults to `https://login.microsoftonline.com` if not 
 
 ## Model-Graded Tests
 
-[Model-graded assertions](/docs/configuration/expected-outputs/model-graded/) such as `factuality` or `llm-rubric` use a default OpenAI grader model unless overridden. When `AZURE_DEPLOYMENT_NAME` is set (and `OPENAI_API_KEY` is not), promptfoo automatically uses the specified Azure deployment for grading. You can also explicitly override the grader as shown below.
+[Model-graded assertions](/docs/configuration/expected-outputs/model-graded/) such as `factuality` or `llm-rubric` use a default OpenAI grader model unless overridden. When both `AZURE_DEPLOYMENT_NAME` and `AZURE_OPENAI_DEPLOYMENT_NAME` are set (and `OPENAI_API_KEY` is not), promptfoo automatically uses the Azure default for grading, provided Azure authentication is configured. You can also explicitly override the grader as shown below.
 
 The easiest way to do this for _all_ your test cases is to add the [`defaultTest`](/docs/configuration/guide/#default-test-cases) property to your config:
 

--- a/src/assertions/toolCallF1.ts
+++ b/src/assertions/toolCallF1.ts
@@ -2,6 +2,40 @@ import invariant from '../util/invariant';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 
+function findJsonEnd(text: string, start: number): number {
+  const closing: string[] = [text[start] === '{' ? '}' : ']'];
+  let inString = false;
+  let escaped = false;
+
+  for (let end = start + 1; end < text.length; end++) {
+    const char = text[end];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+    } else if (char === '{' || char === '[') {
+      closing.push(char === '{' ? '}' : ']');
+    } else if (char === '}' || char === ']') {
+      if (closing.pop() !== char) {
+        return -1;
+      }
+      if (closing.length === 0) {
+        return end;
+      }
+    }
+  }
+  return -1;
+}
+
 /**
  * Extracts tool names from various output formats.
  *
@@ -32,23 +66,26 @@ function extractToolNames(output: unknown): Set<string> {
       }
       return names;
     } catch {
-      // Not valid JSON as a whole, continue to try line-by-line parsing
+      // Not valid JSON as a whole; look for embedded JSON values.
     }
 
-    // Handle Anthropic-style output: text and JSON objects separated by newlines
-    // Example: "Let me check the weather.\n\n{"type":"tool_use","name":"get_weather",...}"
-    const lines = output.split('\n');
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    // Mixed text and JSON may include pretty-printed blocks and nested values.
+    // Balance delimiters outside strings before parsing each complete candidate.
+    for (let start = 0; start < output.length; start++) {
+      const opening = output[start];
+      if (opening !== '{' && opening !== '[') {
+        continue;
+      }
+
+      const end = findJsonEnd(output, start);
+      if (end >= 0) {
         try {
-          const parsed = JSON.parse(trimmed);
-          const parsedNames = extractToolNames(parsed);
-          for (const name of parsedNames) {
+          for (const name of extractToolNames(JSON.parse(output.slice(start, end + 1)))) {
             names.add(name);
           }
+          start = end;
         } catch {
-          // Not valid JSON, ignore this line
+          // A balanced fragment may still be invalid JSON.
         }
       }
     }
@@ -195,9 +232,15 @@ export const handleToolCallF1 = ({
   let expectedTools: string[];
 
   if (Array.isArray(renderedValue)) {
-    expectedTools = renderedValue.map(String);
+    expectedTools = renderedValue
+      .map(String)
+      .map((name) => name.trim())
+      .filter(Boolean);
   } else if (typeof renderedValue === 'string') {
-    expectedTools = renderedValue.split(',').map((s) => s.trim());
+    expectedTools = renderedValue
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean);
   } else {
     invariant(
       false,

--- a/src/providers/mcp/client.ts
+++ b/src/providers/mcp/client.ts
@@ -370,7 +370,9 @@ export class MCPClient {
     oauthConfig: OAuthServerConfig,
     forceRefresh: boolean,
   ): Promise<void> {
-    // If a refresh is already in progress, wait for it instead of starting a new one.
+    // Wait for each active refresh lock. Its owner clears it in finally; once no lock
+    // remains, this caller either uses the refreshed token or starts its own refresh.
+    // Another caller may install a new lock while we wait, so check again each time.
     while (true) {
       const existingRefreshPromise = this.tokenRefreshLocks.get(serverKey)?.promise;
       if (!existingRefreshPromise) {
@@ -384,10 +386,10 @@ export class MCPClient {
         if (this.hasValidToken(serverKey)) {
           return;
         }
-        // Token still needs refresh after waiting, so fall through and try again.
+        // The token is still stale; check for a replacement lock before refreshing.
         logger.debug(`[MCP] Token still needs refresh for ${serverKey}, refreshing again...`);
       } catch {
-        // If the in-progress refresh failed, we'll try again below
+        // The lock owner cleans up even on failure; check for a replacement lock.
         logger.debug(`[MCP] Previous token refresh failed for ${serverKey}, retrying...`);
       }
     }
@@ -476,6 +478,8 @@ export class MCPClient {
         let currentClient = client;
         let retried = false;
 
+        // A successful call returns. Authentication failure allows one refresh and
+        // one retry; all other failures return an error after the catch block.
         while (true) {
           try {
             const result = await currentClient.callTool(

--- a/test/assertions/toolCallF1.test.ts
+++ b/test/assertions/toolCallF1.test.ts
@@ -305,6 +305,35 @@ describe('handleToolCallF1', () => {
       expect(result.score).toBe(1);
     });
 
+    it('extracts complete pretty-printed JSON blocks after text', () => {
+      const output = [
+        'Let me check that. Braces in prose {not JSON} are ignored.',
+        JSON.stringify(
+          { type: 'tool_use', name: 'get_weather', input: { query: 'a } b' } },
+          null,
+          2,
+        ),
+        'And then book the flight.',
+        JSON.stringify(
+          [{ type: 'tool_use', name: 'book_flight', input: { destination: 'LA' } }],
+          null,
+          2,
+        ),
+      ].join('\n\n');
+
+      const result = handleToolCallF1(createParams(output, ['get_weather', 'book_flight']));
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(1);
+    });
+
+    it('does not count an incomplete JSON tool block', () => {
+      const output = 'Here is a partial call: {"type":"tool_use","name":"get_weather"';
+      const result = handleToolCallF1(createParams(output, ['get_weather']));
+
+      expect(result.score).toBe(0);
+    });
+
     it('should handle Anthropic output with only one tool call in string', () => {
       const output = `I'll help you with that.
 
@@ -438,6 +467,15 @@ describe('handleToolCallF1', () => {
         '"tool-call-f1" assertion requires at least one expected tool name',
       );
     });
+
+    it.each(['', '  ', ' , , ', [' ', '']])(
+      'rejects empty expected tool names from %j',
+      (expectedTools) => {
+        expect(() => handleToolCallF1(createParams({}, expectedTools))).toThrow(
+          '"tool-call-f1" assertion requires at least one expected tool name',
+        );
+      },
+    );
 
     it('should throw error when value is undefined', () => {
       const output = { tool_calls: [{ function: { name: 'get_weather', arguments: '{}' } }] };


### PR DESCRIPTION
## Summary

Addresses the nine currently visible AI findings across five files on the [GitHub AI findings page](https://github.com/promptfoo/promptfoo/security/quality/ai-findings):

- Parse complete JSON objects and arrays in mixed text output for `tool-call-f1`, including multiline tool calls; reject empty expected tool names.
- Separate model-assisted checks and the derived F-score recipe from the deterministic assertion-type table; make the assertion-template YAML example valid and correct GitHub capitalization.
- Clarify Azure Content Safety moderation and the required default deployment variables, and explain the MCP token-refresh and tool-call loop exits.

## Validation

- `npx vitest run test/assertions/toolCallF1.test.ts test/providers/mcp/client.test.ts test/providers/defaults.test.ts` (143 passed after merging current `main`)
- `npm run tsc`, `npm run build`, `npm run f`, `npm run l`
- `SKIP_OG_GENERATION=true npm run build` in `site/` after merging current `main`
- Parsed the assertion-template YAML sample and ran a local `echo` provider eval with multiline `tool_use` JSON using `--no-cache`; exported result passed with score 1 and no errors.

Existing cognitive-complexity warnings remain in the assertion parser and MCP client; lint exits successfully.
