### PR TITLE
fix(providers): stop guessing image cost for unpriced models

### DIFF
--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -752,7 +752,9 @@ tests:
       product: a blue ceramic mug
 ```
 
-GPT Image 2.5 also accepts `quality: xhigh` and `quality: max`. For transparent output, use `background: transparent` with PNG or WebP. Cost comes from the response's token usage; it is left unset when usage is missing because older models' per-image estimates do not apply. See the [Image API guide](https://developers.openai.com/api/docs/guides/image-generation).
+GPT Image 2.5 also accepts `quality: xhigh` and `quality: max`. For transparent output, use `background: transparent` with PNG or WebP. See the [Image API guide](https://developers.openai.com/api/docs/guides/image-generation).
+
+Image cost comes from the response's token usage when the model publishes token rates, and otherwise from a per-image list price. Models with neither — including GPT Image 2.5 responses that carry no usage — report no cost rather than an estimate.
 
 This provider supports generation only. Image editing, masks, reference images, variations, and streaming are not implemented.
 

--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -692,55 +692,53 @@ export function prepareRequestBody(
   return body;
 }
 
+// List price of a single image, or undefined when the model, size, and quality combination
+// has no published per-image rate.
+function getPerImageCost(model: string, size: string, quality?: string): number | undefined {
+  if (model === 'dall-e-2') {
+    return DALLE2_COSTS[size as DallE2Size] ?? DALLE2_COSTS['1024x1024'];
+  }
+  if (model === 'dall-e-3') {
+    return DALLE3_COSTS[`${quality || 'standard'}_${size}`] ?? DALLE3_COSTS['standard_1024x1024'];
+  }
+
+  // GPT Image tables are keyed by `${quality}_${size}` and only price the three standard sizes.
+  const tieredQuality =
+    quality === 'low' || quality === 'medium' || quality === 'high' ? quality : undefined;
+  const costKey = `${tieredQuality ?? 'low'}_${size}`;
+
+  if (isGptImage2(model)) {
+    // GPT Image 2 also accepts custom sizes and auto quality, which have no per-image rate.
+    return tieredQuality === undefined ? undefined : GPT_IMAGE2_COSTS[costKey];
+  }
+  if (isGptImage1(model)) {
+    return GPT_IMAGE1_COSTS[costKey] ?? GPT_IMAGE1_COSTS['low_1024x1024'];
+  }
+  if (isGptImage1Mini(model)) {
+    return GPT_IMAGE1_MINI_COSTS[costKey] ?? GPT_IMAGE1_MINI_COSTS['low_1024x1024'];
+  }
+  if (isGptImage15(model)) {
+    return GPT_IMAGE1_5_COSTS[costKey] ?? GPT_IMAGE1_5_COSTS['low_1024x1024'];
+  }
+
+  // GPT Image 2.5 is billed from token usage, and an unrecognized model has no rate at all.
+  // Report no cost instead of guessing one.
+  logger.debug('[OpenAI Image] No per-image rate for model, reporting no cost', {
+    model,
+    size,
+    quality,
+  });
+  return undefined;
+}
+
 export function calculateImageCost(
   model: string,
   size: string,
   quality?: string,
   n: number = 1,
 ): number | undefined {
-  const imageQuality = quality || 'standard';
-  const gptImageQuality =
-    quality === 'medium' || quality === 'high' || quality === 'low' ? quality : 'low';
-
-  // GPT Image 2.5 shares token rates with GPT Image 2, but not per-image token usage.
-  if (isGptImage25(model)) {
-    return undefined;
-  }
-
-  if (model === 'dall-e-3') {
-    const costKey = `${imageQuality}_${size}`;
-    const costPerImage = DALLE3_COSTS[costKey] || DALLE3_COSTS['standard_1024x1024'];
-    return costPerImage * n;
-  } else if (model === 'dall-e-2') {
-    const costPerImage = DALLE2_COSTS[size as DallE2Size] || DALLE2_COSTS['1024x1024'];
-    return costPerImage * n;
-  } else if (isGptImage2(model)) {
-    if (quality !== 'medium' && quality !== 'high' && quality !== 'low') {
-      return undefined;
-    }
-
-    const costKey = `${gptImageQuality}_${size}`;
-    const costPerImage = GPT_IMAGE2_COSTS[costKey];
-    if (costPerImage === undefined) {
-      return undefined;
-    }
-
-    return costPerImage * n;
-  } else if (isGptImage1(model)) {
-    const costKey = `${gptImageQuality}_${size}`;
-    const costPerImage = GPT_IMAGE1_COSTS[costKey] || GPT_IMAGE1_COSTS['low_1024x1024'];
-    return costPerImage * n;
-  } else if (isGptImage1Mini(model)) {
-    const costKey = `${gptImageQuality}_${size}`;
-    const costPerImage = GPT_IMAGE1_MINI_COSTS[costKey] || GPT_IMAGE1_MINI_COSTS['low_1024x1024'];
-    return costPerImage * n;
-  } else if (isGptImage15(model)) {
-    const costKey = `${gptImageQuality}_${size}`;
-    const costPerImage = GPT_IMAGE1_5_COSTS[costKey] || GPT_IMAGE1_5_COSTS['low_1024x1024'];
-    return costPerImage * n;
-  }
-
-  return 0.04 * n;
+  const costPerImage = getPerImageCost(model, size, quality);
+  return costPerImage === undefined ? undefined : costPerImage * n;
 }
 
 function getImageTokenUsage(data: any, cached: boolean): TokenUsage | undefined {

--- a/src/providers/openai/image.ts
+++ b/src/providers/openai/image.ts
@@ -722,12 +722,6 @@ function getPerImageCost(model: string, size: string, quality?: string): number 
   }
 
   // GPT Image 2.5 is billed from token usage, and an unrecognized model has no rate at all.
-  // Report no cost instead of guessing one.
-  logger.debug('[OpenAI Image] No per-image rate for model, reporting no cost', {
-    model,
-    size,
-    quality,
-  });
   return undefined;
 }
 
@@ -738,7 +732,12 @@ export function calculateImageCost(
   n: number = 1,
 ): number | undefined {
   const costPerImage = getPerImageCost(model, size, quality);
-  return costPerImage === undefined ? undefined : costPerImage * n;
+  if (costPerImage === undefined) {
+    // Report no cost instead of guessing one.
+    logger.debug('[OpenAI Image] No per-image rate, reporting no cost', { model, size, quality });
+    return undefined;
+  }
+  return costPerImage * n;
 }
 
 function getImageTokenUsage(data: any, cached: boolean): TokenUsage | undefined {

--- a/test/providers/openai/image.functions.test.ts
+++ b/test/providers/openai/image.functions.test.ts
@@ -269,8 +269,9 @@ describe('OpenAI Image Provider Functions', () => {
       expect(calculateImageCost('dall-e-3', '1024x1024')).toBe(DALLE3_COSTS['standard_1024x1024']);
     });
 
-    it('should use default cost if model is unknown', () => {
-      expect(calculateImageCost('unknown-model', '1024x1024')).toBe(0.04);
+    it('should report no cost if model is unknown', () => {
+      expect(calculateImageCost('unknown-model', '1024x1024')).toBeUndefined();
+      expect(calculateImageCost('unknown-model', '1024x1024', 'high', 4)).toBeUndefined();
     });
 
     it('should multiply cost by number of images', () => {
@@ -304,9 +305,19 @@ describe('OpenAI Image Provider Functions', () => {
       expect(calculateImageCost('gpt-image-2', '2048x1152', 'high')).toBeUndefined();
     });
 
-    it('should use default cost for models other than DALL-E 2 or 3', () => {
-      expect(calculateImageCost('gpt-4', '1024x1024')).toBe(0.04);
-      expect(calculateImageCost('', '1024x1024')).toBe(0.04);
+    it('should report no cost for models with no per-image rate', () => {
+      expect(calculateImageCost('gpt-4', '1024x1024')).toBeUndefined();
+      expect(calculateImageCost('', '1024x1024')).toBeUndefined();
+    });
+
+    it.each([
+      'gpt-image-2.5-sunburst',
+      'gpt-image-2.5-sunburst-2026-09-08',
+      'gpt-image-2.5-flare',
+      'gpt-image-2.5-flare-2026-09-08',
+    ])('should not reuse GPT Image 2 per-image rates for %s', (model) => {
+      expect(calculateImageCost(model, '1024x1024', 'high')).toBeUndefined();
+      expect(calculateImageCost(model, '1024x1024', 'max')).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

`calculateImageCost` in `src/providers/openai/image.ts` ended with a bare `return 0.04 * n;` for any model it did not recognize — a silent, wrong number (DALL-E 3 standard pricing) for a model nobody has priced. That default is worse than reporting nothing: it lands in eval results as if it were a real cost.

GPT Image 2.5 (added in #10812) only escaped that guess because of a special-cased `if (isGptImage25(model)) return undefined;` at the top of the function. Its `undefined` was deliberate and already documented — the model is billed from token usage, and its `xhigh`/`max` quality tiers have no published per-image rate — so the right fix is not to invent a 2.5 per-image table, but to make "no published rate → no cost" the general rule and delete the special case.

Changes:

- Unknown/unpriced models now return `undefined` instead of `0.04 * n`, matching the convention already used elsewhere in the OpenAI billing code (`calculateOpenAIUsageCost` returns `undefined` when `getModelRates` has no entry, and `calculateOpenAIUsageCostFromTokenUsage` explicitly refuses to infer unpublished Bedrock rates). The response simply omits `cost`, which downstream code already handles.
- **Deleted** the `isGptImage25` early return: 2.5 now reaches the same "no rate" path as everything else, with identical behavior.
- The no-cost outcome is no longer silent — it logs at debug with the model, size, and quality, and the docs now state the rule for the image provider generally (replacing the 2.5-only sentence).
- **Simplification pass:** the if/else-if chain of six near-identical `${quality}_${size}` table lookups (each recomputing the key and multiplying by `n`) collapsed into one `getPerImageCost` helper that returns the single-image price; `calculateImageCost` is now three lines. `n` is applied once, `||` fallbacks became `??`, and the redundant `imageQuality`/`gptImageQuality` pair became one `tieredQuality` local. Net −2 lines in `src/` despite adding the debug log and two comments.

No pricing tables were changed, and every priced model/size/quality combination returns exactly what it did before.

## Test plan

`test/providers/openai/image.functions.test.ts`: the two tests that asserted the `0.04` guess now assert `undefined` (they fail on `main`), plus a new `it.each` locking in that all four GPT Image 2.5 ids — aliases and `2026-09-08` snapshots — never borrow GPT Image 2's per-image rates, for both a shared quality (`high`) and a 2.5-only one (`max`).

```
$ npx vitest run test/providers/openai/image.functions.test.ts test/providers/openai/image.test.ts
  Test Files  2 passed (2)
       Tests  146 passed (146)

$ npx vitest run test/providers/openai
  Test Files  42 passed | 1 skipped (43)
       Tests  1819 passed | 9 skipped (1828)

$ npx tsc --noEmit -p tsconfig.json
  (clean)

$ npx biome check --write src/providers/openai/image.ts test/providers/openai/image.functions.test.ts
  Checked 2 files. No fixes applied.

$ npx prettier --write site/docs/providers/openai.md
  unchanged
```
