### PR TITLE
fix(providers): bill deepseek cached prompt tokens correctly

### DIFF
--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -1,8 +1,10 @@
 import logger from '../logger';
 import { OpenAiChatCompletionProvider } from './openai/chat';
+import { getOpenAICompletionTokenDetails } from './openai/util';
 import { calculateCost, clampCachedTokens } from './shared';
 
 import type { ApiProvider, ProviderOptions } from '../types/index';
+import type { OpenAiChatCompletionCostData } from './openai/chat';
 import type { OpenAiCompletionOptions } from './openai/types';
 
 type DeepSeekConfig = OpenAiCompletionOptions;
@@ -97,8 +99,6 @@ export function calculateDeepSeekCost(
 }
 
 class DeepSeekProvider extends OpenAiChatCompletionProvider {
-  private originalConfig?: DeepSeekConfig;
-
   protected get apiKey(): string | undefined {
     return this.config?.apiKey;
   }
@@ -116,8 +116,6 @@ class DeepSeekProvider extends OpenAiChatCompletionProvider {
         apiBaseUrl: 'https://api.deepseek.com/v1',
       },
     });
-
-    this.originalConfig = deepseekConfig;
   }
 
   id(): string {
@@ -139,43 +137,21 @@ class DeepSeekProvider extends OpenAiChatCompletionProvider {
     };
   }
 
