### PR TITLE
fix(providers): stop leaking OPENAI_API_KEY to portkey upstreams

### DIFF
--- a/site/docs/integrations/portkey.md
+++ b/site/docs/integrations/portkey.md
@@ -50,12 +50,12 @@ providers:
 
 A Portkey request can carry two credentials, and they are sent in different places:
 
-| Credential                  | Sent as                 | Set with                                        |
-| --------------------------- | ----------------------- | ----------------------------------------------- |
-| Your Portkey key            | `x-portkey-api-key`     | `PORTKEY_API_KEY`, or `portkeyApiKey` in config |
-| The upstream provider's key | `Authorization: Bearer` | `OPENAI_API_KEY`, or `apiKey` in config         |
+| Credential                  | Sent as                 | Set with                                                               |
+| --------------------------- | ----------------------- | ---------------------------------------------------------------------- |
+| Your Portkey key            | `x-portkey-api-key`     | `PORTKEY_API_KEY`, or `portkeyApiKey` in config                        |
+| The upstream provider's key | `Authorization: Bearer` | `apiKey` in config, or `OPENAI_API_KEY` when `portkeyProvider: openai` |
 
-When Portkey holds the provider credential — a model catalog provider slug or a virtual key — the Portkey key is all you need, and promptfoo does not forward a provider key. A provider key is only sent for direct passthrough, such as `portkeyProvider: openai` with no slug.
+A provider key is only sent for direct passthrough, meaning a `portkeyProvider` that is not a model catalog slug. Everywhere else — a slug (in `portkeyProvider` or in the model name), a virtual key, or a bare model name — Portkey holds the provider credential, so the Portkey key is all you need and promptfoo forwards nothing. `OPENAI_API_KEY` is inherited only when the config routes to OpenAI; passthrough to any other provider needs an explicit `apiKey`.
 
 To send additional headers, use `config.headers`:
 

--- a/src/providers/portkey.ts
+++ b/src/providers/portkey.ts
@@ -177,11 +177,16 @@ export class PortkeyChatCompletionProvider extends OpenAiChatCompletionProvider 
    * inherited from a shared provider config. `OPENAI_API_KEY` names one specific vendor's
    * credential, so it is inherited only when the config routes to that vendor; otherwise a
    * `portkey:claude-sonnet-4-6` target would ship the user's OpenAI key to a different
