### PR TITLE
fix(n8n): send HEAD webhook payloads as query params

### DIFF
--- a/site/docs/providers/n8n.md
+++ b/site/docs/providers/n8n.md
@@ -49,16 +49,16 @@ providers:
 
 ### Config Options
 
-| Option              | Type          | Default     | Description                                                                                                      |
-| ------------------- | ------------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
-| `url`               | string        | -           | Webhook URL (alternative to provider path)                                                                       |
-| `method`            | string        | `POST`      | `GET`, `HEAD`, `POST`, `PUT`, or `PATCH`; `GET` encodes body fields as query parameters and `HEAD` sends no body |
-| `headers`           | object        | -           | Additional request headers with Nunjucks templating                                                              |
-| `body`              | object/string | `{prompt}`  | Request/body-query template; object form is recommended for JSON requests                                        |
-| `transformResponse` | string        | -           | JavaScript expression to extract output                                                                          |
-| `sessionHeader`     | string        | -           | Request header name for the session ID                                                                           |
-| `sessionParser`     | string        | -           | JavaScript expression to extract a session ID                                                                    |
-| `sessionField`      | string        | `sessionId` | Body field name for a supplied session ID                                                                        |
+| Option              | Type          | Default     | Description                                                                                                   |
+| ------------------- | ------------- | ----------- | ------------------------------------------------------------------------------------------------------------- |
+| `url`               | string        | -           | Webhook URL (alternative to provider path)                                                                    |
+| `method`            | string        | `POST`      | `GET`, `HEAD`, `POST`, `PUT`, or `PATCH`; `GET` and `HEAD` send no body and encode fields as query parameters |
+| `headers`           | object        | -           | Additional request headers with Nunjucks templating                                                           |
+| `body`              | object/string | `{prompt}`  | Request/body-query template; object form is recommended for JSON requests                                     |
+| `transformResponse` | string        | -           | JavaScript expression to extract output                                                                       |
+| `sessionHeader`     | string        | -           | Request header name for the session ID                                                                        |
+| `sessionParser`     | string        | -           | JavaScript expression to extract a session ID                                                                 |
+| `sessionField`      | string        | `sessionId` | Body field name for a supplied session ID                                                                     |
 
 YAML method values are case-insensitive. TypeScript configurations using `N8nProviderConfig` use the uppercase names above.
 

--- a/src/providers/n8n.ts
+++ b/src/providers/n8n.ts
@@ -430,7 +430,7 @@ export class N8nProvider implements ApiProvider {
     return this.addSessionField(renderValue(this.config.body), context);
   }
 
