### PR TITLE
fix(assertions): stop silently mis-grading native audio

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -73,15 +73,14 @@ To evaluate tone, pacing, or pronunciation, choose an audio-capable OpenAI Chat 
 assert:
   - type: llm-rubric
     value: The speaker sounds calm and speaks at a steady pace.
-    provider:
-      id: openai:chat:gpt-audio-1.5
-      config:
-        modalities: [text]
+    provider: openai:chat:gpt-audio-1.5
 ```
 
-`modalities: [text]` requests the grader's JSON result as text. The grader listens to the attached audio and uses the transcript as supporting context. This works with audio from [OpenAI Realtime](/docs/providers/openai#realtime-api-models), audio chat, text to speech, or a custom target provider that returns the same audio fields.
+Promptfoo requests the grade as text, so the grader spends its completion budget on the JSON verdict rather than on speech. The grader listens to the attached audio and uses the transcript as supporting context. This works with audio from [OpenAI Realtime](/docs/providers/openai#realtime-api-models), audio chat, text to speech, or a custom target provider that returns the same audio fields.
 
-The target must return inline base64 audio with `format: wav` or `format: mp3`, up to 20 MiB. Blob references and other formats produce a grading error. The built-in Realtime provider converts its default PCM16 output to WAV, including in persistent conversations; use `output_audio_format: pcm16` for grading. Text-only graders retain their existing behavior and evaluate the text output or transcript.
+The target must return inline base64 audio with `format: wav` or `format: mp3`, up to 20 MiB. Blob references and other formats produce a grading error. The built-in Realtime provider converts its default PCM16 output to WAV, including in persistent conversations; use `output_audio_format: pcm16` for grading.
+
+A grader that cannot listen to audio grades the transcript instead and logs a warning. If the output has no transcript either, the assertion errors rather than grading a placeholder.
 
 An assertion with `transform` grades the transformed text and does not attach the original audio. Successful audio grades include `renderedGradingPromptAudio: true` in assertion metadata; `renderedGradingPrompt` contains the text prompt without the attached audio bytes.
 

--- a/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
+++ b/site/docs/configuration/expected-outputs/model-graded/llm-rubric.md
@@ -80,7 +80,7 @@ Promptfoo requests the grade as text, so the grader spends its completion budget
 
 The target must return inline base64 audio with `format: wav` or `format: mp3`, up to 20 MiB. Blob references and other formats produce a grading error. The built-in Realtime provider converts its default PCM16 output to WAV, including in persistent conversations; use `output_audio_format: pcm16` for grading.
 
-A grader that cannot listen to audio grades the transcript instead and logs a warning. If the output has no transcript either, the assertion errors rather than grading a placeholder.
+A grader that cannot listen to audio grades the text output instead and logs a warning. If the output is the audio itself and there is no transcript, the assertion errors rather than grading a placeholder.
 
 An assertion with `transform` grades the transformed text and does not attach the original audio. Successful audio grades include `renderedGradingPromptAudio: true` in assertion metadata; `renderedGradingPrompt` contains the text prompt without the attached audio bytes.
 

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -918,7 +918,7 @@ defaultTest:
       provider: openai:chat:gpt-audio-1.5
 ```
 
-Promptfoo sends the generated audio to this grader and requests a text grade. A grader that cannot listen to audio grades the transcript instead and logs a warning; without a transcript the assertion errors. Audio must be inline base64 WAV or MP3, up to 20 MiB. Keep the Realtime provider's default `output_audio_format: pcm16`; Promptfoo converts it to WAV for both single requests and persistent conversations. G.711 output requires conversion before audio grading. See [audio grading](/docs/configuration/expected-outputs/model-graded/llm-rubric#audio-output) for limits and transformed outputs.
+Promptfoo sends the generated audio to this grader and requests a text grade. A grader that cannot listen to audio grades the text output instead and logs a warning; when the output is the audio itself with no transcript, the assertion errors. Audio must be inline base64 WAV or MP3, up to 20 MiB. Keep the Realtime provider's default `output_audio_format: pcm16`; Promptfoo converts it to WAV for both single requests and persistent conversations. G.711 output requires conversion before audio grading. See [audio grading](/docs/configuration/expected-outputs/model-graded/llm-rubric#audio-output) for limits and transformed outputs.
 
 ### Session settings {#realtime-specific-configuration-options}
 

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -915,13 +915,10 @@ defaultTest:
   assert:
     - type: llm-rubric
       value: The speaker sounds calm and speaks at a steady pace.
