### PR TITLE
fix(providers): honor provider env over ambient process env

### DIFF
--- a/src/providers/abliteration.ts
+++ b/src/providers/abliteration.ts
@@ -29,7 +29,9 @@ export class AbliterationProvider extends OpenAiChatCompletionProvider {
           normalizeApiBaseUrl(providerOptions.env?.ABLIT_API_BASE_URL) ??
           normalizeApiBaseUrl(getEnvString(ABLITERATION_API_BASE_URL_ENV_VAR)) ??
           ABLITERATION_API_BASE_URL,
-        apiKeyEnvar: providerOptions.config?.apiKeyEnvar ?? 'ABLIT_KEY',
+        // `||` (not `??`): an empty selector must fall back to ABLIT_KEY rather
+        // than leaving the base resolver to reach for OPENAI_API_KEY.
+        apiKeyEnvar: providerOptions.config?.apiKeyEnvar || 'ABLIT_KEY',
         showThinking: providerOptions.config?.showThinking ?? false,
       },
     });

--- a/src/providers/abliteration.ts
+++ b/src/providers/abliteration.ts
@@ -2,7 +2,6 @@ import { getEnvString } from '../envars';
 import { renderVarsInObject } from '../util/render';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 
-import type { EnvVarKey } from '../envars';
 import type { EnvOverrides } from '../types/env';
 import type {
   ApiProvider,
@@ -34,16 +33,6 @@ export class AbliterationProvider extends OpenAiChatCompletionProvider {
         showThinking: providerOptions.config?.showThinking ?? false,
       },
     });
-  }
-
-  override getApiKey(): string | undefined {
-    const apiKeyEnvar = this.config.apiKeyEnvar as EnvVarKey | undefined;
-    return (
-      this.config.apiKey ||
-      (apiKeyEnvar
-        ? this.env?.[apiKeyEnvar as keyof EnvOverrides] || getEnvString(apiKeyEnvar)
-        : undefined)
-    );
   }
 
   override getOrganization(): undefined {

--- a/src/providers/cometapi.ts
+++ b/src/providers/cometapi.ts
@@ -86,14 +86,6 @@ export class CometApiImageProvider extends OpenAiImageProvider {
     });
   }
 
-  getApiKey(): string | undefined {
-    if (this.config?.apiKey) {
-      return this.config.apiKey;
-    }
-    const apiKeyEnvar = this.config.apiKeyEnvar || 'COMETAPI_KEY';
-    return this.env?.[apiKeyEnvar] || getEnvString(apiKeyEnvar);
-  }
-
   getApiUrlDefault(): string {
     return 'https://api.cometapi.com/v1';
   }

--- a/src/providers/groq/chat.ts
+++ b/src/providers/groq/chat.ts
@@ -1,4 +1,3 @@
-import { getEnvString } from '../../envars';
 import { OpenAiChatCompletionProvider } from '../openai/chat';
 import { groqSupportsTemperature, isGroqReasoningModel } from './util';
 
