### PR TITLE
fix(providers): keep distinct MCP servers distinct for Claude Agent SDK

### DIFF
--- a/src/providers/mcp/transform.ts
+++ b/src/providers/mcp/transform.ts
@@ -129,21 +129,41 @@ export async function transformMCPConfigToClaudeCode(
     serverConfigs.push(config.server);
   }
 
+  // An explicit `name` owns its key, so two servers sharing one is a config error.
+  // Checked before transforming, which would otherwise fetch OAuth tokens for a
+  // configuration we are about to reject.
+  const names = serverConfigs.flatMap((server) => server.name ?? []);
+  const duplicateName = names.find((name, index) => names.indexOf(name) !== index);
+  if (duplicateName) {
+    throw new Error(
+      `Duplicate Claude Agent SDK MCP server \`${duplicateName}\`; give each configured server a unique \`name\`.`,
+    );
+  }
+
   const servers = await Promise.all(
     serverConfigs.map((server) => transformMCPServerConfigToClaudeCode(server)),
   );
 
-  const seen = new Set<string>();
-  for (const [key] of servers) {
-    if (seen.has(key)) {
-      throw new Error(
-        `Duplicate Claude Agent SDK MCP server \`${key}\`; give each configured server a unique \`name\`.`,
-      );
+  // An unnamed server falls back to a coarse identifier that several servers can
+  // share, so suffix collisions instead of letting `Object.fromEntries` drop one.
+  // The key becomes the SDK's server name — it lands in `mcp__<key>__<tool>` and in
+  // debug logs — so it deliberately carries no `args`, `env`, or auth values.
+  const taken = new Set(names);
+  const entries = servers.map((server, index) => {
+    const { name, url, command } = serverConfigs[index];
+    if (name) {
+      return [name, server] as const;
     }
-    seen.add(key);
-  }
+    const fallback = url ?? command ?? 'default';
+    let key = fallback;
+    for (let suffix = 2; taken.has(key); suffix++) {
+      key = `${fallback}_${suffix}`;
+    }
+    taken.add(key);
+    return [key, server] as const;
+  });
 
-  return Object.fromEntries(servers);
+  return Object.fromEntries(entries);
 }
 
 export function validateMCPConfigForClaudeCode(config: MCPConfig): void {
@@ -207,10 +227,7 @@ export function validateMCPConfigForClaudeCode(config: MCPConfig): void {
 
 async function transformMCPServerConfigToClaudeCode(
   config: MCPServerConfig,
-): Promise<[string, ClaudeCodeMcpServerConfig]> {
-  // The key identifies the server, so fall back to whatever actually distinguishes
-  // one unnamed server from another rather than to a field it may not set.
-  let key: string;
+): Promise<ClaudeCodeMcpServerConfig> {
   let out: ClaudeCodeMcpServerConfig;
 
   if (config.url) {
@@ -229,14 +246,12 @@ async function transformMCPServerConfigToClaudeCode(
     const queryParams = getAuthQueryParams(renderedConfig);
     const serverUrl = applyQueryParams(config.url, queryParams);
 
-    key = config.url;
     out = {
       type: 'http',
       url: serverUrl,
       headers: { ...(config.headers ?? {}), ...getAuthHeaders(renderedConfig, oauthToken) },
     };
   } else if (config.command) {
-    key = [config.command, ...(config.args ?? [])].join(' ');
     out = {
       type: 'stdio',
       command: config.command,
@@ -246,7 +261,6 @@ async function transformMCPServerConfigToClaudeCode(
   } else if (config.path) {
     const isPy = config.path.endsWith('.py');
     const command = isPy ? (process.platform === 'win32' ? 'python' : 'python3') : process.execPath;
-    key = config.path;
     out = {
       type: 'stdio',
       command,
@@ -257,5 +271,5 @@ async function transformMCPServerConfigToClaudeCode(
     throw new Error('MCP configuration cannot be converted to Claude Agent SDK MCP server config');
   }
 
-  return [config.name ?? key, out];
+  return out;
 }

--- a/src/providers/mcp/transform.ts
+++ b/src/providers/mcp/transform.ts
@@ -133,6 +133,16 @@ export async function transformMCPConfigToClaudeCode(
     serverConfigs.map((server) => transformMCPServerConfigToClaudeCode(server)),
   );
 
+  const seen = new Set<string>();
+  for (const [key] of servers) {
+    if (seen.has(key)) {
+      throw new Error(
+        `Duplicate Claude Agent SDK MCP server \`${key}\`; give each configured server a unique \`name\`.`,
+      );
+    }
+    seen.add(key);
+  }
+
   return Object.fromEntries(servers);
 }
 
@@ -198,8 +208,10 @@ export function validateMCPConfigForClaudeCode(config: MCPConfig): void {
 async function transformMCPServerConfigToClaudeCode(
   config: MCPServerConfig,
 ): Promise<[string, ClaudeCodeMcpServerConfig]> {
-  const key = config.name ?? config.url ?? config.command ?? 'default';
-  let out: ClaudeCodeMcpServerConfig | undefined;
+  // The key identifies the server, so fall back to whatever actually distinguishes
+  // one unnamed server from another rather than to a field it may not set.
+  let key: string;
+  let out: ClaudeCodeMcpServerConfig;
 
   if (config.url) {
     // Render environment variables in auth config
@@ -217,12 +229,14 @@ async function transformMCPServerConfigToClaudeCode(
     const queryParams = getAuthQueryParams(renderedConfig);
     const serverUrl = applyQueryParams(config.url, queryParams);
 
+    key = config.url;
     out = {
       type: 'http',
       url: serverUrl,
       headers: { ...(config.headers ?? {}), ...getAuthHeaders(renderedConfig, oauthToken) },
     };
   } else if (config.command) {
+    key = [config.command, ...(config.args ?? [])].join(' ');
     out = {
       type: 'stdio',
       command: config.command,
@@ -232,6 +246,7 @@ async function transformMCPServerConfigToClaudeCode(
   } else if (config.path) {
     const isPy = config.path.endsWith('.py');
     const command = isPy ? (process.platform === 'win32' ? 'python' : 'python3') : process.execPath;
+    key = config.path;
     out = {
       type: 'stdio',
       command,
@@ -242,5 +257,5 @@ async function transformMCPServerConfigToClaudeCode(
     throw new Error('MCP configuration cannot be converted to Claude Agent SDK MCP server config');
   }
 
-  return [key, out];
+  return [config.name ?? key, out];
 }

--- a/test/providers/mcp/transform.test.ts
+++ b/test/providers/mcp/transform.test.ts
@@ -261,14 +261,41 @@ describe('transformMCPConfigToClaudeCode', () => {
     ).resolves.toEqual({});
   });
 
-  it('uses the singular server when it shares a key with a plural server', async () => {
+  it('rejects duplicate server keys instead of silently dropping a server', async () => {
     await expect(
       transformMCPConfigToClaudeCode({
         enabled: true,
         server: { name: 'shared', command: 'single-server' },
         servers: [{ name: 'shared', command: 'plural-server' }],
       }),
-    ).resolves.toEqual({ shared: { type: 'stdio', command: 'single-server', args: [] } });
+    ).rejects.toThrow('Duplicate Claude Agent SDK MCP server `shared`');
+  });
+
+  it('keeps unnamed path-based servers distinct', async () => {
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        servers: [{ path: 'first.js' }, { path: 'second.js' }],
+      }),
+    ).resolves.toEqual({
+      'first.js': { type: 'stdio', command: process.execPath, args: ['first.js'] },
+      'second.js': { type: 'stdio', command: process.execPath, args: ['second.js'] },
+    });
+  });
+
+  it('keeps unnamed servers that share a command but differ by args distinct', async () => {
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        servers: [
+          { command: 'npx', args: ['-y', 'first-server'] },
+          { command: 'npx', args: ['-y', 'second-server'] },
+        ],
+      }),
+    ).resolves.toEqual({
+      'npx -y first-server': { type: 'stdio', command: 'npx', args: ['-y', 'first-server'] },
+      'npx -y second-server': { type: 'stdio', command: 'npx', args: ['-y', 'second-server'] },
+    });
   });
 
   it('rejects a server without a URL, command, or path', async () => {

--- a/test/providers/mcp/transform.test.ts
+++ b/test/providers/mcp/transform.test.ts
@@ -271,6 +271,38 @@ describe('transformMCPConfigToClaudeCode', () => {
     ).rejects.toThrow('Duplicate Claude Agent SDK MCP server `shared`');
   });
 
+  it('rejects duplicate names before any OAuth token is fetched', async () => {
+    // OAuth here has neither tokenUrl nor a discoverable endpoint, so reaching the
+    // token fetch at all would surface that error instead of the duplicate.
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        servers: [
+          {
+            name: 'shared',
+            url: 'https://a.example.com/mcp',
+            auth: {
+              type: 'oauth',
+              grantType: 'client_credentials',
+              clientId: 'id',
+              clientSecret: 'secret',
+            },
+          },
+          {
+            name: 'shared',
+            url: 'https://b.example.com/mcp',
+            auth: {
+              type: 'oauth',
+              grantType: 'client_credentials',
+              clientId: 'id',
+              clientSecret: 'secret',
+            },
+          },
+        ],
+      }),
+    ).rejects.toThrow('Duplicate Claude Agent SDK MCP server `shared`');
+  });
+
   it('keeps unnamed path-based servers distinct', async () => {
     await expect(
       transformMCPConfigToClaudeCode({
@@ -278,8 +310,8 @@ describe('transformMCPConfigToClaudeCode', () => {
         servers: [{ path: 'first.js' }, { path: 'second.js' }],
       }),
     ).resolves.toEqual({
-      'first.js': { type: 'stdio', command: process.execPath, args: ['first.js'] },
-      'second.js': { type: 'stdio', command: process.execPath, args: ['second.js'] },
+      default: { type: 'stdio', command: process.execPath, args: ['first.js'] },
+      default_2: { type: 'stdio', command: process.execPath, args: ['second.js'] },
     });
   });
 
@@ -293,8 +325,91 @@ describe('transformMCPConfigToClaudeCode', () => {
         ],
       }),
     ).resolves.toEqual({
-      'npx -y first-server': { type: 'stdio', command: 'npx', args: ['-y', 'first-server'] },
-      'npx -y second-server': { type: 'stdio', command: 'npx', args: ['-y', 'second-server'] },
+      npx: { type: 'stdio', command: 'npx', args: ['-y', 'first-server'] },
+      npx_2: { type: 'stdio', command: 'npx', args: ['-y', 'second-server'] },
+    });
+  });
+
+  it('keeps unnamed servers whose args differ only by argument boundaries distinct', async () => {
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        servers: [
+          { command: 'node', args: ['a b'] },
+          { command: 'node', args: ['a', 'b'] },
+        ],
+      }),
+    ).resolves.toEqual({
+      node: { type: 'stdio', command: 'node', args: ['a b'] },
+      node_2: { type: 'stdio', command: 'node', args: ['a', 'b'] },
+    });
+  });
+
+  it('keeps unnamed url servers that differ only by query-placed auth distinct', async () => {
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        servers: [
+          {
+            url: 'https://mcp.example.com/v1',
+            auth: { type: 'api_key', api_key: 'first-key', placement: 'query' },
+          },
+          {
+            url: 'https://mcp.example.com/v1',
+            auth: { type: 'api_key', api_key: 'second-key', placement: 'query' },
+          },
+        ],
+      }),
+    ).resolves.toEqual({
+      'https://mcp.example.com/v1': {
+        type: 'http',
+        url: 'https://mcp.example.com/v1?X-API-Key=first-key',
+        headers: {},
+      },
+      'https://mcp.example.com/v1_2': {
+        type: 'http',
+        url: 'https://mcp.example.com/v1?X-API-Key=second-key',
+        headers: {},
+      },
+    });
+  });
+
+  it('keeps argument values out of the derived server key', async () => {
+    // The key becomes the SDK's server name and is logged verbatim by the Claude
+    // Agent SDK provider (`Object.keys(options.mcpServers)`), which is a plain log
+    // message and therefore not sanitized.
+    const servers = await transformMCPConfigToClaudeCode({
+      enabled: true,
+      servers: [{ command: 'npx', args: ['-y', 'some-server', '--api-key', 'sk-secret-value'] }],
+    });
+
+    expect(Object.keys(servers)).toEqual(['npx']);
+  });
+
+  it('preserves the legacy key for a single unnamed server with args', async () => {
+    // `mcp__npx__tool` allow/deny rules written against the old key must keep matching.
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        servers: [{ command: 'npx', args: ['-y', '@h1deya/mcp-server-weather'] }],
+      }),
+    ).resolves.toEqual({
+      npx: { type: 'stdio', command: 'npx', args: ['-y', '@h1deya/mcp-server-weather'] },
+    });
+  });
+
+  it('does not let a derived key steal an explicit name', async () => {
+    await expect(
+      transformMCPConfigToClaudeCode({
+        enabled: true,
+        servers: [
+          { command: 'npx', args: ['first'] },
+          { name: 'npx', command: 'other' },
+        ],
+      }),
+    ).resolves.toEqual({
+      npx: { type: 'stdio', command: 'other', args: [] },
+      npx_2: { type: 'stdio', command: 'npx', args: ['first'] },
     });
   });
 


