### PR TITLE
fix(providers): translate chat prompts for azure responses

### DIFF
--- a/src/providers/azure/responses.ts
+++ b/src/providers/azure/responses.ts
@@ -10,6 +10,7 @@ import invariant from '../../util/invariant';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { applyGpt6AstraRequestRules, isGpt6AstraModel } from '../openai/gpt6';
 import { ResponsesProcessor } from '../responses/index';
+import { parseResponsesInput } from '../responses/input';
 import { getRequestTimeoutMs, LONG_RUNNING_MODEL_TIMEOUT_MS } from '../shared';
 import { AzureGenericProvider } from './generic';
 import { calculateAzureCost } from './util';
@@ -39,7 +40,9 @@ export class AzureResponsesProvider extends AzureGenericProvider {
 
     // Initialize the shared response processor
     this.processor = new ResponsesProcessor({
-      modelName: this.deploymentName,
+      // A deployment name is arbitrary, so an explicit `modelName` is what the price table is
+      // keyed on; the request body's `model` only names a real model when `passthrough` set it.
+      modelName: this.config.modelName ?? this.deploymentName,
       providerType: 'azure',
       functionCallbackHandler: this.functionCallbackHandler,
       // The processor invokes costCalculator(modelName, data.usage, requestConfig). calculateAzureCost
@@ -47,7 +50,9 @@ export class AzureResponsesProvider extends AzureGenericProvider {
       // the Responses-shaped usage object (input_tokens/output_tokens) so cost is non-zero.
       costCalculator: (modelName: string, usage: any, config?: any) =>
         calculateAzureCost(
-          typeof config?.model === 'string' ? config.model : modelName,
+          typeof config?.model === 'string' && config.model !== this.deploymentName
+            ? config.model
+            : modelName,
           {
             ...config,
             passthrough: {
@@ -129,17 +134,7 @@ export class AzureResponsesProvider extends AzureGenericProvider {
       ...context?.prompt?.config,
     };
 
-    let input;
-    try {
-      const parsedJson = JSON.parse(prompt);
-      if (Array.isArray(parsedJson)) {
-        input = parsedJson;
-      } else {
-        input = prompt;
-      }
-    } catch {
-      input = prompt;
-    }
+    const input = parseResponsesInput(prompt);
 
     const passthroughModel = (config.passthrough as { model?: unknown } | undefined)?.model;
     const capabilityModelName = (

--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -23,7 +23,7 @@ import { isSecretField, sanitizeUrl } from '../../util/sanitizer';
 import { sleep } from '../../util/time';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { ResponsesProcessor } from '../responses/index';
-import { normalizeResponsesInput } from '../responses/input';
+import { parseResponsesInput } from '../responses/input';
 import { readResponsesStream } from '../responses/stream';
 import { getRequestTimeoutMs, LONG_RUNNING_MODEL_TIMEOUT_MS } from '../shared';
 import { buildChatSpanContext, extractProviderResponseAttributes, withGenAISpan } from '../tracing';
@@ -860,20 +860,7 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
       ...context?.prompt?.config,
     };
 
-    // Chat-format content parts are translated to their Responses equivalents so multimodal
-    // prompts authored for the chat API work here too (the Responses API rejects
-    // `type: "text"` / `"image_url"` outright).
-    let input;
-    try {
-      const parsedJson = JSON.parse(prompt);
-      if (Array.isArray(parsedJson)) {
-        input = normalizeResponsesInput(parsedJson);
-      } else {
-        input = prompt;
-      }
-    } catch {
-      input = prompt;
-    }
+    const input = parseResponsesInput(prompt);
 
     const {
       isAzureResponsesDeploymentWithReasoningConfig,

--- a/src/providers/responses/input.ts
+++ b/src/providers/responses/input.ts
@@ -68,13 +68,9 @@ function normalizeContentPart(part: unknown, role: unknown): unknown {
  *
  * Only role-bearing message objects are touched. Explicit `type: 'message'` input items are
  * messages too; other typed items (function calls, tool outputs, reasoning items) must keep
- * their shape verbatim. A non-array input (a plain string prompt) is returned unchanged.
+ * their shape verbatim.
  */
-function normalizeResponsesInput<T>(input: T): T {
-  if (!Array.isArray(input)) {
-    return input;
-  }
-
+function normalizeResponsesInput(input: unknown[]): unknown[] {
   return input.map((item) => {
     if (!item || typeof item !== 'object' || Array.isArray(item)) {
       return item;
@@ -91,7 +87,7 @@ function normalizeResponsesInput<T>(input: T): T {
       ...message,
       content: message.content.map((part) => normalizeContentPart(part, message.role)),
     };
-  }) as T;
+  });
 }
 
 /**

--- a/src/providers/responses/input.ts
+++ b/src/providers/responses/input.ts
@@ -70,7 +70,7 @@ function normalizeContentPart(part: unknown, role: unknown): unknown {
  * messages too; other typed items (function calls, tool outputs, reasoning items) must keep
  * their shape verbatim. A non-array input (a plain string prompt) is returned unchanged.
  */
-export function normalizeResponsesInput<T>(input: T): T {
+function normalizeResponsesInput<T>(input: T): T {
   if (!Array.isArray(input)) {
     return input;
   }
@@ -92,4 +92,20 @@ export function normalizeResponsesInput<T>(input: T): T {
       content: message.content.map((part) => normalizeContentPart(part, message.role)),
     };
   }) as T;
+}
+
+/**
+ * Turn a prompt into the Responses API `input` field.
+ *
+ * A prompt that parses as a JSON array is a message list, so it is normalized; anything else (a
+ * plain string, or JSON that isn't an array) is sent verbatim. Every `*:responses:*` provider
+ * builds `input` through here so none of them can miss the chat-format translation.
+ */
+export function parseResponsesInput(prompt: string): unknown {
+  try {
+    const parsed = JSON.parse(prompt);
+    return Array.isArray(parsed) ? normalizeResponsesInput(parsed) : prompt;
+  } catch {
+    return prompt;
+  }
 }

--- a/src/providers/xai/responses.ts
+++ b/src/providers/xai/responses.ts
@@ -9,7 +9,7 @@ import {
 } from '../../util/index';
 import { FunctionCallbackHandler } from '../functionCallbackUtils';
 import { ResponsesProcessor } from '../responses/index';
-import { normalizeResponsesInput } from '../responses/input';
+import { parseResponsesInput } from '../responses/input';
 import { readResponsesStream } from '../responses/stream';
 import { getRequestTimeoutMs } from '../shared';
 import {
@@ -280,20 +280,7 @@ export class XAIResponsesProvider implements ApiProvider {
       ...context?.prompt?.config,
     };
 
-    // Parse input - can be string or array of messages. Chat-format content parts are
-    // translated to their Responses equivalents so multimodal prompts authored for the chat
-    // API work here too (the Responses API rejects `type: "text"` / `"image_url"` outright).
-    let input;
-    try {
-      const parsedJson = JSON.parse(prompt);
-      if (Array.isArray(parsedJson)) {
-        input = normalizeResponsesInput(parsedJson);
-      } else {
-        input = prompt;
-      }
-    } catch {
-      input = prompt;
-    }
+    const input = parseResponsesInput(prompt);
 
     // Handle max_output_tokens
     const maxOutputTokens = config.max_output_tokens ?? 4096;

--- a/test/providers/azure/responses.test.ts
+++ b/test/providers/azure/responses.test.ts
@@ -371,6 +371,34 @@ describe('AzureResponsesProvider', () => {
       });
       expect(body.text.verbosity).toBeUndefined();
     });
+
+    it('translates chat-format content parts into Responses parts', async () => {
+      // Azure was left out when the chat-format translation landed, so multimodal prompts were
+      // forwarded raw and rejected by the API.
+      const provider = new AzureResponsesProvider('gpt-4.1-test');
+
+      const body = await provider.getAzureResponsesBody(
+        JSON.stringify([
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What color is this?' },
+              { type: 'image_url', image_url: { url: 'https://x/y.png', detail: 'low' } },
+            ],
+          },
+        ]),
+      );
+
+      expect(body.input).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'What color is this?' },
+            { type: 'input_image', image_url: 'https://x/y.png', detail: 'low' },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('callApi', () => {
@@ -483,6 +511,33 @@ describe('AzureResponsesProvider', () => {
       // gpt-4.1 is priced in AZURE_MODELS, and tokens now flow through, so cost must be > 0.
       expect(result.cost).toBeGreaterThan(0);
       expect(result.tokenUsage).toMatchObject({ prompt: 1000, completion: 500 });
+    });
+
+    it('prices an arbitrarily named deployment from its configured modelName', async () => {
+      // Cost was looked up from the request body's `model` (always the deployment name), so a
+      // deployment not named after a priced model reported no cost at all.
+      mockFetchWithCache.mockResolvedValue({
+        data: {
+          output: [
+            { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '4' }] },
+          ],
+          usage: { input_tokens: 1_000, output_tokens: 500 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const provider = new AzureResponsesProvider('my-deployment', {
+        config: { modelName: 'gpt-5.6' },
+      });
+      vi.spyOn(provider, 'ensureInitialized').mockImplementation(async function () {
+        (provider as any).authHeaders = { 'api-key': 'test-key' };
+      });
+
+      const result = await provider.callApi('What is 2+2?');
+
+      expect(result.cost).toBeCloseTo((1_000 * 5 + 500 * 30) / 1e6, 12);
     });
 
     it('applies the cached-input rate from Responses usage details', async () => {

--- a/test/providers/responses/input.test.ts
+++ b/test/providers/responses/input.test.ts
@@ -1,32 +1,32 @@
 import { describe, expect, it } from 'vitest';
-import { normalizeResponsesInput } from '../../../src/providers/responses/input';
+import { parseResponsesInput } from '../../../src/providers/responses/input';
 
-describe('normalizeResponsesInput', () => {
-  it('returns non-array input unchanged', () => {
-    expect(normalizeResponsesInput('a plain string prompt')).toBe('a plain string prompt');
-    expect(normalizeResponsesInput(undefined)).toBeUndefined();
-    expect(normalizeResponsesInput(null)).toBeNull();
+const parse = (input: unknown) => parseResponsesInput(JSON.stringify(input));
+
+describe('parseResponsesInput', () => {
+  it('returns the prompt unchanged when it is not a JSON array', () => {
+    expect(parseResponsesInput('a plain string prompt')).toBe('a plain string prompt');
+    expect(parseResponsesInput('{"role":"user"}')).toBe('{"role":"user"}');
+    expect(parseResponsesInput('[unterminated')).toBe('[unterminated');
   });
 
   it('rewrites chat-format text parts to input_text', () => {
     // The Responses API rejects `type: "text"` outright (xAI 422, OpenAI 400), so a prompt
     // authored in the chat format must be translated rather than passed through.
-    expect(
-      normalizeResponsesInput([{ role: 'user', content: [{ type: 'text', text: 'hello' }] }]),
-    ).toEqual([{ role: 'user', content: [{ type: 'input_text', text: 'hello' }] }]);
+    expect(parse([{ role: 'user', content: [{ type: 'text', text: 'hello' }] }])).toEqual([
+      { role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+    ]);
   });
 
   it('uses output_text for assistant turns', () => {
     expect(
-      normalizeResponsesInput([
-        { role: 'assistant', content: [{ type: 'text', text: 'prior reply' }] },
-      ]),
+      parse([{ role: 'assistant', content: [{ type: 'text', text: 'prior reply' }] }]),
     ).toEqual([{ role: 'assistant', content: [{ type: 'output_text', text: 'prior reply' }] }]);
   });
 
   it('flattens nested chat image_url parts into input_image', () => {
     expect(
-      normalizeResponsesInput([
+      parse([
         {
           role: 'user',
           content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } }],
@@ -42,7 +42,7 @@ describe('normalizeResponsesInput', () => {
 
   it('preserves the image detail hint from either nesting level', () => {
     expect(
-      normalizeResponsesInput([
+      parse([
         {
           role: 'user',
           content: [{ type: 'image_url', image_url: { url: 'https://x/y.png', detail: 'low' } }],
@@ -58,9 +58,7 @@ describe('normalizeResponsesInput', () => {
 
   it('accepts an already-flat image_url string', () => {
     expect(
-      normalizeResponsesInput([
-        { role: 'user', content: [{ type: 'image_url', image_url: 'https://x/y.png' }] },
-      ]),
+      parse([{ role: 'user', content: [{ type: 'image_url', image_url: 'https://x/y.png' }] }]),
     ).toEqual([{ role: 'user', content: [{ type: 'input_image', image_url: 'https://x/y.png' }] }]);
   });
 
@@ -75,7 +73,7 @@ describe('normalizeResponsesInput', () => {
         ],
       },
     ];
-    expect(normalizeResponsesInput(input)).toEqual(input);
+    expect(parse(input)).toEqual(input);
   });
 
   it('normalizes explicitly typed message items but preserves other typed input items', () => {
@@ -86,7 +84,7 @@ describe('normalizeResponsesInput', () => {
       { type: 'function_call_output', call_id: 'call_1', output: 'done' },
       { type: 'message', role: 'user', content: [{ type: 'text', text: 'hello' }] },
     ];
-    expect(normalizeResponsesInput(input)).toEqual([
+    expect(parse(input)).toEqual([
       { type: 'function_call', call_id: 'call_1', name: 'lookup', arguments: '{}' },
       { type: 'function_call_output', call_id: 'call_1', output: 'done' },
       { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
@@ -102,12 +100,12 @@ describe('normalizeResponsesInput', () => {
       'not an object',
       null,
     ];
-    expect(normalizeResponsesInput(input)).toEqual(input);
+    expect(parse(input)).toEqual(input);
   });
 
   it('normalizes a mixed multimodal turn end to end', () => {
     expect(
-      normalizeResponsesInput([
+      parse([
         { role: 'system', content: [{ type: 'text', text: 'be terse' }] },
         {
           role: 'user',


### PR DESCRIPTION
## Summary

`AzureResponsesProvider` extends `AzureGenericProvider`, not `OpenAiResponsesProvider`, so it never inherited the chat-format content-part translation added in #10592 (`normalizeResponsesInput`, wired only into `openai/responses.ts` and `xai/responses.ts`). A multimodal prompt on `azure:responses:*` — the usual `{type: 'text'}` / `{type: 'image_url'}` chat parts — was forwarded raw and rejected by the API. `GroqResponsesProvider`, `BedrockOpenAiResponsesProvider` and `OpenClawResponsesProvider` all extend the OpenAI class and were unaffected.

Rather than adding a fourth copy of the call, the identical JSON-parse-then-normalize block that `openai/` and `xai/` had each copied is folded into one `parseResponsesInput()` in `src/providers/responses/input.ts`, and all three providers now build `input` through it — so the next Responses provider can't miss the translation. `normalizeResponsesInput` becomes internal to that module. Net **-15 lines in `src/`**.

Second fix, same file: cost was looked up from the request body's `model`, which for Azure is always the deployment name, so a deployment with an explicit `modelName` (`my-deployment` serving `gpt-5.6`) reported no cost at all. The processor is now keyed on `config.modelName ?? deploymentName`, and the body's `model` is only preferred when `passthrough` overrode it — matching the precedence in `azure/chat.ts`.

## Test plan

Two regression tests added in `test/providers/azure/responses.test.ts` (both verified failing on the pre-fix provider, `2 failed | 40 passed`):
- `translates chat-format content parts into Responses parts`
- `prices an arbitrarily named deployment from its configured modelName`

`test/providers/responses/input.test.ts` now exercises the same cases through `parseResponsesInput`, covering the parse path as well.

```
$ npx vitest run test/providers/openai test/providers/xai test/providers/azure test/providers/responses
Test Files  66 passed | 1 skipped
Tests  2768 passed | 9 skipped

$ npx tsc --noEmit -p tsconfig.json     # clean
$ npx biome check <changed files>       # 5 pre-existing complexity warnings, no errors
$ npx knip --no-progress                # clean
```