### PR TITLE
fix(providers): correct three Bedrock pricing gaps

### DIFF
--- a/src/providers/bedrock/pricing.ts
+++ b/src/providers/bedrock/pricing.ts
@@ -15,11 +15,13 @@ type BedrockPricing = {
   input: number;
   output: number;
   /**
-   * Rates that replace `input`/`output` once total input tokens reach `threshold`.
+   * Rates that replace `input`/`output` once total input tokens exceed `threshold`.
    * Cache rates are derived from the tier's input rate, matching how AWS prices the
    * `-cache-read/-cache-write-...-long-context-...` meters.
    */
   longContext?: { threshold: number; input: number; output: number };
+  /** Rates that replace `input`/`output` on the cross-region `global.` inference profile. */
+  global?: { input: number; output: number };
 };
 
 /**
@@ -93,9 +95,9 @@ const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   'amazon.nova-lite': { input: 0.06, output: 0.24 },
   'amazon.nova-pro': { input: 0.8, output: 3.2 },
   'amazon.nova-premier': { input: 2.5, output: 12.5 },
-  // Amazon Nova 2 (reasoning models). The cross-region global profile is cheaper
-  // ($0.30/$2.50); this is the plain us-east-1 on-demand rate.
-  'amazon.nova-2-lite': { input: 0.33, output: 2.75 },
+  // Amazon Nova 2 (reasoning models). `input`/`output` are the plain us-east-1 on-demand
+  // rates; the cross-region global profile has its own cheaper meter.
+  'amazon.nova-2-lite': { input: 0.33, output: 2.75, global: { input: 0.3, output: 2.5 } },
   // Amazon Titan Text
   'amazon.titan-text-lite': { input: 0.15, output: 0.2 },
   'amazon.titan-text-express': { input: 0.2, output: 0.6 },
@@ -160,11 +162,29 @@ const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   'gemma-3-4b': { input: 0.04, output: 0.08 },
   'gemma-3-12b': { input: 0.09, output: 0.29 },
   'gemma-3-27b': { input: 0.23, output: 0.38 },
-  // OpenAI GPT-OSS (open-weight models served via InvokeModel/Converse). The frontier
-  // gpt-5.x models are not available through Converse — they use the OpenAI-compatible
-  // Responses API (see src/providers/bedrock/openaiResponses.ts).
+  // OpenAI GPT-OSS (open-weight models served via InvokeModel/Converse).
   'openai.gpt-oss-120b': { input: 0.15, output: 0.6 },
   'openai.gpt-oss-20b': { input: 0.07, output: 0.3 },
+  // OpenAI GPT-5.6 frontier models, reachable over Converse through the geo inference
+  // profiles (`bedrock:converse:us.openai.gpt-5.6-sol`). Bedrock lists the first-party rates
+  // plus a 10% regional-processing uplift, and bills the whole request at 2x input /
+  // 1.5x output above 272K input tokens. InvokeModel does not serve these models, so they
+  // stay out of BEDROCK_INVOKE_PRICING_MODEL_PREFIXES.
+  'openai.gpt-5.6-sol': {
+    input: 4.4,
+    output: 22,
+    longContext: { threshold: 272_000, input: 8.8, output: 33 },
+  },
+  'openai.gpt-5.6-terra': {
+    input: 2.2,
+    output: 13.2,
+    longContext: { threshold: 272_000, input: 4.4, output: 19.8 },
+  },
+  'openai.gpt-5.6-luna': {
+    input: 0.22,
+    output: 1.32,
+    longContext: { threshold: 272_000, input: 0.44, output: 1.98 },
+  },
 };
 
 const BEDROCK_REGION_PRICING_MODEL_PREFIXES = [
@@ -368,40 +388,33 @@ const BEDROCK_REGION_PRICING: Record<string, Record<string, BedrockPricing>> = {
   'us-gov-west-1': US_GOV_PRICING,
 };
 
+/** Tables are keyed by model-id substring and matched first-match-wins in insertion order. */
+function matchPricing(
+  table: Record<string, BedrockPricing> | undefined,
+  normalizedModelId: string,
+): BedrockPricing | undefined {
+  return Object.entries(table ?? {}).find(([modelPrefix]) =>
+    normalizedModelId.includes(modelPrefix),
+  )?.[1];
+}
+
 function getBedrockPricing(normalizedModelId: string, region?: string): BedrockPricing | undefined {
   if (normalizedModelId.includes('openai.gpt-oss-') && region) {
-    const pricing = GPT_OSS_REGION_PRICING[region.toLowerCase()];
-    if (!pricing) {
-      return undefined;
-    }
-    for (const [modelPrefix, modelPricing] of Object.entries(pricing)) {
-      if (normalizedModelId.includes(modelPrefix)) {
-        return modelPricing;
-      }
-    }
-    return undefined;
+    return matchPricing(GPT_OSS_REGION_PRICING[region.toLowerCase()], normalizedModelId);
   }
 
   const regionPricing = region ? BEDROCK_REGION_PRICING[region.toLowerCase()] : undefined;
   if (regionPricing) {
-    for (const [modelPrefix, pricing] of Object.entries(regionPricing)) {
-      if (normalizedModelId.includes(modelPrefix)) {
-        return pricing;
-      }
-    }
+    const pricing = matchPricing(regionPricing, normalizedModelId);
     if (
+      pricing ||
       BEDROCK_REGION_PRICING_MODEL_PREFIXES.some((prefix) => normalizedModelId.includes(prefix))
     ) {
-      return undefined;
-    }
-  }
-
-  for (const [modelPrefix, pricing] of Object.entries(BEDROCK_PRICING)) {
-    if (normalizedModelId.includes(modelPrefix)) {
       return pricing;
     }
   }
-  return undefined;
+
+  return matchPricing(BEDROCK_PRICING, normalizedModelId);
 }
 
 const BEDROCK_INVOKE_PRICING_MODEL_PREFIXES = [
@@ -451,9 +464,9 @@ export function calculateBedrockCost(
   // prompt plus any cache reads and writes (`input_tokens` excludes cached tokens).
   const totalInputTokens = promptTokens + cacheReadTokens + cacheWriteTokens;
   const tier =
-    pricing.longContext && totalInputTokens >= pricing.longContext.threshold
+    pricing.longContext && totalInputTokens > pricing.longContext.threshold
       ? pricing.longContext
-      : pricing;
+      : (isGlobalEndpoint && pricing.global) || pricing;
 
   const inputRate = (tier.input / 1_000_000) * pricingMultiplier;
   const inputCost = normalizedModelId.includes('anthropic.claude')

--- a/src/providers/bedrock/pricing.ts
+++ b/src/providers/bedrock/pricing.ts
@@ -20,8 +20,6 @@ type BedrockPricing = {
    * `-cache-read/-cache-write-...-long-context-...` meters.
    */
   longContext?: { threshold: number; input: number; output: number };
-  /** Rates that replace `input`/`output` on the cross-region `global.` inference profile. */
-  global?: { input: number; output: number };
 };
 
 /**
@@ -44,8 +42,9 @@ function isNovaPromptCachingModel(normalizedModelId: string): boolean {
  *
  * Rates are the plain us-east-1 on-demand meters from the AWS Price List API
  * (`aws pricing get-products --service-code AmazonBedrock`), which is the authority — the
- * `-batch`, `-custom-model`, `-flex`, `-priority` and `-cross-region-global` meters carry
- * different rates and must not be used here. Last reconciled 2026-09-01.
+ * `-batch`, `-custom-model`, `-flex` and `-priority` meters carry different rates and must not
+ * be used here; a `-cross-region-global` meter belongs only on a key that spells out the
+ * `global.` profile. Last reconciled 2026-09-01.
  */
 const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   // Claude 5
@@ -95,9 +94,10 @@ const BEDROCK_PRICING: Record<string, BedrockPricing> = {
   'amazon.nova-lite': { input: 0.06, output: 0.24 },
   'amazon.nova-pro': { input: 0.8, output: 3.2 },
   'amazon.nova-premier': { input: 2.5, output: 12.5 },
-  // Amazon Nova 2 (reasoning models). `input`/`output` are the plain us-east-1 on-demand
-  // rates; the cross-region global profile has its own cheaper meter.
-  'amazon.nova-2-lite': { input: 0.33, output: 2.75, global: { input: 0.3, output: 2.5 } },
+  // Amazon Nova 2 (reasoning models). The cross-region global profile bills at its own cheaper
+  // meter, so its key must stay ahead of the plain us-east-1 one.
+  'global.amazon.nova-2-lite': { input: 0.3, output: 2.5 },
+  'amazon.nova-2-lite': { input: 0.33, output: 2.75 },
   // Amazon Titan Text
   'amazon.titan-text-lite': { input: 0.15, output: 0.2 },
   'amazon.titan-text-express': { input: 0.2, output: 0.6 },
@@ -466,7 +466,7 @@ export function calculateBedrockCost(
   const tier =
     pricing.longContext && totalInputTokens > pricing.longContext.threshold
       ? pricing.longContext
-      : (isGlobalEndpoint && pricing.global) || pricing;
+      : pricing;
 
   const inputRate = (tier.input / 1_000_000) * pricingMultiplier;
   const inputCost = normalizedModelId.includes('anthropic.claude')

--- a/test/providers/bedrock/pricing.test.ts
+++ b/test/providers/bedrock/pricing.test.ts
@@ -140,6 +140,47 @@ describe('calculateBedrockCost', () => {
     ).toBeUndefined();
   });
 
+  it('bills the Nova 2 Lite global profile at its own cheaper meter', () => {
+    // AWS publishes $0.30/$2.50 for `global.amazon.nova-2-lite`, against $0.33/$2.75 regionally.
+    expect(
+      calculateBedrockCost('global.amazon.nova-2-lite-v1:0', INPUT_TOKENS, OUTPUT_TOKENS),
+    ).toBeCloseTo(costAtRates(0.3, 2.5), 6);
+    expect(
+      calculateBedrockCost('us.amazon.nova-2-lite-v1:0', INPUT_TOKENS, OUTPUT_TOKENS),
+    ).toBeCloseTo(costAtRates(0.33, 2.75), 6);
+  });
+
+  describe('OpenAI GPT-5.6 frontier models on Converse', () => {
+    // Bedrock rates include the 10% regional-processing uplift over the first-party rates.
+    it.each([
+      { id: 'us.openai.gpt-5.6-sol', input: 4.4, output: 22 },
+      { id: 'us.openai.gpt-5.6-terra', input: 2.2, output: 13.2 },
+      { id: 'us.openai.gpt-5.6-luna', input: 0.22, output: 1.32 },
+    ])('prices $id', ({ id, input, output }) => {
+      expect(calculateBedrockCost(id, INPUT_TOKENS, OUTPUT_TOKENS, 0, 0, 'us-east-1')).toBeCloseTo(
+        costAtRates(input, output),
+        6,
+      );
+    });
+
+    it('applies the 272k long-context tier', () => {
+      expect(calculateBedrockCost('us.openai.gpt-5.6-sol', 272_000, 1_000)).toBeCloseTo(
+        (272_000 / 1e6) * 4.4 + (1_000 / 1e6) * 22,
+        6,
+      );
+      expect(calculateBedrockCost('us.openai.gpt-5.6-sol', 272_001, 1_000)).toBeCloseTo(
+        (272_001 / 1e6) * 8.8 + (1_000 / 1e6) * 33,
+        6,
+      );
+    });
+
+    it('stays fail-closed on InvokeModel, which does not serve these models', () => {
+      expect(
+        calculateBedrockInvokeModelCost('us.openai.gpt-5.6-sol', 1e6, 1e6, 0, 0, 'us-east-1'),
+      ).toBeUndefined();
+    });
+  });
+
   it('matches Command R+ before the broader Command R key', () => {
     expect(calculateBedrockCost('cohere.command-r-plus-v1:0', 1e6, 1e6)).toBeCloseTo(18, 6);
   });
@@ -164,9 +205,17 @@ describe('calculateBedrockCost', () => {
       );
     });
 
-    it('switches to $6/$22.50 at and above 200k input tokens', () => {
+    it('bills exactly 200k input tokens at the standard rate', () => {
+      // The tier is `> threshold`, matching the shared long-context rule in providers/shared.ts.
       expect(calculateBedrockCost(ID, 200_000, 1_000)).toBeCloseTo(
-        (200_000 / 1e6) * 6 + (1_000 / 1e6) * 22.5,
+        (200_000 / 1e6) * 3 + (1_000 / 1e6) * 15,
+        6,
+      );
+    });
+
+    it('switches to $6/$22.50 above 200k input tokens', () => {
+      expect(calculateBedrockCost(ID, 200_001, 1_000)).toBeCloseTo(
+        (200_001 / 1e6) * 6 + (1_000 / 1e6) * 22.5,
         6,
       );
     });

--- a/test/providers/bedrock/pricing.test.ts
+++ b/test/providers/bedrock/pricing.test.ts
@@ -146,6 +146,13 @@ describe('calculateBedrockCost', () => {
       calculateBedrockCost('global.amazon.nova-2-lite-v1:0', INPUT_TOKENS, OUTPUT_TOKENS),
     ).toBeCloseTo(costAtRates(0.3, 2.5), 6);
     expect(
+      calculateBedrockCost(
+        'arn:aws:bedrock:us-east-2::inference-profile/global.amazon.nova-2-lite-v1:0',
+        INPUT_TOKENS,
+        OUTPUT_TOKENS,
+      ),
+    ).toBeCloseTo(costAtRates(0.3, 2.5), 6);
+    expect(
       calculateBedrockCost('us.amazon.nova-2-lite-v1:0', INPUT_TOKENS, OUTPUT_TOKENS),
     ).toBeCloseTo(costAtRates(0.33, 2.75), 6);
   });


### PR DESCRIPTION
## Summary

Three defects in `src/providers/bedrock/pricing.ts`:

1. **Nova 2 Lite `global.` profile billed at the regional rate.** The table entry's own comment
   documented that the cross-region global profile is cheaper ($0.30/$2.50) than the plain
   us-east-1 meter ($0.33/$2.75), but nothing acted on it — `global.amazon.nova-2-lite-v1:0`
   (a supported id in `index.ts`, and documented in `aws-bedrock.md`) was overcharged by 10%.
   Fixed by adding a `global.amazon.nova-2-lite` key ahead of the plain one, which the
   tables' existing first-match-wins substring matching picks up for both the bare profile
   id and the inference-profile ARN.

2. **`bedrock:converse:us.openai.gpt-5.6-*` had no pricing entry**, so `calculateBedrockCost`
   returned `undefined` and the Converse route reported no cost at all. Added the rates
   documented in `site/docs/providers/aws-bedrock.md` (Sol $4.40/$22, Terra $2.20/$13.20,
   Luna $0.22/$1.32 per 1M) — these are exactly the first-party rates in
   `src/providers/openai/util.ts` (4/20, 2/12, 0.2/1.2) plus the 10% Bedrock
   regional-processing uplift, which is the cross-check I used, plus the documented 272K
   long-context tier (2x input / 1.5x output). These models are deliberately left out of
   `BEDROCK_INVOKE_PRICING_MODEL_PREFIXES` since InvokeModel does not serve GPT-5.6.
   GPT-5.5 / GPT-5.4 are not added: AWS does not publish Bedrock rates for them and the docs
   only claim Converse support for 5.6, so guessing would be worse than the current
   `undefined`. Cache-read/write discounts for these models are also not modeled (the
   non-Claude/non-Nova path ignores cache tokens today) — out of scope here.

3. **Long-context threshold was inclusive.** The Sonnet 4 tier triggered at
   `totalInputTokens >= threshold`, while the shared rule (`src/providers/shared.ts`,
   `src/providers/azure/util.ts`, `src/providers/google/vertex.ts`) uses strict `>`. Exactly
   200,000 input tokens billed at the premium tier here and the standard tier everywhere else.
   Now `>`. There is no shared exported long-context helper to reuse — the rule is an inline
   expression inside three different cost functions with different surrounding shapes — so this
   is a one-character consistency fix rather than a new abstraction.

### Simplifications

- Collapsed the three byte-identical prefix-match loops in `getBedrockPricing` into a single
  `matchPricing` helper, and folded the region-table "found or fail-closed" logic into one
  branch. Net −18 lines in that function.
- Dropped the now-stale comment claiming the frontier GPT-5.x models are not available through
  Converse (the docs and the model card say GPT-5.6 is).

The per-region pricing tables were considered for consolidation and deliberately left alone:
they look near-identical but hold genuinely different AWS-published meters per region, so
merging them would either change values or need a lookup layer that costs more than it saves.

## Test plan

`test/providers/bedrock/pricing.test.ts` — six new/changed assertions, all verified failing on
the pre-fix source and passing after:

- `bills the Nova 2 Lite global profile at its own cheaper meter` (global vs `us.` profile)
- `prices us.openai.gpt-5.6-{sol,terra,luna}` and `applies the 272k long-context tier`
- `stays fail-closed on InvokeModel, which does not serve these models`
- `bills exactly 200k input tokens at the standard rate` (this replaces the old
  `switches to $6/$22.50 at and above 200k input tokens`, which pinned the `>=` behavior; the
  above-threshold case is now pinned separately at 200,001)

```
$ npx vitest run test/providers/bedrock/pricing.test.ts   # (pre-fix source) 6 failed | 71 passed
$ npx vitest run test/providers/bedrock/                  # 14 files, 973 passed
$ npx tsc --noEmit -p tsconfig.json                       # clean
$ npx biome check --write src/providers/bedrock/pricing.ts test/providers/bedrock/pricing.test.ts
```
