### PR TITLE
fix(providers): cache unknown watsonx model prices

### DIFF
--- a/src/providers/watsonx.ts
+++ b/src/providers/watsonx.ts
@@ -240,7 +240,7 @@ function createWatsonXAuthCacheHash(authSelection: WatsonXAuthSelection): string
 // in memory per client so different regions/accounts never share model prices.
 let modelSpecsCache = new WeakMap<
   WatsonXAIClient,
-  Map<string, { expiresAt: number; cost: WatsonXModelCost }>
+  Map<string, { expiresAt: number; cost: WatsonXModelCost | undefined }>
 >();
 const MODEL_SPECS_CACHE_TTL_MS = 5 * 60 * 1000;
 
@@ -275,6 +275,7 @@ async function getModelCost(
       reject(new Error('WatsonX model pricing metadata request timed out'));
     }, getRequestTimeoutMs());
   });
+  let cost: WatsonXModelCost | undefined;
   try {
     const response = await Promise.race([
       client.listFoundationModelSpecs({
@@ -284,31 +285,31 @@ async function getModelCost(
       deadline,
     ]);
     const resources = response.result?.resources;
-    if (!Array.isArray(resources)) {
-      return undefined;
+    const spec = Array.isArray(resources)
+      ? resources.find((resource) => resource.model_id === modelId)
+      : undefined;
+    if (spec) {
+      cost = {
+        input: getPricingTierCost(spec.input_tier),
+        output: getPricingTierCost(spec.output_tier),
+      };
     }
-    const spec = resources.find((resource) => resource.model_id === modelId);
-    if (!spec) {
-      return undefined;
-    }
-    const cost = {
-      input: getPricingTierCost(spec.input_tier),
-      output: getPricingTierCost(spec.output_tier),
-    };
-    let clientCache = modelSpecsCache.get(client);
-    if (!clientCache) {
-      clientCache = new Map();
-      modelSpecsCache.set(client, clientCache);
-    }
-    clientCache.set(modelId, { expiresAt: Date.now() + MODEL_SPECS_CACHE_TTL_MS, cost });
-    return cost;
   } catch (error) {
     logger.debug('[WatsonX] Model pricing metadata is unavailable', { error });
-    // Do not cache failures: a later response can retry after recovery.
-    return undefined;
   } finally {
     clearTimeout(timeout);
   }
+
+  // Cache an unknown price too: a model missing from the catalog is a permanent
+  // answer, and a failing endpoint would otherwise cost one timeout-bounded
+  // request per eval row. The TTL still lets both recover.
+  let clientCache = modelSpecsCache.get(client);
+  if (!clientCache) {
+    clientCache = new Map();
+    modelSpecsCache.set(client, clientCache);
+  }
+  clientCache.set(modelId, { expiresAt: Date.now() + MODEL_SPECS_CACHE_TTL_MS, cost });
+  return cost;
 }
 
 async function calculateWatsonXCost(

--- a/test/providers/watsonx-cost.test.ts
+++ b/test/providers/watsonx-cost.test.ts
@@ -121,7 +121,8 @@ describe.each([false, true])('WatsonX regional cost (chat=%s)', (chat) => {
     },
   );
 
-  it('keeps a metadata failure out of the generation error and retries after recovery', async () => {
+  it('keeps a metadata failure out of the generation error and caches it until the TTL', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1000);
     const regionalClient = client();
     regionalClient.listFoundationModelSpecs.mockRejectedValueOnce(
       new Error('Metadata unavailable'),
@@ -133,11 +134,16 @@ describe.each([false, true])('WatsonX regional cost (chat=%s)', (chat) => {
     expect(first).toMatchObject({ output: 'Hello' });
     expect(first.error).toBeUndefined();
     expect(first.cost).toBeUndefined();
-    expect(second.cost).toBeCloseTo((10 * 0.106 + 20 * 0.371) / 1e6, 12);
+    expect(second.cost).toBeUndefined();
+    expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+
+    now.mockReturnValue(1000 + 5 * 60 * 1000);
+    const recovered = await instance.callApi('Hello once more');
+    expect(recovered.cost).toBeCloseTo((10 * 0.106 + 20 * 0.371) / 1e6, 12);
     expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(2);
   });
 
-  it('aborts stalled metadata at the request deadline and retries after recovery', async () => {
+  it('aborts stalled metadata at the request deadline and caches it until the TTL', async () => {
     vi.useFakeTimers();
     vi.stubEnv('REQUEST_TIMEOUT_MS', '50');
     const regionalClient = client();
@@ -173,7 +179,11 @@ describe.each([false, true])('WatsonX regional cost (chat=%s)', (chat) => {
     expect(result.cost).toBeUndefined();
     expect(vi.getTimerCount()).toBe(0);
 
-    const recovered = await instance.callApi('Hello again');
+    expect((await instance.callApi('Hello again')).cost).toBeUndefined();
+    expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    const recovered = await instance.callApi('Hello once more');
     expect(recovered.cost).toBeCloseTo((10 * 0.106 + 20 * 0.371) / 1e6, 12);
     expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(2);
     expect(vi.getTimerCount()).toBe(0);
@@ -213,7 +223,11 @@ describe.each([false, true])('WatsonX regional cost (chat=%s)', (chat) => {
 
       // Late SDK success must not populate the cache; rejection must remain handled.
       settleMetadata();
-      const recovered = await instance.callApi('Hello again');
+      expect((await instance.callApi('Hello again')).cost).toBeUndefined();
+      expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      const recovered = await instance.callApi('Hello once more');
       expect(recovered.cost).toBeCloseTo((10 * 0.106 + 20 * 0.371) / 1e6, 12);
       expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(2);
       expect(vi.getTimerCount()).toBe(0);
@@ -326,13 +340,18 @@ describe('WatsonX metadata cache boundaries', () => {
         ],
       },
     },
-  ])('does not cache missing or malformed model metadata: %j', async (unavailable) => {
+  ])('caches missing or malformed model metadata: %j', async (unavailable) => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1000);
     const regionalClient = client();
     regionalClient.listFoundationModelSpecs.mockResolvedValueOnce(unavailable as any);
     vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
     const instance = provider();
     expect((await instance.callApi('First')).cost).toBeUndefined();
-    expect((await instance.callApi('Second')).cost).toBeDefined();
+    expect((await instance.callApi('Second')).cost).toBeUndefined();
+    expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+
+    now.mockReturnValue(1000 + 5 * 60 * 1000);
+    expect((await instance.callApi('Third')).cost).toBeDefined();
     expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

`getModelCost` in `src/providers/watsonx.ts` cached only successful pricing lookups. Every other outcome returned `undefined` **uncached**:

- `!Array.isArray(resources)` — malformed response
- `!spec` — the model is not in the specs catalog
- the `catch` block, which carried the comment "Do not cache failures: a later response can retry after recovery."

So each eval row paid a fresh `client.listFoundationModelSpecs` call bounded by `getRequestTimeoutMs()`. With an unreachable or slow metadata endpoint that is one timeout per row. Worse, `!spec` is a **permanent** condition — a custom or private deployment that isn't in the catalog re-queried on every single row, forever, and never could succeed.

Fix: cache `WatsonXModelCost | undefined` under the existing per-client TTL. An unknown price is an answer like any other; the 5-minute TTL still lets a transient failure recover.

Simplification: the three early returns and the `catch`'s bespoke return are collapsed into a single exit path — one `cost` local, one cache write, one `return`. The cache-write block is no longer duplicated inside the happy path. Net +47/-27 across src and tests; the src function loses two branches.

The `WeakMap<WatsonXAIClient, …>` keying is untouched, so regions and accounts still never share prices.

## Test plan

Updated `test/providers/watsonx-cost.test.ts` — four cases previously asserted the un-cached behavior and now assert the cached one, each with an explicit TTL-expiry recovery so the retry path stays covered:

- metadata rejection → one call, both rows uncosted, refetch after the TTL
- deadline abort → one call, refetch after the TTL
- late SDK settlement after cancellation → still not written to the cache, refetch after the TTL
- missing / malformed / wrong-model metadata → one call, refetch after the TTL

```
$ npx vitest run test/providers/watsonx.test.ts test/providers/watsonx-preflight.test.ts test/providers/watsonx-cost.test.ts
Test Files  3 passed (3)      Tests  113 passed (113)

# same tests against the unfixed src (git stash push src/providers/watsonx.ts):
Tests  11 failed | 30 passed (41)

$ npx vitest run test/test-hygiene.test.ts
Test Files  1 passed (1)      Tests  115 passed (115)

$ npx tsc --noEmit -p tsconfig.json     # clean
$ npx biome check src/providers/watsonx.ts test/providers/watsonx-cost.test.ts   # clean
```