### PR TITLE
fix(providers): snapshot SageMaker request cache keys

### DIFF
--- a/src/providers/sagemaker.ts
+++ b/src/providers/sagemaker.ts
@@ -640,37 +640,21 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
   }
 
   /**
-   * Generate a consistent cache key for SageMaker requests
-   * Uses crypto.createHash to generate a shorter, more efficient key
+   * Include the serialized request and response parsing settings in the cache identity.
    */
-  private getCacheKey(prompt: string): string {
-    // Create a deterministic representation of the request parameters
+  private getCacheKey(payload: string): string {
     const configForKey = {
+      payload,
       endpoint: this.getEndpointName(),
       modelType: this.modelType,
       contentType: this.getContentType(),
       acceptType: this.getAcceptType(),
-      maxTokens: this.config.maxTokens ?? getEnvInt('AWS_SAGEMAKER_MAX_TOKENS') ?? 1024,
-      temperature:
-        typeof this.config.temperature === 'number'
-          ? this.config.temperature
-          : (getEnvFloat('AWS_SAGEMAKER_TEMPERATURE') ?? 0.7),
-      topP:
-        typeof this.config.topP === 'number'
-          ? this.config.topP
-          : (getEnvFloat('AWS_SAGEMAKER_TOP_P') ?? 1.0),
-      stopSequences: this.config.stopSequences || [],
       responsePath: this.config.responseFormat?.path,
       region: this.getRegion(),
     };
 
-    const configStr = JSON.stringify(configForKey);
-
-    // Generate shorter, more efficient hashed keys
-    const promptHash = crypto.createHash('sha256').update(prompt).digest('hex').substring(0, 16);
-    const configHash = crypto.createHash('sha256').update(configStr).digest('hex').substring(0, 8);
-
-    return `sagemaker:v1:${this.getEndpointName()}:${promptHash}:${configHash}`;
+    const hash = crypto.createHash('sha256').update(JSON.stringify(configForKey)).digest('hex');
+    return `sagemaker:v2:${this.getEndpointName()}:${hash}`;
   }
 
   /**
@@ -706,10 +690,11 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
       );
     }
 
-    // Check if we should use cache - use the transformed prompt for cache key
+    // Snapshot generation defaults before cache lookup or the endpoint request can yield.
+    const payload = this.formatPayload(transformedPrompt);
+    const cacheKey = this.getCacheKey(payload);
     const bustCache = context?.bustCache ?? context?.debug === true; // If debug mode is on, bust the cache
     if (isCacheEnabled() && !bustCache) {
-      const cacheKey = this.getCacheKey(transformedPrompt);
       const cache = getCache ? getCache() : await import('../cache').then((m) => m.getCache());
 
       // Try to get from cache
@@ -750,7 +735,6 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
 
     // Not in cache or cache disabled, make the actual API call
     const runtime = await this.getSageMakerRuntimeInstance();
-    const payload = this.formatPayload(transformedPrompt);
 
     logger.debug(`Calling SageMaker endpoint ${this.getEndpointName()}`);
     logger.debug(
@@ -823,7 +807,6 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
 
       // Save result to cache if successful and caching enabled
       if (isCacheEnabled() && !bustCache && result.output && !result.error) {
-        const cacheKey = this.getCacheKey(transformedPrompt);
         const cache = getCache ? getCache() : await import('../cache').then((m) => m.getCache());
         const resultToCache = JSON.stringify(result);
 

--- a/test/providers/sagemaker.test.ts
+++ b/test/providers/sagemaker.test.ts
@@ -207,6 +207,46 @@ describe('SageMakerCompletionProvider', () => {
       });
     });
 
+    it.each(['cache lookup', 'endpoint request'])(
+      'keeps the request and cache identity together when defaults change during %s',
+      async (stage) => {
+        vi.stubEnv('AWS_SAGEMAKER_MAX_TOKENS', '128');
+        const getCached = mockCacheGet.getMockImplementation()!;
+        mockCacheGet.mockImplementation(async (key: string) => {
+          const cached = await getCached(key);
+          if (stage === 'cache lookup' && mockCacheGet.mock.calls.length === 1) {
+            vi.stubEnv('AWS_SAGEMAKER_MAX_TOKENS', '256');
+          }
+          return cached;
+        });
+        mockSend.mockImplementation(async ({ Body }) => {
+          const output = String(JSON.parse(Body).max_tokens);
+          if (stage === 'endpoint request') {
+            vi.stubEnv('AWS_SAGEMAKER_MAX_TOKENS', '256');
+          }
+          return {
+            Body: new TextEncoder().encode(JSON.stringify({ choices: [{ text: output }] })),
+          };
+        });
+        const provider = new SageMakerCompletionProvider('test-endpoint', {
+          config: { region: 'us-east-1', modelType: 'openai' },
+        });
+
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output: '128' });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output: '256' });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({
+          output: '256',
+          cached: true,
+        });
+        vi.stubEnv('AWS_SAGEMAKER_MAX_TOKENS', '128');
+        expect(await provider.callApi('A quiet garden')).toMatchObject({
+          output: '128',
+          cached: true,
+        });
+        expect(mockSend).toHaveBeenCalledTimes(2);
+      },
+    );
+
     it('uses the model type resolved from the provider ID for response caching', async () => {
       mockSend.mockResolvedValue({
         Body: new TextEncoder().encode(


### PR DESCRIPTION
SageMaker completion requests can cache a response under the wrong generation settings when an environment default changes while a cache lookup or endpoint request is pending. Serialize each request once and reuse its payload-based cache key for lookup and storage. The v2 namespace prevents replay of entries produced by the previous key scheme. This follows up #10731.

Regressions change the token limit at each await point, then verify both responses replay correctly with exactly two endpoint sends.

Validation: focused SageMaker and library-export tests, type/package/UI builds, architecture checks, lint and normal hooks; two offline built-CLI runs with eight passing results and mocked AWS responses. Biome passes; the unchanged `npm run f` script exits 123 when its TypeScript-only diff gives Prettier no files. No vendor inference calls.
