### PR TITLE
fix(examples): use selected CrewAI credentials

### DIFF
--- a/examples/integration-crewai/README.md
+++ b/examples/integration-crewai/README.md
@@ -21,11 +21,11 @@ This example requires the following:
 
 1. **Python 3.10+**
 2. **Node.js >=22.22.0 (Node.js 24 LTS recommended)**
-3. **OpenAI API Key** - You MUST have a valid OpenAI API key to run this example
+3. **Provider credentials** - The default model requires a valid OpenAI API key
 
 ## Environment Setup
 
-You need to set the OpenAI API key. Choose one of these methods:
+For the default OpenAI model, set the OpenAI API key. Choose one of these methods:
 
 ### Option 1: Environment Variable (Recommended)
 
@@ -67,6 +67,9 @@ npm install -g promptfoo
 Set `providers[0].config.model` to a CrewAI model ID such as `openai/gpt-4.1`.
 The provider passes it to `LLM(model=...)` through the agent's `llm` field. CrewAI
 uses a slash between provider and model names.
+CrewAI resolves credentials for the selected provider. If you choose another
+provider, install its required CrewAI provider dependencies and set its credentials,
+such as `ANTHROPIC_API_KEY` for Anthropic.
 
 ### Note on Reliability
 
@@ -90,6 +93,6 @@ promptfoo view
 
 If you see authentication errors:
 
-- Ensure your OpenAI API key is set correctly
+- Ensure the API key for your selected provider is set correctly
 - Verify the key is valid and has sufficient quota
 - Check that the environment variable is accessible to the Python process

--- a/examples/integration-crewai/agent.py
+++ b/examples/integration-crewai/agent.py
@@ -1,14 +1,10 @@
 import asyncio
 import json
-import os
 import re
 import textwrap
 from typing import Any, Dict
 
 from crewai import LLM, Agent, Crew, Task
-
-# ✅ Load the OpenAI API key from the environment
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 
 def get_recruitment_agent(model: str = "openai/gpt-4.1") -> Crew:
@@ -25,7 +21,7 @@ def get_recruitment_agent(model: str = "openai/gpt-4.1") -> Crew:
             You never fail to return a valid JSON object as your final answer.
         """).strip(),
         verbose=False,
-        llm=LLM(model=model, api_key=OPENAI_API_KEY),
+        llm=LLM(model=model),
     )
 
     task = Task(
@@ -62,12 +58,6 @@ async def run_recruitment_agent(prompt, model="openai/gpt-4.1"):
     Runs the recruitment agent with a given job requirements prompt.
     Returns a structured JSON-like dictionary with candidate info.
     """
-    # Check if API key is set
-    if not OPENAI_API_KEY:
-        return {
-            "error": "OpenAI API key not found. Please set the OPENAI_API_KEY environment variable or create a .env file with your API key."
-        }
-
     crew = get_recruitment_agent(model)
     try:
         # ⚡ Trigger the agent to start working

--- a/site/docs/guides/evaluate-crewai.md
+++ b/site/docs/guides/evaluate-crewai.md
@@ -405,7 +405,7 @@ Promptfoo kicks off the evaluation job you set up.
 
 - It uses the promptfooconfig.yaml to call your custom CrewAI provider (from agent.py).
 - It feeds in the job requirements prompt and collects the structured output.
-- It checks the results against your YAML assertions, including the `candidates` list and each candidate's required fields.
+- It checks the results against your YAML assertions, including the output shape and `candidates` list.
 - It shows a clear table: did the agent PASS or FAIL?
 
 In this example, you can see:

--- a/site/docs/guides/evaluate-crewai.md
+++ b/site/docs/guides/evaluate-crewai.md
@@ -192,15 +192,11 @@ Inside your project folder, create a file called `agent.py` that contains the Cr
 ````python
 import asyncio
 import json
-import os
 import re
 import textwrap
 from typing import Any, Dict
 
 from crewai import LLM, Agent, Crew, Task
-
-# ✅ Load the OpenAI API key from the environment
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 def get_recruitment_agent(model: str = "openai/gpt-4.1") -> Crew:
     """
@@ -216,7 +212,7 @@ def get_recruitment_agent(model: str = "openai/gpt-4.1") -> Crew:
             You never fail to return a valid JSON object as your final answer.
         """).strip(),
         verbose=False,
