### PR TITLE
fix(eval): propagate disabled cache to providers from other module instances

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -14,7 +14,7 @@ import {
   runCompareAssertion,
 } from './assertions/index';
 import { extractAndStoreBinaryData } from './blobs/extractor';
-import { getCache, withCacheNamespace } from './cache';
+import { getCache, isCacheEnabled, withCacheNamespace } from './cache';
 import cliState from './cliState';
 import { DEFAULT_MAX_CONCURRENCY, FILE_METADATA_KEY } from './constants';
 import { getEnvBool, getEnvInt, getEvalTimeoutMs, getMaxEvalTimeMs, isCI } from './envars';
@@ -1144,6 +1144,16 @@ function buildCallApiContext({
     repeatIndex,
     testIdx: testIndex,
   };
+
+  if (!isCacheEnabled()) {
+    // Cache was disabled for this run (e.g. --no-cache). The flag lives in
+    // this module's cache state, but the provider under test may have been
+    // built from a different copy of the package (an extension hook importing
+    // "promptfoo"), whose cache module never got flipped. bustCache travels
+    // with the call, so every provider honors it regardless of which copy of
+    // the cache module it reads.
+    callApiContext.bustCache = true;
+  }
 
   if (evalId) {
     callApiContext.evaluationId = evalId;

--- a/test/evaluator.integration.realTransforms.test.ts
+++ b/test/evaluator.integration.realTransforms.test.ts
@@ -23,6 +23,7 @@ vi.mock('../src/cache', () => ({
     set: vi.fn(),
     wrap: vi.fn((_key: any, fn: any) => fn()),
   })),
+  isCacheEnabled: vi.fn(() => true),
   withCacheNamespace: vi.fn(async (_namespace: string | undefined, fn: () => Promise<unknown>) =>
     fn(),
   ),

--- a/test/evaluator.integration.transforms.test.ts
+++ b/test/evaluator.integration.transforms.test.ts
@@ -33,6 +33,7 @@ vi.mock('../src/cache', () => ({
     set: vi.fn(),
     wrap: vi.fn((_key: any, fn: any) => fn()),
   })),
+  isCacheEnabled: vi.fn(() => true),
   withCacheNamespace: vi.fn(async (_namespace: string | undefined, fn: () => Promise<unknown>) =>
     fn(),
   ),

--- a/test/evaluator/repeatCache.test.ts
+++ b/test/evaluator/repeatCache.test.ts
@@ -3,7 +3,7 @@ import './setup';
 import { randomUUID } from 'crypto';
 
 import { expect, it, vi } from 'vitest';
-import { clearCache, getCache } from '../../src/cache';
+import { clearCache, disableCache, enableCache, getCache } from '../../src/cache';
 import cliState from '../../src/cliState';
 import { evaluate, runEval } from '../../src/evaluator';
 import { runExtensionHook } from '../../src/evaluatorHelpers';
@@ -69,6 +69,49 @@ describeEvaluator('evaluator repeat cache isolation', () => {
     expect(contexts).toHaveLength(1);
     expect(contexts[0]).toBeDefined();
     expect(contexts[0]!.bustCache).toBeFalsy();
+  });
+
+  it('passes bustCache to the provider when the run cache is disabled', async () => {
+    // #10787: a provider built by an extension hook importing "promptfoo"
+    // reads a different copy of the cache module, so the CLI's --no-cache
+    // flag never reaches it through module state. bustCache travels with the
+    // call context instead.
+    const contexts: Array<Record<string, any> | undefined> = [];
+    const provider: ApiProvider = {
+      id: () => 'mock-provider',
+      callApi: vi
+        .fn()
+        .mockImplementation(async (_prompt: string, context?: Record<string, any>) => {
+          contexts.push(context);
+          return {
+            output: 'result',
+            tokenUsage: createEmptyTokenUsage(),
+          };
+        }),
+    };
+
+    disableCache();
+    try {
+      await runEval({
+        provider,
+        prompt: { raw: 'Test prompt', label: 'test-label' } as Prompt,
+        delay: 0,
+        nunjucksFilters: undefined,
+        evaluateOptions: {},
+        testIdx: 0,
+        promptIdx: 0,
+        conversations: {},
+        registers: {},
+        isRedteam: false,
+        test: { assert: [] },
+        repeatIndex: 0,
+      });
+    } finally {
+      enableCache();
+    }
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]!.bustCache).toBe(true);
   });
 
   it('isolates per-test repeat provider cache entries from the default namespace', async () => {


### PR DESCRIPTION
## Summary

Fixes #10787: with `--no-cache`, an extension hook that imports `loadApiProvider` from `promptfoo` and attaches the provider to the test still served cached responses.

Root cause: the CLI flips the cache flag on its own copy of the cache module, but the hook's provider is built from the library build's copy — a different module instance whose flag is never flipped. The flag also initializes from `PROMPTFOO_CACHE_ENABLED` at import time, which is why the env-var workaround reaches both copies.

The fix routes the kill switch through the call context instead of module state: when the run's cache is disabled, `buildCallApiContext` sets `bustCache: true`. Providers honor it via `shouldBustCache(context)`, which reads plain call data and therefore holds regardless of which copy of the cache module the provider was built against.

Scope note: providers that consult `context.bustCache` (the OpenAI family, Azure, Ollama, etc.) are covered. A provider that reads only its own module's `isCacheEnabled()` and is created through a hook's import would still see its own flag; that residual is unchanged by this PR and no worse than today.

## Test plan

- New regression test in `test/evaluator/repeatCache.test.ts` captures the provider-visible call context on `runEval`: `bustCache` is `true` under `disableCache()` and falsy when enabled. Red without the change, green with it.
- Full `test/evaluator/` directory: 318 tests pass. `biome check` clean on both touched files; pre-commit hook passed.
