### PR TITLE
fix(providers): handle Vercel stream cancellation

### DIFF
--- a/src/providers/vercel.ts
+++ b/src/providers/vercel.ts
@@ -231,7 +231,10 @@ function createTimeoutController(
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   return {
     signal: abortSignal ? AbortSignal.any([controller.signal, abortSignal]) : controller.signal,
-    cleanup: () => clearTimeout(timeoutId),
+    cleanup: () => {
+      clearTimeout(timeoutId);
+      controller.abort();
+    },
   };
 }
 

--- a/src/providers/vercel.ts
+++ b/src/providers/vercel.ts
@@ -319,6 +319,7 @@ export class VercelAiProvider implements ApiProvider {
   ): Promise<ProviderResponse> {
     const timeout = config.timeout ?? getRequestTimeoutMs();
     const { signal, cleanup } = createTimeoutController(timeout, abortSignal);
+    let streamError: { error: unknown } | undefined;
 
     try {
       const gateway = await createGatewayInstance(config, this.env);
@@ -343,8 +344,12 @@ export class VercelAiProvider implements ApiProvider {
         if (part.type === 'text-delta') {
           output += part.text;
         } else if (part.type === 'error') {
-          throw part.error;
+          // Drain under the request deadline so the SDK can finish its telemetry spans.
+          streamError ??= part;
         }
+      }
+      if (streamError) {
+        throw streamError.error;
       }
       const [usage, finishReason] = await Promise.all([result.usage, result.finishReason]);
       signal.throwIfAborted();
@@ -357,7 +362,12 @@ export class VercelAiProvider implements ApiProvider {
 
       return { output, tokenUsage: mapTokenUsage(usage), finishReason };
     } catch (error) {
-      return handleApiError(error, timeout, 'streaming API call', abortSignal);
+      return handleApiError(
+        streamError ? streamError.error : error,
+        timeout,
+        'streaming API call',
+        abortSignal,
+      );
     } finally {
       cleanup();
     }

--- a/src/providers/vercel.ts
+++ b/src/providers/vercel.ts
@@ -14,6 +14,7 @@ import type {
   ApiEmbeddingProvider,
   ApiProvider,
   CallApiContextParams,
+  CallApiOptionsParams,
   ProviderEmbeddingResponse,
   ProviderOptions,
   ProviderResponse,
@@ -219,14 +220,17 @@ function getGatewayCacheConfig(config: VercelAiConfig, env?: EnvOverrides) {
 /**
  * Creates an AbortController with timeout and returns cleanup function.
  */
-function createTimeoutController(timeoutMs: number): {
+function createTimeoutController(
+  timeoutMs: number,
+  abortSignal?: AbortSignal,
+): {
   signal: AbortSignal;
   cleanup: () => void;
 } {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   return {
-    signal: controller.signal,
+    signal: abortSignal ? AbortSignal.any([controller.signal, abortSignal]) : controller.signal,
     cleanup: () => clearTimeout(timeoutId),
   };
 }
@@ -234,8 +238,17 @@ function createTimeoutController(timeoutMs: number): {
 /**
  * Handles common error cases and returns appropriate ProviderResponse.
  */
-function handleApiError(error: unknown, timeoutMs: number, context: string): ProviderResponse {
+function handleApiError(
+  error: unknown,
+  timeoutMs: number,
+  context: string,
+  abortSignal?: AbortSignal,
+): ProviderResponse {
   const errorMessage = error instanceof Error ? error.message : String(error);
+
+  if (abortSignal?.aborted) {
+    return { error: 'Request aborted' };
+  }
 
   if (error instanceof Error && error.name === 'AbortError') {
     return { error: `Request timed out after ${timeoutMs}ms` };
@@ -302,9 +315,10 @@ export class VercelAiProvider implements ApiProvider {
   private async callApiStreaming(
     messages: ChatMessage[],
     context?: CallApiContextParams,
+    abortSignal?: AbortSignal,
   ): Promise<ProviderResponse> {
     const timeout = this.config.timeout ?? getRequestTimeoutMs();
-    const { signal, cleanup } = createTimeoutController(timeout);
+    const { signal, cleanup } = createTimeoutController(timeout, abortSignal);
 
     try {
       const gateway = await createGatewayInstance(this.config, this.env);
@@ -325,11 +339,15 @@ export class VercelAiProvider implements ApiProvider {
       });
 
       let output = '';
-      for await (const chunk of result.textStream) {
-        output += chunk;
+      for await (const part of result.fullStream) {
+        if (part.type === 'text-delta') {
+          output += part.text;
+        } else if (part.type === 'error') {
+          throw part.error;
+        }
       }
-
       const [usage, finishReason] = await Promise.all([result.usage, result.finishReason]);
+      signal.throwIfAborted();
 
       logger.debug('Vercel AI Gateway streaming response received', {
         model: this.modelName,
@@ -339,7 +357,7 @@ export class VercelAiProvider implements ApiProvider {
 
       return { output, tokenUsage: mapTokenUsage(usage), finishReason };
     } catch (error) {
-      return handleApiError(error, timeout, 'streaming API call');
+      return handleApiError(error, timeout, 'streaming API call', abortSignal);
     } finally {
       cleanup();
     }
@@ -351,9 +369,10 @@ export class VercelAiProvider implements ApiProvider {
   private async callApiStructured(
     messages: ChatMessage[],
     context?: CallApiContextParams,
+    abortSignal?: AbortSignal,
   ): Promise<ProviderResponse> {
     const timeout = this.config.timeout ?? getRequestTimeoutMs();
-    const { signal, cleanup } = createTimeoutController(timeout);
+    const { signal, cleanup } = createTimeoutController(timeout, abortSignal);
 
     try {
       const gateway = await createGatewayInstance(this.config, this.env);
@@ -380,7 +399,7 @@ export class VercelAiProvider implements ApiProvider {
         abortSignal: signal,
       });
 
-      cleanup();
+      signal.throwIfAborted();
 
       logger.debug('Vercel AI Gateway structured output response received', {
         model: this.modelName,
@@ -394,12 +413,20 @@ export class VercelAiProvider implements ApiProvider {
         finishReason: result.finishReason,
       };
     } catch (error) {
+      return handleApiError(error, timeout, 'structured output API call', abortSignal);
+    } finally {
       cleanup();
-      return handleApiError(error, timeout, 'structured output API call');
     }
   }
 
-  async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
+    if (options?.abortSignal?.aborted) {
+      return { error: 'Request aborted' };
+    }
     const cache = await getCache();
     const cacheKey = this.getCacheKey(prompt);
 
@@ -410,7 +437,10 @@ export class VercelAiProvider implements ApiProvider {
         logger.debug(`Returning cached response for Vercel AI Gateway: ${this.modelName}`);
         try {
           const parsed = JSON.parse(cachedResponse) as ProviderResponse;
-          return { ...parsed, cached: true };
+          // Older streaming responses could cache partial output after an SDK error.
+          if (!parsed.error && parsed.finishReason !== 'error') {
+            return { ...parsed, cached: true };
+          }
         } catch {
           // If parsing fails, return as raw output
           return { output: cachedResponse, cached: true };
@@ -424,12 +454,12 @@ export class VercelAiProvider implements ApiProvider {
     // Dispatch to appropriate method based on config
     const response = await withSdkTraceContext(context, async () => {
       if (this.config.responseSchema) {
-        return this.callApiStructured(messages, context);
+        return this.callApiStructured(messages, context, options?.abortSignal);
       }
       if (this.config.streaming) {
-        return this.callApiStreaming(messages, context);
+        return this.callApiStreaming(messages, context, options?.abortSignal);
       }
-      return this.callApiNonStreaming(messages, context);
+      return this.callApiNonStreaming(messages, context, options?.abortSignal);
     });
 
     // Cache the response if successful
@@ -450,9 +480,10 @@ export class VercelAiProvider implements ApiProvider {
   private async callApiNonStreaming(
     messages: ChatMessage[],
     context?: CallApiContextParams,
+    abortSignal?: AbortSignal,
   ): Promise<ProviderResponse> {
     const timeout = this.config.timeout ?? getRequestTimeoutMs();
-    const { signal, cleanup } = createTimeoutController(timeout);
+    const { signal, cleanup } = createTimeoutController(timeout, abortSignal);
 
     try {
       const gateway = await createGatewayInstance(this.config, this.env);
@@ -472,7 +503,7 @@ export class VercelAiProvider implements ApiProvider {
         abortSignal: signal,
       });
 
-      cleanup();
+      signal.throwIfAborted();
 
       logger.debug('Vercel AI Gateway response received', {
         model: this.modelName,
@@ -486,8 +517,9 @@ export class VercelAiProvider implements ApiProvider {
         finishReason: result.finishReason,
       };
     } catch (error) {
+      return handleApiError(error, timeout, 'API call', abortSignal);
+    } finally {
       cleanup();
-      return handleApiError(error, timeout, 'API call');
     }
   }
 }

--- a/src/providers/vercel.ts
+++ b/src/providers/vercel.ts
@@ -73,16 +73,12 @@ function resolveApiKey(config: VercelAiConfig, env?: EnvOverrides): string | und
   if (config.apiKey) {
     return config.apiKey;
   }
-  if (config.apiKeyEnvar) {
-    return (
-      (env?.[config.apiKeyEnvar as keyof EnvOverrides] as string | undefined) ??
-      getEnvString(config.apiKeyEnvar)
-    );
-  }
-  return (
-    (env?.VERCEL_AI_GATEWAY_API_KEY as string | undefined) ??
-    getEnvString('VERCEL_AI_GATEWAY_API_KEY')
-  );
+  const apiKey = config.apiKeyEnvar
+    ? ((env?.[config.apiKeyEnvar as keyof EnvOverrides] as string | undefined) ??
+      getEnvString(config.apiKeyEnvar))
+    : ((env?.VERCEL_AI_GATEWAY_API_KEY as string | undefined) ??
+      getEnvString('VERCEL_AI_GATEWAY_API_KEY'));
+  return apiKey ?? getEnvString('AI_GATEWAY_API_KEY');
 }
 
 /**
@@ -107,7 +103,7 @@ async function createGatewayInstance(
     const { createGateway } = await import('ai');
 
     return createGateway({
-      apiKey: resolveApiKey(config, env),
+      apiKey: config.apiKey,
       baseURL: resolveBaseUrl(config, env),
       headers: config.headers,
     });
@@ -207,7 +203,7 @@ function getGatewayCacheConfig(config: VercelAiConfig, env?: EnvOverrides) {
           .sort(([left], [right]) => left.localeCompare(right)),
       )
     : undefined;
-  const apiKey = resolveApiKey(config, env);
+  const apiKey = config.apiKey;
   const baseUrl = resolveBaseUrl(config, env);
 
   return {
@@ -291,22 +287,22 @@ export class VercelAiProvider implements ApiProvider {
     return `[Vercel AI Gateway Provider ${this.modelName}]`;
   }
 
-  private getCacheKey(prompt: string): string {
+  private getCacheKey(prompt: string, config: VercelAiConfig): string {
     // Version generation responses because AI SDK 6 caps and usage changed.
     return `vercel:v2:${this.modelName}:${sha256(
       JSON.stringify({
         prompt,
-        gateway: getGatewayCacheConfig(this.config, this.env),
+        gateway: getGatewayCacheConfig(config, this.env),
         config: {
-          temperature: this.config.temperature,
-          maxTokens: this.config.maxTokens,
-          topP: this.config.topP,
-          topK: this.config.topK,
-          frequencyPenalty: this.config.frequencyPenalty,
-          presencePenalty: this.config.presencePenalty,
-          stopSequences: this.config.stopSequences,
-          streaming: this.config.streaming,
-          responseSchema: this.config.responseSchema,
+          temperature: config.temperature,
+          maxTokens: config.maxTokens,
+          topP: config.topP,
+          topK: config.topK,
+          frequencyPenalty: config.frequencyPenalty,
+          presencePenalty: config.presencePenalty,
+          stopSequences: config.stopSequences,
+          streaming: config.streaming,
+          responseSchema: config.responseSchema,
         },
       }),
     )}`;
@@ -317,26 +313,27 @@ export class VercelAiProvider implements ApiProvider {
    */
   private async callApiStreaming(
     messages: ChatMessage[],
+    config: VercelAiConfig,
     context?: CallApiContextParams,
     abortSignal?: AbortSignal,
   ): Promise<ProviderResponse> {
-    const timeout = this.config.timeout ?? getRequestTimeoutMs();
+    const timeout = config.timeout ?? getRequestTimeoutMs();
     const { signal, cleanup } = createTimeoutController(timeout, abortSignal);
 
     try {
-      const gateway = await createGatewayInstance(this.config, this.env);
+      const gateway = await createGatewayInstance(config, this.env);
       const { streamText } = await import('ai');
 
       logger.debug('Calling Vercel AI Gateway (streaming)', {
         model: this.modelName,
-        temperature: this.config.temperature,
-        maxTokens: this.config.maxTokens,
+        temperature: config.temperature,
+        maxTokens: config.maxTokens,
       });
 
       const result = streamText({
         model: gateway(this.modelName),
         messages,
-        ...pickGenerateOptions(this.config),
+        ...pickGenerateOptions(config),
         ...getSdkTelemetryOptions(this.id(), context),
         abortSignal: signal,
       });
@@ -371,33 +368,34 @@ export class VercelAiProvider implements ApiProvider {
    */
   private async callApiStructured(
     messages: ChatMessage[],
+    config: VercelAiConfig,
     context?: CallApiContextParams,
     abortSignal?: AbortSignal,
   ): Promise<ProviderResponse> {
-    const timeout = this.config.timeout ?? getRequestTimeoutMs();
+    const timeout = config.timeout ?? getRequestTimeoutMs();
     const { signal, cleanup } = createTimeoutController(timeout, abortSignal);
 
     try {
-      const gateway = await createGatewayInstance(this.config, this.env);
+      const gateway = await createGatewayInstance(config, this.env);
       const { generateObject, jsonSchema } = await import('ai');
 
       // OpenAI requires additionalProperties: false for strict mode
       const schema = jsonSchema<Record<string, unknown>>({
-        ...this.config.responseSchema,
-        additionalProperties: this.config.responseSchema?.additionalProperties ?? false,
+        ...config.responseSchema,
+        additionalProperties: config.responseSchema?.additionalProperties ?? false,
       } as Parameters<typeof jsonSchema>[0]);
 
       logger.debug('Calling Vercel AI Gateway (structured output)', {
         model: this.modelName,
-        temperature: this.config.temperature,
-        maxTokens: this.config.maxTokens,
+        temperature: config.temperature,
+        maxTokens: config.maxTokens,
       });
 
       const result = await generateObject({
         model: gateway(this.modelName),
         messages,
         schema,
-        ...pickGenerateOptions(this.config),
+        ...pickGenerateOptions(config),
         ...getSdkTelemetryOptions(this.id(), context),
         abortSignal: signal,
       });
@@ -430,11 +428,14 @@ export class VercelAiProvider implements ApiProvider {
     if (options?.abortSignal?.aborted) {
       return { error: 'Request aborted' };
     }
+    const config = { ...this.config, apiKey: resolveApiKey(this.config, this.env) };
+    // The SDK can resolve a request-scoped OIDC token when no API key is configured.
+    const cacheEnabled = isCacheEnabled() && Boolean(config.apiKey);
     const cache = await getCache();
-    const cacheKey = this.getCacheKey(prompt);
+    const cacheKey = this.getCacheKey(prompt, config);
 
     // Check cache first
-    if (isCacheEnabled() && !(context?.bustCache ?? context?.debug)) {
+    if (cacheEnabled && !(context?.bustCache ?? context?.debug)) {
       const cachedResponse = await cache.get<string>(cacheKey);
       if (cachedResponse) {
         logger.debug(`Returning cached response for Vercel AI Gateway: ${this.modelName}`);
@@ -456,17 +457,17 @@ export class VercelAiProvider implements ApiProvider {
 
     // Dispatch to appropriate method based on config
     const response = await withSdkTraceContext(context, async () => {
-      if (this.config.responseSchema) {
-        return this.callApiStructured(messages, context, options?.abortSignal);
+      if (config.responseSchema) {
+        return this.callApiStructured(messages, config, context, options?.abortSignal);
       }
-      if (this.config.streaming) {
-        return this.callApiStreaming(messages, context, options?.abortSignal);
+      if (config.streaming) {
+        return this.callApiStreaming(messages, config, context, options?.abortSignal);
       }
-      return this.callApiNonStreaming(messages, context, options?.abortSignal);
+      return this.callApiNonStreaming(messages, config, context, options?.abortSignal);
     });
 
     // Cache the response if successful
-    if (isCacheEnabled() && !response.error) {
+    if (cacheEnabled && !response.error) {
       try {
         await cache.set(cacheKey, JSON.stringify(response));
       } catch (err) {
@@ -482,26 +483,27 @@ export class VercelAiProvider implements ApiProvider {
    */
   private async callApiNonStreaming(
     messages: ChatMessage[],
+    config: VercelAiConfig,
     context?: CallApiContextParams,
     abortSignal?: AbortSignal,
   ): Promise<ProviderResponse> {
-    const timeout = this.config.timeout ?? getRequestTimeoutMs();
+    const timeout = config.timeout ?? getRequestTimeoutMs();
     const { signal, cleanup } = createTimeoutController(timeout, abortSignal);
 
     try {
-      const gateway = await createGatewayInstance(this.config, this.env);
+      const gateway = await createGatewayInstance(config, this.env);
       const { generateText } = await import('ai');
 
       logger.debug('Calling Vercel AI Gateway', {
         model: this.modelName,
-        temperature: this.config.temperature,
-        maxTokens: this.config.maxTokens,
+        temperature: config.temperature,
+        maxTokens: config.maxTokens,
       });
 
       const result = await generateText({
         model: gateway(this.modelName),
         messages,
-        ...pickGenerateOptions(this.config),
+        ...pickGenerateOptions(config),
         ...getSdkTelemetryOptions(this.id(), context),
         abortSignal: signal,
       });
@@ -564,16 +566,18 @@ export class VercelAiEmbeddingProvider implements ApiEmbeddingProvider {
     input: string,
     context?: CallApiContextParams,
   ): Promise<ProviderEmbeddingResponse> {
+    const config = { ...this.config, apiKey: resolveApiKey(this.config, this.env) };
+    const cacheEnabled = isCacheEnabled() && Boolean(config.apiKey);
     const cache = await getCache();
     const cacheKey = `vercel:embedding:${this.modelName}:${sha256(
       JSON.stringify({
         input,
-        gateway: getGatewayCacheConfig(this.config, this.env),
+        gateway: getGatewayCacheConfig(config, this.env),
       }),
     )}`;
 
     // Check cache first
-    if (isCacheEnabled() && !(context?.bustCache ?? context?.debug)) {
+    if (cacheEnabled && !(context?.bustCache ?? context?.debug)) {
       const cachedResponse = await cache.get<string>(cacheKey);
       if (cachedResponse) {
         logger.debug(`Returning cached embedding for Vercel AI Gateway: ${this.modelName}`);
@@ -586,11 +590,11 @@ export class VercelAiEmbeddingProvider implements ApiEmbeddingProvider {
       }
     }
 
-    const timeout = this.config.timeout ?? getRequestTimeoutMs();
+    const timeout = config.timeout ?? getRequestTimeoutMs();
     const { signal, cleanup } = createTimeoutController(timeout);
 
     try {
-      const gateway = await createGatewayInstance(this.config, this.env);
+      const gateway = await createGatewayInstance(config, this.env);
       const { embed } = await import('ai');
 
       logger.debug('Calling Vercel AI Gateway for embedding', { model: this.modelName });
@@ -616,7 +620,7 @@ export class VercelAiEmbeddingProvider implements ApiEmbeddingProvider {
         tokenUsage: { total: result.usage?.tokens },
       };
 
-      if (isCacheEnabled()) {
+      if (cacheEnabled) {
         try {
           await cache.set(cacheKey, JSON.stringify(response));
         } catch (err) {

--- a/test/providers/vercel.test.ts
+++ b/test/providers/vercel.test.ts
@@ -398,12 +398,12 @@ describe('VercelAiProvider', () => {
       const { streamText } = await import('ai');
       async function* textStream() {
         expectActiveEvaluationParent();
-        yield 'response';
+        yield { type: 'text-delta', text: 'response' };
       }
       vi.mocked(streamText).mockImplementationOnce(() => {
         expectActiveEvaluationParent();
         return {
-          textStream: textStream(),
+          fullStream: textStream(),
           usage: Promise.resolve({ inputTokens: 1, outputTokens: 2 }),
           finishReason: Promise.resolve('stop'),
         } as any;
@@ -433,15 +433,14 @@ describe('VercelAiProvider', () => {
     it('should handle streaming responses', async () => {
       const { streamText } = await import('ai');
 
-      // Mock async generator for textStream
       async function* mockTextStream() {
-        yield 'Hello ';
-        yield 'from ';
-        yield 'streaming!';
+        yield { type: 'text-delta', text: 'Hello ' };
+        yield { type: 'text-delta', text: 'from ' };
+        yield { type: 'text-delta', text: 'streaming!' };
       }
 
       vi.mocked(streamText).mockReturnValueOnce({
-        textStream: mockTextStream(),
+        fullStream: mockTextStream(),
         usage: Promise.resolve({ inputTokens: 5, outputTokens: 15, totalTokens: 20 }),
         finishReason: Promise.resolve('stop'),
       } as any);
@@ -467,11 +466,11 @@ describe('VercelAiProvider', () => {
       const { streamText } = await import('ai');
 
       async function* mockTextStream() {
-        yield 'Response';
+        yield { type: 'text-delta', text: 'Response' };
       }
 
       vi.mocked(streamText).mockReturnValueOnce({
-        textStream: mockTextStream(),
+        fullStream: mockTextStream(),
         usage: Promise.resolve({ inputTokens: 5, outputTokens: 10 }),
         finishReason: Promise.resolve('stop'),
       } as any);
@@ -508,6 +507,22 @@ describe('VercelAiProvider', () => {
       expect(result).toEqual({
         error: 'API call error: Stream connection failed',
       });
+    });
+
+    it('returns in-band stream errors without caching partial output', async () => {
+      const { streamText } = await import('ai');
+      vi.mocked(isCacheEnabled).mockReturnValue(true);
+      async function* fullStream() {
+        yield { type: 'text-delta', text: 'Partial response' };
+        yield { type: 'error', error: new Error('Stream failed') };
+      }
+      vi.mocked(streamText).mockImplementation(() => ({ fullStream: fullStream() }) as any);
+      const provider = new VercelAiProvider('fixture/model', { config: { streaming: true } });
+
+      expect(await provider.callApi('Hello')).toEqual({ error: 'API call error: Stream failed' });
+      expect(await provider.callApi('Hello')).toEqual({ error: 'API call error: Stream failed' });
+      expect(streamText).toHaveBeenCalledTimes(2);
+      expect(mockCache.set).not.toHaveBeenCalled();
     });
 
     it('cleans up the timeout when stream creation fails before iteration', async () => {
@@ -551,6 +566,63 @@ describe('VercelAiProvider', () => {
     });
   });
 
+  describe('caller cancellation', () => {
+    it.each(['text', 'streaming', 'structured'])(
+      'cancels %s generation without caching it',
+      async (mode) => {
+        const { generateText, streamText, generateObject } = await import('ai');
+        const controller = new AbortController();
+        vi.mocked(isCacheEnabled).mockReturnValue(true);
+        const abort = (signal: AbortSignal) => {
+          controller.abort();
+          expect(signal.aborted).toBe(true);
+          signal.throwIfAborted();
+        };
+        vi.mocked(generateText).mockImplementation(
+          async ({ abortSignal }) => abort(abortSignal!) as any,
+        );
+        vi.mocked(generateObject).mockImplementation(
+          async ({ abortSignal }) => abort(abortSignal!) as any,
+        );
+        vi.mocked(streamText).mockImplementation(
+          ({ abortSignal }) =>
+            ({
+              fullStream: (async function* () {
+                controller.abort();
+                expect(abortSignal!.aborted).toBe(true);
+                yield { type: 'abort' };
+              })(),
+            }) as any,
+        );
+        const provider = new VercelAiProvider('fixture/model', {
+          config: {
+            streaming: mode === 'streaming',
+            ...(mode === 'structured' ? { responseSchema: { type: 'object' } } : {}),
+          },
+        });
+
+        expect(
+          await provider.callApi('Hello', undefined, { abortSignal: controller.signal }),
+        ).toEqual({
+          error: 'Request aborted',
+        });
+        expect(mockCache.set).not.toHaveBeenCalled();
+      },
+    );
+
+    it('does not call the SDK or return cached output for a cancelled request', async () => {
+      const { generateText } = await import('ai');
+      const provider = new VercelAiProvider('fixture/model');
+      expect(
+        await provider.callApi('Hello', undefined, { abortSignal: AbortSignal.abort() }),
+      ).toEqual({
+        error: 'Request aborted',
+      });
+      expect(generateText).not.toHaveBeenCalled();
+      expect(mockCache.get).not.toHaveBeenCalled();
+    });
+  });
+
   describe('caching', () => {
     it('bypasses legacy generation entries and reuses corrected response entries', async () => {
       const { generateText } = await import('ai');
@@ -584,6 +656,24 @@ describe('VercelAiProvider', () => {
       const cached = await provider.callApi('cache migration fixture');
       expect(cached).toEqual({ ...fresh, cached: true });
       expect(generateText).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries cached partial output from failed streams', async () => {
+      const { generateText } = await import('ai');
+      vi.mocked(isCacheEnabled).mockReturnValue(true);
+      mockCache.get.mockResolvedValue(JSON.stringify({ output: 'Partial', finishReason: 'error' }));
+      vi.mocked(generateText).mockResolvedValueOnce({ text: 'Fresh', finishReason: 'stop' } as any);
+      const provider = new VercelAiProvider('fixture/model');
+
+      expect(await provider.callApi('Hello')).toMatchObject({
+        output: 'Fresh',
+        finishReason: 'stop',
+      });
+      expect(generateText).toHaveBeenCalledTimes(1);
+      expect(mockCache.set).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('Fresh'),
+      );
     });
 
     it('does not invoke the SDK for a traced cache hit', async () => {

--- a/test/providers/vercel.test.ts
+++ b/test/providers/vercel.test.ts
@@ -1,4 +1,5 @@
 import { context as otelContext, propagation, trace } from '@opentelemetry/api';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getCache, isCacheEnabled } from '../../src/cache';
@@ -48,7 +49,10 @@ beforeEach(() => {
 afterEach(() => restoreEnv());
 
 const testTraceparent = '00-0123456789abcdef0123456789abcdef-0123456789abcdef-01';
-const testTracerProvider = new NodeTracerProvider();
+const spanExporter = new InMemorySpanExporter();
+const testTracerProvider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(spanExporter)],
+});
 
 beforeAll(() => {
   testTracerProvider.register();
@@ -405,6 +409,58 @@ describe('VercelAiProvider', () => {
   });
 
   describe('callApi() - streaming', () => {
+    it.each(['Stream failed', undefined, null, false, 0, ''])(
+      'finishes native SDK spans after an in-band stream error: %s',
+      async (error) => {
+        const actualAi = await vi.importActual<typeof import('ai')>('ai');
+        const { createGateway, streamText } = await import('ai');
+        spanExporter.reset();
+        vi.mocked(isCacheEnabled).mockReturnValue(true);
+        const parts = [
+          { type: 'text-start', id: 'text' },
+          { type: 'text-delta', id: 'text', delta: 'Partial response' },
+          { type: 'error', error },
+          { type: 'text-end', id: 'text' },
+          {
+            type: 'finish',
+            finishReason: { unified: 'error' },
+            usage: { inputTokens: { total: 1 }, outputTokens: { total: 1 } },
+          },
+        ];
+        const fetch = vi.fn().mockResolvedValue(
+          new Response(parts.map((part) => `data: ${JSON.stringify(part)}\n\n`).join(''), {
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+        );
+        vi.mocked(createGateway).mockReturnValueOnce(
+          actualAi.createGateway({ apiKey: 'fixture-key', fetch }),
+        );
+        vi.mocked(streamText).mockImplementationOnce(actualAi.streamText);
+        const provider = new VercelAiProvider('fixture/model', { config: { streaming: true } });
+
+        const result = await provider.callApi('Hello', {
+          prompt: { raw: 'Hello', label: 'test' },
+          traceparent: testTraceparent,
+          vars: {},
+        });
+        await testTracerProvider.forceFlush();
+
+        expect(result).toEqual({ error: `API call error: ${error}` });
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(mockCache.set).not.toHaveBeenCalled();
+        const spans = spanExporter.getFinishedSpans();
+        expect(spans.map((span) => span.name).sort()).toEqual([
+          'ai.streamText',
+          'ai.streamText.doStream',
+        ]);
+        const outer = spans.find((span) => span.name === 'ai.streamText')!;
+        const inner = spans.find((span) => span.name === 'ai.streamText.doStream')!;
+        expect(outer.spanContext().traceId).toBe('0123456789abcdef0123456789abcdef');
+        expect(outer.parentSpanContext?.spanId).toBe('0123456789abcdef');
+        expect(inner.parentSpanContext?.spanId).toBe(outer.spanContext().spanId);
+      },
+    );
+
     it('enables native SDK telemetry for traced streaming calls', async () => {
       const { streamText } = await import('ai');
       async function* textStream() {
@@ -537,6 +593,74 @@ describe('VercelAiProvider', () => {
         vi.mocked(streamText).mock.calls.every(([options]) => options.abortSignal?.aborted),
       ).toBe(true);
       expect(mockCache.set).not.toHaveBeenCalled();
+    });
+
+    it.each([undefined, null, false, 0, ''])(
+      'retains an in-band error with payload %s while draining',
+      async (error) => {
+        const { streamText } = await import('ai');
+        vi.mocked(isCacheEnabled).mockReturnValue(true);
+        const drained = vi.fn();
+        vi.mocked(streamText).mockReturnValueOnce({
+          fullStream: (async function* () {
+            yield { type: 'error', error };
+            yield { type: 'error', error: new Error('Later error') };
+            drained();
+            throw new Error('Later transport failure');
+          })(),
+        } as any);
+        const provider = new VercelAiProvider('fixture/model', { config: { streaming: true } });
+
+        expect(await provider.callApi('Hello')).toEqual({ error: `API call error: ${error}` });
+        expect(drained).toHaveBeenCalledOnce();
+        expect(mockCache.set).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(['timeout', 'caller abort'])('bounds error draining with %s', async (stop) => {
+      vi.useFakeTimers();
+      try {
+        const { streamText } = await import('ai');
+        const caller = new AbortController();
+        const draining = Promise.withResolvers<void>();
+        const closed = vi.fn();
+        vi.mocked(isCacheEnabled).mockReturnValue(true);
+        vi.mocked(streamText).mockImplementationOnce(
+          ({ abortSignal }) =>
+            ({
+              fullStream: (async function* () {
+                yield { type: 'error', error: new Error('Stream failed') };
+                const aborted = new Promise<void>((resolve) =>
+                  abortSignal!.addEventListener('abort', () => resolve(), { once: true }),
+                );
+                draining.resolve();
+                await aborted;
+                closed();
+                abortSignal!.throwIfAborted();
+              })(),
+            }) as any,
+        );
+        const provider = new VercelAiProvider('fixture/model', {
+          config: { streaming: true, timeout: 1000 },
+        });
+
+        const result = provider.callApi('Hello', undefined, { abortSignal: caller.signal });
+        await draining.promise;
+        if (stop === 'caller abort') {
+          caller.abort();
+        } else {
+          await vi.advanceTimersByTimeAsync(1000);
+        }
+
+        expect(await result).toEqual({
+          error: stop === 'caller abort' ? 'Request aborted' : 'API call error: Stream failed',
+        });
+        expect(closed).toHaveBeenCalledOnce();
+        expect(vi.mocked(streamText).mock.calls[0][0].abortSignal?.aborted).toBe(true);
+        expect(mockCache.set).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('cleans up the timeout when stream creation fails before iteration', async () => {

--- a/test/providers/vercel.test.ts
+++ b/test/providers/vercel.test.ts
@@ -1,12 +1,13 @@
 import { context as otelContext, propagation, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getCache, isCacheEnabled } from '../../src/cache';
 import {
   createVercelProvider,
   VercelAiEmbeddingProvider,
   VercelAiProvider,
 } from '../../src/providers/vercel';
+import { mockProcessEnv } from '../util/utils';
 
 // Mock the cache module
 vi.mock('../../src/cache', async () => ({
@@ -35,6 +36,16 @@ vi.mock('ai', () => {
     jsonSchema: vi.fn((schema: unknown) => schema),
   };
 });
+
+let restoreEnv: () => void;
+beforeEach(() => {
+  restoreEnv = mockProcessEnv({
+    AI_GATEWAY_API_KEY: 'fixture-default-key',
+    VERCEL_AI_GATEWAY_API_KEY: undefined,
+    VERCEL_OIDC_TOKEN: undefined,
+  });
+});
+afterEach(() => restoreEnv());
 
 const testTraceparent = '00-0123456789abcdef0123456789abcdef-0123456789abcdef-01';
 const testTracerProvider = new NodeTracerProvider();
@@ -1419,6 +1430,91 @@ describe('VercelAiEmbeddingProvider', () => {
       expect(cacheKey).toMatch(/^vercel:embedding:openai\/text-embedding-3-small:[a-f0-9]{64}$/);
       expect(cacheKey).not.toContain(input);
     });
+  });
+});
+
+describe.each(['generation', 'embedding'])('ambient gateway auth (%s)', (task) => {
+  let mockCache: { get: ReturnType<typeof vi.fn>; set: ReturnType<typeof vi.fn> };
+  const createProvider = (config = {}, env = {}) =>
+    task === 'embedding'
+      ? new VercelAiEmbeddingProvider('fixture/model', { config, env })
+      : new VercelAiProvider('fixture/model', { config, env });
+  const call = (provider: VercelAiProvider | VercelAiEmbeddingProvider) =>
+    provider instanceof VercelAiEmbeddingProvider
+      ? provider.callEmbeddingApi('Hello')
+      : provider.callApi('Hello');
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const entries = new Map<string, string>();
+    mockCache = {
+      get: vi.fn(async (key: string) => entries.get(key)),
+      set: vi.fn(async (key: string, value: string) => {
+        entries.set(key, value);
+      }),
+    };
+    vi.mocked(getCache).mockResolvedValue(mockCache as any);
+    vi.mocked(isCacheEnabled).mockReturnValue(true);
+    const { generateText, embed } = await import('ai');
+    vi.mocked(generateText)
+      .mockReset()
+      .mockResolvedValue({ text: 'Fresh' } as any);
+    vi.mocked(embed)
+      .mockReset()
+      .mockResolvedValue({ embedding: [1, 2] } as any);
+  });
+
+  it('separates ambient API-key accounts and reuses the same account cache', async () => {
+    const { createGateway } = await import('ai');
+    mockProcessEnv({ AI_GATEWAY_API_KEY: 'fixture-account-a' });
+    await call(createProvider());
+    mockProcessEnv({ AI_GATEWAY_API_KEY: 'fixture-account-b' });
+    expect((await call(createProvider())).cached).toBeUndefined();
+    expect((await call(createProvider())).cached).toBe(true);
+    expect(vi.mocked(createGateway).mock.calls.map(([config]) => config?.apiKey)).toEqual([
+      'fixture-account-a',
+      'fixture-account-b',
+    ]);
+    expect(mockCache.set).toHaveBeenCalledTimes(2);
+  });
+
+  it('bypasses cache when the SDK resolves OIDC authentication', async () => {
+    const { createGateway } = await import('ai');
+    mockProcessEnv({ AI_GATEWAY_API_KEY: undefined });
+    await call(createProvider());
+    await call(createProvider());
+    expect(createGateway).toHaveBeenCalledWith(expect.objectContaining({ apiKey: undefined }));
+    expect(mockCache.get).not.toHaveBeenCalled();
+    expect(mockCache.set).not.toHaveBeenCalled();
+  });
+
+  it('uses the same API-key snapshot for the cache and SDK request', async () => {
+    const { createGateway } = await import('ai');
+    mockCache.get.mockImplementationOnce(async () => {
+      mockProcessEnv({ AI_GATEWAY_API_KEY: 'changed-during-cache-read' });
+      return undefined;
+    });
+    await call(createProvider());
+    expect(createGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'fixture-default-key' }),
+    );
+  });
+
+  it.each([
+    [{ apiKey: 'explicit', apiKeyEnvar: 'CUSTOM_GATEWAY_KEY' }, {}, 'explicit'],
+    [{ apiKeyEnvar: 'CUSTOM_GATEWAY_KEY' }, {}, 'custom'],
+    [
+      { apiKeyEnvar: 'MISSING_GATEWAY_KEY' },
+      { VERCEL_AI_GATEWAY_API_KEY: 'override' },
+      'fixture-default-key',
+    ],
+    [{}, { VERCEL_AI_GATEWAY_API_KEY: 'override' }, 'override'],
+    [{}, { VERCEL_AI_GATEWAY_API_KEY: '' }, ''],
+  ])('preserves configured credential precedence for %j', async (config, env, expectedKey) => {
+    const { createGateway } = await import('ai');
+    mockProcessEnv({ CUSTOM_GATEWAY_KEY: 'custom', MISSING_GATEWAY_KEY: undefined });
+    await call(createProvider(config, env));
+    expect(createGateway).toHaveBeenCalledWith(expect.objectContaining({ apiKey: expectedKey }));
   });
 });
 

--- a/test/providers/vercel.test.ts
+++ b/test/providers/vercel.test.ts
@@ -522,6 +522,9 @@ describe('VercelAiProvider', () => {
       expect(await provider.callApi('Hello')).toEqual({ error: 'API call error: Stream failed' });
       expect(await provider.callApi('Hello')).toEqual({ error: 'API call error: Stream failed' });
       expect(streamText).toHaveBeenCalledTimes(2);
+      expect(
+        vi.mocked(streamText).mock.calls.every(([options]) => options.abortSignal?.aborted),
+      ).toBe(true);
       expect(mockCache.set).not.toHaveBeenCalled();
     });
 

--- a/test/providers/vercel.test.ts
+++ b/test/providers/vercel.test.ts
@@ -622,7 +622,10 @@ describe('VercelAiProvider', () => {
       try {
         const { streamText } = await import('ai');
         const caller = new AbortController();
-        const draining = Promise.withResolvers<void>();
+        let resolveDraining!: () => void;
+        const draining = new Promise<void>((resolve) => {
+          resolveDraining = resolve;
+        });
         const closed = vi.fn();
         vi.mocked(isCacheEnabled).mockReturnValue(true);
         vi.mocked(streamText).mockImplementationOnce(
@@ -633,7 +636,7 @@ describe('VercelAiProvider', () => {
                 const aborted = new Promise<void>((resolve) =>
                   abortSignal!.addEventListener('abort', () => resolve(), { once: true }),
                 );
-                draining.resolve();
+                resolveDraining();
                 await aborted;
                 closed();
                 abortSignal!.throwIfAborted();
@@ -645,7 +648,7 @@ describe('VercelAiProvider', () => {
         });
 
         const result = provider.callApi('Hello', undefined, { abortSignal: caller.signal });
-        await draining.promise;
+        await draining;
         if (stop === 'caller abort') {
           caller.abort();
         } else {


### PR DESCRIPTION
Vercel stream errors could return and cache partial output as a success, and caller cancellation did not reach the SDK. Return in-band errors, forward cancellation across generation modes, and drain failed streams under the existing timeout so SDK tracing spans finish. Caller cancellation interrupts the drain.

Resolve the effective API key once for both the request and cache identity. Ambient API-key accounts get separate cache entries; requests using SDK-managed OIDC bypass caching. Existing credential precedence is preserved.

Validation: 237 focused tests, TypeScript and package builds, lint/format and hooks; three built-CLI generation modes plus installed-SDK loopback tests for error payloads, tracing spans, held-open transports and cancellation. No vendor inference was used.
