### PR TITLE
fix(eval): keep watch mode alive after a failed rerun

### DIFF
--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -11,7 +11,7 @@ import { disableCache } from '../cache';
 import cliState from '../cliState';
 import { DEFAULT_MAX_CONCURRENCY } from '../constants';
 import { getEnvBool, getEnvFloat, getEnvInt, isCI } from '../envars';
-import { evaluate, PromptSuggestionsRejectedError } from '../evaluator';
+import { evaluate } from '../evaluator';
 import {
   checkEmailStatusAndMaybeExit,
   EmailValidationError,
@@ -171,20 +171,20 @@ function failEvalRun(
   throw new EvalRunError(message);
 }
 
-function handleRecoverableWatchError(error: unknown): boolean {
+/**
+ * Report a failed re-run without ending the watch session.
+ *
+ * chokidar's emitter does not await the change handler, so rethrowing here surfaces as
+ * an unhandled rejection and terminates the process. Every failure is therefore logged
+ * and watching continues, which is also what a watch loop should do with a bad edit.
+ */
+function logWatchError(error: unknown): void {
   if (error instanceof ConfigResolutionError) {
     logConfigResolutionError(error);
-    return true;
+  } else if (!(error instanceof EmailValidationError)) {
+    // Account helpers already render their own user-facing failures.
+    logger.error(error instanceof Error ? error.message : String(error));
   }
-  if (error instanceof EmailValidationError) {
-    // Account helpers already render these user-facing failures.
-    return true;
-  }
-  if (error instanceof EvalRunError || error instanceof PromptSuggestionsRejectedError) {
-    logger.error(error.message);
-    return true;
-  }
-  return false;
 }
 
 /**
@@ -1273,10 +1273,7 @@ export async function doEval(
             try {
               await runEvaluation();
             } catch (error) {
-              if (handleRecoverableWatchError(error)) {
-                return;
-              }
-              throw error;
+              logWatchError(error);
             }
           })
           .on('error', (error) => logger.error(`Watcher error: ${error}`))

--- a/src/node/doEval.ts
+++ b/src/node/doEval.ts
@@ -184,6 +184,11 @@ function logWatchError(error: unknown): void {
   } else if (!(error instanceof EmailValidationError)) {
     // Account helpers already render their own user-facing failures.
     logger.error(error instanceof Error ? error.message : String(error));
+    if (error instanceof Error && error.stack) {
+      // The rejection this replaces printed a stack, the only pointer to where an
+      // unexpected failure came from. Keep it, below the user-facing message.
+      logger.debug(error.stack);
+    }
   }
 }
 

--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -852,11 +852,9 @@ export function resolveTestsWatchPaths(
         );
       }
       // A mapping: only file:// values are file references, the rest are literal vars.
-      return Object.values(entry.vars).flatMap((value) =>
-        typeof value === 'string' && value.startsWith('file://')
-          ? resolveTestsFileReference(value, basePath)
-          : [],
-      );
+      // A value may be a list of references, or nest them, and generateVarCombinations()
+      // and renderPrompt() read every one, so walk the whole mapping.
+      return collectConfigFileReferences(entry.vars, basePath);
     }
     return [];
   });

--- a/src/util/testCaseReader.ts
+++ b/src/util/testCaseReader.ts
@@ -852,8 +852,10 @@ export function resolveTestsWatchPaths(
         );
       }
       // A mapping: only file:// values are file references, the rest are literal vars.
-      // A value may be a list of references, or nest them, and generateVarCombinations()
-      // and renderPrompt() read every one, so walk the whole mapping.
+      // generateVarCombinations() fans a list value out into one case per entry and
+      // renderPrompt() then loads each, so a top-level string scan misses them. Share the
+      // tests-file walker instead. It also reaches deeper nesting, which the loader leaves
+      // as a literal -- watching an extra file only costs a spurious re-run.
       return collectConfigFileReferences(entry.vars, basePath);
     }
     return [];

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -1089,6 +1089,41 @@ describe('evalCommand', () => {
     }
   });
 
+  it('should keep watching after an unexpected failure on a file change', async () => {
+    // chokidar does not await the change handler, so rethrowing an unclassified error
+    // used to escape as an unhandled rejection and terminate the whole watch session.
+    const config = {
+      prompts: [],
+      providers: [],
+    } as UnifiedConfig;
+    const testSuite = {
+      prompts: [],
+      providers: [],
+    } as TestSuite;
+    const loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => logger);
+
+    vi.mocked(resolveConfigs).mockResolvedValue({
+      config,
+      testSuite,
+      basePath: path.resolve('/'),
+    });
+    vi.mocked(evaluate)
+      .mockImplementationOnce(async (_testSuite, evalRecord) => evalRecord as Eval)
+      .mockRejectedValueOnce(new Error('provider exploded'));
+
+    try {
+      await doEval({ watch: true, write: false }, config, defaultConfigPath, {});
+
+      const onChange = chokidarMocks.handlers.get('change');
+      expect(onChange).toBeDefined();
+
+      await expect(onChange?.(defaultConfigPath)).resolves.toBeUndefined();
+      expect(loggerErrorSpy).toHaveBeenCalledWith('provider exploded');
+    } finally {
+      loggerErrorSpy.mockRestore();
+    }
+  });
+
   it('should fail with explicit cloud UUID error when cloud fetch fails', async () => {
     const cloudConfigUuid = '12345678-1234-4234-8234-123456789abc';
     const cmdObj = { config: [cloudConfigUuid] };

--- a/test/util/testCaseWatchPaths.test.ts
+++ b/test/util/testCaseWatchPaths.test.ts
@@ -195,6 +195,16 @@ describe('resolveTestsWatchPaths', () => {
     expect(watched).toEqual([path.join(base, 'vars.csv')]);
   });
 
+  it('watches every reference of an array-valued var', () => {
+    // generateVarCombinations() fans an array out into one case per entry and
+    // renderPrompt() then loads each file, so all of them feed the evaluation.
+    const watched = resolve([
+      { vars: { doc: ['file://tests/a.yaml', 'file://tests/b.yaml'] } },
+    ] as unknown as TestSuiteConfig['tests']);
+    expect(watched).toContain(path.join(base, 'tests/a.yaml'));
+    expect(watched).toContain(path.join(base, 'tests/b.yaml'));
+  });
+
   it('ignores remote references', () => {
     expect(
       resolve('https://docs.google.com/spreadsheets/d/abc' as TestSuiteConfig['tests']),


### PR DESCRIPTION
## Summary

Two watch-mode defects, both newly reachable now that #10562 made `eval --watch` actually fire.

**1. A failed rerun killed the whole watch session.**

The chokidar `change` handler is `async`, and chokidar's `EventEmitter` never awaits the promise it returns. So the `throw error` at the end of the handler's `catch` did not propagate to any caller — it became an **unhandled promise rejection**, which on Node >= 15 terminates the process with a raw stack trace. `.on('error')` does not help: it catches watcher errors, not handler rejections. The result was that any failure the classifier did not recognize (a provider throwing, a bad transform, an assertion module that fails to import) ended the watch session instead of printing a message and waiting for the next edit.

Log-and-continue is the correct behavior for a watch loop, and once every failure is logged the recoverable/non-recoverable distinction stops paying for itself. `handleRecoverableWatchError` (a 15-line boolean classifier over four error types) collapses into `logWatchError`, which keeps only the two branches that actually change how a failure is *rendered*:

- `ConfigResolutionError` → the dedicated `logConfigResolutionError` renderer
- `EmailValidationError` → nothing, because the account helpers already print it

Everything else — including `EvalRunError` and `PromptSuggestionsRejectedError`, which had their own branch doing exactly this — now falls through to the same `logger.error(message)`. That also drops the now-unused `PromptSuggestionsRejectedError` import.

**2. `resolveTestsWatchPaths` missed array-valued `file://` vars, so editing those files did not rerun.**

For an inline test case like:

```yaml
tests:
  - vars:
      doc:
        - file://doc_a.txt
        - file://doc_b.txt
```

`generateVarCombinations()` fans the array out into one case per entry and `renderPrompt()` then loads each file — verified end to end below — but the watcher's `vars` mapping branch only looked at string values, so neither file was watched. Meanwhile the sibling walker in the same file (`collectConfigFileReferences`, used for a generator's `config` and for the contents of a tests *file*) already handles arrays and nesting correctly, which is why the identical config expressed in a separate tests file *did* rerun.

Fixed by deleting the duplicated string-only scan and calling `collectConfigFileReferences` on the mapping, so the inline path and the tests-file path now share one walker.

No change to the watch hazards already handled here: globs are still expanded to concrete files rather than watching a parent directory, and `--tests` / `--vars` keep their different base paths.

Net: **-21 / +61**, of which the source diff is net negative (`-5` in `testCaseReader.ts`/handler, with the rest of `doEval.ts`'s delta being the doc comment); the additions are tests.

## Test plan

**Regression tests fail before the fix, pass after.** With only the two source files reverted:

```
× resolveTestsWatchPaths > watches every reference of an array-valued var
× evalCommand > should keep watching after an unexpected failure on a file change
  Tests  2 failed | 152 passed (154)
```

**With the fix:**

```
npx vitest run test/commands/eval.test.ts test/util/testCaseWatchPaths.test.ts test/util/testCaseReader.test.ts
  Test Files  3 passed (3)
  Tests  245 passed (245)

npx vitest run test/util/ test/node/
  Test Files  94 passed (94)
  Tests  2511 passed (2511)

npx vitest run test/commands/
  Test Files  39 passed (39)
  Tests  779 passed | 1 skipped (780)

npx vitest run test/test-hygiene.test.ts test/hygiene
  Test Files  2 passed (2)
  Tests  127 passed (127)

npx tsc --noEmit -p tsconfig.json      # clean
npx biome ci <changed files>           # exit 0 (2 pre-existing complexity warnings on readTests / doEval, both untouched by this diff)
```

**Real end-to-end check of defect 2**, on a config using the array-valued var form above:

```
$ npx tsx src/main.ts eval -c promptfooconfig.yaml --no-cache
│ file://doc_a.txt │ [PASS] Say alpha │
│ file://doc_b.txt │ [PASS] Say beta  │
  ✓ 2 passed (100%)
```

Both files are genuinely read by the evaluation, and `resolveTestsWatchPaths` on that same config returns `[]` before the fix and both absolute paths after — so those edits were silently ignored by watch mode.

**Real end-to-end check of defect 1.** A config with a `beforeAll` extension hook that throws once a sentinel file appears (an ordinary `Error`, i.e. exactly the class that was rethrown), run under a real `chokidar` watcher via `promptfoo eval --watch`, then touched to force a rerun:

Before the fix — the whole watch session dies:

```
RESULT: watcher DIED after the failed rerun
Error: Extension hook "beforeAll" failed for file://hooks.js:beforeAll: ... kaboom from beforeAll
    at runExtensionHook (src/evaluatorHelpers.ts)
    at Evaluator.evaluate (src/evaluator.ts)
    at runEvaluation (src/node/doEval.ts)
    at FSWatcher.<anonymous> (src/node/doEval.ts)     <-- unhandled rejection out of the handler
```

After the fix — the failure is reported and watching continues:

```
RESULT: watcher STILL ALIVE after the failed rerun
Extension hook "beforeAll" failed for file://hooks.js:beforeAll: ... kaboom from beforeAll
```

Also ran `npx knip --no-progress` (clean) and `npm run architecture:check` (passed).