-  private buildGetUrl(body: N8nRequestBody): string {
+  private buildQueryUrl(body: N8nRequestBody): string {
     const requestUrl = new URL(this.getUrl());
 
     if (typeof body === 'string') {
@@ -531,25 +531,24 @@ export class N8nProvider implements ApiProvider {
     callOptions?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
     // Normalize method to upper-case so `method: get` (or `Post`) in YAML
-    // doesn't bypass the GET / non-idempotent branches downstream — both the
-    // GET-vs-body decision and the maxRetries policy depend on exact case
+    // doesn't bypass the bodyless / non-idempotent branches downstream — both
+    // the payload placement and the maxRetries policy depend on exact case
     // matches against the standard verb spelling.
     const method = (this.config.method || 'POST').toUpperCase();
     const timeout = this.config.timeout || getRequestTimeoutMs();
 
     const body = this.buildRequestBody(prompt, context);
-    const url = method === 'GET' ? this.buildGetUrl(body) : this.getUrl();
+    // GET and HEAD cannot carry a request body (fetch rejects one outright), so
+    // the rendered payload only reaches the workflow via the query string.
+    const isBodyless = method === 'GET' || method === 'HEAD';
+    const url = isBodyless ? this.buildQueryUrl(body) : this.getUrl();
     const headers = this.buildHeaders(prompt, context);
-    const renderedBody = typeof body === 'string' ? body : JSON.stringify(body);
     const fetchOptions: RequestInit = {
       method,
       headers,
+      ...(!isBodyless && { body: typeof body === 'string' ? body : JSON.stringify(body) }),
       ...(callOptions?.abortSignal && { signal: callOptions.abortSignal }),
     };
-
-    if (method !== 'GET' && method !== 'HEAD') {
-      fetchOptions.body = renderedBody;
-    }
 
     logger.debug('[n8n] Calling webhook', {
       hasBody: fetchOptions.body !== undefined,

--- a/test/providers/n8n.test.ts
+++ b/test/providers/n8n.test.ts
@@ -91,7 +91,7 @@ describe('N8nProvider', () => {
       { method: 'HEAD' } satisfies N8nProviderConfig,
       { method: 'head' },
       { method: 'HeAd' },
-    ])('sends $method requests without a body', async (config) => {
+    ])('sends $method requests with the payload in the query string', async (config) => {
       vi.mocked(fetchWithCache).mockImplementation(async (url, options) => {
         // Use the native Fetch contract without sending a network request.
         new Request(url, options);
@@ -104,8 +104,10 @@ describe('N8nProvider', () => {
       const result = await provider.callApi('Hello');
 
       expect(result.error).toBeUndefined();
+      // HEAD carries no body, so the prompt has to travel in the query string
+      // or the webhook receives nothing at all.
       expect(fetchWithCache).toHaveBeenCalledWith(
-        'https://n8n.example.com/webhook/agent',
+        'https://n8n.example.com/webhook/agent?prompt=Hello',
         expect.objectContaining({ method: 'HEAD' }),
         expect.any(Number),
         'text',
@@ -953,7 +955,7 @@ describe('createN8nProvider', () => {
   it('normalizes lowercase / mixed-case method strings before routing GET vs POST', async () => {
     // YAML happily accepts `method: get` even though the TypeScript union
     // declares uppercase verbs. Without normalization, `method === 'GET'`
-    // misses, buildGetUrl() is skipped, and the body is sent with a GET
+    // misses, buildQueryUrl() is skipped, and the body is sent with a GET
     // request — undici rejects with "Request with GET/HEAD method cannot
     // have body". Normalizing also routes the request through the correct
     // (idempotent vs non-idempotent) retry policy.


### PR DESCRIPTION
## Summary

A `method: HEAD` n8n webhook sent **neither a body nor query parameters**, so the rendered prompt was silently dropped and the target workflow received nothing at all.

Root cause: [`7f897cfcc4`](https://github.com/promptfoo/promptfoo/commit/7f897cfcc4) (#10730) added `HEAD` to the body-omission check in `callApi` but not to the URL-building branch one line above:

```ts
const url = method === 'GET' ? this.buildGetUrl(body) : this.getUrl();  // HEAD missed
...
if (method !== 'GET' && method !== 'HEAD') { fetchOptions.body = renderedBody; }
```

`HEAD` is a bodyless method, so the payload has nowhere to go except the query string.

**What changed (net -1 line in `src/providers/n8n.ts`):**

- Collapsed the two duplicated method string comparisons into one `isBodyless` predicate that drives both the URL and the body — deleting the standalone `if` block and the now-inlinable `renderedBody` local.
- Renamed `buildGetUrl` → `buildQueryUrl`, since it now serves both bodyless verbs.
- Left the `isIdempotent` retry-policy list at the bottom of `callApi` alone: idempotent ≠ bodyless (`PUT`/`DELETE` are idempotent but do carry bodies), so conflating them would be a regression.
- Updated the `method` row in the provider docs.

## Test plan

The existing HEAD test encoded the bug (it asserted the bare URL); it now asserts the prompt is carried in the query string, and fails on the pre-fix source.

```
# regression check: stash the src fix, run tests
$ git stash push -- src/providers/n8n.ts && npx vitest run test/providers/n8n.test.ts
  Tests  3 failed | 53 passed (56)
  → expected 'https://n8n.example.com/webhook/agent?prompt=Hello'

# with the fix applied
$ npx vitest run test/providers/n8n.test.ts
  Test Files  1 passed (1)
  Tests  56 passed (56)

$ npx tsc --noEmit -p tsconfig.json          # clean
$ npx biome check src/providers/n8n.ts test/providers/n8n.test.ts   # clean
$ npx prettier --write site/docs/providers/n8n.md                   # clean
```
