### PR TITLE
docs(site): clarify provider example credentials

### DIFF
--- a/examples/provider-litellm/README.md
+++ b/examples/provider-litellm/README.md
@@ -15,14 +15,19 @@ LiteLLM provides a unified interface to 400+ LLMs. Instead of managing different
 
 ## Quick Start
 
-1. **Set your API keys**:
+1. **Set the API keys for the full example**:
+
+   The checked-in evaluation calls all three chat routes and uses OpenAI embeddings for similarity assertions, so running it unchanged requires all three keys:
 
    ```bash
    export OPENAI_API_KEY=your-openai-key
-   # Optional: Add other providers
    export ANTHROPIC_API_KEY=your-anthropic-key
    export GOOGLE_AI_API_KEY=your-google-key
    ```
+
+   The proxy can start with any one of these keys. To evaluate a subset, remove unused chat providers from `promptfooconfig.yaml` and their routes from `litellm_config.yaml`, or use a promptfoo config that selects only routes with configured credentials.
+
+   Keep `OPENAI_API_KEY` for the default embedding route even if you omit GPT chat. To run without OpenAI, configure an embedding provider you can access in both configs, or remove the `similar` assertion and its `defaultTest.options.provider.embedding` setting.
 
 2. **Start the LiteLLM proxy**:
 

--- a/examples/provider-litellm/start-proxy.sh
+++ b/examples/provider-litellm/start-proxy.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 echo "Starting LiteLLM proxy server..."
 echo ""
-echo "Required environment variables:"
+echo "Credentials for routes you use:"
 echo "  - OPENAI_API_KEY (for GPT models and embeddings)"
 echo "  - ANTHROPIC_API_KEY (for Claude models)"
 echo "  - GOOGLE_AI_API_KEY (for Gemini models)"

--- a/site/docs/providers/huggingface.md
+++ b/site/docs/providers/huggingface.md
@@ -220,7 +220,7 @@ providers:
   - id: huggingface:text-generation:gemma-7b-it
     config:
       apiEndpoint: '{{env.HF_INFERENCE_ENDPOINT}}'
-      # apiKey: abc123   # Or set HF_API_TOKEN environment variable
+      # apiKey: abc123   # Or set HF_TOKEN environment variable
 
 tests:
   - vars:


### PR DESCRIPTION
The LiteLLM quick start marked provider keys optional although the checked-in eval uses all three chat routes plus OpenAI embeddings. Document those requirements and subset setup, align the launcher heading, and recommend `HF_TOKEN` consistently in the Hugging Face endpoint example.

Validation: lint/format, five launcher cases, semantic config checks, and offline local CLI (4/4 rows). The full docs build passed at `f264e811`; after the latest main merge, the three changed files and their rendering configuration were unchanged, and the affected checks passed again.

Follow-up to #10780 and #10782.
