### PR TITLE
fix(assertions): stop tool-call-f1 harvesting prose JSON

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -611,7 +611,7 @@ tests:
 
 The `tool-call-f1` assertion computes the [F1 score](https://en.wikipedia.org/wiki/F-score) comparing the set of tools called by the LLM against an expected set of tools. This metric is useful for evaluating agentic LLM applications where you want to measure how accurately the model selects the right tools.
 
-This assertion supports OpenAI Chat Completions tool calls, OpenAI Responses `function_call` items, Anthropic tool-use blocks, and Google/Vertex function calls. It accepts supported objects and arrays directly or as JSON strings, including newline-separated JSON calls mixed with text, and finds calls nested inside a wrapper object such as `{"result": {"tool_calls": [...]}}`. JSON embedded in a text response only counts when it matches one of these tool-call shapes, so unrelated data such as `[{"name": "Alice"}]` is ignored.
+This assertion supports OpenAI Chat Completions tool calls, OpenAI Responses `function_call` items, Anthropic tool-use blocks, and Google/Vertex function calls. It accepts supported objects and arrays directly or as JSON strings, including newline-separated JSON calls mixed with text, and finds calls nested inside a wrapper object such as `{"result": {"tool_calls": [...]}}`. JSON embedded in a text response only counts when it matches one of these tool-call shapes, so unrelated data such as `[{"name": "Alice"}]` is ignored, as is a tool _definition_ such as `{"tools": [{"type": "function", "function": {"name": "get_weather"}}]}`.
 
 For example, this OpenAI Responses item matches `value: [get_weather]`:
 

--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -611,7 +611,7 @@ tests:
 
 The `tool-call-f1` assertion computes the [F1 score](https://en.wikipedia.org/wiki/F-score) comparing the set of tools called by the LLM against an expected set of tools. This metric is useful for evaluating agentic LLM applications where you want to measure how accurately the model selects the right tools.
 
-This assertion supports OpenAI Chat Completions tool calls, OpenAI Responses `function_call` items, Anthropic tool-use blocks, and Google/Vertex function calls. It accepts supported objects and arrays directly or as JSON strings, including newline-separated JSON calls mixed with text.
+This assertion supports OpenAI Chat Completions tool calls, OpenAI Responses `function_call` items, Anthropic tool-use blocks, and Google/Vertex function calls. It accepts supported objects and arrays directly or as JSON strings, including newline-separated JSON calls mixed with text, and finds calls nested inside a wrapper object such as `{"result": {"tool_calls": [...]}}`. JSON embedded in a text response only counts when it matches one of these tool-call shapes, so unrelated data such as `[{"name": "Alice"}]` is ignored.
 
 For example, this OpenAI Responses item matches `value: [get_weather]`:
 

--- a/src/assertions/toolCallF1.ts
+++ b/src/assertions/toolCallF1.ts
@@ -2,13 +2,21 @@ import invariant from '../util/invariant';
 
 import type { AssertionParams, GradingResult } from '../types/index';
 
-function findJsonEnd(text: string, start: number): number {
-  const closing: string[] = [text[start] === '{' ? '}' : ']'];
+/**
+ * Outermost balanced `{...}` / `[...]` fragments of a string, found in a single pass.
+ * Fragments inside an opener that never closes are returned too, so a stray brace in
+ * prose cannot hide a tool call that follows it.
+ */
+function jsonFragments(text: string): string[] {
+  // Each open delimiter collects the spans that completed directly inside it. They are
+  // dropped when it closes, because the enclosing fragment already covers them.
+  const open: { start: number; nested: [number, number][] }[] = [];
+  const spans: [number, number][] = [];
   let inString = false;
   let escaped = false;
 
-  for (let end = start + 1; end < text.length; end++) {
-    const char = text[end];
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
     if (inString) {
       if (escaped) {
         escaped = false;
@@ -17,185 +25,128 @@ function findJsonEnd(text: string, start: number): number {
       } else if (char === '"') {
         inString = false;
       }
-      continue;
-    }
-
-    if (char === '"') {
+    } else if (char === '"') {
       inString = true;
     } else if (char === '{' || char === '[') {
-      closing.push(char === '{' ? '}' : ']');
+      open.push({ start: i, nested: [] });
     } else if (char === '}' || char === ']') {
-      if (closing.pop() !== char) {
-        return -1;
-      }
-      if (closing.length === 0) {
-        return end;
+      const frame = open.pop();
+      if (frame) {
+        (open[open.length - 1]?.nested ?? spans).push([frame.start, i + 1]);
       }
     }
   }
-  return -1;
+
+  for (const frame of open) {
+    for (const span of frame.nested) {
+      spans.push(span);
+    }
+  }
+  return spans.map(([start, end]) => text.slice(start, end));
 }
 
 /**
- * Extracts tool names from various output formats.
- *
- * Supports:
- * - OpenAI format: { tool_calls: [{ function: { name: "..." } }] }
- * - OpenAI Responses format: { type: 'function_call', name: '...' }
- * - OpenAI direct array: [{ function: { name: "..." } }]
- * - Simple format: [{ name: "..." }]
- * - Anthropic format: { type: 'tool_use', name: '...' } or arrays of content blocks
- * - Google/Vertex format: { functionCall: { name: '...' } } or arrays
- * - Google Live format: { toolCall: { functionCalls: [...] } }
- * - String output: JSON-stringified versions of the above, including mixed text/JSON
+ * The name of a single tool call, for shapes that identify themselves as one:
+ * - Anthropic content block: { type: 'tool_use', name: '...' }
+ * - OpenAI Responses item: { type: 'function_call', name: '...' }
+ * - OpenAI tool call: { function: { name: '...' } }
+ * - Google/Vertex: { functionCall: { name: '...' } }
+ */
+function toolCallName(obj: Record<string, unknown>): string | undefined {
+  if ((obj.type === 'tool_use' || obj.type === 'function_call') && typeof obj.name === 'string') {
+    return obj.name;
+  }
+  for (const key of ['function', 'functionCall'] as const) {
+    const call = obj[key];
+    if (call && typeof call === 'object') {
+      const { name } = call as Record<string, unknown>;
+      if (typeof name === 'string') {
+        return name;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Adds names from a list whose entries are known to be tool calls, where a bare `{ name }` counts. */
+function addCallListNames(list: unknown, names: Set<string>): void {
+  if (!Array.isArray(list)) {
+    return;
+  }
+  for (const item of list) {
+    if (item && typeof item === 'object') {
+      const call = item as Record<string, unknown>;
+      const name = toolCallName(call) ?? call.name;
+      if (typeof name === 'string') {
+        names.add(name);
+      }
+    }
+  }
+}
+
+/**
+ * Walks a parsed value and collects names from recognised tool-call shapes only.
+ * Wrappers are traversed, so `{ result: { tool_calls: [...] } }` is found, but an
+ * arbitrary `{ name: '...' }` object is never mistaken for a tool call.
+ */
+function collectToolNames(value: unknown, names: Set<string>): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectToolNames(item, names);
+    }
+    return;
+  }
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const name = toolCallName(obj);
+  if (name !== undefined) {
+    names.add(name);
+    return;
+  }
+
+  // OpenAI envelope: { tool_calls: [...] }, Google Live: { toolCall: { functionCalls: [...] } }
+  addCallListNames(obj.tool_calls, names);
+  addCallListNames((obj.toolCall as Record<string, unknown> | undefined)?.functionCalls, names);
+
+  for (const nested of Object.values(obj)) {
+    collectToolNames(nested, names);
+  }
+}
+
+/**
+ * Extracts tool names from provider output, which may be an object, an array of
+ * content blocks, JSON text, or JSON embedded in a prose response.
  */
 function extractToolNames(output: unknown): Set<string> {
   const names = new Set<string>();
 
-  if (output === null || output === undefined) {
-    return names;
-  }
-
-  // Handle string output - try to parse as JSON and recursively extract
   if (typeof output === 'string') {
-    // First, try parsing the entire string as JSON
     try {
-      const parsed = JSON.parse(output);
-      const parsedNames = extractToolNames(parsed);
-      for (const name of parsedNames) {
-        names.add(name);
-      }
-      return names;
+      return extractToolNames(JSON.parse(output));
     } catch {
-      // Not valid JSON as a whole; look for embedded JSON values.
+      // Not valid JSON as a whole; harvest embedded tool-call JSON instead.
     }
-
-    // Mixed text and JSON may include pretty-printed blocks and nested values.
-    // Balance delimiters outside strings before parsing each complete candidate.
-    for (let start = 0; start < output.length; start++) {
-      const opening = output[start];
-      if (opening !== '{' && opening !== '[') {
-        continue;
-      }
-
-      const end = findJsonEnd(output, start);
-      if (end >= 0) {
-        try {
-          for (const name of extractToolNames(JSON.parse(output.slice(start, end + 1)))) {
-            names.add(name);
-          }
-          start = end;
-        } catch {
-          // A balanced fragment may still be invalid JSON.
-        }
+    for (const fragment of jsonFragments(output)) {
+      try {
+        collectToolNames(JSON.parse(fragment), names);
+      } catch {
+        // A balanced fragment may still be invalid JSON.
       }
     }
     return names;
   }
 
-  if (typeof output !== 'object') {
-    return names;
-  }
+  collectToolNames(output, names);
 
-  const obj = output as Record<string, unknown>;
-
-  // Handle OpenAI format: { tool_calls: [{ function: { name: "..." } }] }
-  if ('tool_calls' in obj && Array.isArray(obj.tool_calls)) {
-    for (const tc of obj.tool_calls) {
-      if (tc && typeof tc === 'object') {
-        const toolCall = tc as Record<string, unknown>;
-        // OpenAI: { function: { name: "..." } }
-        if (toolCall.function && typeof toolCall.function === 'object') {
-          const fn = toolCall.function as Record<string, unknown>;
-          if (typeof fn.name === 'string') {
-            names.add(fn.name);
-          }
-        }
-        // Simple: { name: "..." }
-        if (typeof toolCall.name === 'string') {
-          names.add(toolCall.name);
-        }
-      }
-    }
-    return names;
-  }
-
-  // Handle Anthropic single tool_use block: { type: 'tool_use', name: '...' }
-  if (obj.type === 'tool_use' && typeof obj.name === 'string') {
-    names.add(obj.name);
-    return names;
-  }
-
-  // OpenAI Responses API single item: { type: 'function_call', name: '...' }
-  if (obj.type === 'function_call' && typeof obj.name === 'string') {
-    names.add(obj.name);
-    return names;
-  }
-
-  // Handle Google/Vertex single functionCall: { functionCall: { name: '...' } }
-  if ('functionCall' in obj && obj.functionCall && typeof obj.functionCall === 'object') {
-    const fc = obj.functionCall as Record<string, unknown>;
-    if (typeof fc.name === 'string') {
-      names.add(fc.name);
-    }
-    return names;
-  }
-
-  // Handle Google Live format: { toolCall: { functionCalls: [...] } }
-  if ('toolCall' in obj && obj.toolCall && typeof obj.toolCall === 'object') {
-    const toolCall = obj.toolCall as Record<string, unknown>;
-    if ('functionCalls' in toolCall && Array.isArray(toolCall.functionCalls)) {
-      for (const fc of toolCall.functionCalls) {
-        if (
-          fc &&
-          typeof fc === 'object' &&
-          typeof (fc as Record<string, unknown>).name === 'string'
-        ) {
-          names.add((fc as Record<string, unknown>).name as string);
-        }
-      }
-    }
-    return names;
-  }
-
-  // Handle arrays (Anthropic content blocks, Google arrays, OpenAI arrays)
+  // Simple format: the whole output is a list of calls, e.g. [{ name: '...' }].
   if (Array.isArray(output)) {
     for (const item of output) {
-      if (item && typeof item === 'object') {
-        const block = item as Record<string, unknown>;
-
-        // Anthropic content block: { type: 'tool_use', name: '...' }
-        if (block.type === 'tool_use' && typeof block.name === 'string') {
-          names.add(block.name);
-          continue;
-        }
-
-        // Google/Vertex array item: { functionCall: { name: '...' } }
-        if (
-          'functionCall' in block &&
-          block.functionCall &&
-          typeof block.functionCall === 'object'
-        ) {
-          const fc = block.functionCall as Record<string, unknown>;
-          if (typeof fc.name === 'string') {
-            names.add(fc.name);
-          }
-          continue;
-        }
-
-        // OpenAI format: { function: { name: "..." } }
-        if (block.function && typeof block.function === 'object') {
-          const fn = block.function as Record<string, unknown>;
-          if (typeof fn.name === 'string') {
-            names.add(fn.name);
-          }
-          continue;
-        }
-
-        // Simple format: { name: "..." }
-        if (typeof block.name === 'string') {
-          names.add(block.name);
-        }
+      const name = (item as Record<string, unknown> | null | undefined)?.name;
+      if (typeof name === 'string') {
+        names.add(name);
       }
     }
   }

--- a/src/assertions/toolCallF1.ts
+++ b/src/assertions/toolCallF1.ts
@@ -7,9 +7,10 @@ import type { AssertionParams, GradingResult } from '../types/index';
  * Fragments inside an opener that never closes are returned too, so a stray brace in
  * prose cannot hide a tool call that follows it.
  *
- * `respectStrings` skips delimiters inside JSON strings, which is right for real JSON
- * but mis-tokenizes prose containing an odd number of quotes; the caller retries
- * without it when the first pass finds nothing.
+ * A quote only opens a JSON string once a delimiter is open, so prose quotes cannot
+ * swallow the JSON that follows them. `respectStrings: false` drops string tracking
+ * altogether, which the caller runs as a second pass for prose that opens a delimiter
+ * inside quotes.
  */
 function jsonFragments(text: string, respectStrings: boolean): string[] {
   // Each open delimiter collects the spans that completed directly inside it. They are
@@ -29,7 +30,7 @@ function jsonFragments(text: string, respectStrings: boolean): string[] {
       } else if (char === '"') {
         inString = false;
       }
-    } else if (char === '"' && respectStrings) {
+    } else if (char === '"' && respectStrings && open.length > 0) {
       inString = true;
     } else if (char === '{' || char === '[') {
       open.push({ start: i, nested: [] });
@@ -53,26 +54,30 @@ function jsonFragments(text: string, respectStrings: boolean): string[] {
  * The name of a single tool call, for shapes that identify themselves as one:
  * - Anthropic content block: { type: 'tool_use', name: '...' }
  * - OpenAI Responses item: { type: 'function_call', name: '...' }
- * - OpenAI tool call: { function: { name: '...' } }
  * - Google/Vertex: { functionCall: { name: '...' } }
+ *
+ * `{ function: { name } }` is missing on purpose: it is also the shape of an OpenAI tool
+ * *definition* (`{ type: 'function', function: { name, parameters } }`), so it only counts
+ * inside a list already known to hold calls.
  */
 function toolCallName(obj: Record<string, unknown>): string | undefined {
   if ((obj.type === 'tool_use' || obj.type === 'function_call') && typeof obj.name === 'string') {
     return obj.name;
   }
-  for (const key of ['function', 'functionCall'] as const) {
-    const call = obj[key];
-    if (call && typeof call === 'object') {
-      const { name } = call as Record<string, unknown>;
-      if (typeof name === 'string') {
-        return name;
-      }
+  const call = obj.functionCall;
+  if (call && typeof call === 'object') {
+    const { name } = call as Record<string, unknown>;
+    if (typeof name === 'string') {
+      return name;
     }
   }
   return undefined;
 }
 
-/** Adds names from a list whose entries are known to be tool calls, where a bare `{ name }` counts. */
+/**
+ * Adds names from a list whose entries are known to be tool calls, where
+ * `{ function: { name } }` and a bare `{ name }` count too.
+ */
 function addCallListNames(list: unknown, names: Set<string>): void {
   if (!Array.isArray(list)) {
     return;
@@ -80,7 +85,10 @@ function addCallListNames(list: unknown, names: Set<string>): void {
   for (const item of list) {
     if (item && typeof item === 'object') {
       const call = item as Record<string, unknown>;
-      const name = toolCallName(call) ?? call.name;
+      const fn = call.function;
+      const fnName =
+        fn && typeof fn === 'object' ? (fn as Record<string, unknown>).name : undefined;
+      const name = toolCallName(call) ?? fnName ?? call.name;
       if (typeof name === 'string') {
         names.add(name);
       }
@@ -88,15 +96,21 @@ function addCallListNames(list: unknown, names: Set<string>): void {
   }
 }
 
+/** Wrappers nest a few levels; the cap keeps adversarial nesting off the call stack. */
+const MAX_WRAPPER_DEPTH = 100;
+
 /**
  * Walks a parsed value and collects names from recognised tool-call shapes only.
  * Wrappers are traversed, so `{ result: { tool_calls: [...] } }` is found, but an
  * arbitrary `{ name: '...' }` object is never mistaken for a tool call.
  */
-function collectToolNames(value: unknown, names: Set<string>): void {
+function collectToolNames(value: unknown, names: Set<string>, depth = 0): void {
+  if (depth > MAX_WRAPPER_DEPTH) {
+    return;
+  }
   if (Array.isArray(value)) {
     for (const item of value) {
-      collectToolNames(item, names);
+      collectToolNames(item, names, depth + 1);
     }
     return;
   }
@@ -116,7 +130,17 @@ function collectToolNames(value: unknown, names: Set<string>): void {
   addCallListNames((obj.toolCall as Record<string, unknown> | undefined)?.functionCalls, names);
 
   for (const nested of Object.values(obj)) {
-    collectToolNames(nested, names);
+    collectToolNames(nested, names, depth + 1);
+  }
+}
+
+/** Parses one balanced fragment and harvests its calls; false when it is not JSON. */
+function addFragmentNames(fragment: string, names: Set<string>): boolean {
+  try {
+    collectToolNames(JSON.parse(fragment), names);
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -133,16 +157,17 @@ function extractToolNames(output: unknown): Set<string> {
     } catch {
       // Not valid JSON as a whole; harvest embedded tool-call JSON instead.
     }
+    // Both passes always run and their names are merged: an earlier call must not stop
+    // the quote-insensitive pass from recovering a later one.
     for (const respectStrings of [true, false]) {
       for (const fragment of jsonFragments(output, respectStrings)) {
-        try {
-          collectToolNames(JSON.parse(fragment), names);
-        } catch {
-          // A balanced fragment may still be invalid JSON.
+        if (!addFragmentNames(fragment, names)) {
+          // Prose can bracket a call, e.g. `[see: {"type":"tool_use",...}]`. Unwrapping one
+          // level recovers it; retrying every level would make the scan quadratic again.
+          for (const inner of jsonFragments(fragment.slice(1, -1), respectStrings)) {
+            addFragmentNames(inner, names);
+          }
         }
-      }
-      if (names.size > 0) {
-        break;
       }
     }
     return names;

--- a/src/assertions/toolCallF1.ts
+++ b/src/assertions/toolCallF1.ts
@@ -6,8 +6,12 @@ import type { AssertionParams, GradingResult } from '../types/index';
  * Outermost balanced `{...}` / `[...]` fragments of a string, found in a single pass.
  * Fragments inside an opener that never closes are returned too, so a stray brace in
  * prose cannot hide a tool call that follows it.
+ *
+ * `respectStrings` skips delimiters inside JSON strings, which is right for real JSON
+ * but mis-tokenizes prose containing an odd number of quotes; the caller retries
+ * without it when the first pass finds nothing.
  */
-function jsonFragments(text: string): string[] {
+function jsonFragments(text: string, respectStrings: boolean): string[] {
   // Each open delimiter collects the spans that completed directly inside it. They are
   // dropped when it closes, because the enclosing fragment already covers them.
   const open: { start: number; nested: [number, number][] }[] = [];
@@ -25,7 +29,7 @@ function jsonFragments(text: string): string[] {
       } else if (char === '"') {
         inString = false;
       }
-    } else if (char === '"') {
+    } else if (char === '"' && respectStrings) {
       inString = true;
     } else if (char === '{' || char === '[') {
       open.push({ start: i, nested: [] });
@@ -129,11 +133,16 @@ function extractToolNames(output: unknown): Set<string> {
     } catch {
       // Not valid JSON as a whole; harvest embedded tool-call JSON instead.
     }
-    for (const fragment of jsonFragments(output)) {
-      try {
-        collectToolNames(JSON.parse(fragment), names);
-      } catch {
-        // A balanced fragment may still be invalid JSON.
+    for (const respectStrings of [true, false]) {
+      for (const fragment of jsonFragments(output, respectStrings)) {
+        try {
+          collectToolNames(JSON.parse(fragment), names);
+        } catch {
+          // A balanced fragment may still be invalid JSON.
+        }
+      }
+      if (names.size > 0) {
+        break;
       }
     }
     return names;
@@ -142,14 +151,7 @@ function extractToolNames(output: unknown): Set<string> {
   collectToolNames(output, names);
 
   // Simple format: the whole output is a list of calls, e.g. [{ name: '...' }].
-  if (Array.isArray(output)) {
-    for (const item of output) {
-      const name = (item as Record<string, unknown> | null | undefined)?.name;
-      if (typeof name === 'string') {
-        names.add(name);
-      }
-    }
-  }
+  addCallListNames(output, names);
 
   return names;
 }

--- a/test/assertions/toolCallF1.test.ts
+++ b/test/assertions/toolCallF1.test.ts
@@ -400,6 +400,49 @@ describe('handleToolCallF1', () => {
     });
   });
 
+  describe('embedded JSON in prose', () => {
+    it.each([
+      ['a list of named records', 'Users: [{"name": "Alice"}, {"name": "Bob"}].'],
+      ['a named config entry', 'Config [{"name":"retries","value":3}] applied.'],
+      ['an unrelated named object', 'Metadata {"name":"session-1"} attached.'],
+    ])('does not treat %s as tool calls', (_name, prose) => {
+      const output = `${prose}\n{"tool_calls":[{"function":{"name":"get_weather"}}]}`;
+
+      const result = handleToolCallF1(createParams(output, ['get_weather']));
+
+      expect(result.reason).toContain('Called: [get_weather]');
+      expect(result.score).toBe(1);
+      expect(result.pass).toBe(true);
+    });
+
+    it('finds a tool call that follows an unbalanced brace', () => {
+      const output = 'Use {braces here\n{"type":"tool_use","name":"get_weather"}';
+
+      const result = handleToolCallF1(createParams(output, ['get_weather']));
+
+      expect(result.score).toBe(1);
+    });
+
+    it('scans brace-heavy output in linear time', () => {
+      const start = Date.now();
+      handleToolCallF1(createParams('{'.repeat(60_000), ['get_weather']));
+
+      // The previous scanner restarted at every brace, taking seconds for this input.
+      expect(Date.now() - start).toBeLessThan(1000);
+    });
+  });
+
+  describe('tool calls nested in a wrapper', () => {
+    it.each([
+      ['an OpenAI envelope', { result: { tool_calls: [{ function: { name: 'get_weather' } }] } }],
+      ['a Responses item', { output: [{ type: 'function_call', name: 'get_weather' }] }],
+      ['an Anthropic block', { message: { content: [{ type: 'tool_use', name: 'get_weather' }] } }],
+    ])('finds %s inside an outer object', (_name, output) => {
+      expect(handleToolCallF1(createParams(output, ['get_weather'])).score).toBe(1);
+      expect(handleToolCallF1(createParams(JSON.stringify(output), ['get_weather'])).score).toBe(1);
+    });
+  });
+
   describe('expected tools input format', () => {
     it('should accept array of tool names', () => {
       const output = { tool_calls: [{ function: { name: 'get_weather', arguments: '{}' } }] };

--- a/test/assertions/toolCallF1.test.ts
+++ b/test/assertions/toolCallF1.test.ts
@@ -428,6 +428,31 @@ describe('handleToolCallF1', () => {
       expect(result.score).toBe(1);
     });
 
+    it.each([
+      ['quote', 'He said "hello.'],
+      ['quoted brace', 'A "{" appears, then'],
+    ])('finds a later tool call when an unbalanced %s follows an earlier one', (_name, prose) => {
+      const output = `{"type":"tool_use","name":"get_weather"}\n${prose}\n{"type":"tool_use","name":"get_time"}`;
+
+      const result = handleToolCallF1(createParams(output, ['get_weather', 'get_time']));
+
+      expect(result.reason).toContain('Called: [get_time, get_weather]');
+      expect(result.score).toBe(1);
+    });
+
+    it('finds a tool call whose arguments contain a brace, after an unbalanced quote', () => {
+      const output =
+        'He said "hello.\n{"type":"tool_use","name":"get_weather","input":{"query":"{foo"}}';
+
+      expect(handleToolCallF1(createParams(output, ['get_weather'])).score).toBe(1);
+    });
+
+    it('finds a tool call wrapped in prose brackets', () => {
+      const output = 'Details [tool follows: {"type":"tool_use","name":"get_weather"}]';
+
+      expect(handleToolCallF1(createParams(output, ['get_weather'])).score).toBe(1);
+    });
+
     it('scans brace-heavy output in linear time', () => {
       const start = Date.now();
       handleToolCallF1(createParams('{'.repeat(60_000), ['get_weather']));
@@ -445,6 +470,31 @@ describe('handleToolCallF1', () => {
     ])('finds %s inside an outer object', (_name, output) => {
       expect(handleToolCallF1(createParams(output, ['get_weather'])).score).toBe(1);
       expect(handleToolCallF1(createParams(JSON.stringify(output), ['get_weather'])).score).toBe(1);
+    });
+
+    it('does not treat a tool definition as a call', () => {
+      const output = {
+        tools: [
+          { type: 'function', function: { name: 'get_weather', parameters: { type: 'object' } } },
+        ],
+      };
+
+      expect(handleToolCallF1(createParams(output, ['get_weather'])).score).toBe(0);
+      expect(handleToolCallF1(createParams(JSON.stringify(output), ['get_weather'])).score).toBe(0);
+    });
+
+    it('grades deeply nested output instead of overflowing the stack', () => {
+      const output: Record<string, unknown> = {};
+      let leaf = output;
+      for (let i = 0; i < 20_000; i++) {
+        leaf.nested = {};
+        leaf = leaf.nested as Record<string, unknown>;
+      }
+      leaf.tool_calls = [{ function: { name: 'get_weather' } }];
+      // JSON.stringify would overflow on this too, so build the params around it.
+      const params = { ...createParams({}, ['get_weather']), output };
+
+      expect(() => handleToolCallF1(params)).not.toThrow();
     });
   });
 

--- a/test/assertions/toolCallF1.test.ts
+++ b/test/assertions/toolCallF1.test.ts
@@ -415,8 +415,13 @@ describe('handleToolCallF1', () => {
       expect(result.pass).toBe(true);
     });
 
-    it('finds a tool call that follows an unbalanced brace', () => {
-      const output = 'Use {braces here\n{"type":"tool_use","name":"get_weather"}';
+    it.each([
+      ['brace', 'Use {braces here'],
+      ['quote', 'He said "hello.'],
+      ['escaped quote', 'Model wrote \\"x\\" and'],
+      ['quoted brace', 'A "{" appears, then'],
+    ])('finds a tool call that follows an unbalanced %s', (_name, prose) => {
+      const output = `${prose}\n{"type":"tool_use","name":"get_weather"}`;
 
       const result = handleToolCallF1(createParams(output, ['get_weather']));
 


### PR DESCRIPTION
## Summary

The embedded-JSON scanner added in #10789 fed **every** balanced JSON fragment found anywhere in a mixed text/JSON output into the tool-name extractor, whose array branch has a catch-all "simple format `{ name: '...' }`" rule. Ordinary JSON data appearing in prose was therefore harvested as a called tool, deflating precision and silently flipping passing evals to failures at the default threshold of 1.0:

| output | expected | before | after |
| --- | --- | --- | --- |
| `Users: [{"name": "Alice"}, {"name": "Bob"}].\n{"tool_calls":[…get_weather…]}` | `[get_weather]` | **0.500** (Called: Alice, Bob, get_weather) | 1.000 |
| `Config [{"name":"retries","value":3}] applied.\n{"tool_calls":[…get_weather…]}` | `[get_weather]` | **0.667** | 1.000 |

The same scanner restarted `findJsonEnd` at every `{`/`[`, making the scan O(braces × length). Measured on the old code: 60KB of braces (a model emitting code, or a truncated JSON blob) cost **~9 seconds of CPU per assertion**.

### What changed

`findJsonEnd` and the flat, top-level-only shape checks are gone, replaced by two smaller pieces:

- `jsonFragments` — one left-to-right pass with a delimiter stack that yields the outermost balanced fragments. Fragments inside an opener that never closes are still yielded, so the "stray brace in prose followed by a real tool call" case #10789 fixed keeps working. A quote only opens a JSON string once a delimiter is open, so prose quotes cannot swallow the JSON after them; a second pass ignoring string state covers prose that opens a delimiter *inside* quotes, and both passes' names are merged. A fragment that is not valid JSON falls back to the fragments one level inside it, which recovers a call the model wrapped in prose brackets. 60KB of braces now takes ~6ms; a 200KB adversarial `{` + `{}`×100000 takes ~28ms.
- `collectToolNames` — a depth-capped recursive walk that harvests only shapes that identify themselves as tool calls (`tool_use` / `function_call` items, `{ functionCall: { name } }`, `tool_calls` and `toolCall.functionCalls` lists). An arbitrary `{ name }` object is never mistaken for a tool call, and neither is an OpenAI tool *definition*: `{ function: { name } }` is the shape of both a call and a definition, so it only counts inside a list already known to hold calls.

Because the walk recurses, it also fixes a pre-existing gap: a tool-call envelope nested inside a wrapper is now found, where it previously scored 0 both before and after #10789.

| output | expected | before | after |
| --- | --- | --- | --- |
| `{"result":{"tool_calls":[…get_weather…]}}` | `[get_weather]` | **0** | 1.000 |
| `{"output":[{"type":"function_call","name":"get_weather"}]}` | `[get_weather]` | **0** | 1.000 |
| `{"tools":[{"type":"function","function":{"name":"get_weather","parameters":{…}}}]}` (a definition, nothing called) | `[get_weather]` | 0 | **0** |

The permissive "whole output is a bare list of `{ name }` calls" rule is kept, since there the entire provider output *is* the call list.

Docs updated with one sentence describing the wrapper traversal and the shapes that are ignored.

## Test plan

Added to `test/assertions/toolCallF1.test.ts`: three prose-contamination cases, four unbalanced-prose recovery cases (brace, quote, escaped quote, quoted brace), two "earlier call must not hide a later one" cases, a call whose arguments contain a brace after a prose quote, a call wrapped in prose brackets, a linear-time guard (`'{'.repeat(60_000)` under 1s), three nested-wrapper cases (object and JSON-string forms), a tool-definition case, and a deep-nesting case that must grade rather than overflow.

- Each new assertion confirmed failing on the implementation it fixes, and passing after.
- `npx vitest run test/assertions/toolCallF1.test.ts test/assertions/toolCallF1.responses.test.ts` → **88 passed**, every pre-existing case still green (bare Responses `function_call` item, pretty-printed multiline block in prose, single-line JSON call in prose, Anthropic/Google shapes).
- `npx vitest run test/assertions/` → **1447 passed** (62 files).
- `npx tsc --noEmit -p tsconfig.json` → clean.
- `npx biome check` on the changed files, `npx prettier --write` on the doc → clean.
