### PR TITLE
fix(providers): defer FAL SDK loading until inference

### DIFF
--- a/src/providers/fal.ts
+++ b/src/providers/fal.ts
@@ -101,7 +101,6 @@ class FalProvider<Input = Record<string, unknown>> implements ApiProvider {
   input: Input;
 
   private fal: typeof import('@fal-ai/client') | null = null;
-  private client: import('@fal-ai/client').FalClient | null = null;
 
   constructor(
     modelType: 'image',
@@ -166,22 +165,6 @@ class FalProvider<Input = Record<string, unknown>> implements ApiProvider {
       cached = response !== undefined;
     }
 
-    if (!this.fal) {
-      try {
-        this.fal = await import('@fal-ai/client');
-      } catch (err) {
-        logger.error(`Error loading @fal-ai/client: ${err}`);
-        throw new Error(
-          'The @fal-ai/client package is required. Please install it with: npm install @fal-ai/client',
-        );
-      }
-    }
-
-    this.client = this.fal.createFalClient({
-      credentials: this.apiKey,
-      ...this.clientConfig,
-    });
-
     if (!response) {
       response = await this.runInference(input);
     }
@@ -212,10 +195,10 @@ class FalProvider<Input = Record<string, unknown>> implements ApiProvider {
       }
     }
 
-    const client = (this.client ??= this.fal.createFalClient({
+    const client = this.fal.createFalClient({
       credentials: this.apiKey,
       ...this.clientConfig,
-    }));
+    });
     const result = await client.subscribe(this.modelName, {
       input: input as Record<string, unknown>,
     });

--- a/test/providers/fal.test.ts
+++ b/test/providers/fal.test.ts
@@ -822,20 +822,32 @@ describe('Fal Provider', () => {
       });
 
       it.each([true, false])('handles a missing SDK with a cache hit: %s', async (cached) => {
+        // Exercise the dependency swap even when the SDK was already loaded.
+        await import('@fal-ai/client');
         const importSdk = vi.fn(() => {
           throw new Error('Fixture missing SDK');
         });
         vi.doMock('@fal-ai/client', importSdk);
-        vi.mocked(isCacheEnabled).mockReturnValue(cached);
-        vi.mocked(getCache().get).mockResolvedValue(JSON.stringify('cached image'));
+        vi.resetModules();
         try {
+          const freshCache = await import('../../src/cache');
+          vi.mocked(freshCache.isCacheEnabled).mockReturnValue(cached);
+          vi.mocked(freshCache.getCache).mockReturnValue({
+            get: vi.fn().mockResolvedValue(JSON.stringify('cached image')),
+          } as any);
+          const { FalImageGenerationProvider: FreshFalImageGenerationProvider } = await import(
+            '../../src/providers/fal'
+          );
+          const freshProvider = new FreshFalImageGenerationProvider('fal-ai/flux/schnell', {
+            config: { apiKey: 'test-api-key' },
+          });
           if (cached) {
-            await expect(provider.callApi('test prompt')).resolves.toEqual({
+            await expect(freshProvider.callApi('test prompt')).resolves.toEqual({
               cached: true,
               output: 'cached image',
             });
           } else {
-            await expect(provider.callApi('test prompt')).rejects.toThrow(
+            await expect(freshProvider.callApi('test prompt')).rejects.toThrow(
               'The @fal-ai/client package is required. Please install it with: npm install @fal-ai/client',
             );
           }
@@ -846,6 +858,7 @@ describe('Fal Provider', () => {
             createFalClient: mockCreateClient,
             fal: { config: mockConfig, subscribe: mockSubscribe },
           }));
+          vi.resetModules();
         }
       });
     });

--- a/test/providers/fal.test.ts
+++ b/test/providers/fal.test.ts
@@ -392,6 +392,7 @@ describe('Fal Provider', () => {
           output: '![cached prompt](https://cached.example.com/image.png)',
         });
         expect(mockSubscribe).not.toHaveBeenCalled();
+        expect(mockCreateClient).not.toHaveBeenCalled();
         expect(mockCache.get).toHaveBeenCalledWith(
           expect.stringContaining('fal:fal-ai/flux/schnell:'),
         );
@@ -789,9 +790,6 @@ describe('Fal Provider', () => {
           authorization: 'Key fixture-external',
           url: 'https://external.example/proxy',
         });
-        expect(mockCreateClient.mock.results[0].value).not.toBe(
-          mockCreateClient.mock.results[1].value,
-        );
         expect(mockConfig).not.toHaveBeenCalled();
         expect(mockSubscribe).not.toHaveBeenCalled();
       });
@@ -823,14 +821,25 @@ describe('Fal Provider', () => {
         });
       });
 
-      it('preserves the optional SDK installation error', async () => {
-        vi.doMock('@fal-ai/client', () => {
+      it.each([true, false])('handles a missing SDK with a cache hit: %s', async (cached) => {
+        const importSdk = vi.fn(() => {
           throw new Error('Fixture missing SDK');
         });
+        vi.doMock('@fal-ai/client', importSdk);
+        vi.mocked(isCacheEnabled).mockReturnValue(cached);
+        vi.mocked(getCache().get).mockResolvedValue(JSON.stringify('cached image'));
         try {
-          await expect(provider.callApi('test prompt')).rejects.toThrow(
-            'The @fal-ai/client package is required. Please install it with: npm install @fal-ai/client',
-          );
+          if (cached) {
+            await expect(provider.callApi('test prompt')).resolves.toEqual({
+              cached: true,
+              output: 'cached image',
+            });
+          } else {
+            await expect(provider.callApi('test prompt')).rejects.toThrow(
+              'The @fal-ai/client package is required. Please install it with: npm install @fal-ai/client',
+            );
+          }
+          expect(importSdk).toHaveBeenCalledTimes(cached ? 0 : 1);
         } finally {
           vi.doMock('@fal-ai/client', async (importOriginal) => ({
             ...(await importOriginal()),


### PR DESCRIPTION
FAL cache hits import the optional SDK and create a client before returning saved output. Initialize the SDK only when inference is needed, preserving credential/proxy isolation and the missing-package error on cache misses. This follows up #10749.

Isolate the missing-SDK tests in a fresh module graph, including when the SDK was loaded earlier, to address the Node 22 CI failure.

Validation: the 29-test FAL suite passes on Node 22.22 and 24.20, including V8 coverage and shuffled runs. The unchanged runtime also passed 617 provider tests, type/package/UI checks and built-CLI cache/missing-SDK fixtures. The copy-only postbuild passed via `node --import tsx` after the sandbox blocked the `tsx` CLI socket. Lint/format and normal hooks pass. No vendor inference calls.
