### PR TITLE
fix(db): reopen the database after a failed lock recovery

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -35,6 +35,15 @@ let dbPromise: Promise<Drizzle> | null = null;
 let sqliteInstance: Client | null = null;
 let sqliteInstanceIsTesting = false;
 
+// Drop every cached handle so the next getDb() builds a fresh connection instead of
+// handing back a client that is closed or otherwise unusable.
+function clearCachedDb(): void {
+  sqliteInstance = null;
+  sqliteInstanceIsTesting = false;
+  dbInstance = null;
+  dbPromise = null;
+}
+
 function isMissingPathError(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException | null)?.code;
   return code === 'ENOENT' || code === 'ENOTDIR';
@@ -242,6 +251,35 @@ function serializeTopLevelOperations(
 ): Drizzle {
   const rawExecute = client.execute.bind(client);
 
+  // libsql 0.5.29 can leave a failed statement active: later writes appear to succeed
+  // but disappear at close. Returns false when the connection could not be healed and
+  // was discarded, so the caller must fail closed.
+  const recoverConnection = async (): Promise<boolean> => {
+    try {
+      const result = await rawExecute('PRAGMA busy_timeout');
+      const busyTimeoutMs = Number(result.rows[0]?.timeout ?? 5000);
+      await client.reconnect();
+      // journal_mode persists in the file; restore only connection settings.
+      await configureConnection(rawExecute, busyTimeoutMs, 'preserve');
+      return true;
+    } catch (recoveryError) {
+      logger.warn('Could not recover database connection after lock failure', {
+        error: recoveryError,
+      });
+      try {
+        client.close();
+      } catch {
+        // The connection is already unusable; the lock error is what callers need.
+      }
+      // A closed client must not stay cached, or every later write would reject for
+      // the rest of the process. The next getDb() builds a fresh connection instead.
+      if (sqliteInstance === client) {
+        clearCachedDb();
+      }
+      return false;
+    }
+  };
+
   const withLockRecovery = async <T>(operation: () => Promise<T>, retry: boolean): Promise<T> => {
     for (let attempt = 1; ; attempt++) {
       // The native transaction() method does not check client.closed itself.
@@ -254,26 +292,10 @@ function serializeTopLevelOperations(
         if (!isTransientDatabaseLockError(error)) {
           throw error;
         }
-        // libsql 0.5.29 can leave a failed statement active: later writes appear to
-        // succeed but disappear at close. Heal even when this operation will not
-        // retry. Reconnecting shared in-memory tests would destroy their schema.
-        if (reconnectOnLockFailure) {
-          try {
-            const result = await rawExecute('PRAGMA busy_timeout');
-            const busyTimeoutMs = Number(result.rows[0]?.timeout ?? 5000);
-            await client.reconnect();
-            // journal_mode persists in the file; restore only connection settings.
-            await configureConnection(rawExecute, busyTimeoutMs, 'preserve');
-          } catch (recoveryError) {
-            logger.warn('Could not recover database connection after lock failure', {
-              error: recoveryError,
-            });
-            try {
-              client.close();
-            } finally {
-              throw error;
-            }
-          }
+        // Heal even when this operation will not retry. Reconnecting shared in-memory
+        // tests would destroy their schema, so they opt out.
+        if (reconnectOnLockFailure && !(await recoverConnection())) {
+          throw error;
         }
         if (!retry || attempt >= TRANSIENT_LOCK_RETRY_ATTEMPTS) {
           throw error;
@@ -377,10 +399,7 @@ export async function getDb() {
         unregisterTestDatabaseClient(sqliteInstance);
         sqliteInstance.close();
       }
-      sqliteInstance = null;
-      sqliteInstanceIsTesting = false;
-      dbInstance = null;
-      dbPromise = null;
+      clearCachedDb();
       throw error;
     });
   }
@@ -436,10 +455,7 @@ export async function closeDb() {
       // Even if close fails, we should still clear the instances
       // to prevent reuse of a potentially corrupted connection
     } finally {
-      sqliteInstance = null;
-      sqliteInstanceIsTesting = false;
-      dbInstance = null;
-      dbPromise = null;
+      clearCachedDb();
     }
   }
 }

--- a/src/tracing/store.ts
+++ b/src/tracing/store.ts
@@ -146,14 +146,11 @@ function computeDepth(
 }
 
 export class TraceStore {
-  private db: Awaited<ReturnType<typeof getDb>> | null = null;
-
+  // This store is a process-wide singleton, so it must not cache the handle: getDb()
+  // already returns the cached connection, and re-asking is what lets a store that
+  // outlived a closed or evicted connection pick up the replacement.
   private async getDatabase() {
-    if (!this.db) {
-      logger.debug('[TraceStore] Initializing database connection');
-      this.db = await getDb();
-    }
-    return this.db;
+    return getDb();
   }
 
   async createTrace(trace: StoreTraceData): Promise<void> {

--- a/test/database/fixtures/lockRecoveryProbe.ts
+++ b/test/database/fixtures/lockRecoveryProbe.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from 'node:url';
 
 import { createClient } from '@libsql/client/node';
 import { Sqlite3Client } from '@libsql/client/sqlite3';
-import { closeDb, getDb, getDbPath } from '../../../src/database/index';
+import { closeDb, getDb, getDbPath, isDbOpen } from '../../../src/database/index';
 import type { Client } from '@libsql/client/node';
 
 export interface LockRecoveryProbeResult {
@@ -10,6 +10,9 @@ export interface LockRecoveryProbeResult {
   followupError: string | null;
   followupRowsAffected: number | null;
   transactionAfterFailureError: string | null;
+  dbOpenAfterFailure: boolean | null;
+  reopenedError: string | null;
+  reopenedRowsAffected: number | null;
   callbackCalls: number;
   clientClosedAfterFailure: boolean;
   beforeCloseIds: number[];
@@ -63,6 +66,9 @@ const result: LockRecoveryProbeResult = {
   followupError: null,
   followupRowsAffected: null,
   transactionAfterFailureError: null,
+  dbOpenAfterFailure: null,
+  reopenedError: null,
+  reopenedRowsAffected: null,
   callbackCalls: 0,
   clientClosedAfterFailure: false,
   beforeCloseIds: [],
@@ -175,6 +181,14 @@ try {
         await tx.run('INSERT INTO lock_recovery_test VALUES (4)');
       }),
     );
+    // A failed recovery must not poison the process: the cached handles are dropped,
+    // so the next getDb() opens a fresh connection that can still write.
+    result.dbOpenAfterFailure = isDbOpen();
+    result.reopenedError = await captureError(async () => {
+      const reopened = await getDb();
+      const insert = await reopened.run('INSERT INTO lock_recovery_test VALUES (5)');
+      result.reopenedRowsAffected = insert.rowsAffected;
+    });
   }
   if (mode === 'script') {
     const query = await contender.execute('SELECT COUNT(*) AS count FROM attached_rows');

--- a/test/database/index.test.ts
+++ b/test/database/index.test.ts
@@ -845,7 +845,7 @@ describe('database', () => {
     );
 
     it.each(['reconnect-failure', 'configuration-failure'])(
-      'rejects later statements and transactions after %s',
+      'rejects later statements and transactions after %s, but reopens on demand',
       async (mode) => {
         const result = await runDatabaseProbe<LockRecoveryProbeResult>(
           'lockRecoveryProbe',
@@ -859,8 +859,13 @@ describe('database', () => {
         expect(result.followupError).toMatch(/closed/i);
         expect(result.transactionAfterFailureError).toMatch(/closed/i);
         expect(result.callbackCalls).toBe(0);
-        expect(result.beforeCloseIds).toEqual([1]);
-        expect(result.afterCloseIds).toEqual([1]);
+        // The closed client is evicted, so getDb() opens a fresh one instead of
+        // failing every remaining write for the life of the process.
+        expect(result.dbOpenAfterFailure).toBe(false);
+        expect(result.reopenedError).toBeNull();
+        expect(result.reopenedRowsAffected).toBe(1);
+        expect(result.beforeCloseIds).toEqual([1, 5]);
+        expect(result.afterCloseIds).toEqual([1, 5]);
       },
     );
   });

--- a/test/database/index.test.ts
+++ b/test/database/index.test.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+import { Sqlite3Client } from '@libsql/client/sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import cliState from '../../src/cliState';
 import {
@@ -18,6 +19,7 @@ import { getEnvBool } from '../../src/envars';
 import logger from '../../src/logger';
 import { getConfigDirectoryPath } from '../../src/util/config/manage';
 import { mockProcessEnv } from '../util/utils';
+import type { Client } from '@libsql/client/node';
 
 import type { LockRecoveryProbeResult } from './fixtures/lockRecoveryProbe';
 import type { WalCheckpointProbeResult } from './fixtures/walCheckpointProbe';
@@ -126,6 +128,43 @@ async function runDatabaseProbe<T>(
   return JSON.parse(resultLine.slice(DATABASE_PROBE_RESULT_PREFIX.length));
 }
 
+const ORIGINAL_SQLITE3_EXECUTE = Sqlite3Client.prototype.execute;
+// Armed by injectLockFailures(); the interceptor itself has to be installed before
+// getDb() because serializeTopLevelOperations binds client.execute up front.
+const lockFailures = { sql: '', remaining: 0 };
+
+/** Fails the next `count` statements containing `sql` with a transient lock error. */
+function injectLockFailures(sql: string, count: number): void {
+  lockFailures.sql = sql;
+  lockFailures.remaining = count;
+}
+
+/**
+ * Opens the file-backed database, which is the only configuration that reconnects
+ * after a lock failure: the shared in-memory test database opts out because dropping
+ * its last connection would destroy the schema.
+ */
+async function openFileBackedDb(): Promise<{
+  db: Awaited<ReturnType<typeof getDb>>;
+  client: Client;
+}> {
+  vi.mocked(getEnvBool).mockImplementation(() => false);
+  await closeDb();
+  Sqlite3Client.prototype.execute = function (statement, args?) {
+    const text = typeof statement === 'string' ? statement : statement.sql;
+    if (lockFailures.remaining > 0 && text.includes(lockFailures.sql)) {
+      lockFailures.remaining--;
+      return Promise.reject(
+        Object.assign(new Error('SQLITE_BUSY: database is locked'), { code: 'SQLITE_BUSY' }),
+      );
+    }
+    return ORIGINAL_SQLITE3_EXECUTE.call(this, statement as string, args);
+  };
+  const db = await getDb();
+  await db.run('CREATE TABLE recovery_probe (id INTEGER PRIMARY KEY)');
+  return { db, client: (db as typeof db & { $client: Client }).$client };
+}
+
 describe('database', () => {
   let tempConfigDir: string;
 
@@ -149,6 +188,8 @@ describe('database', () => {
   });
 
   afterEach(async () => {
+    lockFailures.remaining = 0;
+    Sqlite3Client.prototype.execute = ORIGINAL_SQLITE3_EXECUTE;
     await closeDb();
     cliState.config = undefined;
     vi.unstubAllEnvs();
@@ -868,6 +909,83 @@ describe('database', () => {
         expect(result.afterCloseIds).toEqual([1, 5]);
       },
     );
+
+    it('retries the statement once the connection recovers', async () => {
+      const { db, client } = await openFileBackedDb();
+      injectLockFailures('INSERT INTO recovery_probe', 1);
+
+      await expect(db.run('INSERT INTO recovery_probe VALUES (1)')).resolves.toBeDefined();
+
+      expect(client.closed).toBe(false);
+      expect(isDbOpen()).toBe(true);
+      expect(await getDb()).toBe(db);
+      expect(await db.all('SELECT id FROM recovery_probe')).toEqual([{ id: 1 }]);
+    });
+
+    it('evicts the closed connection when recovery fails so the next getDb reopens', async () => {
+      const { db, client } = await openFileBackedDb();
+      client.reconnect = () => Promise.reject(new Error('Injected reconnect failure'));
+      injectLockFailures('INSERT INTO recovery_probe', 2);
+
+      await expect(db.run('INSERT INTO recovery_probe VALUES (1)')).rejects.toMatchObject({
+        cause: { code: 'SQLITE_BUSY' },
+      });
+
+      // Fail closed for the operation that lost the lock, but do not keep the dead
+      // client cached: every later write would reject for the rest of the process.
+      expect(client.closed).toBe(true);
+      expect(isDbOpen()).toBe(false);
+
+      lockFailures.remaining = 0;
+      const reopened = await getDb();
+      expect(reopened).not.toBe(db);
+      await reopened.run('INSERT INTO recovery_probe VALUES (2)');
+      expect(await reopened.all('SELECT id FROM recovery_probe')).toEqual([{ id: 2 }]);
+    });
+
+    it('keeps the replacement connection cached when a stale handle fails recovery', async () => {
+      const { db, client } = await openFileBackedDb();
+      client.reconnect = () => Promise.reject(new Error('Injected reconnect failure'));
+      // close() failing must not mask the lock error nor skip the cache eviction.
+      client.close = () => {
+        throw new Error('Injected close failure');
+      };
+      injectLockFailures('INSERT INTO recovery_probe', 4);
+
+      await expect(db.run('INSERT INTO recovery_probe VALUES (1)')).rejects.toMatchObject({
+        cause: { code: 'SQLITE_BUSY' },
+      });
+      expect(isDbOpen()).toBe(false);
+
+      const reopened = await getDb();
+      expect(reopened).not.toBe(db);
+
+      // The stale handle is no longer the cached client, so its next failed recovery
+      // must leave the healthy replacement alone.
+      await expect(db.run('INSERT INTO recovery_probe VALUES (2)')).rejects.toMatchObject({
+        cause: { code: 'SQLITE_BUSY' },
+      });
+      expect(isDbOpen()).toBe(true);
+      expect(await getDb()).toBe(reopened);
+
+      Reflect.deleteProperty(client, 'close');
+      client.close();
+    });
+
+    it('clears the cached handles when opening the database fails', async () => {
+      vi.mocked(getEnvBool).mockImplementation(() => false);
+      await closeDb();
+      vi.mocked(getConfigDirectoryPath).mockImplementation(() => {
+        throw new Error('Injected config directory failure');
+      });
+
+      await expect(getDb()).rejects.toThrow('Injected config directory failure');
+      expect(isDbOpen()).toBe(false);
+
+      vi.mocked(getConfigDirectoryPath).mockReturnValue(tempConfigDir);
+      await expect(getDb()).resolves.toBeDefined();
+      expect(isDbOpen()).toBe(true);
+    });
   });
 
   describe('isDbOpen', () => {

--- a/test/tracing/store.test.ts
+++ b/test/tracing/store.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDb } from '../../src/database/index';
 import { mockGlobal } from '../util/utils';
 
 const mockRandomUUID = vi.fn(() => 'test-uuid');
@@ -10,6 +11,8 @@ const restoreCrypto = mockGlobal('crypto', {
 afterAll(() => {
   restoreCrypto();
 });
+
+vi.mock('../../src/database/index', () => ({ getDb: vi.fn() }));
 
 // Mock logger
 vi.mock('../../src/logger', () => ({
@@ -60,10 +63,8 @@ describe('TraceStore', () => {
       transaction: vi.fn(async (callback) => callback(mockDb)),
     };
 
-    // Create trace store and inject mock DB
+    vi.mocked(getDb).mockResolvedValue(mockDb);
     traceStore = new TraceStore();
-    // Use private property access to inject the mock
-    (traceStore as any).db = mockDb;
   });
 
   afterEach(() => {

--- a/test/tracing/storePersistence.test.ts
+++ b/test/tracing/storePersistence.test.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 
 import { eq } from 'drizzle-orm';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { getDb } from '../../src/database/index';
+import { closeDb, getDb } from '../../src/database/index';
 import { spansTable, tracesTable } from '../../src/database/tables';
 import { runDbMigrations } from '../../src/migrate';
 import { TraceStore } from '../../src/tracing/store';
@@ -67,6 +67,20 @@ describe('TraceStore span persistence', () => {
       .where(eq(spansTable.traceId, 'concurrent-insertions'));
     expect(spans).toHaveLength(1);
     expect(spans[0]).toMatchObject({ name: 'target.call', spanId: 'shared-span' });
+  });
+
+  it('follows the current connection after the one it used is closed', async () => {
+    const traceStore = await createTrace('reconnect-after-close');
+    await traceStore.addSpans('reconnect-after-close', [
+      { spanId: 'before-close', name: 'target.call', startTime: 1 },
+    ]);
+
+    // A failed lock recovery drops the cached connection the same way: this store
+    // is a process-wide singleton, so it must not keep using the closed handle.
+    await closeDb();
+    await runDbMigrations();
+
+    await expect(traceStore.getSpans('reconnect-after-close')).resolves.toEqual([]);
   });
 
   it('allows the same span ID in different traces', async () => {


### PR DESCRIPTION
## Summary

`withLockRecovery` (`src/database/index.ts`) heals the connection after a transient `SQLITE_BUSY`/`SQLITE_LOCKED` failure. When that recovery itself failed, it closed the client and rethrew the original lock error — but never cleared the module-level `dbInstance` / `sqliteInstance` / `dbPromise`.

Every later `getDb()` then handed back the same closed client, and the `if (client.closed) throw new Error('Database connection is closed')` guard at the top of the same function rejected **every** subsequent write for the remaining life of the process. An eval in progress silently loses all its remaining result writes. Introduced in #9009.

The fix keeps the fail-closed semantics for the operation that failed, and only stops the dead client from being resurrected: on that path we now drop the cached handles (guarded on `sqliteInstance === client`, so a connection someone else already replaced is left alone) and the next `getDb()` builds a fresh connection.

Simplifications along the way:

- The four-field teardown was duplicated in `getDb()`'s init-failure catch and `closeDb()`'s `finally`. Both now call one `clearCachedDb()`, so there is exactly one place that knows the field list.
- The reconnect block moved out of `withLockRecovery` into a `recoverConnection()` helper that returns whether the connection was healed. `withLockRecovery`'s catch is now four lines instead of twenty-five, and the `try { client.close() } finally { throw error }` trick (which swallowed close errors as a side effect of the `finally` throw) became an explicit `try/catch` that says so.
- No behavior change for `reconnectOnLockFailure: !isTesting`, the serialized top-level operation queue, or the existing retry/backoff.

### `TraceStore` followed the dead connection

Reopening the module-level connection is only half the recovery if something is holding an older handle. `TraceStore` (`src/tracing/store.ts`) is a process-wide singleton that cached the drizzle object from its first `getDb()`, so after the eviction above — or after any `closeDb()` — every trace/span operation kept hitting the closed client:

```
first getSpans:  []
second getSpans: THREW: Failed query: select ... from "spans" ...
                 Caused by: Database connection is closed
module getDb():  works again
```

It was the only long-lived holder in the codebase; every other call site already re-asks `getDb()` per operation, and `getDb()` returns the cached connection anyway. The store's own cache bought nothing but the staleness, so it is gone.

## Test plan

Regression coverage extends the existing `lockRecoveryProbe` fixture: for the `reconnect-failure` and `configuration-failure` modes it now records `isDbOpen()` after the failure and re-runs `getDb()` to write another row, and the test asserts the row actually persists.

That probe runs in a subprocess, so the recovery paths were invisible to coverage. `test/database/index.test.ts` now also exercises them in process against a real file-backed database (the only configuration where `reconnectOnLockFailure` is on) with an injected transient lock error: the retry after a successful recovery, the eviction when recovery fails, the `sqliteInstance === client` guard when a stale handle fails recovery later, a `close()` that itself throws, and `getDb()`'s own init-failure teardown.

`test/tracing/storePersistence.test.ts` covers the store: use a `TraceStore`, close the connection under it, and assert the next call goes to the reopened one.

```
$ npx vitest run test/database/index.test.ts -t 'reopens on demand'   # with fix
  Tests  2 passed | 49 skipped (51)

$ git stash push src/database/index.ts && npx vitest run test/database/index.test.ts -t 'lock recovery'   # without fix
  Tests  4 failed | 8 passed

$ npx vitest run test/tracing/storePersistence.test.ts   # without the store fix
  Tests  1 failed | 9 passed
  Caused by: Error: Database connection is closed

$ npx vitest run test/database test/tracing test/test-hygiene.test.ts
  Test Files  31 passed (31)
  Tests  793 passed (793)

$ npx vitest run test/models test/server/routes
  Tests  710 passed (710)

$ npx tsc --noEmit -p tsconfig.json     # clean
$ npm run knip -- --no-progress         # clean
$ npx biome check src/database/index.ts src/tracing/store.ts test/database test/tracing   # clean
```

Coverage of `src/database/index.ts` under `test/database/index.test.ts` alone: 90.3% lines (every line this PR adds is now covered in process).
