### PR TITLE
fix(providers): accept key+certificate PEM bundles for signature auth

### DIFF
--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -355,17 +355,20 @@ export function diagnosePrivateKeyMaterial(material: unknown): string | undefine
   if (!text) {
     return 'it is empty';
   }
-  if (text.includes('BEGIN CERTIFICATE')) {
-    return 'it is a certificate, not a private key';
-  }
-  if (text.includes('PUBLIC KEY-----')) {
-    return 'it is a public key, not a private key';
+  // A private key block anywhere wins: bundles that also carry the certificate or public
+  // key -- what `openssl pkcs12 -nodes` emits, in either order -- sign fine, so only
+  // material with no private key at all gets the "wrong kind of file" diagnoses.
+  if (!text.includes('PRIVATE KEY-----')) {
+    if (text.includes('BEGIN CERTIFICATE')) {
+      return 'it is a certificate, not a private key';
+    }
+    if (text.includes('PUBLIC KEY-----')) {
+      return 'it is a public key, not a private key';
+    }
+    return 'it is not PEM-encoded (no "-----BEGIN ... PRIVATE KEY-----" header)';
   }
   if (text.includes('ENCRYPTED PRIVATE KEY') || text.includes('Proc-Type: 4,ENCRYPTED')) {
     return 'it is passphrase-protected; decrypt it first or supply an unencrypted key';
-  }
-  if (!text.includes('PRIVATE KEY-----')) {
-    return 'it is not PEM-encoded (no "-----BEGIN ... PRIVATE KEY-----" header)';
   }
   if (!text.includes('-----END')) {
     return 'it is truncated (no "-----END ... PRIVATE KEY-----" line)';

--- a/src/providers/http.ts
+++ b/src/providers/http.ts
@@ -370,7 +370,10 @@ export function diagnosePrivateKeyMaterial(material: unknown): string | undefine
   if (text.includes('ENCRYPTED PRIVATE KEY') || text.includes('Proc-Type: 4,ENCRYPTED')) {
     return 'it is passphrase-protected; decrypt it first or supply an unencrypted key';
   }
-  if (!text.includes('-----END')) {
+  // Judge truncation on the private key's own block: in a bundle the certificate's
+  // `-----END` line would otherwise stand in for the key's missing one.
+  const keyBlock = text.slice(text.indexOf('PRIVATE KEY-----')).split('-----BEGIN')[0];
+  if (!keyBlock.includes('-----END')) {
     return 'it is truncated (no "-----END ... PRIVATE KEY-----" line)';
   }
   return undefined;

--- a/test/providers/http-signature-key-diagnostics.test.ts
+++ b/test/providers/http-signature-key-diagnostics.test.ts
@@ -118,6 +118,16 @@ describe('diagnosePrivateKeyMaterial', () => {
   });
 
   it.each([
+    ['key first', () => rsaPrivate.slice(0, 120) + '\n' + cert],
+    ['certificate first', () => cert + rsaPrivate.slice(0, 120)],
+  ])('reports a truncated key even when a certificate follows it (%s)', (_label, get) => {
+    // The certificate carries its own `-----END`, which must not pass for the key's.
+    expect(diagnosePrivateKeyMaterial(get())).toBe(
+      'it is truncated (no "-----END ... PRIVATE KEY-----" line)',
+    );
+  });
+
+  it.each([
     ['RSA', () => rsaPrivate],
     ['EC', () => ecPrivate],
   ])('passes a valid %s key through untouched', (_label, get) => {

--- a/test/providers/http-signature-key-diagnostics.test.ts
+++ b/test/providers/http-signature-key-diagnostics.test.ts
@@ -55,6 +55,8 @@ const baseAuth = {
   signatureAlgorithm: 'SHA256',
 };
 
+const cert = '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n';
+
 describe('diagnosePrivateKeyMaterial', () => {
   it('reports empty material', () => {
     expect(diagnosePrivateKeyMaterial('')).toBe('it is empty');
@@ -73,8 +75,21 @@ describe('diagnosePrivateKeyMaterial', () => {
   });
 
   it('distinguishes a certificate', () => {
-    const cert = '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n';
     expect(diagnosePrivateKeyMaterial(cert)).toBe('it is a certificate, not a private key');
+  });
+
+  it.each([
+    ['key first', () => rsaPrivate + cert],
+    ['certificate first', () => cert + rsaPrivate],
+  ])('accepts a key+certificate bundle (%s), which crypto signs with', (_label, get) => {
+    // `openssl pkcs12 -nodes` and most corporate PKI exports emit both blocks in one file.
+    expect(diagnosePrivateKeyMaterial(get())).toBeUndefined();
+  });
+
+  it('still flags an encrypted key bundled with its certificate', () => {
+    expect(diagnosePrivateKeyMaterial(encryptedPrivate + cert)).toBe(
+      'it is passphrase-protected; decrypt it first or supply an unencrypted key',
+    );
   });
 
   it.each([
@@ -147,8 +162,12 @@ describe('generateSignature key diagnostics', () => {
     );
   });
 
-  it('still signs successfully with a valid key', async () => {
-    const signature = await generateSignature({ ...baseAuth, privateKey: rsaPrivate }, 1);
+  it.each([
+    ['a valid key', () => rsaPrivate],
+    ['a key+certificate bundle', () => rsaPrivate + cert],
+    ['a certificate+key bundle', () => cert + rsaPrivate],
+  ])('still signs successfully with %s', async (_label, get) => {
+    const signature = await generateSignature({ ...baseAuth, privateKey: get() }, 1);
     expect(signature).toEqual(expect.any(String));
     expect(Buffer.from(signature, 'base64').byteLength).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary

`diagnosePrivateKeyMaterial` (added in #10586) checked `text.includes('BEGIN CERTIFICATE')` **before** checking for a private key block. A combined key+certificate PEM bundle — what `openssl pkcs12 -nodes` emits and what most corporate PKI exports hand you — therefore matched the certificate branch and signature auth failed with:

```
Private key from the configured privateKey cannot be used: it is a certificate, not a private key
```

even though the bundle is perfectly usable: `crypto.createSign().sign(bundle)` produces a valid signature in **either** block order (verified locally, 256-byte RSA signature both ways). The function's whole purpose is to turn OpenSSL 3's opaque `error:1E08010C:DECODER routines::unsupported` into a specific message, so it must only reject material that genuinely has no usable private key.

**Change:** nest the "certificate" and "public key" diagnoses under the no-private-key branch, so the presence of a `PRIVATE KEY-----` block always wins. Material that really is only a certificate, or only a public key, still gets its specific message; a bundled *encrypted* key still gets the passphrase message. Because bundles now reach the truncation check for the first time, that check is scoped to the private key's own block — the certificate's `-----END` line must not stand in for a key's missing one. No new helper, no new exports.

Properties the docstring promises are preserved: plain string matching only (no regex, no backtracking on user input), and no key material is ever echoed.

## Test plan

Extended `test/providers/http-signature-key-diagnostics.test.ts` (key generated in-test via `generateKeyPairSync`, certificate block as a synthetic PEM, matching the fixture idiom in `test/providers/http-tls.test.ts`):

- `diagnosePrivateKeyMaterial`: key+cert bundle and cert+key bundle (reversed order) → `undefined`; encrypted key + cert bundle → still passphrase-protected; truncated key + cert bundle, in either order → still truncated. Existing key-only, cert-only, public-key, empty, non-string, truncated, non-PEM, and valid-RSA/EC cases unchanged.
- `generateSignature`: parameterised the "still signs successfully" case over a plain key, a key+cert bundle, and a cert+key bundle — all produce a real signature end to end.

Commands run:

```
npx vitest run test/providers/http-signature-key-diagnostics.test.ts   # before fix: 7 failed | 22 passed
npx vitest run test/providers/http-signature-key-diagnostics.test.ts   # after fix:  29 passed
npx vitest run test/providers/http                                     # 11 files, 452 passed
npx tsc --noEmit -p tsconfig.json                                      # clean
npx biome check src/providers/http.ts test/providers/http-signature-key-diagnostics.test.ts
                                                                       # no errors (5 pre-existing complexity warnings)
npx prettier --check <changed files>                                   # clean
```

