### PR TITLE
fix(providers): reject withdrawn bedrock models on all geos

### DIFF
--- a/site/docs/providers/anthropic.md
+++ b/site/docs/providers/anthropic.md
@@ -75,9 +75,10 @@ the same `not_found_error` a retired model returns.
 ### Retired on the Anthropic API
 
 These IDs return `404 not_found_error` from Anthropic. Promptfoo still accepts them — they
-remain valid on AWS Bedrock, GCP Vertex, and OpenAI-compatible gateways, which set their own
-lifecycle dates, and cost attribution for historical evals needs the rates — but a direct
-`anthropic:messages:` call will fail.
+remain valid on GCP Vertex and OpenAI-compatible gateways, which set their own lifecycle
+dates, and cost attribution for historical evals needs the rates — but a direct
+`anthropic:messages:` call will fail. AWS Bedrock has since withdrawn some of them; see
+[Cross-Platform Model Availability](#cross-platform-model-availability).
 
 | Model ID                     | Description            | Suggested replacement |
 | ---------------------------- | ---------------------- | --------------------- |
@@ -124,12 +125,12 @@ Claude models are available across multiple platforms. Here's how the model name
 | Claude 4.5 Sonnet | claude-sonnet-4-5-20250929 (claude-sonnet-4-5) | claude-sonnet-4-5-20250929                                            | anthropic.claude-sonnet-4-5-20250929-v1:0         | claude-sonnet-4-5@20250929                     |
 | Claude 4.5 Haiku  | claude-haiku-4-5-20251001 (claude-haiku-4-5)   | claude-haiku-4-5-20251001                                             | anthropic.claude-haiku-4-5-20251001-v1:0          | claude-haiku-4-5@20251001                      |
 | Claude 4.1 Opus   | Retired on the direct API                      | claude-opus-4-1-20250805                                              | anthropic.claude-opus-4-1-20250805-v1:0           | claude-opus-4-1@20250805                       |
-| Claude 4 Opus     | Retired on the direct API                      | claude-opus-4-20250514                                                | anthropic.claude-opus-4-20250514-v1:0             | claude-opus-4@20250514                         |
+| Claude 4 Opus     | Retired on the direct API                      | claude-opus-4-20250514                                                | Withdrawn from Bedrock                            | claude-opus-4@20250514                         |
 | Claude 4 Sonnet   | Retired on the direct API                      | claude-sonnet-4-20250514                                              | anthropic.claude-sonnet-4-20250514-v1:0           | claude-sonnet-4@20250514                       |
 | Claude 3.7 Sonnet | Retired on the direct API                      | claude-3-7-sonnet-20250219                                            | anthropic.claude-3-7-sonnet-20250219-v1:0         | claude-3-7-sonnet@20250219                     |
 | Claude 3.5 Sonnet | Retired on the direct API                      | claude-3-5-sonnet-20241022                                            | anthropic.claude-3-5-sonnet-20241022-v2:0         | claude-3-5-sonnet-v2@20241022                  |
-| Claude 3.5 Haiku  | Retired on the direct API                      | claude-3-5-haiku-20241022                                             | anthropic.claude-3-5-haiku-20241022-v1:0          | claude-3-5-haiku@20241022                      |
-| Claude 3 Opus     | Retired on the direct API                      | claude-3-opus-20240229                                                | anthropic.claude-3-opus-20240229-v1:0             | claude-3-opus@20240229                         |
+| Claude 3.5 Haiku  | Retired on the direct API                      | claude-3-5-haiku-20241022                                             | Withdrawn from Bedrock                            | claude-3-5-haiku@20241022                      |
+| Claude 3 Opus     | Retired on the direct API                      | claude-3-opus-20240229                                                | Withdrawn from Bedrock                            | claude-3-opus@20240229                         |
 | Claude 3 Haiku    | Retired on the direct API                      | claude-3-haiku-20240307                                               | anthropic.claude-3-haiku-20240307-v1:0            | claude-3-haiku@20240307                        |
 
 ### Supported Parameters

--- a/site/docs/providers/aws-bedrock.md
+++ b/site/docs/providers/aws-bedrock.md
@@ -506,7 +506,7 @@ providers:
       region: 'us-east-1'
       temperature: 0.7
       max_tokens: 256
-  - id: bedrock:us.anthropic.claude-3-5-haiku-20241022-v1:0
+  - id: bedrock:us.anthropic.claude-haiku-4-5-20251001-v1:0
     config:
       region: 'us-east-1'
       temperature: 0.7

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -18,7 +18,7 @@ import {
 import { parseChatPrompt } from '../shared';
 import { AwsBedrockGenericProvider, type BedrockOptions, createBedrockCacheKeyHash } from './base';
 import { calculateBedrockInvokeModelCost } from './pricing';
-import { novaOutputFromMessage, novaParseMessages } from './util';
+import { INFERENCE_PROFILE_PREFIX, novaOutputFromMessage, novaParseMessages } from './util';
 
 import type {
   ApiEmbeddingProvider,
@@ -2652,17 +2652,15 @@ export function getHandlerForModel(
   if (ret) {
     return ret;
   }
+  // Withdrawn from Bedrock: absent from list-foundation-models in all 17 commercial
+  // regions on 2026-09-04. Listed here so they fail with a clear message instead of
+  // falling through to the family catch-alls below and failing at request time. Matched
+  // without the inference profile prefix so every geo spelling is rejected too.
   if (
     [
       'anthropic.claude-3-opus-20240229-v1:0',
-      'us.anthropic.claude-3-opus-20240229-v1:0',
       'anthropic.claude-opus-4-20250514-v1:0',
-      'us.anthropic.claude-opus-4-20250514-v1:0',
-      // Withdrawn from Bedrock: absent from list-foundation-models in all 17 commercial
-      // regions on 2026-09-04. Listed here so it fails with a clear message instead of
-      // falling through to the `anthropic.claude` catch-all and failing at request time.
       'anthropic.claude-3-5-haiku-20241022-v1:0',
-      'us.anthropic.claude-3-5-haiku-20241022-v1:0',
       'anthropic.claude-instant-v1',
       'anthropic.claude-v1',
       'anthropic.claude-v2',
@@ -2671,7 +2669,7 @@ export function getHandlerForModel(
       'cohere.command-light-text-v14',
       'meta.llama2-13b-chat-v1',
       'meta.llama2-70b-chat-v1',
-    ].includes(modelName)
+    ].includes(modelName.replace(INFERENCE_PROFILE_PREFIX, ''))
   ) {
     throw new Error(`Unknown Amazon Bedrock model: ${modelName}`);
   }

--- a/src/providers/bedrock/knowledgeBase.ts
+++ b/src/providers/bedrock/knowledgeBase.ts
@@ -6,7 +6,7 @@ import { sha256 } from '../../util/createHash';
 import { createEmptyTokenUsage } from '../../util/tokenUsageUtils';
 import { isSamplingParamsDeprecatedClaudeModel } from '../anthropic/util';
 import { AwsBedrockGenericProvider } from './base';
-import { createBedrockRequestHandler, hasProxyEnv } from './util';
+import { createBedrockRequestHandler, hasProxyEnv, INFERENCE_PROFILE_PREFIX } from './util';
 import type {
   BedrockAgentRuntimeClient,
   RetrieveAndGenerateCommandInput,
@@ -183,7 +183,7 @@ export class AwsBedrockKnowledgeBaseProvider
     if (!modelArn) {
       if (/^arn:aws(?:-[^:]+)?:bedrock:/.test(this.modelName)) {
         modelArn = this.modelName; // Already has full ARN format
-      } else if (/^(?:us|eu|apac|global|jp|au)\./.test(this.modelName)) {
+      } else if (INFERENCE_PROFILE_PREFIX.test(this.modelName)) {
         // Preserve system-defined inference profile IDs instead of wrapping them
         // in a foundation-model ARN.
         modelArn = this.modelName;

--- a/src/providers/bedrock/util.ts
+++ b/src/providers/bedrock/util.ts
@@ -4,6 +4,14 @@ import { getEnvString } from '../../envars';
 
 const REQUEST_TIMEOUT_MS = 300_000; // 5 minutes
 
+/**
+ * Matches the geo/global prefix of a system-defined inference profile ID, e.g. the
+ * `us.` in `us.anthropic.claude-sonnet-4-6`.
+ *
+ * See https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+ */
+export const INFERENCE_PROFILE_PREFIX = /^(?:us|eu|apac|global|jp|au)\./;
+
 export function hasProxyEnv(): boolean {
   return Boolean(getEnvString('HTTP_PROXY') || getEnvString('HTTPS_PROXY'));
 }

--- a/test/providers/bedrock/index.test.ts
+++ b/test/providers/bedrock/index.test.ts
@@ -41,9 +41,8 @@ const RETIRED_BEDROCK_MODEL_IDS = [
   'amazon.titan-text-lite-v1',
   'amazon.titan-text-premier-v1:0',
   'anthropic.claude-3-opus-20240229-v1:0',
-  'us.anthropic.claude-3-opus-20240229-v1:0',
   'anthropic.claude-opus-4-20250514-v1:0',
-  'us.anthropic.claude-opus-4-20250514-v1:0',
+  'anthropic.claude-3-5-haiku-20241022-v1:0',
   'anthropic.claude-instant-v1',
   'anthropic.claude-v1',
   'anthropic.claude-v2',
@@ -3771,6 +3770,20 @@ describe('AWS_BEDROCK_MODELS mapping', () => {
       `Unknown Amazon Bedrock model: ${modelName}`,
     );
   });
+
+  it.each(RETIRED_BEDROCK_MODEL_IDS)(
+    'rejects retired model id %s under every inference profile prefix',
+    (modelName) => {
+      // Regional/global inference profiles must be rejected too — otherwise ids such as
+      // `eu.anthropic.claude-3-5-haiku-20241022-v1:0` fall through to the `anthropic.claude`
+      // catch-all and fail at request time with an opaque AWS error.
+      for (const prefix of ['us.', 'eu.', 'apac.', 'global.', 'jp.', 'au.']) {
+        expect(() => getHandlerForModel(`${prefix}${modelName}`)).toThrow(
+          `Unknown Amazon Bedrock model: ${prefix}${modelName}`,
+        );
+      }
+    },
+  );
 
   it('keeps Claude 3.5/3.7 Sonnet (still offered in APAC regions)', () => {
     expect(AWS_BEDROCK_MODELS['anthropic.claude-3-5-sonnet-20240620-v1:0']).toBe(


### PR DESCRIPTION
## Summary

The withdrawn-model guard in `getHandlerForModel` (`src/providers/bedrock/index.ts`) matched
the raw model ID against a hand-written list that only carried the bare and `us.` spellings.
Every other inference-profile spelling bypassed it: `eu.anthropic.claude-3-5-haiku-20241022-v1:0`
and its `apac.` / `global.` / `jp.` / `au.` variants fell through to the
`modelName.includes('anthropic.claude')` catch-all and failed later at request time with an
opaque AWS error — exactly the outcome the guard's own comment says it exists to prevent.

Changes:

- Match the list against the ID with its inference-profile prefix stripped, so every geo
  spelling is rejected with the same clear `Unknown Amazon Bedrock model: <id>` error.
- **Deleted** the three now-redundant hand-listed `us.` duplicates from the guard (and the
  two from the test fixture).
- Hoisted the `^(?:us|eu|apac|global|jp|au)\.` regex that already existed inline in
  `knowledgeBase.ts` into `bedrock/util.ts` as `INFERENCE_PROFILE_PREFIX` and reused it in
  both places instead of duplicating the literal.

Docs shipped IDs the guard hard-throws on, so a user copy-pasting them got
`Unknown Amazon Bedrock model`:

- `site/docs/providers/aws-bedrock.md` — the example provider list pointed at
  `bedrock:us.anthropic.claude-3-5-haiku-20241022-v1:0`; now `us.anthropic.claude-haiku-4-5-20251001-v1:0`,
  which is registered in `AWS_BEDROCK_MODELS`.
- `site/docs/providers/anthropic.md` — the cross-platform availability table listed Bedrock
  IDs for Claude 3.5 Haiku, Claude 3 Opus, and Claude 4 Opus, all three of which the guard
  rejects; they now read "Withdrawn from Bedrock", matching the table's existing
  "Not available" convention. The "Retired on the Anthropic API" preamble no longer claims
  those IDs "remain valid on AWS Bedrock".

Net: +39 / -19, with the behavior fix itself net-negative in `index.ts`.

## Test plan

Added `it.each(RETIRED_BEDROCK_MODEL_IDS)('rejects retired model id %s under every inference
profile prefix')` in `test/providers/bedrock/index.test.ts`, exercising `us.` / `eu.` /
`apac.` / `global.` / `jp.` / `au.`, and added the previously-uncovered
`anthropic.claude-3-5-haiku-20241022-v1:0` to that fixture.

```
# fails before the fix (source stashed, test kept):
$ npx vitest run test/providers/bedrock/index.test.ts -t "inference profile prefix"
  Tests  7 failed | 7 passed | 350 skipped
  FAIL … rejects retired model id anthropic.claude-3-5-haiku-20241022-v1:0 under every inference profile prefix
  AssertionError: expected [Function] to throw an error

# passes after:
$ npx vitest run test/providers/bedrock test/providers/bedrock.agents.test.ts
  Test Files  15 passed (15)
  Tests  995 passed (995)

$ npx vitest run test/providers/families
  Test Files  1 passed (1) | Tests  60 passed (60)

$ npx tsc --noEmit -p tsconfig.json
  (clean)

$ npx biome check src/providers/bedrock/{index,util,knowledgeBase}.ts test/providers/bedrock/index.test.ts
  Found 2 warnings  # both pre-existing noExcessiveCognitiveComplexity, unchanged from base

$ npx prettier --check site/docs/providers/anthropic.md site/docs/providers/aws-bedrock.md
  All matched files use Prettier code style!
```