### PR DESCRIPTION
## Summary

`transformMCPServerConfigToClaudeCode` derived each MCP server's key as
`config.name ?? config.url ?? config.command ?? 'default'`, and `Object.fromEntries`
silently kept only the last entry when two servers landed on the same key. The eval
then ran against fewer MCP servers than configured, with no warning:

- two unnamed path-based servers both keyed to `'default'`;
- two unnamed servers sharing a `command` (e.g. `npx` with different `args`) both keyed to `npx`;
- two unnamed servers on the same `url` with different query-placed API keys.

**Fix:** keep that same coarse key, and disambiguate a collision with a numeric
suffix (`npx`, `npx_2`) instead of dropping a server.

The key is not just a map key: the Claude Agent SDK uses it as the server name, so it
appears in tool names (`mcp__<key>__<tool>`) and is logged verbatim by the provider
(`Object.keys(options.mcpServers)` in `src/providers/claude-agent-sdk.ts`). It
therefore stays deliberately coarse — folding `args` into it would both break
`mcp__npx__tool` allow/deny rules written against the old key and leak credentials
passed as CLI args into debug logs, since that log site builds a plain message string
and `logger` only sanitizes the context argument.

A remaining duplicate **explicit** `name` is rejected rather than silently dropped,
since a config that names two servers identically is a user error. That check runs
before the servers are transformed, so an invalid config no longer fetches OAuth
tokens on its way to being rejected.

Behavior change: previously a singular `server` sharing a name with a `servers` entry
silently overrode it (test-documented in #10645, not a designed feature). It is now an
error. Note that the runtime MCP client (`src/providers/mcp/client.ts`) resolves
`servers || [server]` instead, so that config shape was already ambiguous across the
two code paths.

## Test plan

`test/providers/mcp/transform.test.ts` covers each case: duplicate `name` rejection
(and that it precedes OAuth), two path servers, two same-command-different-args
servers, two servers whose args differ only by argument boundaries (`['a b']` vs
`['a', 'b']`), two same-url servers with different query auth, no argument value in
the derived key, the legacy `npx` key preserved for a single unnamed server with args,
and a derived key not stealing an explicit `name`.

```
$ npx vitest run test/providers/mcp/ test/providers/claude-agent-sdk.test.ts
  Test Files  8 passed (8)
  Tests  475 passed (475)

$ npx tsc --noEmit -p tsconfig.json     # clean
$ npx biome check src/providers/mcp/transform.ts test/providers/mcp/transform.test.ts   # clean
```
