### PR TITLE
docs(site): clarify gateway model and protocol support

### DIFF
--- a/site/docs/providers/atlascloud.md
+++ b/site/docs/providers/atlascloud.md
@@ -20,17 +20,15 @@ You can also pass `apiKey` directly in the provider config, but using an environ
 
 ## Basic Configuration
 
+This example uses the `deepseek-v3` chat ID from Atlas Cloud's [first-model guide](https://www.atlascloud.ai/docs/en/models/get-start). Use Atlas Cloud's model ID for your selected endpoint; native vendor IDs may differ.
+
 ```yaml title="promptfooconfig.yaml"
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 providers:
-  - id: atlascloud:deepseek-ai/DeepSeek-V3-0324
+  - id: atlascloud:deepseek-v3
     config:
       temperature: 0.7
       max_tokens: 500
-
-  - id: atlascloud:qwen/qwen3-32b
-    config:
-      temperature: 0.2
 
 prompts:
   - 'Answer clearly and concisely: {{question}}'
@@ -43,11 +41,11 @@ tests:
         value: 'Paris'
 ```
 
-By default, the Atlas Cloud provider sends chat requests to `https://api.atlascloud.ai/v1`.
+By default, the Atlas Cloud provider sends chat requests to `https://api.atlascloud.ai/v1/chat/completions`. Atlas Cloud's image and video APIs use separate endpoints and asynchronous prediction handling; the `atlascloud:` provider implements the chat API.
 
 ## Configuration Options
 
-Atlas Cloud supports the standard OpenAI chat options already available in promptfoo, including:
+The provider accepts the shared OpenAI chat options below. Check your selected Atlas Cloud model's API reference for supported parameters and features:
 
 - `temperature`
 - `max_tokens`
@@ -67,7 +65,7 @@ If you route Atlas Cloud through a proxy or internal gateway, override `apiBaseU
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: atlascloud:deepseek-ai/DeepSeek-V3-0324
+  - id: atlascloud:deepseek-v3
     config:
       apiBaseUrl: https://proxy.example.com/atlas/v1
       apiKeyEnvar: MY_ATLASCLOUD_TOKEN
@@ -81,16 +79,14 @@ Precedence is:
 
 ## Model Examples
 
-Atlas Cloud's catalog changes over time. You should use the exact model ID returned by `GET /v1/models`. For example, this provider was verified against live Atlas Cloud model IDs such as `deepseek-ai/DeepSeek-V3-0324` and `qwen/qwen3-32b`.
+Atlas Cloud's catalog changes over time. Use the exact chat model ID from its model library or API reference. The public first-model guide uses:
 
 ```yaml
 providers:
-  - atlascloud:deepseek-ai/DeepSeek-V3-0324
-  - atlascloud:qwen/qwen3-32b
-  - atlascloud:moonshotai/Kimi-K2-Instruct
+  - atlascloud:deepseek-v3
 ```
 
-Use the exact model ID shown in the Atlas Cloud model library or docs.
+The provider forwards your configured model ID unchanged. Keep existing gateway IDs when they are available for your account; this example is not a migration rule for other aliases.
 
 ## Example
 

--- a/site/docs/providers/cometapi.md
+++ b/site/docs/providers/cometapi.md
@@ -29,12 +29,14 @@ providers:
 
 Where `<type>` can be:
 
-- `chat` - For chat completions (text, vision, multimodal)
-- `completion` - For text completions
-- `embedding` - For text embeddings
-- `image` - For image generation (DALL-E, Flux models)
+- `chat` - `/v1/chat/completions`, with text or image input supported by the selected model
+- `completion` - `/v1/completions`
+- `embedding` - `/v1/embeddings`
+- `image` - `/v1/images/generations`, returning a completed Images API response
 
 You can also use `cometapi:<model>` which defaults to chat mode.
+
+Choose a model that supports the selected endpoint. CometAPI also offers other protocols: its [GPT-6 Astra tool-calling guidance](https://apidoc.cometapi.com/api/text/chat) requires Responses, and its [FLUX.2 Pro quickstart](https://apidoc.cometapi.com/quickstarts/image/flux-api) requires task submission and polling. The `cometapi:` modes above do not implement those flows. A [custom provider](/docs/providers/custom-api/) can use their required endpoints and handle polling.
 
 ### Examples
 
@@ -44,7 +46,7 @@ You can also use `cometapi:<model>` which defaults to chat mode.
 providers:
   - cometapi:chat:gpt-5-mini
   - cometapi:chat:claude-3-5-sonnet-20241022
-  - cometapi:chat:your-favorite-model
+  - cometapi:chat:your-chat-model
   # Or use default chat mode
   - cometapi:gpt-5-mini
 ```
