### PR TITLE
fix(providers): select TrueFoundry tasks explicitly

### DIFF
--- a/examples/provider-truefoundry/README.md
+++ b/examples/provider-truefoundry/README.md
@@ -136,27 +136,36 @@ TrueFoundry provides access to models from multiple providers. Use the format `p
 
 ## Embeddings
 
-TrueFoundry also supports embedding models:
+Set `task: embedding` explicitly and use the provider for embedding-based assertions such as `similar`:
 
 ```yaml
-providers:
-  - id: truefoundry:openai-main/text-embedding-3-large
-    config:
-      metadata:
-        user_id: 'embedding-user'
-      loggingConfig:
-        enabled: true
+defaultTest:
+  options:
+    provider:
+      embedding:
+        id: truefoundry:openai-main/text-embedding-3-large
+        config:
+          task: embedding
+          metadata:
+            user_id: 'embedding-user'
+          loggingConfig:
+            enabled: true
 ```
 
 ### Cohere Embeddings
 
-When using Cohere models, specify the `input_type`:
+For Cohere, select the embedding task and pass the required `input_type` through `passthrough`:
 
 ```yaml
-providers:
-  - id: truefoundry:cohere-main/embed-english-v3.0
-    config:
-      input_type: 'search_query' # Options: search_query, search_document, classification, clustering
+defaultTest:
+  options:
+    provider:
+      embedding:
+        id: truefoundry:cohere-main/embed-english-v3.0
+        config:
+          task: embedding
+          passthrough:
+            input_type: search_query # Or search_document, classification, clustering
 ```
 
 ## Observability

--- a/site/docs/providers/truefoundry.md
+++ b/site/docs/providers/truefoundry.md
@@ -53,8 +53,9 @@ tests:
 
 ### Basic Configuration Options
 
-The TrueFoundry provider supports all standard OpenAI configuration options:
+The TrueFoundry provider supports the following configuration options:
 
+- `task`: Set `chat` or `embedding` explicitly. When omitted, model IDs containing `embedding` select embeddings; other IDs select chat. The full account/model ID is sent unchanged.
 - `temperature`: Controls randomness in output between 0 and 2
 - `max_tokens`: Maximum number of tokens to generate
 - `max_completion_tokens`: Maximum number of tokens that can be generated in the chat completion
@@ -142,55 +143,59 @@ providers:
 providers:
   - truefoundry:groq-main/llama-3.3-70b-versatile
   - truefoundry:mistral-main/mistral-large-latest
-  - truefoundry:cohere-main/embed-english-v3.0 # Embeddings
 ```
 
 ## Embeddings
 
-TrueFoundry supports embedding models through the same unified API:
+Use `task: embedding` to select the embeddings API for any account/model ID, including custom aliases. Configure it as the embedding provider for a [`similar` assertion](/docs/configuration/expected-outputs/similar):
 
 ```yaml title="promptfooconfig.yaml"
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+prompts:
+  - '{{query}}'
 providers:
-  - id: truefoundry:openai-main/text-embedding-3-large
-    config:
-      metadata:
-        user_id: 'embedding-test'
-      loggingConfig:
-        enabled: true
+  - echo
+defaultTest:
+  options:
+    provider:
+      embedding:
+        id: truefoundry:openai-main/text-embedding-3-large
+        config:
+          task: embedding
+          metadata:
+            user_id: 'embedding-test'
+          loggingConfig:
+            enabled: true
 tests:
   - vars:
       query: 'What is machine learning?'
     assert:
-      - type: is-valid-openai-embedding
+      - type: similar
+        value: 'How does machine learning work?'
+        threshold: 0.8
 ```
 
 ### Cohere Embeddings
 