-      provider:
-        id: openai:chat:gpt-audio-1.5
-        config:
-          modalities: [text]
+      provider: openai:chat:gpt-audio-1.5
 ```
 
-Promptfoo sends the generated audio to this grader and requests a text grade. Text-only graders continue to evaluate the transcript. Audio must be inline base64 WAV or MP3, up to 20 MiB. Keep the Realtime provider's default `output_audio_format: pcm16`; Promptfoo converts it to WAV for both single requests and persistent conversations. G.711 output requires conversion before audio grading. See [audio grading](/docs/configuration/expected-outputs/model-graded/llm-rubric#audio-output) for limits and transformed outputs.
+Promptfoo sends the generated audio to this grader and requests a text grade. A grader that cannot listen to audio grades the transcript instead and logs a warning; without a transcript the assertion errors. Audio must be inline base64 WAV or MP3, up to 20 MiB. Keep the Realtime provider's default `output_audio_format: pcm16`; Promptfoo converts it to WAV for both single requests and persistent conversations. G.711 output requires conversion before audio grading. See [audio grading](/docs/configuration/expected-outputs/model-graded/llm-rubric#audio-output) for limits and transformed outputs.
 
 ### Session settings {#realtime-specific-configuration-options}
 

--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -25,6 +25,7 @@ import {
   loadRubricPrompt,
   materializeImageOutputsForGrading,
   renderLlmRubricPrompt,
+  requireAudioGradingEvidence,
   runJsonGradingPrompt,
 } from './rubric';
 import { fail, graderFail, normalizeMatcherTokenUsage, tryParse } from './shared';
@@ -216,6 +217,9 @@ export async function matchesLlmRubric(
     cliState.config?.redteam &&
     shouldUseRemoteGrading({ canUseCodexDefaultProvider: true })
   ) {
+    if (audio?.data) {
+      requireAudioGradingEvidence(audio, 'Remote grading');
+    }
     try {
       return {
         ...(await doRemoteGrading({

--- a/src/matchers/llmGrading.ts
+++ b/src/matchers/llmGrading.ts
@@ -21,6 +21,7 @@ import {
   shouldUseRemoteGrading,
 } from './providers';
 import {
+  ATTACHED_AUDIO_OUTPUT_PLACEHOLDER,
   LlmRubricProviderError,
   loadRubricPrompt,
   materializeImageOutputsForGrading,
@@ -175,7 +176,7 @@ function getGradingOutputForAudio(llmOutput: string, audio: ProviderResponse['au
     .replace(/^data:audio\/[^;,]+;base64,/i, '')
     .replace(/\s/g, '');
   return outputData === audio.data.replace(/\s/g, '')
-    ? audio.transcript || '[Audio output]'
+    ? audio.transcript || ATTACHED_AUDIO_OUTPUT_PLACEHOLDER
     : llmOutput;
 }
 
@@ -218,7 +219,7 @@ export async function matchesLlmRubric(
     shouldUseRemoteGrading({ canUseCodexDefaultProvider: true })
   ) {
     if (audio?.data) {
-      requireAudioGradingEvidence(audio, 'Remote grading');
+      requireAudioGradingEvidence(gradingOutput, 'Remote grading');
     }
     try {
       return {

--- a/src/matchers/providers.ts
+++ b/src/matchers/providers.ts
@@ -94,12 +94,14 @@ export function callProviderWithContext(
   label: string,
   vars: Record<string, VarValue>,
   context?: CallApiContextParams,
+  promptConfig?: Record<string, unknown>,
 ): Promise<ProviderResponse> {
   const callApiContext = {
     ...context,
     prompt: {
       raw: prompt,
       label,
+      ...(promptConfig ? { config: promptConfig } : {}),
     },
     vars,
   };

--- a/src/matchers/rubric.ts
+++ b/src/matchers/rubric.ts
@@ -38,6 +38,8 @@ const DEFAULT_GRADING_IMAGE_MAX_RAW_CHARS =
 const DEFAULT_GRADING_IMAGE_MAX_TOTAL_RAW_CHARS =
   Math.ceil(DEFAULT_GRADING_IMAGE_MAX_TOTAL_BYTES / 3) * 4 +
   DEFAULT_GRADING_MAX_IMAGES * DATA_URI_METADATA_MAX_CHARS;
+/** Stands in for an audio-only output, which has no text a grader could read. */
+export const ATTACHED_AUDIO_OUTPUT_PLACEHOLDER = '[Audio output]';
 const MULTIMODAL_GRADING_INSTRUCTION =
   'The evaluated output includes the attached image(s). Treat the attached image(s) as primary evidence in <Output>. Inspect the visual content directly, and do not infer visual traits, demographics, safety issues, or rubric failures from the user prompt or from any base64/data URI text.';
 const BLOB_HASH_REGEX = /^[a-f0-9]{64}$/i;
@@ -710,20 +712,18 @@ function appendMediaToChatPrompt(
 }
 
 /**
- * A grader that can neither hear the clip nor read a transcript would grade a
- * placeholder and return a confident, meaningless verdict. Fall back to the
- * transcript loudly, or fail.
+ * A grader that cannot hear the clip grades whatever text the output carries.
+ * When that text is only the placeholder — the output was the audio itself and
+ * there is no transcript — there is nothing to grade, so fail instead of
+ * returning a confident, meaningless verdict.
  */
-export function requireAudioGradingEvidence(
-  audio: NonNullable<ProviderResponse['audio']>,
-  grader: string,
-): void {
-  if (!audio.transcript) {
+export function requireAudioGradingEvidence(gradedOutput: unknown, grader: string): void {
+  if (gradedOutput === ATTACHED_AUDIO_OUTPUT_PLACEHOLDER) {
     throw new Error(
       `${grader} cannot listen to audio output and the output has no transcript. Grade with an audio-capable provider such as openai:chat:gpt-audio.`,
     );
   }
-  logger.warn('[Grading] Grader cannot listen to audio; grading the transcript instead', {
+  logger.warn('[Grading] Grader cannot listen to audio; grading the text output instead', {
     grader,
   });
 }
@@ -733,9 +733,6 @@ function buildAudioGradingPart(
   provider: ApiProvider,
 ): MultimodalPromptPart | undefined {
   if (!provider.supportsAudioInput?.()) {
-    if (audio.data) {
-      requireAudioGradingEvidence(audio, `Grading provider ${provider.id()}`);
-    }
     return undefined;
   }
   if (audio.blobRef || hasBlobRefImageValue(audio.data)) {
@@ -902,6 +899,9 @@ export async function runJsonGradingPrompt({
     imageCount,
     audioAttached,
   } = await buildGradingProviderPrompt(renderedPrompt, images, finalProvider, audio);
+  if (audio?.data && !audioAttached) {
+    requireAudioGradingEvidence(vars.output, `Grading provider ${finalProvider.id()}`);
+  }
   const resp = await callProviderWithContext(
     finalProvider,
     providerPrompt,

--- a/src/matchers/rubric.ts
+++ b/src/matchers/rubric.ts
@@ -709,11 +709,33 @@ function appendMediaToChatPrompt(
   ]);
 }
 
+/**
+ * A grader that can neither hear the clip nor read a transcript would grade a
+ * placeholder and return a confident, meaningless verdict. Fall back to the
+ * transcript loudly, or fail.
+ */
+export function requireAudioGradingEvidence(
+  audio: NonNullable<ProviderResponse['audio']>,
+  grader: string,
+): void {
+  if (!audio.transcript) {
+    throw new Error(
+      `${grader} cannot listen to audio output and the output has no transcript. Grade with an audio-capable provider such as openai:chat:gpt-audio.`,
+    );
+  }
+  logger.warn('[Grading] Grader cannot listen to audio; grading the transcript instead', {
+    grader,
+  });
+}
+
 function buildAudioGradingPart(
   audio: NonNullable<ProviderResponse['audio']>,
   provider: ApiProvider,
 ): MultimodalPromptPart | undefined {
-  if (provider.getAudioInputFormat?.() !== 'openai') {
+  if (!provider.supportsAudioInput?.()) {
+    if (audio.data) {
+      requireAudioGradingEvidence(audio, `Grading provider ${provider.id()}`);
+    }
     return undefined;
   }
   if (audio.blobRef || hasBlobRefImageValue(audio.data)) {
@@ -886,6 +908,8 @@ export async function runJsonGradingPrompt({
     label,
     vars,
     providerCallContext,
+    // Native-audio graders speak their answer by default; grading needs text back.
+    audioAttached ? { modalities: ['text'] } : undefined,
   );
   if (resp.error || !resp.output) {
     if (throwOnError) {

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -92,12 +92,10 @@ function getChatSearchSurcharge(modelName: string): number {
 }
 
 export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
-  getAudioInputFormat(): 'openai' | undefined {
+  supportsAudioInput(): boolean {
     const model =
       (this.config.passthrough as { model?: unknown } | undefined)?.model ?? this.modelName;
-    return typeof model === 'string' && /^gpt-(?:audio|4o(?:-mini)?-audio)(?:-|$)/.test(model)
-      ? 'openai'
-      : undefined;
+    return typeof model === 'string' && /^gpt-(?:audio|4o(?:-mini)?-audio)(?:-|$)/.test(model);
   }
 
   static OPENAI_CHAT_MODELS = OPENAI_CHAT_MODELS;

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -127,8 +127,8 @@ export interface ApiProvider extends MinimalApiProvider {
   config?: any;
   delay?: number;
   getSessionId?: () => string;
-  /** Native audio input content format accepted by this provider and its configured model. */
-  getAudioInputFormat?: () => 'openai' | undefined;
+  /** Whether this provider and its configured model accept native audio input. */
+  supportsAudioInput?: () => boolean;
   inputs?: Inputs;
   label?: ProviderLabel;
   transform?: string | TransformFunction;

--- a/test/assertions/llmRubric.audio.test.ts
+++ b/test/assertions/llmRubric.audio.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { handleLlmRubric } from '../../src/assertions/llmRubric';
 import { fetchWithCache } from '../../src/cache';
+import logger from '../../src/logger';
 import { OpenAiChatCompletionProvider } from '../../src/providers/openai/chat';
 import { OpenAiResponsesProvider } from '../../src/providers/openai/responses';
 
@@ -174,6 +175,49 @@ describe('llm-rubric audio grading', () => {
         'Grade Hello. for The speaker sounds calm.',
       );
       expect(result.metadata).not.toHaveProperty('renderedGradingPromptAudio');
+    },
+  );
+
+  it('requests a text-only grade so the audio grader does not answer in speech', async () => {
+    await grade(new OpenAiChatCompletionProvider('gpt-audio-1.5'));
+    const body = JSON.parse(vi.mocked(fetchWithCache).mock.calls[0][1]!.body as string);
+    expect(body.modalities).toEqual(['text']);
+  });
+
+  it.each([new OpenAiChatCompletionProvider('gpt-4.1'), new OpenAiResponsesProvider('gpt-5.6')])(
+    'warns when a text grader drops the audio ($modelName)',
+    async (provider) => {
+      const warn = vi.spyOn(logger, 'warn');
+      const call = vi
+        .spyOn(provider, 'callApi')
+        .mockResolvedValue({ output: '{"pass":true,"score":1}' });
+      expect(await grade(provider)).toMatchObject({ pass: true });
+      expect(JSON.parse(call.mock.calls[0][0])[1].content).toBe(
+        'Grade Hello. for The speaker sounds calm.',
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('grading the transcript instead'),
+        expect.anything(),
+      );
+    },
+  );
+
+  it.each([new OpenAiChatCompletionProvider('gpt-4.1'), new OpenAiResponsesProvider('gpt-5.6')])(
+    'fails instead of grading an audio placeholder ($modelName)',
+    async (provider) => {
+      const call = vi.spyOn(provider, 'callApi');
+      await expect(
+        grade(provider, { ...audio, transcript: undefined }, {
+          output: audio.data,
+          outputString: audio.data,
+          providerResponse: {
+            output: audio.data,
+            isBase64: true,
+            audio: { ...audio, transcript: undefined },
+          },
+        } as Partial<AssertionParams>),
+      ).rejects.toThrow('cannot listen to audio output and the output has no transcript');
+      expect(call).not.toHaveBeenCalled();
     },
   );
 

--- a/test/assertions/llmRubric.audio.test.ts
+++ b/test/assertions/llmRubric.audio.test.ts
@@ -196,8 +196,25 @@ describe('llm-rubric audio grading', () => {
         'Grade Hello. for The speaker sounds calm.',
       );
       expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('grading the transcript instead'),
+        expect.stringContaining('grading the text output instead'),
         expect.anything(),
+      );
+    },
+  );
+
+  it.each([new OpenAiChatCompletionProvider('gpt-4.1'), new OpenAiResponsesProvider('gpt-5.6')])(
+    'grades the text output of a transcript-less target ($modelName)',
+    async (provider) => {
+      const call = vi
+        .spyOn(provider, 'callApi')
+        .mockResolvedValue({ output: '{"pass":true,"score":1}' });
+      // Text-to-speech targets attach audio with no transcript and a separate
+      // text output; that text is real evidence, so grade it rather than error.
+      expect(await grade(provider, { data: audio.data, format: 'wav' })).toMatchObject({
+        pass: true,
+      });
+      expect(JSON.parse(call.mock.calls[0][0])[1].content).toBe(
+        'Grade Hello. for The speaker sounds calm.',
       );
     },
   );

--- a/test/evaluator/assertions.test.ts
+++ b/test/evaluator/assertions.test.ts
@@ -26,7 +26,7 @@ describeEvaluator('evaluator assertions', () => {
     });
     const grader: ApiProvider = {
       id: () => 'audio-grader',
-      getAudioInputFormat: () => 'openai',
+      supportsAudioInput: () => true,
       callApi: vi.fn(async () => {
         callOrder.push('grader');
         return { output: '{"pass":true,"score":1}' };
@@ -60,7 +60,7 @@ describeEvaluator('evaluator assertions', () => {
       });
       const grader: ApiProvider = {
         ...mockGradingApiProviderPasses,
-        getAudioInputFormat: () => 'openai',
+        supportsAudioInput: () => true,
       };
       const testSuite: TestSuite = {
         providers: [mockApiProvider],


### PR DESCRIPTION
## Summary

`llm-rubric` audio grading (#10814) could return a confident pass/fail without the grader ever hearing the audio.

**Root cause.** `buildAudioGradingPart` attaches the clip only when the grading provider implements the audio-input capability hook, and `OpenAiChatCompletionProvider` is the only class that does. With any other grader — Anthropic, Google, Bedrock, Azure, or an OpenAI **Responses** provider (which is what a bare `openai:gpt-5.6+` now resolves to after b051efdc6a) — the audio part was dropped with no warning. Meanwhile `getGradingOutputForAudio` had already replaced the base64 output with `audio.transcript || '[Audio output]'`, so a transcript-less audio target got graded against the literal string `[Audio output]`. Silently wrong, not an error.

Second bug: audio grading requests never asked for text, so a `gpt-audio` grader defaulted to `modalities: ['text', 'audio']` and spent its completion budget speaking the verdict.

**Changes.**

- Audio evidence now has to reach the grader. A grader that cannot listen falls back to the output's text with a `logger.warn`, and errors when that text is only the `[Audio output]` placeholder — i.e. the output *is* the clip and there is no transcript — instead of grading the placeholder. A target that returns real text alongside a clip (`openai:tts`, `elevenlabs:tts`, a custom provider) still grades that text. The remote-grading path, which can never attach audio, goes through the same check.
- Audio grading requests `modalities: ['text']` via the existing `Prompt.config` merge (`callProviderWithContext` gained one optional argument) — no provider cloning or mutation, and it is exactly what the docs previously told users to configure by hand.

**Simplified.**

- `getAudioInputFormat(): 'openai' | undefined` → `supportsAudioInput(): boolean`. One implementer and one format made the string return value and the `!== 'openai'` comparison dead weight.
- Docs drop the now-redundant `config: { modalities: [text] }` from both grader examples, and the "text-only graders retain their existing behavior" sentence is replaced with the actual warn/fail contract.

## Test plan

New regression cases in `test/assertions/llmRubric.audio.test.ts` (7 cases across 4 tests, verified against `src/` from `main`):

- `fails instead of grading an audio placeholder` — text grader + base64 output + no transcript now rejects and never contacts the grader (previously graded `[Audio output]` and passed). Fails on `main`.
- `warns when a text grader drops the audio` — text fallback is logged, for both `gpt-4.1` (Chat) and `gpt-5.6` (Responses). Fails on `main`.
- `requests a text-only grade so the audio grader does not answer in speech` — body carries `modalities: ['text']` with no grader-side config. Fails on `main`.
- `grades the text output of a transcript-less target` — text grader + text output + transcript-less clip still grades the text. Passes on `main`; it pins the behavior this PR must not break.

```
npx vitest run test/assertions/llmRubric.audio.test.ts    # 29 passed (22 before)
git checkout main -- src/ && npx vitest run …             # 5 failed | 24 passed
npx vitest run test/matchers test/assertions test/evaluator/assertions.test.ts test/providers/openai/chat.test.ts  # 1897 passed
npx tsc --noEmit -p tsconfig.json                         # clean
npx biome check <changed files>                           # clean
npx prettier --check <changed .md>                        # clean
npm run knip -- --no-progress                             # clean
npm run architecture:check                                # boundaries passed
```