-   * provider. Callers that need another bearer can set one explicitly through `config.apiKey`
-   * or `config.headers`.
+   * provider. A passthrough to another vendor takes its bearer from `config.apiKey`; in the
+   * managed shapes, where nothing is forwarded, only `config.headers` can still set one.
    */
   getApiKey(): string | undefined {
-    const upstream = this.config.portkeyProvider;
+    // Provider names come from user YAML, so guard the type and compare case-insensitively:
+    // `portkeyProvider: OpenAI` names the same upstream as `openai`.
+    const upstream =
+      typeof this.config.portkeyProvider === 'string'
+        ? this.config.portkeyProvider.toLowerCase()
+        : '';
     if (
       !upstream ||
       upstream.startsWith('@') ||

--- a/src/providers/portkey.ts
+++ b/src/providers/portkey.ts
@@ -1,4 +1,5 @@
 import { getEnvString } from '../envars';
+import { resolveProviderApiKey } from './credentials';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { hasHeaderOverride } from './openai/index';
 
@@ -119,18 +120,6 @@ function resolvePortkeyApiKey(
   return config.portkeyApiKey || env?.PORTKEY_API_KEY || getEnvString('PORTKEY_API_KEY');
 }
 
-/**
- * True when Portkey itself holds the upstream provider credential — a model catalog slug
- * (`@provider/model`) or a legacy virtual key — so there is no provider key to forward.
- */
-function usesManagedCredentials(modelName: string, config: PortkeyConfig): boolean {
-  return Boolean(
-    config.portkeyVirtualKey ||
-      config.portkeyProvider?.startsWith('@') ||
-      modelName.startsWith('@'),
-  );
-}
-
 export class PortkeyChatCompletionProvider extends OpenAiChatCompletionProvider {
   declare config: PortkeyConfig;
 
@@ -181,18 +170,25 @@ export class PortkeyChatCompletionProvider extends OpenAiChatCompletionProvider 
 
   /**
    * Resolves the `Authorization` bearer, which Portkey forwards to the upstream provider.
-   * The inherited implementation returned the Portkey key here (leaving Portkey's own header
-   * unset) and otherwise fell back to `OPENAI_API_KEY`, sending an OpenAI key to the gateway
-   * even when Portkey already held the provider credential.
+   *
+   * Only a direct passthrough sends one. A model catalog slug (`@provider/model`), a legacy
+   * virtual key, and a bare model name all leave the provider credential with Portkey, so
+   * nothing is forwarded there — including an apiKey inherited from a shared provider config.
+   * `OPENAI_API_KEY` names one specific vendor's credential, so it is inherited only when the
+   * config routes to that vendor; otherwise a `portkey:claude-sonnet-4-6` target would ship
+   * the user's OpenAI key to a different provider. Callers that need another bearer can set
+   * one explicitly through `config.apiKey` or `config.headers`.
    */
   getApiKey(): string | undefined {
-    // Portkey owns the upstream credential for catalog slugs and virtual keys, so forward
-    // nothing — including an apiKey inherited from a shared provider config. Callers that
-    // still need a bearer can set one explicitly through `config.headers`.
-    if (usesManagedCredentials(this.modelName, this.config)) {
+    const upstream = this.config.portkeyProvider;
+    if (!upstream || upstream.startsWith('@') || this.config.portkeyVirtualKey) {
       return undefined;
     }
-    return this.config.apiKey || this.env?.OPENAI_API_KEY || getEnvString('OPENAI_API_KEY');
+    return resolveProviderApiKey(
+      { apiKey: this.config.apiKey },
+      this.env,
+      upstream === 'openai' ? ['OPENAI_API_KEY'] : [],
+    );
   }
 
   protected override getMissingApiKeyErrorMessage(): string {

--- a/src/providers/portkey.ts
+++ b/src/providers/portkey.ts
@@ -171,19 +171,28 @@ export class PortkeyChatCompletionProvider extends OpenAiChatCompletionProvider 
   /**
    * Resolves the `Authorization` bearer, which Portkey forwards to the upstream provider.
    *
-   * Only a direct passthrough sends one. A model catalog slug (`@provider/model`), a legacy
-   * virtual key, and a bare model name all leave the provider credential with Portkey, so
-   * nothing is forwarded there — including an apiKey inherited from a shared provider config.
-   * `OPENAI_API_KEY` names one specific vendor's credential, so it is inherited only when the
-   * config routes to that vendor; otherwise a `portkey:claude-sonnet-4-6` target would ship
-   * the user's OpenAI key to a different provider. Callers that need another bearer can set
-   * one explicitly through `config.apiKey` or `config.headers`.
+   * Only a direct passthrough sends one. A model catalog slug (`@provider/model`, in the model
+   * name or in `portkeyProvider`), a legacy virtual key, and a bare model name all leave the
+   * provider credential with Portkey, so nothing is forwarded there — including an apiKey
+   * inherited from a shared provider config. `OPENAI_API_KEY` names one specific vendor's
+   * credential, so it is inherited only when the config routes to that vendor; otherwise a
+   * `portkey:claude-sonnet-4-6` target would ship the user's OpenAI key to a different
+   * provider. Callers that need another bearer can set one explicitly through `config.apiKey`
+   * or `config.headers`.
    */
   getApiKey(): string | undefined {
     const upstream = this.config.portkeyProvider;
-    if (!upstream || upstream.startsWith('@') || this.config.portkeyVirtualKey) {
+    if (
+      !upstream ||
+      upstream.startsWith('@') ||
+      this.modelName.startsWith('@') ||
+      this.config.portkeyVirtualKey
+    ) {
       return undefined;
     }
+    // Only `apiKey` is passed through: the constructor sets `apiKeyEnvar` to PORTKEY_API_KEY
+    // for the missing-key diagnostics, and honouring it here would put Portkey's own key in
+    // the bearer.
     return resolveProviderApiKey(
       { apiKey: this.config.apiKey },
       this.env,

--- a/test/providers/portkey.test.ts
+++ b/test/providers/portkey.test.ts
@@ -266,6 +266,16 @@ describe('PortkeyChatCompletionProvider', () => {
       ['model catalog slug in the model name', '@bedrock-eu/claude', {}],
       ['model catalog slug in portkeyProvider', 'claude', { portkeyProvider: '@bedrock-eu' }],
       ['legacy virtual key', 'claude', { portkeyVirtualKey: 'bedrock-prod' }],
+      ['bare model name', 'claude-sonnet-4-6', {}],
+      ['slug-shaped model name', 'anthropic-slug/claude-sonnet-4-6', {}],
+      [
+        'virtual key alongside an openai passthrough',
+        'gpt-4o',
+        {
+          portkeyProvider: 'openai',
+          portkeyVirtualKey: 'openai-prod',
+        },
+      ],
     ])(
       'should not leak OPENAI_API_KEY when Portkey holds the credential (%s)',
       (_, model, config) => {
@@ -276,6 +286,41 @@ describe('PortkeyChatCompletionProvider', () => {
         expect(provider.getApiKey()).toBeUndefined();
       },
     );
+
+    it('should not inherit OPENAI_API_KEY for a passthrough to another vendor', () => {
+      vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
+      const provider = new PortkeyChatCompletionProvider('claude-sonnet-4-6', {
+        config: { portkeyApiKey: 'pk-config-key', portkeyProvider: 'anthropic' },
+      });
+      expect(provider.getApiKey()).toBeUndefined();
+    });
+
+    it('should forward an explicit apiKey for a passthrough to another vendor', () => {
+      vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
+      const provider = new PortkeyChatCompletionProvider('claude-sonnet-4-6', {
+        config: { portkeyProvider: 'anthropic', apiKey: 'sk-ant-explicit' },
+      });
+      expect(provider.getApiKey()).toBe('sk-ant-explicit');
+    });
+
+    it('should prefer the per-provider env override for the openai passthrough bearer', () => {
+      vi.stubEnv('OPENAI_API_KEY', 'sk-process-env');
+      const provider = new PortkeyChatCompletionProvider('gpt-4o', {
+        config: { portkeyProvider: 'openai' },
+        env: { OPENAI_API_KEY: 'sk-override' },
+      });
+      expect(provider.getApiKey()).toBe('sk-override');
+    });
+
+    it('should not put an inherited OPENAI_API_KEY on the wire for a bare model name', () => {
+      vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
+      const provider = new PortkeyChatCompletionProvider('claude-sonnet-4-6', {
+        config: { portkeyApiKey: 'pk-config-key' },
+      });
+      const headers = provider.getOpenAiRequestHeaders();
+      expect(headers).toMatchObject({ 'x-portkey-api-key': 'pk-config-key' });
+      expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain('authorization');
+    });
   });
 
   describe('header collisions', () => {

--- a/test/providers/portkey.test.ts
+++ b/test/providers/portkey.test.ts
@@ -308,6 +308,26 @@ describe('PortkeyChatCompletionProvider', () => {
       expect(provider.getApiKey()).toBe('sk-ant-explicit');
     });
 
+    // Provider names arrive from user YAML, where casing is not enforced.
+    it.each([['openai'], ['OpenAI'], ['OPENAI']])(
+      'should inherit OPENAI_API_KEY for an openai passthrough spelled %s',
+      (portkeyProvider) => {
+        vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
+        const provider = new PortkeyChatCompletionProvider('gpt-4o', {
+          config: { portkeyProvider },
+        });
+        expect(provider.getApiKey()).toBe('sk-openai');
+      },
+    );
+
+    it('should not throw when portkeyProvider is not a string', () => {
+      vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
+      const provider = new PortkeyChatCompletionProvider('gpt-4o', {
+        config: { portkeyProvider: 123 as unknown as string },
+      });
+      expect(provider.getApiKey()).toBeUndefined();
+    });
+
     it('should prefer the per-provider env override for the openai passthrough bearer', () => {
       vi.stubEnv('OPENAI_API_KEY', 'sk-process-env');
       const provider = new PortkeyChatCompletionProvider('gpt-4o', {

--- a/test/providers/portkey.test.ts
+++ b/test/providers/portkey.test.ts
@@ -269,6 +269,11 @@ describe('PortkeyChatCompletionProvider', () => {
       ['bare model name', 'claude-sonnet-4-6', {}],
       ['slug-shaped model name', 'anthropic-slug/claude-sonnet-4-6', {}],
       [
+        'model catalog slug in the model name alongside a declared upstream',
+        '@openai-slug/gpt-4o',
+        { portkeyProvider: 'openai' },
+      ],
+      [
         'virtual key alongside an openai passthrough',
         'gpt-4o',
         {
@@ -310,16 +315,6 @@ describe('PortkeyChatCompletionProvider', () => {
         env: { OPENAI_API_KEY: 'sk-override' },
       });
       expect(provider.getApiKey()).toBe('sk-override');
-    });
-
-    it('should not put an inherited OPENAI_API_KEY on the wire for a bare model name', () => {
-      vi.stubEnv('OPENAI_API_KEY', 'sk-openai');
-      const provider = new PortkeyChatCompletionProvider('claude-sonnet-4-6', {
-        config: { portkeyApiKey: 'pk-config-key' },
-      });
-      const headers = provider.getOpenAiRequestHeaders();
-      expect(headers).toMatchObject({ 'x-portkey-api-key': 'pk-config-key' });
-      expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain('authorization');
     });
   });
 


### PR DESCRIPTION
## Summary

A Portkey request carries two credentials: `x-portkey-api-key` (Portkey's own) and `Authorization: Bearer` (the **upstream provider's**, forwarded only in direct passthrough). `PortkeyChatCompletionProvider.getApiKey()` picked the bearer by inverting a managed-credential check — anything that was not an `@slug` or a virtual key was assumed to be OpenAI passthrough and inherited the ambient `OPENAI_API_KEY`.

So every one of these shipped the user's OpenAI key to the gateway (and potentially onward to a completely different vendor):

- `portkey:claude-sonnet-4-6` — a bare model name, a natural thing to write
- `portkey:my-slug/claude-sonnet-4-6` — a slug reference without the `@`
- `portkey:claude-sonnet-4-6` with an explicit `portkeyProvider: anthropic`

The fix resolves the bearer from the **declared upstream** instead of from what it is not:

- no `portkeyProvider`, an `@catalog-slug` (in `portkeyProvider` or in the model name), or a virtual key → Portkey holds the credential, forward nothing (unchanged behaviour for those shapes, including an `apiKey` inherited from a shared provider config);
- `portkeyProvider: openai` → inherit `OPENAI_API_KEY` as before. The name comes from user YAML, so it is matched case-insensitively (`OpenAI`, `OPENAI`) and type-guarded;
- any other `portkeyProvider` → `config.apiKey` only, since `OPENAI_API_KEY` names one vendor's credential.

Simplification: deletes the `usesManagedCredentials` helper and the hand-rolled `config.apiKey || env?.OPENAI_API_KEY || getEnvString(...)` chain, replacing the latter with the shared `resolveProviderApiKey` helper from `src/providers/credentials.ts`. The docs credential table now states the actual rule.

## Test plan

**Unit** — `npx vitest run test/providers/portkey.test.ts test/util/provider.test.ts` → 123 passed. The three new leak cases (bare model name, slug-shaped model name, non-OpenAI passthrough) fail on `main` and pass with the fix; a fourth (an `@` catalog slug in the model name alongside `portkeyProvider: openai`) guards the model-name check that the first draft of this fix dropped. New tests also cover explicit `apiKey` passthrough to a non-OpenAI vendor, the per-provider `env:` override, the three `openai` spellings, and a non-string `portkeyProvider`.

**On the wire** — ran a real eval with the local CLI (`OPENAI_API_KEY=sk-MY-OPENAI-SECRET PORTKEY_API_KEY=pk-portkey-secret`, `portkeyApiBaseUrl` pointed at a local node echo server that logs request headers), covering eight selector shapes:

| target                                            | before                           | after                        |
| ------------------------------------------------- | -------------------------------- | ---------------------------- |
| `@anthropic-slug/claude-sonnet-4-6`                | no bearer                        | no bearer                    |
| bare model + `portkeyVirtualKey`                   | no bearer                        | no bearer                    |
| `@openai-slug/gpt-4o` + `portkeyProvider: openai`  | no bearer                        | no bearer                    |
| `anthropic-slug/claude-sonnet-4-6`                 | **`Bearer sk-MY-OPENAI-SECRET`** | no bearer                    |
| `claude-sonnet-4-6`                                | **`Bearer sk-MY-OPENAI-SECRET`** | no bearer                    |
| `gpt-4o` + `portkeyProvider: openai`/`OpenAI`/`OPENAI` | `Bearer sk-MY-OPENAI-SECRET`  | `Bearer sk-MY-OPENAI-SECRET` |
| `portkeyProvider: anthropic`, no `apiKey`          | **`Bearer sk-MY-OPENAI-SECRET`** | no bearer                    |
| `portkeyProvider: anthropic` + `apiKey`            | `Bearer sk-ant-explicit`         | `Bearer sk-ant-explicit`     |

`x-portkey-api-key: pk-portkey-secret` was present on every request in both runs, `x-portkey-provider` kept the user's original casing, and 8/8 results passed each time.

**Other** — `npx vitest run test/providers/openai` (1815 passed, 9 skipped), `npx tsc --noEmit -p tsconfig.json`, `npx biome ci`, `npx prettier --check site/docs/integrations/portkey.md`.
