### PR TITLE
fix(eval): preserve audio grading results and order

### DIFF
--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -1446,8 +1446,7 @@ async function gradeRunEvalResponse({
     providerTransformedOutput,
   };
 
-  // Finish audio grading per row instead of retaining every inline clip in the queue.
-  if (deferGrading && !response.audio?.data) {
+  if (deferGrading) {
     invariant(providerCallQueue, 'providerCallQueue is required when deferGrading is enabled');
     ret.response = processedResponse;
     const gradingPromise = withProviderCallExecutionContext(
@@ -3946,8 +3945,10 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
       processedIndices.add(index);
       await flushPromptMetrics();
     };
-    const flushGroupedRows = () =>
-      runGroupedGradingForRows(groupedRows, providerCallQueue, processGroupedRows);
+    const flushGroupedRows = async () => {
+      await runGroupedGradingForRows(groupedRows, providerCallQueue, processGroupedRows);
+      groupedRows.length = 0;
+    };
 
     try {
       for (const evalStep of groupedRunEvalOptions) {
@@ -3980,6 +3981,11 @@ class Evaluator<TEvaluation extends EvaluationRecord, TResult extends Evaluation
           })
         ) {
           break;
+        }
+
+        // Finish audio grading before collecting another inline clip.
+        if (rows.some((row) => row.response?.audio && deferredGradingPromises.has(row))) {
+          await flushGroupedRows();
         }
       }
     } catch (error) {

--- a/test/evaluator/assertions.test.ts
+++ b/test/evaluator/assertions.test.ts
@@ -5,7 +5,7 @@ import { randomUUID } from 'crypto';
 import { expect, it, vi } from 'vitest';
 import { evaluate } from '../../src/evaluator';
 import Eval from '../../src/models/eval';
-import { type ApiProvider, type TestSuite } from '../../src/types/index';
+import { type ApiProvider, ResultFailureReason, type TestSuite } from '../../src/types/index';
 import {
   mockApiProvider,
   mockGradingApiProviderFails,
@@ -15,6 +15,94 @@ import {
 import { describeEvaluator } from './lifecycle';
 
 describeEvaluator('evaluator assertions', () => {
+  it.each(['failed', 'aborted'])(
+    'preserves completed audio output when grading is %s',
+    async (outcome) => {
+      const abortController = new AbortController();
+      vi.mocked(mockApiProvider.callApi).mockResolvedValue({
+        output: 'Hello.',
+        audio: { data: Buffer.alloc(2048, 1).toString('base64'), format: 'wav' },
+        cost: 0.25,
+        tokenUsage: { prompt: 5, completion: 10, total: 15, numRequests: 1 },
+      });
+      const grader: ApiProvider = {
+        id: () => 'audio-grader',
+        getAudioInputFormat: () => 'openai',
+        callApi: vi.fn(async () => {
+          const error = new Error('Grading interrupted');
+          if (outcome === 'aborted') {
+            error.name = 'AbortError';
+            abortController.abort(error);
+          }
+          throw error;
+        }),
+      };
+      const testSuite: TestSuite = {
+        providers: [mockApiProvider],
+        prompts: [toPrompt('Say hello')],
+        tests: [
+          { assert: [{ type: 'llm-rubric', value: 'The speaker sounds calm.', provider: grader }] },
+        ],
+      };
+      const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+      await evaluate(testSuite, evalRecord, {
+        maxConcurrency: 1,
+        abortSignal: abortController.signal,
+      });
+      const summary = await evalRecord.toEvaluateSummary();
+      expect(summary.results).toHaveLength(1);
+      const row = summary.results[0];
+      expect(row.success).toBe(false);
+      expect(row.failureReason).toBe(ResultFailureReason.ERROR);
+      expect(row.error).toContain('Grading interrupted');
+      expect(row.response?.output).toBe('Hello.');
+      expect(row.response?.audio?.blobRef).toBeDefined();
+      expect(row.response?.audio?.data).toBeUndefined();
+      expect(row.cost).toBe(0.25);
+      expect(row.tokenUsage?.total).toBe(15);
+    },
+  );
+
+  it('runs different audio graders serially at maxConcurrency 1', async () => {
+    vi.mocked(mockApiProvider.callApi).mockResolvedValue({
+      output: 'Hello.',
+      audio: { data: Buffer.alloc(2048, 1).toString('base64'), format: 'wav' },
+    });
+    let activeCalls = 0;
+    let maximumActiveCalls = 0;
+    const graders: ApiProvider[] = ['first-grader', 'second-grader'].map((id) => ({
+      id: () => id,
+      getAudioInputFormat: () => 'openai',
+      callApi: vi.fn(async () => {
+        maximumActiveCalls = Math.max(maximumActiveCalls, ++activeCalls);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        activeCalls--;
+        return { output: '{"pass":true,"score":1}' };
+      }),
+    }));
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('Say hello')],
+      tests: [
+        {
+          assert: graders.map((provider) => ({
+            type: 'llm-rubric',
+            value: 'The speaker sounds calm.',
+            provider,
+          })),
+        },
+      ],
+    };
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 1 });
+    const summary = await evalRecord.toEvaluateSummary();
+    expect(summary.stats.successes).toBe(1);
+    for (const grader of graders) {
+      expect(grader.callApi).toHaveBeenCalledTimes(1);
+    }
+    expect(maximumActiveCalls).toBe(1);
+  });
+
   it('finishes audio grading before collecting the next serial target response', async () => {
     const callOrder: string[] = [];
     vi.mocked(mockApiProvider.callApi).mockImplementation(async () => {
@@ -48,6 +136,56 @@ describeEvaluator('evaluator assertions', () => {
       expect(row.response?.audio?.blobRef).toBeDefined();
       expect(row.response?.audio?.data).toBeUndefined();
     }
+  });
+
+  it('processes mixed audio and text rows once across grading flushes', async () => {
+    const kinds = ['text', 'audio', 'text', 'audio', 'text'];
+    const callOrder: string[] = [];
+    vi.mocked(mockApiProvider.callApi).mockImplementation(async (prompt) => {
+      callOrder.push(`target:${prompt}`);
+      return {
+        output: prompt,
+        ...(prompt.includes('audio') && {
+          audio: { data: Buffer.alloc(2048, 1).toString('base64'), format: 'wav' },
+        }),
+      };
+    });
+    const grader: ApiProvider = {
+      id: () => 'mixed-grader',
+      getAudioInputFormat: () => 'openai',
+      callApi: vi.fn(async (_prompt, context) => {
+        callOrder.push(`grader:${context?.vars.output}`);
+        return { output: '{"pass":true,"score":1}' };
+      }),
+    };
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: [toPrompt('{{index}} {{kind}}')],
+      tests: kinds.map((kind, index) => ({
+        vars: { kind, index },
+        assert: [{ type: 'llm-rubric', value: 'The response is clear.', provider: grader }],
+      })),
+    };
+    const progress = vi.fn();
+    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    await evaluate(testSuite, evalRecord, { maxConcurrency: 1, progressCallback: progress });
+    const summary = await evalRecord.toEvaluateSummary();
+    expect(summary.stats.successes).toBe(kinds.length);
+    expect(summary.results).toHaveLength(kinds.length);
+    expect(grader.callApi).toHaveBeenCalledTimes(kinds.length);
+    expect(progress).toHaveBeenCalledTimes(kinds.length);
+    expect(callOrder).toEqual([
+      'target:0 text',
+      'target:1 audio',
+      'grader:0 text',
+      'grader:1 audio',
+      'target:2 text',
+      'target:3 audio',
+      'grader:2 text',
+      'grader:3 audio',
+      'target:4 text',
+      'grader:4 text',
+    ]);
   });
 
   it.each([1, 2])(


### PR DESCRIPTION
Audio results at `--max-concurrency 1` bypassed grouped grading. A thrown grader error discarded the completed target response and usage, and graders on separate endpoints could run concurrently.

Keep audio rows in grouped grading and flush after each audio row. This preserves output, audio, cost, and tokens on grading errors or cancellation, serializes graders, and releases inline clips before the next target call. Clear completed batches so mixed audio/text evaluations process every row once.

Fixes two regressions from #10814.

## Validation

- All 35 focused evaluator tests pass, including exception, cancellation, serial dispatch, and mixed-row coverage. The first three regression cases fail before the fix.
- Built CLI with local mocks preserves output/audio, $0.25 cost, and 15 tokens after a grader exception. Separate grader endpoints peak at one concurrent request.
- Core build, TypeScript, architecture checks, lint, and formatting pass.
- Full backend suite: 24,878 passed, 10 skipped, 7 failed. The seven failures also reproduce on the unchanged baseline and come from the shared local installation having older `hono`, `js-yaml`, and `protobufjs` versions than the lockfile. A clean install was blocked by Socket's registry returning E403; dependencies are unchanged in this PR.
