### PR TITLE
fix(providers): keep SageMaker request and cache settings consistent

### DIFF
--- a/src/providers/sagemaker.ts
+++ b/src/providers/sagemaker.ts
@@ -92,6 +92,7 @@ interface SageMakerOptions extends ProviderOptions {
 abstract class SageMakerGenericProvider {
   env?: EnvOverrides;
   sagemakerRuntime?: any; // SageMaker runtime client
+  private initializedRuntime?: { client: any; region: string };
   config: SageMakerConfig;
   endpointName: string;
   delay?: number; // Delay between API calls in milliseconds
@@ -166,20 +167,30 @@ abstract class SageMakerGenericProvider {
   /**
    * Initialize and return the SageMaker runtime client
    */
-  async getSageMakerRuntimeInstance() {
-    if (!this.sagemakerRuntime) {
+  async getSageMakerRuntimeInstance(region?: string) {
+    if (
+      !this.sagemakerRuntime ||
+      (region !== undefined &&
+        this.initializedRuntime !== undefined &&
+        this.sagemakerRuntime === this.initializedRuntime.client &&
+        region !== this.initializedRuntime.region)
+    ) {
       try {
         const { SageMakerRuntimeClient } = await import('@aws-sdk/client-sagemaker-runtime');
         const credentials = await this.getCredentials();
 
-        this.sagemakerRuntime = new SageMakerRuntimeClient({
-          region: this.getRegion(),
+        const runtimeRegion = region ?? this.getRegion();
+        const runtime = new SageMakerRuntimeClient({
+          region: runtimeRegion,
           maxAttempts: getEnvInt('AWS_SAGEMAKER_MAX_RETRIES', 3),
           retryMode: 'adaptive',
           ...(credentials ? { credentials } : {}),
         });
 
-        logger.debug(`SageMaker client initialized for region ${this.getRegion()}`);
+        this.sagemakerRuntime = runtime;
+        this.initializedRuntime = { client: runtime, region: runtimeRegion };
+        logger.debug(`SageMaker client initialized for region ${runtimeRegion}`);
+        return runtime;
       } catch {
         throw new Error(
           'The @aws-sdk/client-sagemaker-runtime package is required. Please install it with: npm install @aws-sdk/client-sagemaker-runtime',
@@ -562,7 +573,10 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
   /**
    * Parse the response from SageMaker endpoint
    */
-  async parseResponse(responseBody: string): Promise<any> {
+  async parseResponse(
+    responseBody: string,
+    responsePath: string | null = this.config.responseFormat?.path ?? null,
+  ): Promise<any> {
     let responseJson;
 
     logger.debug(`Parsing response for model type: ${this.modelType}`);
@@ -575,15 +589,12 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
     }
 
     // If response format specifies a path, extract it using expression evaluation
-    if (this.config.responseFormat?.path) {
+    if (responsePath) {
       try {
-        const pathExpression = this.config.responseFormat.path;
-        const extracted = await this.extractFromPath(responseJson, pathExpression);
+        const extracted = await this.extractFromPath(responseJson, responsePath);
         return extracted;
       } catch (error) {
-        logger.warn(
-          `Failed to extract from path: ${this.config.responseFormat.path}, Error: ${error}`,
-        );
+        logger.warn(`Failed to extract from path: ${responsePath}, Error: ${error}`);
         logger.debug(
           `Response JSON structure: ${JSON.stringify(responseJson).substring(0, 200)}...`,
         );
@@ -640,24 +651,6 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
   }
 
   /**
-   * Include the serialized request and response parsing settings in the cache identity.
-   */
-  private getCacheKey(payload: string): string {
-    const configForKey = {
-      payload,
-      endpoint: this.getEndpointName(),
-      modelType: this.modelType,
-      contentType: this.getContentType(),
-      acceptType: this.getAcceptType(),
-      responsePath: this.config.responseFormat?.path,
-      region: this.getRegion(),
-    };
-
-    const hash = crypto.createHash('sha256').update(JSON.stringify(configForKey)).digest('hex');
-    return `sagemaker:v2:${this.getEndpointName()}:${hash}`;
-  }
-
-  /**
    * Invoke SageMaker endpoint for text generation with caching, delay support, and transformations
    */
   async callApi(
@@ -690,17 +683,33 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
       );
     }
 
-    // Snapshot generation defaults before cache lookup or the endpoint request can yield.
+    // Keep request and parsing settings together across cache and network awaits.
     const payload = this.formatPayload(transformedPrompt);
-    const cacheKey = this.getCacheKey(payload);
+    const request = {
+      payload,
+      endpoint: this.getEndpointName(),
+      modelType: this.modelType,
+      contentType: this.getContentType(),
+      acceptType: this.getAcceptType(),
+      responsePath: this.config.responseFormat?.path ?? null,
+      region: this.getRegion(),
+    };
+    let cacheKey: string | undefined;
+    const getCacheKey = () => {
+      if (cacheKey === undefined) {
+        const hash = crypto.createHash('sha256').update(JSON.stringify(request)).digest('hex');
+        cacheKey = `sagemaker:v3:${request.endpoint}:${hash}`;
+      }
+      return cacheKey;
+    };
     const bustCache = context?.bustCache ?? context?.debug === true; // If debug mode is on, bust the cache
     if (isCacheEnabled() && !bustCache) {
       const cache = getCache ? getCache() : await import('../cache').then((m) => m.getCache());
 
       // Try to get from cache
-      const cachedResult = await cache.get<string>(cacheKey);
+      const cachedResult = await cache.get<string>(getCacheKey());
       if (cachedResult) {
-        logger.debug(`Using cached SageMaker response for ${this.getEndpointName()}`);
+        logger.debug(`Using cached SageMaker response for ${request.endpoint}`);
 
         try {
           // Parse the cached result
@@ -728,15 +737,15 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
     // Apply delay if specified and not using cached response
     if (delayMs && delayMs > 0) {
       logger.debug(
-        `Applying delay of ${delayMs}ms before calling SageMaker endpoint ${this.getEndpointName()}`,
+        `Applying delay of ${delayMs}ms before calling SageMaker endpoint ${request.endpoint}`,
       );
       await sleep(delayMs);
     }
 
     // Not in cache or cache disabled, make the actual API call
-    const runtime = await this.getSageMakerRuntimeInstance();
+    const runtime = await this.getSageMakerRuntimeInstance(request.region);
 
-    logger.debug(`Calling SageMaker endpoint ${this.getEndpointName()}`);
+    logger.debug(`Calling SageMaker endpoint ${request.endpoint}`);
     logger.debug(
       `With payload: ${payload.length > 1000 ? payload.substring(0, 1000) + '...' : payload}`,
     );
@@ -745,9 +754,9 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
       const { InvokeEndpointCommand } = await import('@aws-sdk/client-sagemaker-runtime');
 
       const command = new InvokeEndpointCommand({
-        EndpointName: this.getEndpointName(),
-        ContentType: this.getContentType(),
-        Accept: this.getAcceptType(),
+        EndpointName: request.endpoint,
+        ContentType: request.contentType,
+        Accept: request.acceptType,
         Body: payload,
       });
 
@@ -768,7 +777,7 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
         `SageMaker response (truncated): ${responseBody.length > 1000 ? responseBody.substring(0, 1000) + '...' : responseBody}`,
       );
 
-      const output = await this.parseResponse(responseBody);
+      const output = await this.parseResponse(responseBody, request.responsePath);
 
       // Handle known errors:
       if (typeof output === 'object' && output !== null && 'code' in output) {
@@ -799,7 +808,7 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
         },
         metadata: {
           latencyMs: _latency,
-          modelType: this.config.modelType || 'custom',
+          modelType: request.modelType,
           transformed: isTransformed,
           originalPrompt: isTransformed ? prompt : undefined,
         },
@@ -811,9 +820,9 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
         const resultToCache = JSON.stringify(result);
 
         try {
-          await cache.set(cacheKey, resultToCache);
+          await cache.set(getCacheKey(), resultToCache);
           logger.debug(
-            `Stored SageMaker response in cache with key: ${cacheKey.substring(0, 100)}...`,
+            `Stored SageMaker response in cache with key: ${getCacheKey().substring(0, 100)}...`,
           );
         } catch (_) {
           logger.warn(`Failed to store SageMaker response in cache: ${_}`);

--- a/test/providers/sagemaker.test.ts
+++ b/test/providers/sagemaker.test.ts
@@ -1,3 +1,6 @@
+import crypto from 'crypto';
+
+import { SageMakerRuntimeClient } from '@aws-sdk/client-sagemaker-runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import logger from '../../src/logger';
 
@@ -23,8 +26,8 @@ vi.mock('../../src/cache', () => ({
 
 // Mock AWS SDK
 vi.mock('@aws-sdk/client-sagemaker-runtime', () => ({
-  SageMakerRuntimeClient: vi.fn().mockImplementation(function () {
-    return { send: mockSend };
+  SageMakerRuntimeClient: vi.fn().mockImplementation(function ({ region }) {
+    return { send: (command: unknown) => mockSend(command, region) };
   }),
   InvokeEndpointCommand: vi.fn().mockImplementation(function (params) {
     return params;
@@ -48,6 +51,7 @@ describe('SageMakerCompletionProvider', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   describe('cache flag behavior', () => {
@@ -246,6 +250,233 @@ describe('SageMakerCompletionProvider', () => {
         expect(mockSend).toHaveBeenCalledTimes(2);
       },
     );
+
+    it.each([
+      ['endpoint', 'EndpointName', 'first-endpoint', 'second-endpoint'],
+      ['contentType', 'ContentType', 'application/json', 'application/x-json'],
+      ['acceptType', 'Accept', 'application/json', 'application/x-json'],
+    ] as const)(
+      'keeps %s bound to its request across cache lookup',
+      async (field, wireField, first, second) => {
+        const provider = new SageMakerCompletionProvider('test-endpoint', {
+          config: { region: 'us-east-1', modelType: 'custom', [field]: first },
+        });
+        const getCached = mockCacheGet.getMockImplementation()!;
+        mockCacheGet.mockImplementation(async (key: string) => {
+          const cached = await getCached(key);
+          if (mockCacheGet.mock.calls.length === 1) {
+            provider.config[field] = second;
+          }
+          return cached;
+        });
+        mockSend.mockImplementation(async (command) => ({
+          Body: new TextEncoder().encode(JSON.stringify({ output: command[wireField] })),
+        }));
+
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output: first });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output: second });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({
+          output: second,
+          cached: true,
+        });
+        provider.config[field] = first;
+        expect(await provider.callApi('A quiet garden')).toMatchObject({
+          output: first,
+          cached: true,
+        });
+        expect(mockSend).toHaveBeenCalledTimes(2);
+        expect(mockSend.mock.calls.map(([command]) => command[wireField])).toEqual([first, second]);
+      },
+    );
+
+    it.each([
+      ['cache lookup', undefined],
+      ['cache lookup', 'json.first'],
+      ['endpoint request', undefined],
+      ['endpoint request', 'json.first'],
+    ] as const)('keeps response path %s / %s bound to its cached output', async (stage, path) => {
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'custom', responseFormat: { path } },
+      });
+      const getCached = mockCacheGet.getMockImplementation()!;
+      mockCacheGet.mockImplementation(async (key: string) => {
+        const cached = await getCached(key);
+        if (stage === 'cache lookup' && mockCacheGet.mock.calls.length === 1) {
+          provider.config.responseFormat!.path = 'json.second';
+        }
+        return cached;
+      });
+      mockSend.mockImplementation(async () => {
+        if (stage === 'endpoint request') {
+          provider.config.responseFormat!.path = 'json.second';
+        }
+        return {
+          Body: new TextEncoder().encode(
+            JSON.stringify({ output: 'first', first: 'first', second: 'second' }),
+          ),
+        };
+      });
+
+      expect(await provider.callApi('A quiet garden')).toMatchObject({ output: 'first' });
+      expect(await provider.callApi('A quiet garden')).toMatchObject({ output: 'second' });
+      expect(await provider.callApi('A quiet garden')).toMatchObject({
+        output: 'second',
+        cached: true,
+      });
+      provider.config.responseFormat!.path = path;
+      expect(await provider.callApi('A quiet garden')).toMatchObject({
+        output: 'first',
+        cached: true,
+      });
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it.each(['cache lookup', 'credential loading'])(
+      'keeps the runtime region bound to its request during %s',
+      async (stage) => {
+        const provider = new SageMakerCompletionProvider('test-endpoint', {
+          config: { region: 'us-east-1', modelType: 'custom' },
+        });
+        const getCached = mockCacheGet.getMockImplementation()!;
+        mockCacheGet.mockImplementation(async (key: string) => {
+          const cached = await getCached(key);
+          if (stage === 'cache lookup' && mockCacheGet.mock.calls.length === 1) {
+            provider.config.region = 'us-west-2';
+          }
+          return cached;
+        });
+        const credentials = vi.spyOn(provider, 'getCredentials').mockImplementation(async () => {
+          if (stage === 'credential loading') {
+            provider.config.region = 'us-west-2';
+          }
+          return undefined;
+        });
+        mockSend.mockImplementation(async (_command, region) => ({
+          Body: new TextEncoder().encode(JSON.stringify({ output: region })),
+        }));
+
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output: 'us-east-1' });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output: 'us-west-2' });
+        expect(await provider.callApi('A second garden')).toMatchObject({ output: 'us-west-2' });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({
+          output: 'us-west-2',
+          cached: true,
+        });
+        provider.config.region = 'us-east-1';
+        expect(await provider.callApi('A quiet garden')).toMatchObject({
+          output: 'us-east-1',
+          cached: true,
+        });
+        expect(mockSend).toHaveBeenCalledTimes(3);
+        expect(SageMakerRuntimeClient).toHaveBeenCalledTimes(2);
+        expect(credentials).toHaveBeenCalledTimes(2);
+      },
+    );
+
+    it('keeps concurrent requests on their captured runtime regions', async () => {
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'custom' },
+      });
+      let release!: () => void;
+      let started!: () => void;
+      const waiting = new Promise<void>((resolve) => {
+        started = resolve;
+      });
+      const pendingCredentials = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      vi.spyOn(provider, 'getCredentials')
+        .mockImplementationOnce(async () => {
+          started();
+          await pendingCredentials;
+          return undefined;
+        })
+        .mockResolvedValue(undefined);
+      mockSend.mockImplementation(async (_command, region) => ({
+        Body: new TextEncoder().encode(JSON.stringify({ output: region })),
+      }));
+
+      const first = provider.callApi('A quiet garden');
+      await waiting;
+      provider.config.region = 'us-west-2';
+      const second = await provider.callApi('A quiet garden');
+      release();
+      expect(await first).toMatchObject({ output: 'us-east-1' });
+      expect(second).toMatchObject({ output: 'us-west-2' });
+      expect(await provider.callApi('A quiet garden')).toMatchObject({
+        output: 'us-west-2',
+        cached: true,
+      });
+      provider.config.region = 'us-east-1';
+      expect(await provider.callApi('A quiet garden')).toMatchObject({
+        output: 'us-east-1',
+        cached: true,
+      });
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it('preserves an injected runtime without loading credentials', async () => {
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'custom' },
+      });
+      const send = vi
+        .fn()
+        .mockResolvedValue({ Body: new TextEncoder().encode('{"output":"injected"}') });
+      provider.sagemakerRuntime = { send };
+      const credentials = vi.spyOn(provider, 'getCredentials');
+      for (const region of ['us-east-1', 'us-west-2']) {
+        provider.config.region = region;
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output: 'injected' });
+      }
+      expect(send).toHaveBeenCalledTimes(2);
+      expect(SageMakerRuntimeClient).not.toHaveBeenCalled();
+      expect(credentials).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { cacheEnabled: false, bustCache: false },
+      { cacheEnabled: true, bustCache: true },
+    ])('does not hash unused cache keys for %j', async ({ cacheEnabled, bustCache }) => {
+      mockIsCacheEnabled.mockReturnValue(cacheEnabled);
+      mockSend.mockResolvedValue({ Body: new TextEncoder().encode('{"output":"A garden"}') });
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'custom' },
+      });
+      const createHash = vi.spyOn(crypto, 'createHash');
+
+      expect(
+        await provider.callApi('A quiet garden', {
+          vars: {},
+          prompt: { raw: 'A quiet garden', label: 'Garden' },
+          bustCache,
+        }),
+      ).toMatchObject({
+        output: 'A garden',
+      });
+      expect(createHash).not.toHaveBeenCalled();
+      expect(mockCacheGet).not.toHaveBeenCalled();
+      expect(mockCacheSet).not.toHaveBeenCalled();
+    });
+
+    it('uses the original request when caching is enabled during the endpoint response', async () => {
+      mockIsCacheEnabled.mockReturnValue(false);
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'custom', endpoint: 'first-endpoint' },
+      });
+      mockSend.mockImplementation(async ({ EndpointName }) => {
+        provider.config.endpoint = 'second-endpoint';
+        mockIsCacheEnabled.mockReturnValue(true);
+        return { Body: new TextEncoder().encode(JSON.stringify({ output: EndpointName })) };
+      });
+
+      expect(await provider.callApi('A quiet garden')).toMatchObject({ output: 'first-endpoint' });
+      provider.config.endpoint = 'first-endpoint';
+      expect(await provider.callApi('A quiet garden')).toMatchObject({
+        output: 'first-endpoint',
+        cached: true,
+      });
+      expect(mockSend).toHaveBeenCalledTimes(1);
+    });
 
     it('uses the model type resolved from the provider ID for response caching', async () => {
       mockSend.mockResolvedValue({


### PR DESCRIPTION
SageMaker captured its request payload for caching but reread the endpoint, content/accept types, region and response path after awaited work. Changing those settings during a lookup or request could store a response under the wrong cache identity. Capture and reuse those settings throughout the request, and use a new cache namespace to exclude earlier inconsistent entries.

Select clients by the captured region only on completion cache misses, preserving concurrent and injected clients. Compute the cache hash lazily when needed. This is a focused follow-up to merged #10798.

Validation: 37 SageMaker tests and nine architecture tests; full package/UI build and postbuild; 12 library export tests; and 20 actual built-CLI rows passed with mocked transport. Lint, changed-file Biome and normal commit hooks passed. `npm run f` passed Biome, then exited 123 because the TypeScript-only diff supplies no files to Prettier; the formatting script is unchanged.
