### PR TITLE
fix(providers): preserve OpenRouter BYOK and cached costs

### DIFF
--- a/site/docs/providers/openrouter.md
+++ b/site/docs/providers/openrouter.md
@@ -63,6 +63,28 @@ providers:
       apiKeyEnvar: MY_PROXY_KEY # optional: read the Bearer token from $MY_PROXY_KEY
 ```
 
+## Cost reporting
+
+By default, promptfoo uses the [reported `usage.cost`](https://openrouter.ai/docs/cookbook/administration/usage-accounting) as the charge to your OpenRouter account. Missing or invalid charges remain unknown. Reported upstream amounts remain separate metadata fields.
+
+For responses explicitly marked `usage.is_byok: true`, generic `cost` is unavailable unless you configure complete, valid token rates. With [Bring Your Own Key (BYOK)](https://openrouter.ai/docs/guides/overview/auth/byok), your upstream provider bills inference separately, so a zero or fee-only OpenRouter charge does not establish the combined cost. Responses with a missing or invalid BYOK flag continue to use the reported account charge; their route remains unknown in metadata.
+
+To supply your own per-token estimate, configure `cost`, or both `inputCost` and `outputCost`. Valid configured rates take priority over reported billing, including for BYOK. Both prompt and completion token counts are required. Incomplete or invalid rates or counts leave cost unknown. This estimate is based on your configured rates, not a reconciled invoice.
+
+Successful responses expose validated billing facts under `metadata.openrouter`:
+
+| Field                                                          | Meaning                                                        |
+| -------------------------------------------------------------- | -------------------------------------------------------------- |
+| `accountCharge`                                                | Reported charge to your OpenRouter account, including zero.    |
+| `isByok`                                                       | Reported boolean route flag; omitted when missing or invalid.  |
+| `reportedUpstreamInferenceCost`                                | OpenRouter-reported upstream inference amount, when available. |
+| `reportedUpstreamPromptCost`, `reportedUpstreamCompletionCost` | Independently reported prompt and completion components.       |
+| `reportedServerToolCost`                                       | Reported server tool component, when available.                |
+
+Missing or invalid amounts are omitted. These fields appear in response details and JSON exports, independently of any configured estimate. Cost assertions require a known cost; their existing error handling can omit response metadata from the exported error row. General cost totals sum only known costs and can therefore be incomplete when some responses have unavailable cost.
+
+Cache replays retain logical cost and billing metadata. The evaluator records zero additional incurred cost for cached responses with a known cost.
+
 ## Features
 
 - Access to 300+ models through a single API

--- a/src/providers/openrouter.ts
+++ b/src/providers/openrouter.ts
@@ -17,6 +17,16 @@ import type {
 import type { OpenAiChatCompletionCostData } from './openai/chat';
 import type { OpenAiCompletionOptions } from './openai/types';
 
+type OpenRouterUsage = NonNullable<OpenAiChatCompletionCostData['usage']> & {
+  cost?: unknown;
+  is_byok?: unknown;
+  cost_details?: unknown;
+};
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
 /**
  * OpenRouter provider extends OpenAI chat completion provider with special handling
  * for models like Gemini that include thinking/reasoning tokens.
@@ -70,12 +80,8 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
   protected override calculateResponseCost(
     data: OpenAiChatCompletionCostData,
     config: OpenAiCompletionOptions,
-    cached: boolean,
   ): number | undefined {
-    if (cached) {
-      return 0;
-    }
-
+    // Preserve logical cost on cache replay; the evaluator tracks incurred spending separately.
     if (
       config.cost !== undefined ||
       config.inputCost !== undefined ||
@@ -88,18 +94,10 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
       const promptTokens = data.usage?.prompt_tokens;
       const completionTokens = data.usage?.completion_tokens;
       if (
-        typeof inputCost !== 'number' ||
-        !Number.isFinite(inputCost) ||
-        inputCost < 0 ||
-        typeof outputCost !== 'number' ||
-        !Number.isFinite(outputCost) ||
-        outputCost < 0 ||
-        typeof promptTokens !== 'number' ||
-        !Number.isFinite(promptTokens) ||
-        promptTokens < 0 ||
-        typeof completionTokens !== 'number' ||
-        !Number.isFinite(completionTokens) ||
-        completionTokens < 0
+        !isNonNegativeFiniteNumber(inputCost) ||
+        !isNonNegativeFiniteNumber(outputCost) ||
+        !isNonNegativeFiniteNumber(promptTokens) ||
+        !isNonNegativeFiniteNumber(completionTokens)
       ) {
         return undefined;
       }
@@ -107,14 +105,51 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
       return Number.isFinite(cost) ? cost : undefined;
     }
 
-    // usage.cost is the total charged to the OpenRouter account. Its upstream
-    // inference cost is a separate value; native vendor rates cannot substitute.
+    const usage = data.usage as OpenRouterUsage | undefined;
+    // BYOK inference is billed separately by the upstream provider. A waived
+    // charge or gateway fee cannot represent its total cost.
+    if (usage?.is_byok === true) {
+      return undefined;
+    }
+
+    // Without an explicit BYOK flag, retain the reported OpenRouter account
+    // charge. Upstream components and native vendor rates cannot substitute.
     // https://openrouter.ai/docs/cookbook/administration/usage-accounting
-    const usage = data.usage as
-      | (NonNullable<OpenAiChatCompletionCostData['usage']> & { cost?: unknown })
-      | undefined;
     const cost = usage?.cost;
-    return typeof cost === 'number' && Number.isFinite(cost) && cost >= 0 ? cost : undefined;
+    return isNonNegativeFiniteNumber(cost) ? cost : undefined;
+  }
+
+  private getBillingMetadata(data: OpenAiChatCompletionCostData): ProviderResponse['metadata'] {
+    const usage = data.usage as OpenRouterUsage | undefined;
+    if (!usage || typeof usage !== 'object' || Array.isArray(usage)) {
+      return undefined;
+    }
+    const details =
+      usage.cost_details &&
+      typeof usage.cost_details === 'object' &&
+      !Array.isArray(usage.cost_details)
+        ? (usage.cost_details as Record<string, unknown>)
+        : undefined;
+
+    // These are independent reported facts, regardless of whether generic cost
+    // is a configured estimate, the account charge, or unavailable.
+    const billing: Record<string, unknown> = {};
+    const amounts = {
+      accountCharge: usage.cost,
+      reportedUpstreamInferenceCost: details?.upstream_inference_cost,
+      reportedUpstreamPromptCost: details?.upstream_inference_prompt_cost,
+      reportedUpstreamCompletionCost: details?.upstream_inference_completions_cost,
+      reportedServerToolCost: details?.server_tool_cost,
+    };
+    for (const [name, amount] of Object.entries(amounts)) {
+      if (isNonNegativeFiniteNumber(amount)) {
+        billing[name] = amount;
+      }
+    }
+    if (typeof usage.is_byok === 'boolean') {
+      billing.isByok = usage.is_byok;
+    }
+    return Object.keys(billing).length > 0 ? { openrouter: billing } : undefined;
   }
 
   async callApi(
@@ -287,7 +322,8 @@ export class OpenRouterProvider extends OpenAiChatCompletionProvider {
       output,
       tokenUsage: getTokenUsage(data, cached),
       cached,
-      cost: this.calculateResponseCost(data, config, cached),
+      cost: this.calculateResponseCost(data, config),
+      metadata: this.getBillingMetadata(data),
       ...(finishReason && { finishReason }),
     };
   }

--- a/test/providers/openrouter.test.ts
+++ b/test/providers/openrouter.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { clearCache, disableCache, enableCache } from '../../src/cache';
+import { clearCache, isCacheEnabled, withCacheEnabled } from '../../src/cache';
 import { OpenRouterProvider } from '../../src/providers/openrouter';
 import * as fetchModule from '../../src/util/fetch/index';
 import { mockProcessEnv } from '../util/utils';
@@ -331,6 +331,257 @@ describe('OpenRouter', () => {
         return new OpenRouterProvider(model, { config: { apiKey: 'test-key', ...config } });
       }
 
+      describe('BYOK accounting', () => {
+        it('preserves the documented non-BYOK charge and independent cost components', async () => {
+          mockResponse({
+            prompt_tokens: 10,
+            completion_tokens: 15,
+            total_tokens: 25,
+            cost: 0.0012,
+            is_byok: false,
+            cost_details: {
+              upstream_inference_cost: null,
+              upstream_inference_prompt_cost: 0.0008,
+              upstream_inference_completions_cost: 0.0004,
+            },
+          });
+          const result = await provider().callApi('Cost prompt');
+          expect(result.cost).toBe(0.0012);
+          expect(result.metadata?.openrouter).toEqual({
+            accountCharge: 0.0012,
+            isByok: false,
+            reportedUpstreamPromptCost: 0.0008,
+            reportedUpstreamCompletionCost: 0.0004,
+          });
+        });
+
+        it.each([
+          { charge: 0, details: { upstream_inference_cost: 0.02 } },
+          { charge: 0.001, details: { upstream_inference_cost: 0.02 } },
+          { charge: 0.25, details: { upstream_inference_cost: 0 } },
+          { charge: 0.25, details: undefined },
+          { charge: 0.25, details: null },
+          { charge: 0.25, details: { upstream_inference_cost: '0.02' } },
+        ])('leaves explicit BYOK cost unknown (%j)', async ({ charge, details }) => {
+          mockResponse({ cost: charge, is_byok: true, cost_details: details });
+          const result = await provider().callApi('Cost prompt');
+          expect(result.output).toBe('Cost fixture');
+          expect(result.error).toBeUndefined();
+          expect(result.cost).toBeUndefined();
+          expect(result.metadata?.openrouter).toMatchObject({
+            accountCharge: charge,
+            isByok: true,
+          });
+        });
+
+        it('keeps missing BYOK status unknown in the documented usage-accounting example', async () => {
+          mockResponse({
+            prompt_tokens: 194,
+            completion_tokens: 2,
+            total_tokens: 196,
+            cost: 0.95,
+            cost_details: { upstream_inference_cost: 19 },
+          });
+          const result = await provider().callApi('Cost prompt');
+          expect(result.cost).toBe(0.95);
+          expect(result.metadata?.openrouter).toEqual({
+            accountCharge: 0.95,
+            reportedUpstreamInferenceCost: 19,
+          });
+        });
+
+        it.each(['true', 1, null, {}, []])(
+          'does not coerce an invalid BYOK flag (%j)',
+          async (flag) => {
+            mockResponse({ cost: 0.25, is_byok: flag });
+            const result = await provider().callApi('Cost prompt');
+            expect(result.cost).toBe(0.25);
+            expect(result.metadata?.openrouter).toEqual({ accountCharge: 0.25 });
+          },
+        );
+
+        it('does not add upstream or server-tool components to a non-BYOK charge', async () => {
+          mockResponse({
+            cost: 0.25,
+            is_byok: false,
+            cost_details: {
+              upstream_inference_cost: 0.25,
+              upstream_inference_prompt_cost: 0.1,
+              upstream_inference_completions_cost: 0.15,
+              server_tool_cost: 0.05,
+            },
+          });
+          const result = await provider().callApi('Cost prompt');
+          expect(result.cost).toBe(0.25);
+          expect(result.metadata?.openrouter).toEqual({
+            accountCharge: 0.25,
+            isByok: false,
+            reportedUpstreamInferenceCost: 0.25,
+            reportedUpstreamPromptCost: 0.1,
+            reportedUpstreamCompletionCost: 0.15,
+            reportedServerToolCost: 0.05,
+          });
+        });
+
+        it.each([
+          { config: { cost: 0.01 }, expected: 0.3 },
+          { config: { inputCost: 0.01, outputCost: 0.02 }, expected: 0.5 },
+          { config: { cost: 0 }, expected: 0 },
+          { config: { inputCost: 0.01 }, expected: undefined },
+          { config: { cost: -1 }, expected: undefined },
+          { config: { cost: Infinity }, expected: undefined },
+        ])('preserves configured BYOK rate semantics (%j)', async ({ config, expected }) => {
+          mockResponse({ prompt_tokens: 10, completion_tokens: 20, cost: 0, is_byok: true });
+          const result = await provider(config).callApi('Cost prompt');
+          if (expected === undefined) {
+            expect(result.cost).toBeUndefined();
+          } else {
+            expect(result.cost).toBeCloseTo(expected);
+          }
+          expect(result.metadata?.openrouter).toEqual({ accountCharge: 0, isByok: true });
+        });
+
+        it('uses prompt-level BYOK rates while retaining the reported charge as metadata', async () => {
+          mockResponse({ prompt_tokens: 10, completion_tokens: 20, cost: 0.001, is_byok: true });
+          const result = await provider({ cost: 1 }).callApi('Cost prompt', {
+            vars: {},
+            prompt: { raw: 'Cost prompt', label: 'Cost prompt', config: { cost: 0.02 } },
+          });
+          expect(result.cost).toBeCloseTo(0.6);
+          expect(result.metadata?.openrouter).toEqual({ accountCharge: 0.001, isByok: true });
+        });
+
+        it('leaves a configured BYOK estimate unknown without token counts', async () => {
+          mockResponse({ cost: 0, is_byok: true });
+          const result = await provider({ cost: 0.01 }).callApi('Cost prompt');
+          expect(result.cost).toBeUndefined();
+          expect(result.metadata?.openrouter).toEqual({ accountCharge: 0, isByok: true });
+        });
+
+        it.each([
+          undefined,
+          null,
+          {},
+          [],
+          0,
+          'invalid',
+          { unrelated: true },
+          { cost: null, is_byok: null },
+        ])('does not invent billing facts from empty or malformed usage (%j)', async (usage) => {
+          mockResponse(usage);
+          const result = await provider().callApi('Cost prompt');
+          expect(result.output).toBe('Cost fixture');
+          expect(result.cost).toBeUndefined();
+          expect(result.metadata?.openrouter).toBeUndefined();
+        });
+
+        it.each([undefined, null, [], 'invalid', true, {}])(
+          'tolerates malformed cost details (%j)',
+          async (details) => {
+            mockResponse({ cost: 0, is_byok: true, cost_details: details });
+            const result = await provider().callApi('Cost prompt');
+            expect(result.cost).toBeUndefined();
+            expect(result.metadata?.openrouter).toEqual({ accountCharge: 0, isByok: true });
+          },
+        );
+
+        it('preserves valid zero and partial upstream facts independently', async () => {
+          mockResponse({
+            cost: 0,
+            is_byok: true,
+            cost_details: {
+              upstream_inference_cost: 0,
+              upstream_inference_prompt_cost: '0.1',
+              upstream_inference_completions_cost: 0.2,
+              server_tool_cost: 0,
+            },
+          });
+          const result = await provider().callApi('Cost prompt');
+          expect(result.cost).toBeUndefined();
+          expect(result.metadata?.openrouter).toEqual({
+            accountCharge: 0,
+            isByok: true,
+            reportedUpstreamInferenceCost: 0,
+            reportedUpstreamCompletionCost: 0.2,
+            reportedServerToolCost: 0,
+          });
+        });
+
+        it.each([-1, '0.02', null, true, {}])(
+          'omits invalid upstream components (%j)',
+          async (amount) => {
+            mockResponse({
+              cost: 0,
+              is_byok: true,
+              cost_details: {
+                upstream_inference_cost: amount,
+                upstream_inference_prompt_cost: amount,
+                upstream_inference_completions_cost: amount,
+                server_tool_cost: amount,
+              },
+            });
+            const result = await provider().callApi('Cost prompt');
+            expect(result.cost).toBeUndefined();
+            expect(result.metadata?.openrouter).toEqual({ accountCharge: 0, isByok: true });
+          },
+        );
+
+        for (const imageInput of [false, true]) {
+          it.each([
+            { name: 'standard', byok: false, config: {}, expected: 0.25 },
+            { name: 'BYOK', byok: true, config: {}, expected: undefined },
+            { name: 'configured BYOK', byok: true, config: { cost: 0.01 }, expected: 0.3 },
+          ])(
+            `preserves $name accounting on ${imageInput ? 'image-input' : 'text'} cache replay`,
+            async ({ byok, config, expected }) => {
+              const content = [
+                { type: 'text', text: 'Describe this fixture' },
+                {
+                  type: 'image_url',
+                  image_url: {
+                    url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aK1cAAAAASUVORK5CYII=',
+                  },
+                },
+              ];
+              const prompt = imageInput
+                ? JSON.stringify([{ role: 'user', content }])
+                : 'Cost cache prompt';
+              const wasCacheEnabled = isCacheEnabled();
+              await withCacheEnabled(true, async () => {
+                mockResponse({
+                  prompt_tokens: 10,
+                  completion_tokens: 20,
+                  total_tokens: 30,
+                  cost: 0.25,
+                  is_byok: byok,
+                });
+                const instance = provider(config);
+                const first = await instance.callApi(prompt);
+                const second = await instance.callApi(prompt);
+                if (expected === undefined) {
+                  expect(first.cost).toBeUndefined();
+                } else {
+                  expect(first.cost).toBeCloseTo(expected);
+                }
+                expect(first.cached).toBe(false);
+                expect(second.cached).toBe(true);
+                expect(second.cost).toBe(first.cost);
+                expect(first.metadata?.openrouter).toEqual({ accountCharge: 0.25, isByok: byok });
+                expect(second.metadata).toEqual(first.metadata);
+                expect(mockedFetchWithRetries).toHaveBeenCalledTimes(1);
+                const [url, options] = mockedFetchWithRetries.mock.calls[0];
+                expect(url).toBe(`${OPENROUTER_API_BASE}/chat/completions`);
+                expect(options?.headers).toMatchObject({ Authorization: 'Bearer test-key' });
+                if (imageInput) {
+                  expect(JSON.parse(options?.body as string).messages[0].content).toEqual(content);
+                }
+              });
+              expect(isCacheEnabled()).toBe(wasCacheEnabled);
+            },
+          );
+        }
+      });
+
       it('uses the total account charge rather than upstream inference cost', async () => {
         mockResponse({
           prompt_tokens: 10,
@@ -363,10 +614,17 @@ describe('OpenRouter', () => {
       });
 
       it.each([-1, '0.01', null, {}, true])('rejects malformed reported cost %j', async (cost) => {
-        mockResponse({ prompt_tokens: 10, completion_tokens: 20, total_tokens: 30, cost });
+        mockResponse({
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+          cost,
+          is_byok: false,
+        });
         const result = await provider({}, 'gpt-4o').callApi('Cost prompt');
         expect(result.output).toBe('Cost fixture');
         expect(result.cost).toBeUndefined();
+        expect(result.metadata?.openrouter).toEqual({ isByok: false });
       });
 
       it('preserves complete explicit per-token rates for arbitrary gateway IDs', async () => {
@@ -422,21 +680,60 @@ describe('OpenRouter', () => {
         expect(options?.headers).toMatchObject({ Authorization: 'Bearer custom-fixture-key' });
       });
 
-      it.each([{}, { cost: 1 }])('does not rebill a promptfoo cache hit (%j)', async (config) => {
-        expect(process.env.PROMPTFOO_CACHE_TYPE).toBe('memory');
-        enableCache();
-        try {
-          mockResponse({ prompt_tokens: 10, completion_tokens: 20, total_tokens: 30, cost: 0.25 });
-          const instance = provider(config);
-          const first = await instance.callApi('Cost cache prompt');
-          const second = await instance.callApi('Cost cache prompt');
-          expect(first.cached).toBe(false);
-          expect(second).toMatchObject({ cached: true, cost: 0, tokenUsage: { cached: 30 } });
-          expect(mockedFetchWithRetries).toHaveBeenCalledTimes(1);
-        } finally {
-          disableCache();
-        }
-      });
+      it.each([
+        { name: 'reported', config: {}, usage: { cost: 0.25 }, expectedCost: 0.25 },
+        { name: 'reported zero', config: {}, usage: { cost: 0 }, expectedCost: 0 },
+        { name: 'manual', config: { cost: 0.01 }, usage: { cost: 0.25 }, expectedCost: 0.3 },
+        {
+          name: 'directional manual',
+          config: { inputCost: 0.01, outputCost: 0.02 },
+          usage: { cost: 0.25 },
+          expectedCost: 0.5,
+        },
+        { name: 'manual zero', config: { cost: 0 }, usage: { cost: 0.25 }, expectedCost: 0 },
+        { name: 'missing billing', config: {}, usage: {}, expectedCost: undefined },
+        { name: 'invalid billing', config: {}, usage: { cost: '0.25' }, expectedCost: undefined },
+        {
+          name: 'partial manual rate',
+          config: { inputCost: 0.01 },
+          usage: { cost: 0.25 },
+          expectedCost: undefined,
+        },
+        {
+          name: 'invalid manual rate',
+          config: { cost: -1 },
+          usage: { cost: 0.25 },
+          expectedCost: undefined,
+        },
+        {
+          name: 'missing token counts',
+          config: { cost: 0.01 },
+          usage: { cost: 0.25, prompt_tokens: undefined, completion_tokens: undefined },
+          expectedCost: undefined,
+        },
+      ])(
+        'preserves logical cost on a promptfoo cache replay ($name)',
+        async ({ config, usage, expectedCost }) => {
+          expect(process.env.PROMPTFOO_CACHE_TYPE).toBe('memory');
+          const wasCacheEnabled = isCacheEnabled();
+          await withCacheEnabled(true, async () => {
+            mockResponse({ prompt_tokens: 10, completion_tokens: 20, total_tokens: 30, ...usage });
+            const instance = provider(config);
+            const first = await instance.callApi('Cost cache prompt');
+            const second = await instance.callApi('Cost cache prompt');
+            expect(first.cached).toBe(false);
+            if (expectedCost === undefined) {
+              expect(first.cost).toBeUndefined();
+            } else {
+              expect(first.cost).toBeCloseTo(expectedCost);
+            }
+            expect(second).toMatchObject({ cached: true, tokenUsage: { cached: 30 } });
+            expect(second.cost).toBe(first.cost);
+            expect(mockedFetchWithRetries).toHaveBeenCalledTimes(1);
+          });
+          expect(isCacheEnabled()).toBe(wasCacheEnabled);
+        },
+      );
 
       it('preserves HTTP errors without assigning their billing metadata', async () => {
         mockResponse({ cost: 0.25 }, 400);


### PR DESCRIPTION
OpenRouter cache hits replace logical response cost with zero, changing cost assertions and eval totals. Explicit BYOK responses can also report an account charge that excludes separately billed inference.

Preserve reported or configured logical cost on cache replay. Leave explicit BYOK cost unknown unless complete valid manual rates provide an estimate, and retain validated account/upstream/tool billing metadata separately. Restore prior cache state in tests and explain unknown costs and partial totals in the guide. This follows up #10777.

Sources checked September 8, 2026: [usage accounting](https://openrouter.ai/docs/cookbook/administration/usage-accounting) and [BYOK billing](https://openrouter.ai/docs/guides/overview/auth/byok).

Validation: 126 provider/assertion tests, 77 cache tests and a shuffled 119-test provider run; 84 offline built-CLI outcomes covering inputs, cache replay, metadata, assertions and HTTP errors; type checking, package/docs builds, formatting and normal hooks. No vendor inference calls.
