### PR TITLE
fix(providers): resolve azure model for guards and cost

### DIFF
--- a/src/providers/azure/chat.ts
+++ b/src/providers/azure/chat.ts
@@ -26,13 +26,14 @@ import { applyGpt6AstraRequestRules, isGpt6AstraModel } from '../openai/gpt6';
 import { getRequestTimeoutMs, parseChatPrompt, transformTools } from '../shared';
 import { DEFAULT_AZURE_API_VERSION } from './defaults';
 import { AzureGenericProvider } from './generic';
-import { calculateAzureCost } from './util';
+import { calculateAzureCost, resolveAzureModelName } from './util';
 
 import type {
   CallApiContextParams,
   CallApiOptionsParams,
   ProviderResponse,
 } from '../../types/index';
+import type { McpToolCallEntry } from '../mcp/types';
 import type { AzureChatResponsesOptions, AzureProviderOptions } from './types';
 
 export class AzureChatCompletionProvider extends AzureGenericProvider {
@@ -77,7 +78,9 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
    * Reasoning models use max_completion_tokens instead of max_tokens,
    * don't support temperature, and accept reasoning_effort parameter.
    */
-  protected isReasoningModel(modelName = this.config.modelName ?? this.deploymentName): boolean {
+  protected isReasoningModel(
+    modelName = resolveAzureModelName(this.config, this.deploymentName),
+  ): boolean {
     // Check explicit config flags first
     if (this.config.isReasoningModel || this.config.o1) {
       return true;
@@ -126,13 +129,16 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
    * accepted; `presence_penalty`, `stop`, and `reasoning_effort: none` are rejected. The direct
    * xAI provider strips the same three parameters for its GROK_4_MODELS list.
    *
-   * Matched on the deployment name, like the other Azure model heuristics. Grok 3 and
-   * grok-code-fast accept these parameters, so only Grok 4 and newer are matched — the
-   * two-or-more-digit alternative keeps a future `grok-10` on the restricted path rather
-   * than silently regressing it to the failing default.
+   * Matched on the resolved model, like the other Azure model heuristics, so a deployment
+   * named `prod-chat` that serves Grok is still recognized. Grok 3 and grok-code-fast accept
+   * these parameters, so only Grok 4 and newer are matched — the two-or-more-digit
+   * alternative keeps a future `grok-10` on the restricted path rather than silently
+   * regressing it to the failing default.
    */
-  protected isGrok4OrNewerModel(): boolean {
-    return /grok-(?:[4-9]|\d{2,})/.test(this.deploymentName.toLowerCase());
+  protected isGrok4OrNewerModel(
+    modelName = resolveAzureModelName(this.config, this.deploymentName),
+  ): boolean {
+    return /grok-(?:[4-9]|\d{2,})/.test(modelName.toLowerCase());
   }
 
   /**
@@ -145,7 +151,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
   protected isSamplingParamsDeprecatedClaudeModel(config = this.config): boolean {
     return (
       Boolean(config.isClaudeOpus47OrLater) ||
-      isSamplingParamsDeprecatedClaudeModel(config.modelName ?? this.deploymentName, {
+      isSamplingParamsDeprecatedClaudeModel(resolveAzureModelName(config, this.deploymentName), {
         allowGenerationFallback: false,
       })
     );
@@ -197,16 +203,12 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
         }
       : {};
 
-    // Check if this is configured as a reasoning model
-    const passthroughModel = (config.passthrough as { model?: unknown } | undefined)?.model;
-    const capabilityModelName = (
-      typeof passthroughModel === 'string'
-        ? passthroughModel
-        : (config.modelName ?? this.deploymentName)
-    ).toLowerCase();
-    const isReasoningModel = this.isReasoningModel(capabilityModelName);
+    // The model the deployment serves, which is what every capability heuristic below
+    // (and the cost lookup in callApiInternal) keys on — not the deployment name.
+    const modelName = resolveAzureModelName(config, this.deploymentName);
+    const isReasoningModel = this.isReasoningModel(modelName);
     const samplingParamsDeprecated = this.isSamplingParamsDeprecatedClaudeModel(config);
-    const grokSamplingRestricted = this.isGrok4OrNewerModel();
+    const grokSamplingRestricted = this.isGrok4OrNewerModel(modelName);
 
     // Get max tokens based on model type
     const maxTokensDefault = config.omitDefaults
@@ -297,7 +299,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
     };
 
     if (
-      isForcedToolChoiceUnsupportedClaudeModel(config.modelName ?? this.deploymentName) &&
+      isForcedToolChoiceUnsupportedClaudeModel(modelName) &&
       body.tool_choice &&
       body.tool_choice !== 'auto' &&
       body.tool_choice !== 'none'
@@ -308,15 +310,9 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
       delete body.tool_choice;
     }
 
-    applyGpt6AstraRequestRules(body, capabilityModelName, 'chat');
+    applyGpt6AstraRequestRules(body, modelName.toLowerCase(), 'chat');
 
-    return {
-      body,
-      config:
-        typeof passthroughModel === 'string'
-          ? { ...config, modelName: capabilityModelName }
-          : config,
-    };
+    return { body, config: { ...config, modelName } };
   }
 
   async callApi(
@@ -475,6 +471,9 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
     let output = '';
     let logProbs: any;
     let finishReason: string;
+    // Executed MCP tool calls, published as `metadata.toolCalls` so assertions can
+    // check tool routing and arguments without wrapping the provider.
+    const mcpToolCalls: McpToolCallEntry[] = [];
 
     try {
       if (data.error) {
@@ -544,6 +543,8 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
             output = await this.functionCallbackHandler.processCalls(
               allCalls.length === 1 ? allCalls[0] : allCalls,
               config.functionToolCallbacks,
+              undefined,
+              { toolCalls: mcpToolCalls },
             );
           } else {
             // No callbacks configured, return raw tool/function calls
@@ -593,7 +594,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
         logProbs,
         finishReason,
         cost: calculateAzureCost(
-          config.modelName ?? this.deploymentName,
+          config.modelName,
           config,
           data.usage?.prompt_tokens,
           data.usage?.completion_tokens,
@@ -610,6 +611,7 @@ export class AzureChatCompletionProvider extends AzureGenericProvider {
           flaggedInput,
           flaggedOutput,
         },
+        ...(mcpToolCalls.length > 0 && { metadata: { toolCalls: mcpToolCalls } }),
       };
     } catch (err) {
       return {

--- a/src/providers/azure/util.ts
+++ b/src/providers/azure/util.ts
@@ -127,8 +127,8 @@ export function throwConfigurationError(message: string): never {
  * deployment name directly: an explicit `passthrough.model` — what is sent on the wire —
  * wins, then `modelName`, and only then the deployment name.
  *
- * Case is preserved: the cost tables are keyed on the vendor's own ids (`DeepSeek-R1`,
- * `Phi-4`, `Meta-Llama-3-8B-Instruct`), so lower-casing here silently loses their price.
+ * Case is preserved so the id stays what the user configured; every consumer that matches
+ * on it (the capability heuristics, `calculateAzureCost`) lower-cases for itself.
  */
 export function resolveAzureModelName(
   config: { modelName?: string; passthrough?: object } | undefined,
@@ -165,7 +165,12 @@ export function calculateAzureCost(
     return undefined;
   }
 
-  const model = AZURE_MODELS.find((entry) => entry.id === modelName);
+  // Matched case-insensitively: the table is keyed on the vendor's own casing
+  // (`DeepSeek-R1`, `Meta-Llama-3-8B-Instruct`), which users rarely reproduce exactly, and
+  // every other Azure model heuristic already lower-cases before matching. The rate lookups
+  // below key off `model.id` so they stay aligned with the entry that matched.
+  const lowerModelName = modelName.toLowerCase();
+  const model = AZURE_MODELS.find((entry) => entry.id.toLowerCase() === lowerModelName);
   if (!model) {
     return undefined;
   }
@@ -178,9 +183,9 @@ export function calculateAzureCost(
   const outputCost = longContext?.output ?? model.cost.output;
   const cacheReadCost =
     longContext?.cacheRead ??
-    (longContext ? AZURE_LONG_CONTEXT_CACHE_READ_RATES.get(modelName) : undefined) ??
+    (longContext ? AZURE_LONG_CONTEXT_CACHE_READ_RATES.get(model.id) : undefined) ??
     model.cost.cacheRead ??
-    AZURE_CACHE_READ_RATES.get(modelName) ??
+    AZURE_CACHE_READ_RATES.get(model.id) ??
     inputCost;
   const cachedTokens = clampCachedTokens(cachedPromptTokens, promptTokens);
   const audioInputTokens = clampCachedTokens(audioPromptTokens, promptTokens);
@@ -220,7 +225,7 @@ export function calculateAzureCost(
   const serviceTier = (config.passthrough as { service_tier?: unknown } | undefined)?.service_tier;
   const priorityMultiplier =
     serviceTier === 'priority'
-      ? (model.cost.priorityMultiplier ?? AZURE_PRIORITY_MULTIPLIERS.get(modelName) ?? 1)
+      ? (model.cost.priorityMultiplier ?? AZURE_PRIORITY_MULTIPLIERS.get(model.id) ?? 1)
       : 1;
 
   return (

--- a/src/providers/azure/util.ts
+++ b/src/providers/azure/util.ts
@@ -120,6 +120,27 @@ export function throwConfigurationError(message: string): never {
 }
 
 /**
+ * Resolve the model an Azure deployment actually serves.
+ *
+ * Azure separates the connection (the deployment name that goes in the URL) from the
+ * model behind it, so capability heuristics and cost lookups must not read the
+ * deployment name directly: an explicit `passthrough.model` — what is sent on the wire —
+ * wins, then `modelName`, and only then the deployment name.
+ *
+ * Case is preserved: the cost tables are keyed on the vendor's own ids (`DeepSeek-R1`,
+ * `Phi-4`, `Meta-Llama-3-8B-Instruct`), so lower-casing here silently loses their price.
+ */
+export function resolveAzureModelName(
+  config: { modelName?: string; passthrough?: object } | undefined,
+  deploymentName: string,
+): string {
+  const passthroughModel = (config?.passthrough as { model?: unknown } | undefined)?.model;
+  return typeof passthroughModel === 'string'
+    ? passthroughModel
+    : (config?.modelName ?? deploymentName);
+}
+
+/**
  * Calculate Azure cost based on model name and token usage
  */
 export function calculateAzureCost(

--- a/src/providers/functionCallbackUtils.ts
+++ b/src/providers/functionCallbackUtils.ts
@@ -237,9 +237,16 @@ export class FunctionCallbackHandler {
     const isArray = Array.isArray(calls);
     const callsArray = isArray ? calls : [calls];
 
+    // The calls run concurrently, so give each its own bucket and drain them in order:
+    // a shared sink would record MCP calls by latency instead of by the model's call order.
+    const sink = options?.toolCalls;
+    const buckets = sink ? callsArray.map((): McpToolCallEntry[] => []) : undefined;
     const results = await Promise.all(
-      callsArray.map((call) => this.processCall(call, callbacks, context, options)),
+      callsArray.map((call, index) =>
+        this.processCall(call, callbacks, context, buckets && { toolCalls: buckets[index] }),
+      ),
     );
+    sink?.push(...(buckets?.flat() ?? []));
 
     // If any callback succeeded, return processed results
     const hasSuccess = results.some(

--- a/src/providers/functionCallbackUtils.ts
+++ b/src/providers/functionCallbackUtils.ts
@@ -4,7 +4,7 @@ import {
   loadCallbackFromFileUrl,
   wrapError,
 } from '../util/functions/loadFunction';
-import { getMcpErrorMessage, isMcpErrorResult } from './mcp/util';
+import { getMcpErrorMessage, isMcpErrorResult, normalizeMcpContent } from './mcp/util';
 import { withGenAIToolSpan } from './tracing';
 
 import type {
@@ -15,6 +15,12 @@ import type {
   ToolCall,
 } from './functionCallbackTypes';
 import type { MCPClient } from './mcp/client';
+import type { McpToolCallEntry } from './mcp/types';
+
+/** Optional sink for the MCP tool calls a `processCall(s)` run executed. */
+interface ProcessCallOptions {
+  toolCalls?: McpToolCallEntry[];
+}
 
 /**
  * Resolve a `file://` callback reference through the shared path-traversal guard,
@@ -128,15 +134,23 @@ export class FunctionCallbackHandler {
    * @param call The function call to process (can be various formats)
    * @param callbacks Configuration mapping function names to callbacks
    * @param context Optional context to pass to the callback
+   * @param options Optional sink collecting the MCP tool calls that ran
    * @returns The result of processing
    */
   async processCall(
     call: FunctionCall | ToolCall | any,
     callbacks?: FunctionCallbackConfig,
     context?: any,
+    options?: ProcessCallOptions,
   ): Promise<FunctionCallResult> {
     // Extract function information from various formats
     const functionInfo = this.extractFunctionInfo(call);
+    const callId =
+      typeof call?.call_id === 'string'
+        ? call.call_id
+        : typeof call?.id === 'string'
+          ? call.id
+          : undefined;
 
     // Check if this is an MCP tool first (before checking function callbacks)
     if (this.mcpClient && functionInfo) {
@@ -147,7 +161,12 @@ export class FunctionCallbackHandler {
       }
 
       if (this.mcpToolNames.has(functionInfo.name)) {
-        return await this.executeMcpTool(functionInfo.name, functionInfo.arguments);
+        return await this.executeMcpTool(
+          functionInfo.name,
+          functionInfo.arguments,
+          callId,
+          options?.toolCalls,
+        );
       }
     }
 
@@ -166,11 +185,7 @@ export class FunctionCallbackHandler {
         functionInfo.arguments || '{}',
         callbacks,
         context,
-        typeof call?.call_id === 'string'
-          ? call.call_id
-          : typeof call?.id === 'string'
-            ? call.id
-            : undefined,
+        callId,
       );
       return {
         output: result,
@@ -206,14 +221,14 @@ export class FunctionCallbackHandler {
    * @param calls Array of calls or a single call
    * @param callbacks Configuration mapping function names to callbacks
    * @param context Optional context to pass to callbacks
-   * @param options Processing options
+   * @param options Optional sink collecting the MCP tool calls that ran
    * @returns Processed output in appropriate format
    */
   async processCalls(
     calls: any,
     callbacks?: FunctionCallbackConfig,
     context?: any,
-    _options?: { returnRawOnError?: boolean },
+    options?: ProcessCallOptions,
   ): Promise<any> {
     if (!calls) {
       return calls;
@@ -223,7 +238,7 @@ export class FunctionCallbackHandler {
     const callsArray = isArray ? calls : [calls];
 
     const results = await Promise.all(
-      callsArray.map((call) => this.processCall(call, callbacks, context)),
+      callsArray.map((call) => this.processCall(call, callbacks, context, options)),
     );
 
     // If any callback succeeded, return processed results
@@ -337,64 +352,45 @@ export class FunctionCallbackHandler {
   }
 
   /**
-   * Executes an MCP tool
+   * Executes an MCP tool, recording it in `toolCalls` when the caller supplied a sink so
+   * the provider can publish it as `metadata.toolCalls`.
    */
-  private async executeMcpTool(toolName: string, args: unknown): Promise<FunctionCallResult> {
+  private async executeMcpTool(
+    toolName: string,
+    args: unknown,
+    callId?: string,
+    toolCalls?: McpToolCallEntry[],
+  ): Promise<FunctionCallResult> {
+    // Declared outside the try so the catch below can still report the arguments;
+    // parsing stays inside it, so malformed JSON keeps failing the call as before.
+    let parsedArgs: any;
+    const record = (output: unknown, is_error: boolean) => {
+      toolCalls?.push({ id: callId, name: toolName, input: parsedArgs ?? args, output, is_error });
+    };
+
     try {
       if (!this.mcpClient) {
         throw new Error('MCP client not available');
       }
 
       // Parse arguments: support stringified JSON, object, or empty
-      const parsedArgs =
+      parsedArgs =
         args == null || args === '' ? {} : typeof args === 'string' ? JSON.parse(args) : args;
       const result = await this.mcpClient.callTool(toolName, parsedArgs);
 
       if (isMcpErrorResult(result)) {
-        return {
-          output: `MCP Tool Error (${toolName}): ${getMcpErrorMessage(result)}`,
-          isError: true,
-        };
+        const errorMessage = getMcpErrorMessage(result);
+        record(errorMessage, true);
+        return { output: `MCP Tool Error (${toolName}): ${errorMessage}`, isError: true };
       }
 
-      // Normalize MCP content to a readable string to avoid "[object Object]"
-      const normalizeContent = (content: any): string => {
-        if (content == null) {
-          return '';
-        }
-        if (typeof content === 'string') {
-          return content;
-        }
-        if (Array.isArray(content)) {
-          return content
-            .map((part) => {
-              if (typeof part === 'string') {
-                return part;
-              }
-              if (part && typeof part === 'object') {
-                if ('text' in part && (part as any).text != null) {
-                  return String((part as any).text);
-                }
-                if ('json' in part) {
-                  return JSON.stringify((part as any).json);
-                }
-                if ('data' in part) {
-                  return JSON.stringify((part as any).data);
-                }
-                return JSON.stringify(part);
-              }
-              return String(part);
-            })
-            .join('\n');
-        }
-        return JSON.stringify(content);
-      };
-
-      const content = normalizeContent(result?.content);
+      const content = normalizeMcpContent(result?.content);
+      record(content, false);
       return { output: `MCP Tool Result (${toolName}): ${content}`, isError: false };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       logger.debug(`MCP tool execution failed for ${toolName}: ${errorMessage}`);
+      record(errorMessage, true);
       return {
         output: `MCP Tool Error (${toolName}): ${errorMessage}`,
         isError: true,

--- a/src/providers/mcp/util.ts
+++ b/src/providers/mcp/util.ts
@@ -42,6 +42,42 @@ export function getMcpErrorMessage(result: MCPToolResult): string {
 }
 
 /**
+ * Normalize an MCP tool result's content to a readable string, so a structured
+ * content block never reaches the eval output as `[object Object]`.
+ */
+export function normalizeMcpContent(content: unknown): string {
+  if (content == null) {
+    return '';
+  }
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === 'string') {
+          return part;
+        }
+        if (part && typeof part === 'object') {
+          if ('text' in part && part.text != null) {
+            return String(part.text);
+          }
+          if ('json' in part) {
+            return JSON.stringify(part.json);
+          }
+          if ('data' in part) {
+            return JSON.stringify(part.data);
+          }
+          return JSON.stringify(part);
+        }
+        return String(part);
+      })
+      .join('\n');
+  }
+  return JSON.stringify(content);
+}
+
+/**
  * Render environment variables in server config auth fields.
  * Supports {{VAR_NAME}} syntax for variable substitution.
  */

--- a/src/providers/openai/chat.ts
+++ b/src/providers/openai/chat.ts
@@ -15,7 +15,7 @@ import {
 } from '../functionCallbackUtils';
 import { MCPClient } from '../mcp/client';
 import { transformMCPToolsToOpenAi } from '../mcp/transform';
-import { getMcpErrorMessage, isMcpErrorResult } from '../mcp/util';
+import { getMcpErrorMessage, isMcpErrorResult, normalizeMcpContent } from '../mcp/util';
 import {
   getRequestTimeoutMs,
   parseChatPrompt,
@@ -686,40 +686,7 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
                     is_error: true,
                   });
                 } else {
-                  // Normalize MCP content to a readable string
-                  const normalizeContent = (content: any): string => {
-                    if (content == null) {
-                      return '';
-                    }
-                    if (typeof content === 'string') {
-                      return content;
-                    }
-                    if (Array.isArray(content)) {
-                      return content
-                        .map((part) => {
-                          if (typeof part === 'string') {
-                            return part;
-                          }
-                          if (part && typeof part === 'object') {
-                            if ('text' in part && (part as any).text != null) {
-                              return String((part as any).text);
-                            }
-                            if ('json' in part) {
-                              return JSON.stringify((part as any).json);
-                            }
-                            if ('data' in part) {
-                              return JSON.stringify((part as any).data);
-                            }
-                            return JSON.stringify(part);
-                          }
-                          return String(part);
-                        })
-                        .join('\n');
-                    }
-                    return JSON.stringify(content);
-                  };
-
-                  const content = normalizeContent(mcpResult?.content);
+                  const content = normalizeMcpContent(mcpResult?.content);
                   results.push(`MCP Tool Result (${functionName}): ${content}`);
                   mcpToolCalls.push({
                     id: toolCallId,

--- a/test/providers/azure.test.ts
+++ b/test/providers/azure.test.ts
@@ -753,6 +753,23 @@ describe('Azure Provider Tests', () => {
         }
       });
 
+      it.each([
+        { label: 'modelName', config: { modelName: 'grok-4.6' } },
+        { label: 'passthrough.model', config: { passthrough: { model: 'grok-4.6' } } },
+      ])('strips them for a deployment aliased by $label', async ({ config }) => {
+        // The deployment name says nothing about the model, so the guard has to read the
+        // resolved model or the request 400s.
+        const provider = new AzureChatCompletionProvider('prod-chat', {
+          config: { apiHost: 'test.openai.azure.com', stop: ['x'], ...config },
+        });
+
+        const { body } = await (provider as any).getOpenAiBody('hello');
+
+        expect(body.presence_penalty).toBeUndefined();
+        expect(body.frequency_penalty).toBeUndefined();
+        expect(body.stop).toBeUndefined();
+      });
+
       it('leaves non-Grok deployments alone', async () => {
         const provider = new AzureChatCompletionProvider('gpt-4o-prod', {
           config: { apiHost: 'test.openai.azure.com', stop: ['x'] },

--- a/test/providers/azure/chat-mcp-integration.test.ts
+++ b/test/providers/azure/chat-mcp-integration.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithCache } from '../../../src/cache';
 import { AzureChatCompletionProvider } from '../../../src/providers/azure/chat';
 
 const mcpMocks = vi.hoisted(() => {
@@ -163,6 +164,69 @@ describe('AzureChatCompletionProvider MCP Integration', () => {
     const handler = (providerWithoutMCP as any).functionCallbackHandler;
     expect(handler).toBeDefined();
     expect((handler as any).mcpClient).toBeUndefined();
+  });
+
+  it('publishes executed MCP tool calls as metadata.toolCalls', async () => {
+    await (provider as any).initializationPromise;
+    (provider as any).authHeaders = { 'api-key': 'test-key' };
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: {
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'list_resources', arguments: '{"kind":"tokens"}' },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    } as any);
+
+    const result = await provider.callApi('list the tokens');
+
+    expect(mcpMocks.mockCallTool).toHaveBeenCalledWith('list_resources', { kind: 'tokens' });
+    expect(result.metadata?.toolCalls).toEqual([
+      {
+        id: 'call_1',
+        name: 'list_resources',
+        input: { kind: 'tokens' },
+        output: 'Available resources: [button-tokens.json, color-tokens.json, spacing-tokens.json]',
+        is_error: false,
+      },
+    ]);
+  });
+
+  it('omits metadata.toolCalls when no MCP tool ran', async () => {
+    await (provider as any).initializationPromise;
+    (provider as any).authHeaders = { 'api-key': 'test-key' };
+    vi.mocked(fetchWithCache).mockResolvedValue({
+      data: {
+        choices: [
+          { index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      },
+      cached: false,
+      status: 200,
+      statusText: 'OK',
+    } as any);
+
+    const result = await provider.callApi('hello');
+
+    expect(result.metadata).toBeUndefined();
   });
 
   it('should prioritize MCP tools over function callbacks', async () => {

--- a/test/providers/azure/chat.test.ts
+++ b/test/providers/azure/chat.test.ts
@@ -399,9 +399,9 @@ describe('AzureChatCompletionProvider', () => {
       },
     );
 
-    it('prices a mixed-case passthrough.model without lower-casing it', async () => {
-      // AZURE_MODELS is keyed on the vendor's own ids, so lower-casing `DeepSeek-R1`
-      // loses the cost-table entry entirely.
+    it('prices a deployment by its passthrough.model, not its deployment name', async () => {
+      // `prod-chat` is not in AZURE_MODELS, so the cost lookup has to key on the model the
+      // deployment actually serves. Casing is handled in calculateAzureCost (see util.test.ts).
       provider = new AzureChatCompletionProvider('prod-chat', {
         config: {
           apiHost: 'test.azure.com',

--- a/test/providers/azure/chat.test.ts
+++ b/test/providers/azure/chat.test.ts
@@ -399,6 +399,36 @@ describe('AzureChatCompletionProvider', () => {
       },
     );
 
+    it('prices a mixed-case passthrough.model without lower-casing it', async () => {
+      // AZURE_MODELS is keyed on the vendor's own ids, so lower-casing `DeepSeek-R1`
+      // loses the cost-table entry entirely.
+      provider = new AzureChatCompletionProvider('prod-chat', {
+        config: {
+          apiHost: 'test.azure.com',
+          apiKey: 'test-key',
+          passthrough: { model: 'DeepSeek-R1' },
+        },
+      });
+      setAuthHeaders(provider);
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        data: {
+          choices: [
+            { index: 0, message: { role: 'assistant', content: 'hello' }, finish_reason: 'stop' },
+          ],
+          usage: { prompt_tokens: 1_000, completion_tokens: 500, total_tokens: 1_500 },
+        },
+        cached: false,
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const result = await provider.callApi('test prompt');
+
+      expect(result.cost).toBeCloseTo((1_000 * 0.55 + 500 * 2.19) / 1e6, 12);
+      const request = JSON.parse(vi.mocked(fetchWithCache).mock.calls[0][1]?.body as string);
+      expect(request.model).toBe('DeepSeek-R1');
+    });
+
     it('should parse JSON response with json_schema format when finish_reason is not content_filter', async () => {
       const mockResponse = {
         id: 'mock-id',

--- a/test/providers/azure/util.test.ts
+++ b/test/providers/azure/util.test.ts
@@ -589,6 +589,24 @@ describe('calculateAzureCost', () => {
     const cost = calculateAzureCost('gpt-4', {}, undefined, 50);
     expect(cost).toBeUndefined();
   });
+
+  it('matches model ids case-insensitively', () => {
+    // Users write the id they see in Foundry, not the table's casing, and a deployment name
+    // is arbitrary text — matching on case silently reports `cost: undefined` instead.
+    expect(calculateAzureCost('deepseek-r1', {}, 1_000, 500)).toBeCloseTo(
+      (1_000 * 0.55 + 500 * 2.19) / 1e6,
+      12,
+    );
+    // Cache-read rates are keyed on the canonical id, so they must follow the matched entry.
+    expect(calculateAzureCost('GPT-4O', {}, 1_000, 500, 1_000)).toBeCloseTo(
+      calculateAzureCost('gpt-4o', {}, 1_000, 500, 1_000)!,
+      12,
+    );
+    expect(calculateAzureCost('gpt-4o', {}, 1_000, 500, 1_000)).toBeCloseTo(
+      (1_000 * 1.25 + 500 * 10) / 1e6,
+      12,
+    );
+  });
 });
 
 describe('AZURE_MODELS cost coverage', () => {

--- a/test/providers/functionCallbackUtils.test.ts
+++ b/test/providers/functionCallbackUtils.test.ts
@@ -795,6 +795,36 @@ describe('FunctionCallbackHandler', () => {
       });
     });
 
+    it('records concurrent MCP tool calls in the order the model requested them', async () => {
+      mockMCPClient.getAllTools.mockReturnValue([
+        { name: 'slow_tool', description: 'Resolves last' },
+        { name: 'fast_tool', description: 'Resolves first' },
+      ]);
+      const pending = new Map<string, (value: unknown) => void>();
+      mockMCPClient.callTool.mockImplementation(
+        (name: string) => new Promise((resolve) => pending.set(name, resolve)),
+      );
+      const toolCalls: any[] = [];
+
+      const processed = handler.processCalls(
+        [
+          { id: 'call_slow', type: 'function', function: { name: 'slow_tool', arguments: '{}' } },
+          { id: 'call_fast', type: 'function', function: { name: 'fast_tool', arguments: '{}' } },
+        ],
+        undefined,
+        undefined,
+        { toolCalls },
+      );
+
+      // Both tools were started before either resolved; finish them in reverse order.
+      expect([...pending.keys()]).toEqual(['slow_tool', 'fast_tool']);
+      pending.get('fast_tool')!({ content: 'fast' });
+      pending.get('slow_tool')!({ content: 'slow' });
+      await processed;
+
+      expect(toolCalls.map((entry) => entry.name)).toEqual(['slow_tool', 'fast_tool']);
+    });
+
     it('should handle invalid JSON arguments in MCP tools', async () => {
       mockMCPClient.getAllTools.mockReturnValue([
         { name: 'json_tool', description: 'A tool requiring JSON args' },


### PR DESCRIPTION
## Summary

Azure separates the **connection** (the deployment name that goes in the URL) from the **model** the deployment actually serves. `src/providers/azure/chat.ts` read those two apart in three inconsistent, hand-rolled ways, producing three bugs:

1. **Grok 4+ guard ignored the model.** `isGrok4OrNewerModel()` tested only `this.deploymentName`, so a deployment named e.g. `prod-chat` backed by `grok-4.6` (via `modelName` or `passthrough.model`) still sent `presence_penalty`, `frequency_penalty` and `stop` — the three parameters Grok 4+ rejects with HTTP 400.
2. **`passthrough.model` was lower-cased** into `config.modelName`, and `AZURE_MODELS` is keyed on the vendor's own ids. Every mixed-case model (`DeepSeek-R1`, `Phi-4`, `Meta-Llama-3-8B-Instruct`, `Kimi-K2.5`, …) therefore missed the cost table and reported `cost: undefined`.
3. **No `metadata.toolCalls` for MCP.** `openai:chat` and `anthropic:messages` publish executed MCP tool calls as `metadata.toolCalls`; `azure:chat` runs MCP through `FunctionCallbackHandler` and published nothing, so Azure MCP evals could not assert on tool routing.

### What changed (shared, not three more Azure branches)

- **New `resolveAzureModelName(config, deploymentName)` in `src/providers/azure/util.ts`** — one precedence rule (`passthrough.model` > `modelName` > deployment name) with case preserved. It replaces three divergent inline copies in `chat.ts` and now backs `isReasoningModel`, `isGrok4OrNewerModel`, `isSamplingParamsDeprecatedClaudeModel`, `isForcedToolChoiceUnsupportedClaudeModel`, the GPT-6-Astra rules, and `calculateAzureCost`. `getOpenAiBody` returns the resolved `modelName` unconditionally, so the conditional-config branch is gone.
  - `src/providers/azure/responses.ts` has the identical inline block; it is untouched here because a sibling PR owns that file, but it can drop its copy for this helper (both files already import `./util`).
- **MCP tool calls are recorded by the shared handler.** `FunctionCallbackHandler.processCall(s)` takes an optional `{ toolCalls }` sink — replacing the dead, never-passed `_options: { returnRawOnError }` parameter — and `executeMcpTool` pushes an `McpToolCallEntry` (same shape openai/anthropic emit). `azure/chat.ts` passes the sink and publishes `metadata.toolCalls` only when a tool actually ran.
- **Deleted the duplicated `normalizeContent`.** `openai/chat.ts` and `functionCallbackUtils.ts` carried byte-identical 30-line copies; hoisted to `normalizeMcpContent` in `src/providers/mcp/util.ts` and both now import it.

Net: +247 / −114 across 8 files, of which the source change is +145 / −108 with two duplicated blocks and one dead parameter removed.

## Test plan

All four new tests fail on `main` and pass with the fix (verified by stashing `src/` and re-running):

```
$ git stash push -- src/ && npx vitest run test/providers/azure.test.ts test/providers/azure/chat.test.ts test/providers/azure/chat-mcp-integration.test.ts
Tests  4 failed | 136 passed (140)
```

- `test/providers/azure.test.ts` — "strips them for a deployment aliased by $label" (`modelName` and `passthrough.model` cases) asserts `presence_penalty` / `frequency_penalty` / `stop` are omitted for a Grok 4.6 model behind a `prod-chat` deployment.
- `test/providers/azure/chat.test.ts` — "prices a deployment by its passthrough.model, not its deployment name" asserts a non-undefined `DeepSeek-R1` cost for a `prod-chat` deployment and that `body.model` keeps its case.
- `test/providers/azure/chat-mcp-integration.test.ts` — asserts `metadata.toolCalls` carries the executed call (id, name, parsed input, normalized output, `is_error: false`), and that `metadata` stays undefined when no MCP tool ran.

Commands run:

```
npx vitest run test/providers test/test-hygiene.test.ts
  → Test Files 243 passed | 1 skipped, Tests 10054 passed | 9 skipped
npx tsc --noEmit -p tsconfig.json                → clean
npx tsc --noEmit -p src/app/tsconfig.json        → clean
npx biome check <changed files>                  → only the 4 pre-existing
   noExcessiveCognitiveComplexity warnings (5 on main, 4 here)
npx knip --no-progress                           → clean
```

### Follow-up: case-insensitive cost matching

Preserving the configured casing prices a model only when the user types the vendor's exact
id, so `passthrough: { model: 'deepseek-r1' }` still fell out of `AZURE_MODELS`.
`calculateAzureCost` now matches the table case-insensitively and keys the cache-read and
priority rate maps off the matched entry's `id`, which fixes the same class of
`cost: undefined` on every Azure path (chat, responses, foundry-agent), not just
`passthrough.model`. Verified byte-identical costs for all 218 `AZURE_MODELS` entries across
standard/priority tiers and short/long context; regression test in
`test/providers/azure/util.test.ts` ("matches model ids case-insensitively").


### Follow-up: MCP tool calls recorded in request order

`processCalls` runs the calls concurrently, so the shared `toolCalls` sink filled
`metadata.toolCalls` by completion latency rather than by the model's `tool_calls` order —
nondeterministic for index-based assertions and inconsistent with `openai:chat`, which
executes sequentially. Each call now gets its own bucket that is drained in order.
Regression test in `test/providers/functionCallbackUtils.test.ts` ("records concurrent MCP
tool calls in the order the model requested them"), which fails with the shared sink.