-  async callApi(prompt: string, context?: any, callApiOptions?: any): Promise<any> {
-    const response = await super.callApi(prompt, context, callApiOptions);
-
-    if (!response || response.error) {
-      return response;
+  protected override calculateResponseCost(
+    data: OpenAiChatCompletionCostData,
+    config: OpenAiCompletionOptions,
+    cached: boolean,
+  ): number | undefined {
+    if (cached) {
+      return 0;
     }
-
-    // Extract cache hit information if available
-    let cachedTokens = 0;
-    if (typeof response.raw === 'string') {
-      try {
-        const rawData = JSON.parse(response.raw);
-        if (rawData?.usage?.prompt_tokens_details?.cached_tokens) {
-          cachedTokens = rawData.usage.prompt_tokens_details.cached_tokens;
-        }
-      } catch (err) {
-        logger.debug(`Failed to parse raw response for cache info: ${err}`);
-      }
-    } else if (typeof response.raw === 'object' && response.raw !== null) {
-      const rawData = response.raw;
-      if (rawData?.usage?.prompt_tokens_details?.cached_tokens) {
-        cachedTokens = rawData.usage.prompt_tokens_details.cached_tokens;
-      }
-    }
-
-    // Calculate cost with cache information
-    if (response.tokenUsage && !response.cached) {
-      response.cost = calculateDeepSeekCost(
-        this.modelName,
-        this.config || {},
-        response.tokenUsage.prompt,
-        response.tokenUsage.completion,
-        cachedTokens,
-      );
-    }
-
-    return response;
+    return calculateDeepSeekCost(
+      this.modelName,
+      config,
+      data.usage?.prompt_tokens,
+      data.usage?.completion_tokens,
+      getOpenAICompletionTokenDetails(data.usage ?? {})?.cacheReadInputTokens,
+    );
   }
 }
 

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -979,12 +979,14 @@ export function getOpenAICacheWriteInputTokens(usage: any): number | undefined {
 export function getOpenAICompletionTokenDetails(
   usage: any,
 ): TokenUsage['completionDetails'] | undefined {
-  // Some OpenAI-compatible APIs (e.g. Moonshot) report cached prompt tokens at
-  // the top level of usage instead of inside prompt_tokens_details.
+  // Some OpenAI-compatible APIs report cached prompt tokens at the top level of
+  // usage instead of inside prompt_tokens_details: Moonshot uses `cached_tokens`
+  // and DeepSeek uses `prompt_cache_hit_tokens`.
   const cachedInputTokens =
     usage.prompt_tokens_details?.cached_tokens ??
     usage.input_tokens_details?.cached_tokens ??
     usage.cached_tokens ??
+    usage.prompt_cache_hit_tokens ??
     0;
   const cacheWriteInputTokens = getOpenAICacheWriteInputTokens(usage);
   const completionDetails = usage.completion_tokens_details ?? usage.output_tokens_details;

--- a/test/providers/deepseek.test.ts
+++ b/test/providers/deepseek.test.ts
@@ -161,7 +161,10 @@ describe('DeepSeekProvider cost reporting', () => {
           prompt_tokens: 100,
           completion_tokens: 50,
           total_tokens: 150,
-          prompt_tokens_details: { cached_tokens: cached },
+          // DeepSeek's wire format: cache hits are reported at the top level of
+          // usage, not inside prompt_tokens_details.
+          prompt_cache_hit_tokens: cached,
+          prompt_cache_miss_tokens: 100 - cached,
         },
       },
       cached: false,

--- a/test/providers/deepseek.test.ts
+++ b/test/providers/deepseek.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../src/cache';
 import {
   calculateDeepSeekCost,
   createDeepSeekProvider,
   DEEPSEEK_CHAT_MODELS,
 } from '../../src/providers/deepseek';
+
+vi.mock('../../src/cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/cache')>()),
+  fetchWithCache: vi.fn(),
+}));
 
 describe('DeepSeek usage boundaries', () => {
   it('bills input-only and output-only responses and preserves valid zero usage', () => {
@@ -139,5 +145,56 @@ describe('DEEPSEEK_CHAT_MODELS', () => {
 describe('createDeepSeekProvider', () => {
   it('should preserve the historical non-thinking default', () => {
     expect(createDeepSeekProvider('deepseek').id()).toBe('deepseek:deepseek-chat');
+  });
+});
+
+describe('DeepSeekProvider cost reporting', () => {
+  beforeEach(() => {
+    vi.mocked(fetchWithCache).mockReset();
+  });
+
+  it.each([0, 40, 100])('bills %s cached prompt tokens at the cache-read rate', async (cached) => {
+    vi.mocked(fetchWithCache).mockResolvedValueOnce({
+      data: {
+        choices: [{ message: { content: 'DeepSeek response' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 100,
+          completion_tokens: 50,
+          total_tokens: 150,
+          prompt_tokens_details: { cached_tokens: cached },
+        },
+      },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    });
+
+    const provider = createDeepSeekProvider('deepseek:deepseek-chat', {
+      config: { config: { apiKey: 'fixture-key' } },
+    });
+    const result = await provider.callApi('Test prompt');
+
+    expect(result.cost).toBe(calculateDeepSeekCost('deepseek-chat', {}, 100, 50, cached));
+    expect(result.tokenUsage?.completionDetails?.cacheReadInputTokens).toBe(
+      cached === 0 ? undefined : cached,
+    );
+  });
+
+  it('reports zero incremental cost for promptfoo cache hits', async () => {
+    vi.mocked(fetchWithCache).mockResolvedValueOnce({
+      data: {
+        choices: [{ message: { content: 'Cached DeepSeek response' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+      },
+      cached: true,
+      status: 200,
+      statusText: 'OK',
+    });
+
+    const provider = createDeepSeekProvider('deepseek:deepseek-chat', {
+      config: { config: { apiKey: 'fixture-key' } },
+    });
+
+    await expect(provider.callApi('Test prompt')).resolves.toMatchObject({ cached: true, cost: 0 });
   });
 });

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -167,6 +167,29 @@ describe('getTokenUsage', () => {
     });
   });
 
+  it('should read cached tokens from usage.prompt_cache_hit_tokens (e.g. DeepSeek)', () => {
+    const data = {
+      usage: {
+        total_tokens: 100,
+        prompt_tokens: 40,
+        completion_tokens: 60,
+        prompt_cache_hit_tokens: 32,
+        prompt_cache_miss_tokens: 8,
+      },
+    };
+
+    const result = getTokenUsage(data, false);
+    expect(result).toEqual({
+      total: 100,
+      prompt: 40,
+      completion: 60,
+      numRequests: 1,
+      completionDetails: {
+        cacheReadInputTokens: 32,
+      },
+    });
+  });
+
   it('should prefer prompt_tokens_details.cached_tokens over the top-level field', () => {
     const data = {
       usage: {


### PR DESCRIPTION
## Summary

The DeepSeek cache-hit discount was dead code. `DeepSeekProvider.callApi` post-processed `super.callApi()`'s `ProviderResponse` looking for `response.raw`, but the base OpenAI chat provider never sets `raw` on its response (`grep -n "raw:" src/providers/openai/chat.ts` returns nothing). So `cachedTokens` was always `0`, and cached prompt tokens were billed at the full input rate. DeepSeek's cache-read rate is ~1/50th of the input rate (`0.0028` vs `0.14` per 1M for `deepseek-chat`), so reported cost was materially overstated for cache-heavy workloads.

MiniMax got the correct shape in #10745: read cached tokens from the raw `data.usage` inside the `calculateResponseCost` hook, where the usage payload is actually available. DeepSeek was left on the old broken shape.

This is **not a 0.122.2 regression** — the defect predates it — but it is a real cost-reporting error and the correct fix now exists in-repo, so it is worth landing.

Changes:

- Deleted the entire `callApi` override: two `response.raw` parsing branches, the `try`/`catch`, the `logger.debug`, and the manual `response.cost` assignment.
- Replaced it with a `calculateResponseCost` override that reads cached tokens via the shared `getOpenAICompletionTokenDetails(data.usage)?.cacheReadInputTokens`, exactly as `minimax.ts` does.
- Deleted the dead `private originalConfig` field (assigned in the constructor, never read).
- Taught `getOpenAICompletionTokenDetails` to read DeepSeek's top-level `usage.prompt_cache_hit_tokens`. DeepSeek does **not** send `prompt_tokens_details.cached_tokens` — [its documented usage schema](https://api-docs.deepseek.com/api/create-chat-completion) is `prompt_tokens`, `prompt_cache_hit_tokens`, `prompt_cache_miss_tokens`, `completion_tokens`, `total_tokens`; the nested `prompt_tokens_details.cached_tokens` shape is LiteLLM's normalization, not the wire format. Without this the hook still read a field DeepSeek never sends, so cached tokens stayed billed at the full input rate (and never appeared in `tokenUsage.completionDetails`). This sits next to the existing Moonshot top-level `cached_tokens` fallback.

Two incidental correctness improvements fall out of the hook: the cost now uses the merged config (so prompt-level `inputCost`/`outputCost`/`cacheReadCost` overrides apply — the old override read `this.config`, ignoring them), and promptfoo cache hits now report `cost: 0` instead of `undefined`, matching MiniMax and the base OpenAI billing path.

## Test plan

Added a regression block to `test/providers/deepseek.test.ts` that drives `callApi` through a mocked `fetchWithCache` with DeepSeek's real usage shape (`prompt_cache_hit_tokens` / `prompt_cache_miss_tokens`) and asserts the response is billed at the cache-read rate for 0 / 40 / 100 cached prompt tokens, plus a promptfoo-cache-hit case. Added a `getTokenUsage` case in `test/providers/openai/util.test.ts` for the same field.

```
$ npx vitest run test/providers/deepseek.test.ts test/providers/openai/util.test.ts
Test Files  2 passed (2) | Tests  232 passed (232)

# reverting only src/providers/deepseek.ts:      3 failed
# reverting only src/providers/openai/util.ts:   3 failed (40- and 100-cached-token billing, plus the util case)

$ npx vitest run test/providers/openai test/providers/deepseek.test.ts test/providers/moonshot.test.ts test/providers/minimax.test.ts
Test Files  45 passed | 1 skipped (46) | Tests  1929 passed | 9 skipped (1938)

$ npx tsc --noEmit -p tsconfig.json          # clean
$ npx biome check src/providers/openai/util.ts test/providers/openai/util.test.ts test/providers/deepseek.test.ts   # clean
```
