### PR TITLE
docs(site): clarify provider cost and availability

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -287,9 +287,9 @@ See [`is-sql`](#is-sql) for advanced usage, including specific database types an
 
 ### Cost
 
-The `cost` assertion checks if the cost of the LLM call is below a specified threshold.
+The `cost` assertion checks whether the cost reported by the selected provider is at or below a specified threshold.
 
-This requires LLM providers to return cost information. Currently this is only supported by OpenAI GPT models and custom providers.
+This requires the provider to return cost information; an unknown cost cannot be checked. Use `--no-cache` when comparing fresh inference costs, because response-cache cost reporting depends on the provider.
 
 Example:
 

--- a/site/docs/providers/slack.md
+++ b/site/docs/providers/slack.md
@@ -425,7 +425,7 @@ prompts:
 
 #### 3. Load Testing
 
-Run sequentially in a shared channel so overlapping prompts do not collect the same response:
+Use a sequential run as a baseline in a shared channel. Concurrent load tests require isolated channels so prompts do not collect the same response:
 
 ```bash
 promptfoo eval -c bot-test-config.yaml -j 1

--- a/site/docs/providers/snowflake.md
+++ b/site/docs/providers/snowflake.md
@@ -12,7 +12,7 @@ description: 'Configure Snowflake Cortex text generation through its REST API wi
 1. Obtain your Snowflake account identifier (format: `orgname-accountname`)
 2. Generate a bearer token (JWT, OAuth, or programmatic access token)
 3. Ensure you have the `SNOWFLAKE.CORTEX_USER` database role
-4. Check [model availability in your region](https://docs.snowflake.com/en/user-guide/snowflake-cortex/aisql-regional-availability) and your account's model access settings
+4. Check [model availability in your region](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api#model-availability) and your account's model access settings
 
 ## Provider Format
 


### PR DESCRIPTION
Clarify that cost assertions use the selected provider’s reported cost and recommend uncached runs for fresh inference comparisons. Link Snowflake onboarding to the REST model-availability catalog, and distinguish a sequential Slack baseline from concurrent tests using isolated channels.

Validation: MDX, lint/format, normal hooks and the production site build passed. The rendered paragraphs and REST catalog link were verified.