-When using Cohere models, you must specify the `input_type` parameter:
+When using Cohere models, select the embedding task and send the required [`input_type`](https://www.truefoundry.com/docs/ai-gateway/embed#input-type-cohere) through `passthrough`. For example, replace the embedding provider above with:
 
-```yaml title="promptfooconfig.yaml"
-# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-providers:
-  - id: truefoundry:cohere-main/embed-english-v3.0
-    config:
-      input_type: 'search_query' # Options: search_query, search_document, classification, clustering
-      metadata:
-        user_id: 'embedding-test'
+```yaml
+defaultTest:
+  options:
+    provider:
+      embedding:
+        id: truefoundry:cohere-main/embed-english-v3.0
+        config:
+          task: embedding
+          passthrough:
+            input_type: search_query # Or search_document, classification, clustering
+          metadata:
+            user_id: 'embedding-test'
 ```
 
 ### Multimodal Embeddings (Vertex AI)
 
-TrueFoundry supports multimodal embeddings for images and videos through Vertex AI:
-
-```yaml title="promptfooconfig.yaml"
-# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-providers:
-  - id: truefoundry:vertex-ai-main/multimodalembedding@001
-    config:
-      metadata:
-        use_case: 'image-search'
-```
+TrueFoundry's gateway supports [Vertex AI image and video embeddings](https://www.truefoundry.com/docs/ai-gateway/embed#multimodal-embeddings-vertex-ai). Promptfoo's TrueFoundry embedding adapter accepts text strings and reads the text embedding vector. Image/video payloads and their additional output vectors require a [custom provider](/docs/providers/custom-api/).
 
 ## Tool Use and Function Calling
 

--- a/src/providers/truefoundry.ts
+++ b/src/providers/truefoundry.ts
@@ -25,6 +25,7 @@ type TrueFoundryMCPServer = {
 };
 
 type TrueFoundryCompletionOptions = OpenAiCompletionOptions & {
+  task?: 'chat' | 'embedding';
   metadata?: TrueFoundryMetadata;
   loggingConfig?: TrueFoundryLoggingConfig;
   mcp_servers?: TrueFoundryMCPServer[];
@@ -382,7 +383,7 @@ export class TrueFoundryEmbeddingProvider extends OpenAiEmbeddingProvider {
  *
  * @param providerPath - Provider path, e.g., "truefoundry:openai/gpt-4"
  * @param options - Provider options
- * @returns A TrueFoundry provider (chat or embedding based on model type)
+ * @returns A TrueFoundry provider selected by config.task, with legacy model-name inference
  */
 export function createTrueFoundryProvider(
   providerPath: string,
@@ -395,8 +396,15 @@ export function createTrueFoundryProvider(
   const splits = providerPath.split(':');
   const modelName = splits.slice(1).join(':');
 
-  // Determine if this is an embedding model based on model name
-  const isEmbeddingModel = modelName.toLowerCase().includes('embedding');
+  const task = options.config?.config?.task;
+  if (task !== undefined && task !== 'chat' && task !== 'embedding') {
+    throw new Error('TrueFoundry config.task must be "chat" or "embedding"');
+  }
+
+  // Keep legacy inference when task is omitted. Account and deployment names are opaque,
+  // so explicit task selection must not consume or rewrite any part of the model name.
+  const isEmbeddingModel =
+    task === 'embedding' || (task === undefined && modelName.toLowerCase().includes('embedding'));
 
   const providerOptions: TrueFoundryProviderOptions = {
     ...options.config,

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -57,6 +57,34 @@ vi.mock('../../src/redteam/remoteGeneration', async (importOriginal) => {
 
 describe('Provider Registry', () => {
   it.each([
+    ['cohere-main/embed-english-v3.0', 'embedding', 'TrueFoundryEmbeddingProvider'],
+    ['tenant/vector-index:stable', 'embedding', 'TrueFoundryEmbeddingProvider'],
+    ['embedding-team/chat-alias:stable', 'chat', 'TrueFoundryProvider'],
+    ['openai-main/text-embedding-3-large', undefined, 'TrueFoundryEmbeddingProvider'],
+    ['tenant/chat-alias', undefined, 'TrueFoundryProvider'],
+  ])('selects TrueFoundry task for %s with task %s', async (modelName, task, className) => {
+    const providerPath = `truefoundry:${modelName}`;
+    const factory = providerMap.find((entry) => entry.test(providerPath));
+    const provider = await factory!.create(
+      providerPath,
+      { config: { task, apiBaseUrl: 'https://tenant.example/gateway' } },
+      { basePath: '.', options: {}, env: { TRUEFOUNDRY_API_KEY: 'scoped-test-key' } },
+    );
+    expect(provider.constructor.name).toBe(className);
+    expect(provider).toHaveProperty('modelName', modelName);
+    expect(provider.id()).toBe(providerPath);
+    expect(provider).toHaveProperty('config.apiBaseUrl', 'https://tenant.example/gateway');
+  });
+
+  it('rejects invalid TrueFoundry task configuration through the registry', async () => {
+    const providerPath = 'truefoundry:tenant/model';
+    const factory = providerMap.find((entry) => entry.test(providerPath));
+    await expect(
+      factory!.create(providerPath, { config: { task: 'image' } }, { basePath: '.', options: {} }),
+    ).rejects.toThrow('TrueFoundry config.task must be "chat" or "embedding"');
+  });
+
+  it.each([
     ['localai:chat:served-model:q4:latest', 'LocalAiChatProvider'],
     ['localai:completion:served-model:q4:latest', 'LocalAiCompletionProvider'],
     ['localai:embedding:served-model:q4:latest', 'LocalAiEmbeddingProvider'],

--- a/test/providers/truefoundry.test.ts
+++ b/test/providers/truefoundry.test.ts
@@ -795,6 +795,98 @@ describe('TrueFoundry', () => {
   });
 
   describe('createTrueFoundryProvider', () => {
+    beforeEach(() => {
+      mockedFetchWithRetries.mockReset();
+    });
+
+    it.each(['cohere-main/embed-english-v3.0', 'tenant/vector-index:stable'])(
+      'selects embeddings explicitly and preserves the wire ID %s',
+      async (modelName) => {
+        const provider = createTrueFoundryProvider(`truefoundry:${modelName}`, {
+          config: {
+            config: {
+              task: 'embedding',
+              apiBaseUrl: 'https://tenant.example/gateway',
+              passthrough: { input_type: 'search_query' },
+            },
+          },
+          env: { TRUEFOUNDRY_API_KEY: 'scoped-test-key' },
+        });
+        expect(provider).toBeInstanceOf(TrueFoundryEmbeddingProvider);
+        expect(provider.id()).toBe(`truefoundry:${modelName}`);
+
+        mockedFetchWithRetries.mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: [{ embedding: [0.1, 0.2], index: 0 }],
+              usage: { prompt_tokens: 3, total_tokens: 3 },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        );
+        const response = await (provider as TrueFoundryEmbeddingProvider).callEmbeddingApi('hello');
+        expect(response).toMatchObject({
+          embedding: [0.1, 0.2],
+          tokenUsage: { total: 3, prompt: 3, numRequests: 1 },
+        });
+        expect(mockedFetchWithRetries).toHaveBeenCalledWith(
+          'https://tenant.example/gateway/embeddings',
+          expect.objectContaining({
+            headers: expect.objectContaining({ Authorization: 'Bearer scoped-test-key' }),
+            body: JSON.stringify({ input: 'hello', model: modelName, input_type: 'search_query' }),
+          }),
+          expect.any(Number),
+          undefined,
+        );
+      },
+    );
+
+    it('uses explicit chat even when the account name contains embedding', async () => {
+      const provider = createTrueFoundryProvider('truefoundry:embedding-team/chat-alias:stable', {
+        config: { config: { task: 'chat', apiKey: 'test-key' } },
+      });
+      expect(provider).toBeInstanceOf(TrueFoundryProvider);
+      mockedFetchWithRetries.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'hello' } }] }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      );
+      const response = await provider.callApi('hello');
+      expect(response.output).toBe('hello');
+      const [url, request] = mockedFetchWithRetries.mock.calls[0];
+      expect(url).toBe(`${TRUEFOUNDRY_API_BASE}/chat/completions`);
+      const body = JSON.parse(request?.body as string);
+      expect(body.model).toBe('embedding-team/chat-alias:stable');
+      expect(body).not.toHaveProperty('task');
+    });
+
+    it('returns embedding API errors for explicitly selected tenant aliases', async () => {
+      const provider = createTrueFoundryProvider('truefoundry:tenant/vector-index', {
+        config: { config: { task: 'embedding', apiKey: 'test-key' } },
+      }) as TrueFoundryEmbeddingProvider;
+      mockedFetchWithRetries.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Unknown deployment' } }), {
+          status: 400,
+          statusText: 'Bad Request',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      const response = await provider.callEmbeddingApi('hello');
+      expect(response.error).toContain('400 Bad Request');
+      expect(response.error).toContain('Unknown deployment');
+      expect(response).not.toHaveProperty('embedding');
+    });
+
+    it.each(['', 'embeddings', 'image', null, false])('rejects unsupported task %j', (task) => {
+      expect(() =>
+        createTrueFoundryProvider('truefoundry:tenant/model', {
+          config: { config: { task } },
+        }),
+      ).toThrow('TrueFoundry config.task must be "chat" or "embedding"');
+      expect(mockedFetchWithRetries).not.toHaveBeenCalled();
+    });
+
     it('should create chat provider for non-embedding models', () => {
       const provider = createTrueFoundryProvider('truefoundry:openai/gpt-4', {
         config: {


### PR DESCRIPTION
TrueFoundry previously selected embeddings only when the model name contained `embedding`, sending models such as Cohere embed aliases through chat. Add `config.task: embedding | chat` to select the adapter explicitly while preserving the existing name heuristic when omitted. Full tenant model IDs and request authentication stay intact.

Update the embedding examples to configure a similarity assertion's embedding provider and describe the adapter's text-input boundary.

Validation: 56 TrueFoundry tests and 6 registry task tests, TypeScript, backend/app builds, and normal hooks passed. The built CLI fixture (two successful cases and one expected provider error), production documentation build, and architecture boundary check also passed.