@@ -55,7 +57,7 @@ providers:
 providers:
   - cometapi:image:dall-e-3
   - cometapi:image:flux-schnell
-  - cometapi:image:any-image-model
+  - cometapi:image:your-image-model
 ```
 
 **Text Completion Models:**
@@ -63,7 +65,7 @@ providers:
 ```yaml
 providers:
   - cometapi:completion:deepseek-chat
-  - cometapi:completion:any-completion-model
+  - cometapi:completion:your-completion-model
 ```
 
 **Embedding Models:**
@@ -71,10 +73,10 @@ providers:
 ```yaml
 providers:
   - cometapi:embedding:text-embedding-3-small
-  - cometapi:embedding:any-embedding-model
+  - cometapi:embedding:your-embedding-model
 ```
 
-All standard OpenAI parameters are supported:
+Each mode accepts its corresponding OpenAI-compatible configuration options. Parameter support, image sizes, tool calling, and output formats depend on the selected CometAPI model. Confirm those details in its API reference before using or replacing an example ID:
 
 ```yaml
 providers:
@@ -121,7 +123,8 @@ npx promptfoo@latest eval --prompts "Describe what's in this image: {{image_url}
 
 **Image Generation with Custom Parameters:**
 
-```yaml
+```yaml title="promptfooconfig.yaml"
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 providers:
   - id: cometapi:image:dall-e-3
     config:
@@ -167,13 +170,15 @@ curl -H "Authorization: Bearer $COMETAPI_KEY" https://api.cometapi.com/v1/models
 
 Or browse models on the [CometAPI pricing page](https://api.cometapi.com/pricing).
 
-**Using Any Model:** Simply specify the model name with the appropriate type prefix:
+**Selecting a model:** Use the exact CometAPI model ID with the matching type prefix. A catalog entry alone does not establish support for every endpoint or feature:
 
-- `cometapi:chat:any-model-name` for text/chat models
-- `cometapi:image:any-image-model` for image generation
-- `cometapi:embedding:any-embedding-model` for embeddings
-- `cometapi:completion:any-completion-model` for text completions
-- `cometapi:any-model-name` (defaults to chat mode)
+- `cometapi:chat:<model>` for Chat Completions models
+- `cometapi:image:<model>` for synchronous Images API models
+- `cometapi:embedding:<model>` for Embeddings API models
+- `cometapi:completion:<model>` for legacy Completions API models
+- `cometapi:<model>` (defaults to chat mode)
+
+For example, the [GPT Image quickstart](https://apidoc.cometapi.com/quickstarts/image/gpt-image-api) returns `b64_json`, while FLUX.2 Pro returns a task ID from a different endpoint. Changing an image model name does not make those response formats interchangeable. Native vendor retirement dates also do not establish whether a CometAPI alias is available; check CometAPI's documentation for that exact ID.
 
 ## Environment Variables
 


### PR DESCRIPTION
Atlas Cloud onboarding used historical gateway aliases, while CometAPI guidance implied that every catalog model and OpenAI parameter worked with every provider mode. Use Atlas’s documented `deepseek-v3` chat example and describe Comet’s actual endpoint and model-specific limits, including Responses and asynchronous FLUX flows.

Validation: all 11 YAML blocks parsed; `npm run l`, `npm run f`, normal commit hooks and `git diff --check` passed. The production Docusaurus build passed with `SKIP_OG_GENERATION=true`. No runtime changes or live inference.

Primary sources checked September 8, 2026: [Atlas Cloud chat quickstart](https://www.atlascloud.ai/docs/en/models/get-start) and [Comet chat API](https://apidoc.cometapi.com/api/text/chat).
