### PR TITLE
fix(providers): restore Responses routing for live OpenAI models

### DIFF
--- a/src/providers/openai/responses.ts
+++ b/src/providers/openai/responses.ts
@@ -37,6 +37,7 @@ import {
   getTokenUsage,
   hasSensitiveOpenAiCachePath,
   hasSensitiveOpenAiCacheString,
+  OPENAI_RESPONSES_ONLY_MODELS,
 } from './util';
 
 import type { EnvOverrides } from '../../types/env';
@@ -689,18 +690,12 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     'gpt-5-nano-2025-08-07',
     'gpt-5-mini',
     'gpt-5-mini-2025-08-07',
-    'gpt-5-pro',
-    'gpt-5-pro-2025-10-06',
     // GPT-5.1 models
     'gpt-5.1',
     'gpt-5.1-2025-11-13',
     // GPT-5.2 models
     'gpt-5.2',
     'gpt-5.2-2025-12-11',
-    'gpt-5.2-pro',
-    'gpt-5.2-pro-2025-12-11',
-    // GPT-5.3 models
-    'gpt-5.3-codex',
     // GPT-6 Astra
     'gpt-6-astra',
     // GPT-5.6 models
@@ -711,8 +706,6 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     // GPT-5.5 models
     'gpt-5.5',
     'gpt-5.5-2026-04-23',
-    'gpt-5.5-pro',
-    'gpt-5.5-pro-2026-04-23',
     // GPT-5.4 models
     'gpt-5.4',
     'gpt-5.4-2026-03-05',