@@ -21,11 +20,6 @@ const GROQ_API_BASE_URL = 'https://api.groq.com/openai/v1';
 export class GroqProvider extends OpenAiChatCompletionProvider {
   protected get apiKey(): string | undefined {
     return this.config?.apiKey;
-  }
-
-  override getApiKey(): string | undefined {
-    const apiKeyEnvar = this.config.apiKeyEnvar || 'GROQ_API_KEY';
-    return this.config.apiKey || getEnvString(apiKeyEnvar) || this.env?.[apiKeyEnvar];
   }
 
   protected isReasoningModel(): boolean {

--- a/src/providers/groq/responses.ts
+++ b/src/providers/groq/responses.ts
@@ -1,4 +1,3 @@
-import { getEnvString } from '../../envars';
 import { OpenAiResponsesProvider } from '../openai/responses';
 import { groqSupportsTemperature, isGroqReasoningModel } from './util';
 
@@ -24,11 +23,6 @@ const GROQ_API_BASE_URL = 'https://api.groq.com/openai/v1';
 export class GroqResponsesProvider extends OpenAiResponsesProvider {
   protected get apiKey(): string | undefined {
     return this.config?.apiKey;
-  }
-
-  override getApiKey(): string | undefined {
-    const apiKeyEnvar = this.config.apiKeyEnvar || 'GROQ_API_KEY';
-    return this.config.apiKey || getEnvString(apiKeyEnvar) || this.env?.[apiKeyEnvar];
   }
 
   protected isReasoningModel(): boolean {

--- a/test/providers/abliteration.test.ts
+++ b/test/providers/abliteration.test.ts
@@ -283,6 +283,17 @@ describe('AbliterationProvider', () => {
     expect(provider.getApiKey()).toBe('provider-key');
   });
 
+  it('does not fall back to OpenAI credentials when the key variable is blank', () => {
+    mockAbliterationEnv({ ABLIT_KEY: undefined, OPENAI_API_KEY: 'openai-key' });
+
+    const provider = new AbliterationProvider('abliterated-model', {
+      config: { apiKeyEnvar: '' },
+    });
+
+    expect(provider.config.apiKeyEnvar).toBe('ABLIT_KEY');
+    expect(provider.getApiKey()).toBeUndefined();
+  });
+
   it('does not fall back to OpenAI credentials', async () => {
     mockAbliterationEnv({
       ABLIT_KEY: undefined,

--- a/test/providers/groq/connection-config.test.ts
+++ b/test/providers/groq/connection-config.test.ts
@@ -103,13 +103,21 @@ describe.each([
     expect(request().headers).toHaveProperty('Authorization', 'Bearer scoped-key');
   });
 
-  it('preserves process precedence for the selected key variable', async () => {
+  it('prefers the provider-scoped key over the ambient process environment', async () => {
     reply(responses);
     await new Provider('private/model', {
       config: { apiKeyEnvar: 'GROQ_PROXY_KEY' },
       env: { GROQ_PROXY_KEY: 'scoped-key', OPENAI_API_KEY: 'unrelated-scoped-openai-key' },
     }).callApi('Hello');
-    expect(request().headers).toHaveProperty('Authorization', 'Bearer proxy-process-key');
+    expect(request().headers).toHaveProperty('Authorization', 'Bearer scoped-key');
+  });
+
+  it('prefers the default provider-scoped key over the ambient process environment', async () => {
+    reply(responses);
+    await new Provider('private/model', {
+      env: { GROQ_API_KEY: 'scoped-default-key' },
+    }).callApi('Hello');
+    expect(request().headers).toHaveProperty('Authorization', 'Bearer scoped-default-key');
   });
 
   it('uses an explicit key when the selected environment variable is absent', async () => {


### PR DESCRIPTION
## Summary

`GroqProvider` and `GroqResponsesProvider` each carried a `getApiKey()` override that resolved credentials as:

```ts
return this.config.apiKey || getEnvString(apiKeyEnvar) || this.env?.[apiKeyEnvar];
```

Process env was consulted **before** the provider/suite-level `env:` override — the reverse of the shared resolver `resolveProviderApiKey` (`src/providers/credentials.ts`) that every other provider goes through. Reproduced with an ambient `GROQ_API_KEY` in `process.env` plus a provider-level `env.GROQ_API_KEY`: Groq picked the ambient shell key while the equivalent OpenAI provider picked the provider-level one.

**This is a pure deletion.** Both Groq constructors already set `config.apiKeyEnvar = … || 'GROQ_API_KEY'`, and the base `OpenAiGenericProvider.getApiKey()` calls `resolveProviderApiKey(this.config, this.env, ['OPENAI_API_KEY'])`, which uses `config.apiKeyEnvar` when set — so removing the overrides restores the correct precedence and drops the now-unused `getEnvString` imports.

While in the neighbourhood, two sibling overrides that were byte-for-byte equivalent to the base implementation were deleted too (both already had the correct order, so no behavior change):

- `CometApiImageProvider.getApiKey()` — constructor already sets `apiKeyEnvar: 'COMETAPI_KEY'`.
- `AbliterationProvider.getApiKey()` — constructor already sets `apiKeyEnvar: 'ABLIT_KEY'`; the unused `EnvVarKey` import goes with it.
  The constructor default was `??`, so an explicit `apiKeyEnvar: ''` survived it and the base resolver — which reads an empty selector as *no* selection — would have reached for `OPENAI_API_KEY` and sent an unrelated OpenAI secret to `api.abliteration.ai`. Changed to `||` so a blank selector normalizes back to `ABLIT_KEY`, with a regression test in `test/providers/abliteration.test.ts`.

`helicone.ts` keeps its own resolver (it appends a `'placeholder-api-key'` fallback and does not use `apiKeyEnvar`), and `nscale.ts` / `cerebras.ts` never had an override. The `protected get apiKey()` accessors above the deleted Groq overrides are kept: they are the redaction hook used by `toJSON()` and match the sibling idiom in `deepseek.ts`, `xai/chat.ts`, and `hyperbolic/chat.ts`.

Net: **-33 / +10**, of which the source change is deletion only.

## Test plan

`test/providers/groq/connection-config.test.ts` contained a case (`preserves process precedence for the selected key variable`) that pinned the inverted behavior; it is flipped to assert the provider-scoped key wins, and a companion case covers the default `GROQ_API_KEY` envar.

Both new/changed assertions fail on the pre-fix source (verified by stashing the `src/providers/groq/*` changes):

```
Expected: "Bearer scoped-default-key"
Received: "Bearer groq-process-key"
 ❯ test/providers/groq/connection-config.test.ts:120:31
 Tests  4 failed | 16 passed (20)
```

Commands run:

```
npx vitest run test/providers/groq test/providers/inherited-auth-config.test.ts \
  test/providers/abliteration.test.ts test/providers/cometapi.test.ts test/providers/openai
  → Test Files 49 passed | 1 skipped, Tests 1950 passed | 9 skipped

npx vitest run test/providers/index.test.ts test/providers/registry.test.ts
  → Test Files 2 passed, Tests 357 passed

npx tsc --noEmit -p tsconfig.json          → clean
npx biome check --write <changed files>    → Checked 5 files, no fixes applied
```