-        llm=LLM(model=model, api_key=OPENAI_API_KEY)
+        llm=LLM(model=model)
     )
 
     task = Task(
@@ -252,12 +248,6 @@ async def run_recruitment_agent(prompt, model='openai/gpt-4.1'):
     Runs the recruitment agent with a given job requirements prompt.
     Returns a structured JSON-like dictionary with candidate info.
     """
-    # Check if API key is set
-    if not OPENAI_API_KEY:
-        return {
-            "error": "OpenAI API key not found. Please set the OPENAI_API_KEY environment variable or create a .env file with your API key."
-        }
-
     crew = get_recruitment_agent(model)
     try:
         # ⚡ Trigger the agent to start working
@@ -335,6 +325,9 @@ if __name__ == "__main__":
 
 CrewAI receives the model through `Agent(llm=LLM(...))`. Use its `provider/model`
 format, such as `openai/gpt-4.1`, for the custom provider’s `config.model` field.
+CrewAI resolves credentials for the selected provider. If you change providers,
+install that provider’s required CrewAI dependencies and set its credentials,
+such as `ANTHROPIC_API_KEY` for Anthropic.
 
 ### Edit `promptfooconfig.yaml`
 
@@ -392,7 +385,7 @@ tests:
 
 Now that everything is set up, it’s time to run your first real evaluation!
 
-In your terminal, you first **export your OpenAI API key** so CrewAI and Promptfoo can connect securely:
+For the default OpenAI model, first **export your OpenAI API key**:
 
 ```
 export OPENAI_API_KEY="sk-xxx-your-api-key-here"
@@ -412,13 +405,13 @@ Promptfoo kicks off the evaluation job you set up.
 
 - It uses the promptfooconfig.yaml to call your custom CrewAI provider (from agent.py).
 - It feeds in the job requirements prompt and collects the structured output.
-- It checks the results against your Python and YAML assertions (like checking for a `candidates` list and a summary).
+- It checks the results against your YAML assertions, including the `candidates` list and each candidate's required fields.
 - It shows a clear table: did the agent PASS or FAIL?
 
 In this example, you can see:
 
 - The CrewAI Recruitment Agent ran against the input “List top candidates with RoR and React.”
-- It returned a mock structured JSON with Alex, William, and Stanislav, plus a summary.
+- It returned structured JSON with candidate information.
 - Pass rate: **100%**
 
 <img width="800" height="499" alt="Promptfoo eval results" src="/img/docs/crewai/promptfoo-eval.png" />

--- a/test/examples/integrationCrewai.test.ts
+++ b/test/examples/integrationCrewai.test.ts
@@ -14,6 +14,7 @@ const CANDIDATES = {
 const CHECK_EXAMPLE = String.raw`
 import importlib.util
 import json
+import os
 import sys
 from types import ModuleType, SimpleNamespace
 
@@ -25,7 +26,17 @@ class LLM:
         if settings.get("error") == "llm":
             raise RuntimeError("fixture LLM initialization failed")
         self.model = model
+        # Native CrewAI providers resolve their own environment credentials when
+        # no explicit key is supplied. Unknown model paths stay opaque here.
+        key_variable = {
+            "openai": "OPENAI_API_KEY",
+            "anthropic": "ANTHROPIC_API_KEY",
+        }.get(model.split("/", 1)[0])
         self.api_key = api_key
+        if self.api_key is None and key_variable:
+            self.api_key = os.getenv(key_variable)
+        if key_variable and self.api_key is None:
+            raise ValueError(f"{key_variable} is required")
 
 class Agent:
     def __init__(self, llm=None, **kwargs):
@@ -68,13 +79,24 @@ describe('integration-crewai example', () => {
     pythonPath = await validatePythonPath(configured ?? 'python', Boolean(configured));
   });
 
-  function runExample(settings: Record<string, unknown>) {
+  function runExample(
+    settings: Record<string, unknown>,
+    credentials: { OPENAI_API_KEY?: string; ANTHROPIC_API_KEY?: string } = {
+      OPENAI_API_KEY: 'fixture-key',
+    },
+  ) {
     const result = spawnSync(
       pythonPath,
       ['-c', CHECK_EXAMPLE, EXAMPLE_PATH, JSON.stringify(settings)],
       {
         encoding: 'utf8',
-        env: { ...process.env, OPENAI_API_KEY: 'fixture-key', PYTHONDONTWRITEBYTECODE: '1' },
+        env: {
+          ...process.env,
+          OPENAI_API_KEY: undefined,
+          ANTHROPIC_API_KEY: undefined,
+          ...credentials,
+          PYTHONDONTWRITEBYTECODE: '1',
+        },
         timeout: 5000,
       },
     );
@@ -109,6 +131,29 @@ describe('integration-crewai example', () => {
       error: 'An unexpected error occurred: fixture kickoff failed',
       raw: '',
     });
+  });
+
+  it.each([undefined, 'fixture-openai-key'])(
+    'uses the configured provider credentials when the OpenAI key is %s',
+    (openaiKey) => {
+      const result = runExample(
+        { config: { model: 'anthropic/claude-sonnet-4-6' }, output: CANDIDATES },
+        { OPENAI_API_KEY: openaiKey, ANTHROPIC_API_KEY: 'fixture-anthropic-key' },
+      );
+      expect(result.response).toEqual({ output: CANDIDATES });
+      expect(result.observed).toEqual({
+        model: 'anthropic/claude-sonnet-4-6',
+        api_key: 'fixture-anthropic-key',
+        inputs: { job_requirements: 'Find a Ruby engineer' },
+      });
+    },
+  );
+
+  it('reports missing credentials for the default OpenAI model', () => {
+    const result = runExample({ output: CANDIDATES }, {});
+    expect(result.response.error).toContain('OPENAI_API_KEY');
+    expect(result.response).not.toHaveProperty('output');
+    expect(result.observed).toEqual({});
   });
 
   it('surfaces LLM initialization failures as provider errors', () => {


### PR DESCRIPTION
Selecting a non-OpenAI model in the CrewAI example still requires an OpenAI key and passes that key to the selected provider. Let CrewAI resolve credentials for the selected provider. Preserve the default OpenAI model and surface missing-key errors.

Update the copied guide code and credential instructions, and describe the assertions the example actually runs. This follows merged #10781.

Validation: 127 focused tests, including provider selection with a competing OpenAI key; 22 offline framework checks using installed CrewAI/OpenAI SDKs; TypeScript, Python style, lint/format, and the full documentation build. Optional Anthropic SDK behavior was checked against its installed CrewAI source and a regression stub. No vendor inference calls.