@@ -720,24 +713,19 @@ export class OpenAiResponsesProvider extends OpenAiGenericProvider {
     'gpt-5.4-mini-2026-03-17',
     'gpt-5.4-nano',
     'gpt-5.4-nano-2026-03-17',
-    'gpt-5.4-pro',
-    'gpt-5.4-pro-2026-03-05',
     // NOTE: gpt-image-1, gpt-image-1-mini, and gpt-image-1.5 are NOT supported with the Responses API.
     // Use openai:image:gpt-image-1, openai:image:gpt-image-1-mini, or openai:image:gpt-image-1.5 instead (which uses /images/generations endpoint)
     // Reasoning models
     'o1',
     'o1-2024-12-17',
-    'o1-pro',
-    'o1-pro-2025-03-19',
-    'o3-pro',
-    'o3-pro-2025-06-10',
     'o3',
     'o3-2025-04-16',
     'o4-mini',
     'o4-mini-2025-04-16',
     'o3-mini',
     'o3-mini-2025-01-31',
-    'gpt-5-codex-mini',
+    // Models that only exist on this endpoint are tracked in one place.
+    ...OPENAI_RESPONSES_ONLY_MODELS.map((model) => model.id),
   ];
 
   config: OpenAiCompletionOptions;

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -394,6 +394,13 @@ export function assertOpenAiApiModel(model: unknown, apiUrl?: string): void {
 }
 
 export const OPENAI_RESPONSES_ONLY_MODELS: OpenAIModelInfo[] = [
+  ...['computer-use-preview', 'computer-use-preview-2025-03-11'].map((model) => ({
+    id: model,
+    cost: {
+      input: 3 / 1e6,
+      output: 12 / 1e6,
+    },
+  })),
   ...['o1-pro', 'o1-pro-2025-03-19'].map((model) => ({
     id: model,
     cost: {
@@ -406,6 +413,20 @@ export const OPENAI_RESPONSES_ONLY_MODELS: OpenAIModelInfo[] = [
     cost: {
       input: 20 / 1e6,
       output: 80 / 1e6,
+    },
+  })),
+  ...['gpt-5-codex', 'gpt-5.1-codex', 'gpt-5.1-codex-max'].map((model) => ({
+    id: model,
+    cost: {
+      input: 1.25 / 1e6,
+      output: 10 / 1e6,
+    },
+  })),
+  ...['gpt-5.1-codex-mini'].map((model) => ({
+    id: model,
+    cost: {
+      input: 0.25 / 1e6,
+      output: 2 / 1e6,
     },
   })),
   ...['gpt-5-codex-mini'].map((model) => ({
@@ -422,7 +443,7 @@ export const OPENAI_RESPONSES_ONLY_MODELS: OpenAIModelInfo[] = [
       output: 120 / 1e6,
     },
   })),
-  ...['gpt-5.3-codex'].map((model) => ({
+  ...['gpt-5.2-codex', 'gpt-5.3-codex'].map((model) => ({
     id: model,
     cost: {
       input: 1.75 / 1e6,
@@ -541,14 +562,7 @@ const RETIRED_OPENAI_MODELS: OpenAIModelInfo[] = [
       output: 4 / 1e6,
     },
   },
-  ...[
-    'gpt-5-chat',
-    'gpt-5-chat-latest',
-    'gpt-5.1-chat-latest',
-    'gpt-5-codex',
-    'gpt-5.1-codex',
-    'gpt-5.1-codex-max',
-  ].map((model) => ({
+  ...['gpt-5-chat', 'gpt-5-chat-latest', 'gpt-5.1-chat-latest'].map((model) => ({
     id: model,
     cost: {
       input: 1.25 / 1e6,
@@ -562,7 +576,7 @@ const RETIRED_OPENAI_MODELS: OpenAIModelInfo[] = [
       output: 6.0 / 1e6,
     },
   },
-  ...['gpt-5.2-chat-latest', 'gpt-5.3-chat-latest', 'gpt-5.2-codex'].map((model) => ({
+  ...['gpt-5.2-chat-latest', 'gpt-5.3-chat-latest'].map((model) => ({
     id: model,
     cost: {
       input: 1.75 / 1e6,
@@ -576,20 +590,6 @@ const RETIRED_OPENAI_MODELS: OpenAIModelInfo[] = [
       output: 2.4 / 1e6,
       audioInput: 10 / 1e6,
       audioOutput: 20 / 1e6,
-    },
-  },
-  ...['computer-use-preview', 'computer-use-preview-2025-03-11'].map((model) => ({
-    id: model,
-    cost: {
-      input: 3 / 1e6,
-      output: 12 / 1e6,
-    },
-  })),
-  {
-    id: 'gpt-5.1-codex-mini',
-    cost: {
-      input: 0.25 / 1e6,
-      output: 2 / 1e6,
     },
   },
   ...['gpt-realtime-mini-2025-10-06'].map((model) => ({

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1068,12 +1068,8 @@ export const providerMap: ProviderFactory[] = [
           providerOptions,
         );
       }
-      if (shouldDefaultToOpenAiResponses(modelType)) {
-        return new OpenAiResponsesProvider(modelType, providerOptions);
-      }
-      if (OpenAiChatCompletionProvider.OPENAI_CHAT_MODEL_NAMES.includes(modelType)) {
-        return new OpenAiChatCompletionProvider(modelType, providerOptions);
-      }
+      // Models living on a different endpoint family are matched before the version
+      // gate, so a future `gpt-6-realtime`-style name is not swallowed by it.
       if (OpenAiCompletionProvider.OPENAI_COMPLETION_MODEL_NAMES.includes(modelType)) {
         return new OpenAiCompletionProvider(modelType, providerOptions);
       }
@@ -1082,6 +1078,12 @@ export const providerMap: ProviderFactory[] = [
       }
       if (OpenAiRealtimeProvider.OPENAI_REALTIME_MODEL_NAMES.includes(modelType)) {
         return new OpenAiRealtimeProvider(modelType, providerOptions);
+      }
+      if (shouldDefaultToOpenAiResponses(modelType)) {
+        return new OpenAiResponsesProvider(modelType, providerOptions);
+      }
+      if (OpenAiChatCompletionProvider.OPENAI_CHAT_MODEL_NAMES.includes(modelType)) {
+        return new OpenAiChatCompletionProvider(modelType, providerOptions);
       }
       if (OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES.includes(modelType)) {
         return new OpenAiResponsesProvider(modelType, providerOptions);

--- a/test/providers/openai/responses/models.test.ts
+++ b/test/providers/openai/responses/models.test.ts
@@ -17,17 +17,10 @@ const unsupportedAudioModels = [
 describe('OpenAiResponsesProvider model registry', () => {
   it.each([
     'codex-mini-latest',
-    'computer-use-preview',
-    'computer-use-preview-2025-03-11',
     'gpt-5-chat',
     'gpt-5-chat-latest',
-    'gpt-5-codex',
     'gpt-5.1-chat-latest',
-    'gpt-5.1-codex',
-    'gpt-5.1-codex-max',
-    'gpt-5.1-codex-mini',
     'gpt-5.2-chat-latest',
-    'gpt-5.2-codex',
     'gpt-5.3-chat-latest',
     'o1-mini',
     'o1-mini-2024-09-12',

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -533,17 +533,6 @@ describe('calculateOpenAICost', () => {
     }
   });
 
-  it('should keep GPT-5.4 and GPT-5.5 Pro out of Chat Completions routing', () => {
-    expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.4-pro')).toBe(false);
-    expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.4-pro-2026-03-05')).toBe(false);
-    expect(OPENAI_RESPONSES_ONLY_MODELS.some((model) => model.id === 'gpt-5.4-pro')).toBe(true);
-    expect(
-      OPENAI_RESPONSES_ONLY_MODELS.some((model) => model.id === 'gpt-5.4-pro-2026-03-05'),
-    ).toBe(true);
-    expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.5-pro')).toBe(false);
-    expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.5-pro-2026-04-23')).toBe(false);
-  });
-
   // Availability re-verified against GET /v1/models/<id> on 2026-09-09.
   it.each([
     'computer-use-preview',
@@ -558,6 +547,10 @@ describe('calculateOpenAICost', () => {
     'gpt-5.2-pro',
     'gpt-5.2-pro-2025-12-11',
     'gpt-5.3-codex',
+    'gpt-5.4-pro',
+    'gpt-5.4-pro-2026-03-05',
+    'gpt-5.5-pro',
+    'gpt-5.5-pro-2026-04-23',
     'o1-pro',
     'o1-pro-2025-03-19',
     'o3-pro',

--- a/test/providers/openai/util.test.ts
+++ b/test/providers/openai/util.test.ts
@@ -544,9 +544,17 @@ describe('calculateOpenAICost', () => {
     expect(OPENAI_CHAT_MODELS.some((model) => model.id === 'gpt-5.5-pro-2026-04-23')).toBe(false);
   });
 
+  // Availability re-verified against GET /v1/models/<id> on 2026-09-09.
   it.each([
+    'computer-use-preview',
+    'computer-use-preview-2025-03-11',
+    'gpt-5-codex',
     'gpt-5-pro',
     'gpt-5-pro-2025-10-06',
+    'gpt-5.1-codex',
+    'gpt-5.1-codex-max',
+    'gpt-5.1-codex-mini',
+    'gpt-5.2-codex',
     'gpt-5.2-pro',
     'gpt-5.2-pro-2025-12-11',
     'gpt-5.3-codex',
@@ -1013,8 +1021,6 @@ describe('OpenAI model catalogs', () => {
   it.each([
     'chatgpt-4o-latest',
     'codex-mini-latest',
-    'computer-use-preview',
-    'computer-use-preview-2025-03-11',
     'gpt-3.5-turbo-0301',
     'gpt-3.5-turbo-0613',
     'gpt-3.5-turbo-16k-0613',
@@ -1032,13 +1038,8 @@ describe('OpenAI model catalogs', () => {
     'gpt-4o-search-preview-2025-03-11',
     'gpt-5-chat',
     'gpt-5-chat-latest',
-    'gpt-5-codex',
     'gpt-5.1-chat-latest',
-    'gpt-5.1-codex',
-    'gpt-5.1-codex-max',
-    'gpt-5.1-codex-mini',
     'gpt-5.2-chat-latest',
-    'gpt-5.2-codex',
     'gpt-5.3-chat-latest',
     'gpt-audio-mini-2025-10-06',
     'gpt-realtime-mini-2025-10-06',

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -352,6 +352,7 @@ describe('Provider Registry', () => {
       // off Chat Completions. Availability verified against GET /v1/models/<id>.
       it.each([
         'computer-use-preview',
+        'computer-use-preview-2025-03-11',
         'gpt-5-codex',
         'gpt-5.1-codex',
         'gpt-5.1-codex-max',

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -348,11 +348,22 @@ describe('Provider Registry', () => {
         expect(provider).toHaveProperty('modelName', model);
       });
 
-      it('keeps earlier Responses-only models on Responses', async () => {
-        const provider = await registry.create('openai:gpt-5.5-pro');
+      // These predate the version gate, so only the Responses-only catalog keeps them
+      // off Chat Completions. Availability verified against GET /v1/models/<id>.
+      it.each([
+        'computer-use-preview',
+        'gpt-5-codex',
+        'gpt-5.1-codex',
+        'gpt-5.1-codex-max',
+        'gpt-5.1-codex-mini',
+        'gpt-5.2-codex',
+        'gpt-5.5-pro',
+        'o1-pro',
+      ])('keeps earlier Responses-only model %s on Responses', async (model) => {
+        const provider = await registry.create(`openai:${model}`);
 
         expect(provider).toBeInstanceOf(OpenAiResponsesProvider);
-        expect(provider).toHaveProperty('modelName', 'gpt-5.5-pro');
+        expect(provider).toHaveProperty('modelName', model);
       });
 
       it.each([


### PR DESCRIPTION
## Summary

#10636 ("remove retired OpenAI models") moved several **Responses-API-only** models out of `OPENAI_RESPONSES_ONLY_MODELS` and into the billing-only `RETIRED_OPENAI_MODELS` list. Those models are not retired — they are still served by OpenAI today.

With no entry in any routing catalog, the bare selector fell through every lookup in `src/providers/registry.ts` and hit the "Unknown OpenAI model type" fallback, which returns an `OpenAiChatCompletionProvider`. These models have no Chat Completions surface, so every eval using them started failing.

Routing regression (bare selector, 0.122.2 → `main`):

| Provider path | 0.122.2 | before this PR |
| --- | --- | --- |
| `openai:computer-use-preview` | `OpenAiResponsesProvider` | `OpenAiChatCompletionProvider` |
| `openai:gpt-5-codex` | `OpenAiResponsesProvider` | `OpenAiChatCompletionProvider` |
| `openai:gpt-5.1-codex` | `OpenAiResponsesProvider` | `OpenAiChatCompletionProvider` |
| `openai:gpt-5.1-codex-max` | `OpenAiResponsesProvider` | `OpenAiChatCompletionProvider` |
| `openai:gpt-5.1-codex-mini` | `OpenAiResponsesProvider` | `OpenAiChatCompletionProvider` |
| `openai:gpt-5.2-codex` | `OpenAiResponsesProvider` | `OpenAiChatCompletionProvider` |

### What changed

- **Restored** `computer-use-preview`, `computer-use-preview-2025-03-11`, `gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, and `gpt-5.2-codex` to `OPENAI_RESPONSES_ONLY_MODELS`, with their original pricing. Every one was re-verified live: `GET /v1/models/<id>` returns 200 and each appears in `GET /v1/models`. IDs that genuinely 404 (`codex-mini-latest`, `gpt-5.3-codex-spark`, `gpt-4o-realtime-preview`, `gpt-4o-mini-realtime-preview-2024-12-17`, …) stay removed.

- **Deleted the duplicated catalog.** `OpenAiResponsesProvider.OPENAI_RESPONSES_MODEL_NAMES` hand-copied 14 IDs that already live in `OPENAI_RESPONSES_ONLY_MODELS` — that duplication is exactly how the two lists drifted apart. The Responses-only tail is now derived: `...OPENAI_RESPONSES_ONLY_MODELS.map((model) => model.id)`. A Responses-only model can no longer be added to one list and forgotten in the other.

- **Reordered the registry's OpenAI branch** so the completion / TTS / realtime lookups run *before* `shouldDefaultToOpenAiResponses`. The version gate matches on name shape (`gpt-<major>.<minor>` ≥ 5.6), so a future `gpt-6-realtime`-style ID would have been silently swallowed by it before its own endpoint list was consulted. This is behavior-preserving today — verified that none of the completion/TTS/realtime IDs matches the gate and none overlaps the chat catalog — so it is forward-compat hygiene, not a live fix.

Net: **-5 lines** (57 added, 62 removed).

## Test plan

Regression coverage (all three assertions fail on `main` and pass here — 14 failing tests when the `src/` changes are stashed):

- `test/providers/registry.test.ts` — `keeps earlier Responses-only model %s on Responses` now parameterised over the restored IDs, asserting `OpenAiResponsesProvider` for each bare selector. This is the test that reproduces the reported bug.
- `test/providers/openai/util.test.ts` — restored IDs moved from the "does not advertise retired model" table into "should keep active Responses-only model %s out of Chat Completions routing".
- `test/providers/openai/responses/models.test.ts` — restored IDs removed from the "does not advertise retired model" table.

```
$ npx vitest run test/providers/openai/util.test.ts test/providers/openai/responses/models.test.ts test/providers/registry.test.ts
  Test Files  3 passed (3)
       Tests  408 passed (408)

# same three files with the src/ changes stashed (proves the tests bite):
  Test Files  2 failed | 1 passed (3)
       Tests  14 failed | 394 passed (408)

$ npx vitest run test/providers          # whole provider suite
  Test Files  242 passed | 1 skipped (243)
       Tests  9934 passed | 9 skipped (9943)

$ npx tsc --noEmit -p tsconfig.json      # clean
$ npx biome check <changed files>        # only pre-existing complexity warnings
```

Live verification (never printed the key):

```
$ curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $OPENAI_API_KEY" \
    https://api.openai.com/v1/models/<id>

200 computer-use-preview          200 gpt-5.1-codex-max      404 codex-mini-latest
200 computer-use-preview-2025-03-11  200 gpt-5.1-codex-mini  404 gpt-5-codex-mini
200 gpt-5-codex                   200 gpt-5.2-codex          404 gpt-5.3-codex-spark
200 gpt-5.1-codex                 200 gpt-5.3-codex          404 gpt-4o-realtime-preview
```

Cross-check: `src/providers/azure/defaults.ts` and `src/providers/azure/util.ts` still carry `gpt-5-codex`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex-mini`, and `gpt-5.2-codex` as current Azure deployments, corroborating that they are live.

Note for the reviewer: `gpt-5-codex-mini` (already in `OPENAI_RESPONSES_ONLY_MODELS`) now 404s on this account. It is left untouched here — routing it away from Responses would be a behavior change on a 404 that could equally be an org-access gap, and it does not affect the regression this PR fixes.

