### PR TITLE
fix(cloudflare): drop gateway routes that cannot work

### DIFF
--- a/site/docs/providers/cloudflare-gateway.md
+++ b/site/docs/providers/cloudflare-gateway.md
@@ -111,7 +111,7 @@ The `cloudflare-gateway` adapter supports these provider-specific chat routes:
 | Grok (xAI)   | `grok`          | `XAI_API_KEY`                |
 
 :::note
-The provider-specific `cloudflare-gateway:` routes for Workers AI, Google AI Studio, Cohere, Hugging Face, and Replicate currently send OpenAI Chat Completions requests to incompatible native endpoints. Use Cloudflare's [OpenAI-compatible REST API](https://developers.cloudflare.com/ai-gateway/usage/rest-api/) for models it supports, as shown below for Workers AI. Other native endpoints require a [custom provider](/docs/providers/custom-api).
+`cloudflare-gateway:` routes for Workers AI, Google AI Studio, Cohere, Hugging Face, and Replicate are rejected with an error, because their native endpoints do not accept OpenAI Chat Completions requests. Use Cloudflare's [OpenAI-compatible REST API](https://developers.cloudflare.com/ai-gateway/usage/rest-api/) for models it supports, as shown below for Workers AI. Other native endpoints require a [custom provider](/docs/providers/custom-api).
 
 AWS Bedrock request signing is not implemented by the `cloudflare-gateway` adapter.
 :::

--- a/src/providers/cloudflare-gateway.ts
+++ b/src/providers/cloudflare-gateway.ts
@@ -70,25 +70,21 @@ interface GatewayProviderConfig {
 /**
  * Supported provider configurations for Cloudflare AI Gateway
  *
- * Note: Some providers have special URL requirements:
- * - azure-openai: Requires resourceName and deploymentName in config
- * - workers-ai: Model name is appended to URL path
+ * Only gateway routes that speak the OpenAI Chat Completions or Anthropic Messages
+ * protocol are listed. Routes whose native endpoints reject those payloads
+ * (workers-ai, google-ai-studio, cohere, huggingface, replicate) are deliberately
+ * absent; use Cloudflare's OpenAI-compatible REST API or a custom provider instead.
+ * AWS Bedrock is likewise unsupported because it requires AWS request signing.
  *
- * AWS Bedrock is NOT supported because it requires AWS request signing
- * which is incompatible with the gateway proxy approach.
+ * Note: azure-openai requires resourceName and deploymentName in config.
  */
 const PROVIDER_CONFIGS: Record<string, GatewayProviderConfig> = {
   openai: { apiKeyEnvar: 'OPENAI_API_KEY' },
   anthropic: { apiKeyEnvar: 'ANTHROPIC_API_KEY' },
   groq: { apiKeyEnvar: 'GROQ_API_KEY' },
   'perplexity-ai': { apiKeyEnvar: 'PERPLEXITY_API_KEY' },
-  'google-ai-studio': { apiKeyEnvar: 'GOOGLE_API_KEY' },
   mistral: { apiKeyEnvar: 'MISTRAL_API_KEY' },
-  cohere: { apiKeyEnvar: 'COHERE_API_KEY' },
   'azure-openai': { apiKeyEnvar: 'AZURE_OPENAI_API_KEY' },
-  'workers-ai': { apiKeyEnvar: 'CLOUDFLARE_API_KEY' },
-  huggingface: { apiKeyEnvar: 'HUGGINGFACE_API_KEY' },
-  replicate: { apiKeyEnvar: 'REPLICATE_API_KEY' },
   grok: { apiKeyEnvar: 'XAI_API_KEY' },
 };
 
@@ -193,14 +189,12 @@ function getCfAigToken(config?: CloudflareGatewayConfig, env?: EnvOverrides): st
  *
  * Most providers use: https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/{provider}
  * Azure OpenAI uses: https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/azure-openai/{resource_name}/{deployment_name}
- * Workers AI uses: https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/workers-ai/{model_id}
  */
 function buildGatewayUrl(
   accountId: string,
   gatewayId: string,
   provider: string,
   config?: CloudflareGatewayConfig,
-  modelName?: string,
 ): string {
   const baseUrl = `${CLOUDFLARE_GATEWAY_BASE_URL}/${accountId}/${gatewayId}`;
 
@@ -223,11 +217,6 @@ function buildGatewayUrl(
   // Mistral's native gateway proxy retains the upstream /v1 path.
   if (provider === 'mistral') {
     return `${baseUrl}/mistral/v1`;
-  }
-
-  if (provider === 'workers-ai') {
-    invariant(modelName, 'Workers AI requires a model name (e.g., @cf/meta/llama-3.1-8b-instruct)');
-    return `${baseUrl}/workers-ai/${modelName}`;
   }
 
   return `${baseUrl}/${provider}`;
@@ -289,7 +278,6 @@ export class CloudflareGatewayOpenAiProvider extends OpenAiChatCompletionProvide
       gatewayId,
       underlyingProvider,
       providerOptions.config,
-      modelName,
     );
     const passthrough = getPassthroughConfig(providerOptions.config);
 

--- a/test/providers/cloudflare-gateway.test.ts
+++ b/test/providers/cloudflare-gateway.test.ts
@@ -653,25 +653,19 @@ describe('CloudflareGateway Provider', () => {
   });
 
   describe('Supported Providers', () => {
-    // Note: bedrock is NOT supported because it requires AWS request signing
-    // azure-openai and workers-ai have special URL handling but are supported
+    // Note: azure-openai has special URL handling but is supported
     const supportedProviders = [
       'openai',
       'anthropic',
       'groq',
       'perplexity-ai',
-      'google-ai-studio',
       'mistral',
-      'cohere',
       'azure-openai',
-      'workers-ai',
-      'huggingface',
-      'replicate',
       'grok',
     ];
 
     it.each(supportedProviders)('should support %s provider', (providerName) => {
-      // azure-openai and workers-ai need extra config
+      // azure-openai needs extra config
       const extraConfig =
         providerName === 'azure-openai'
           ? { resourceName: 'test-resource', deploymentName: 'test-deployment' }
@@ -687,12 +681,25 @@ describe('CloudflareGateway Provider', () => {
       expect(provider.id()).toBe(`cloudflare-gateway:${providerName}:test-model`);
     });
 
-    it('should not support bedrock provider', () => {
+    // bedrock requires AWS request signing; the rest expose native endpoints that
+    // reject OpenAI Chat Completions payloads.
+    const unsupportedProviders = [
+      'bedrock',
+      'workers-ai',
+      'google-ai-studio',
+      'cohere',
+      'huggingface',
+      'replicate',
+    ];
+
+    it.each(unsupportedProviders)('should reject %s provider', (providerName) => {
       expect(() =>
-        createCloudflareGatewayProvider('cloudflare-gateway:bedrock:anthropic.claude-v2', {
+        createCloudflareGatewayProvider(`cloudflare-gateway:${providerName}:test-model`, {
           config: minimumConfig,
         }),
-      ).toThrow('Unsupported Cloudflare AI Gateway provider');
+      ).toThrow(
+        `Unsupported Cloudflare AI Gateway provider: "${providerName}". Supported providers: ${supportedProviders.join(', ')}`,
+      );
     });
   });
 
@@ -855,50 +862,6 @@ describe('CloudflareGateway Provider', () => {
         expect.stringContaining('api-version=2024-06-01'),
         expect.any(Object),
       );
-    });
-  });
-
-  describe('Workers AI Provider', () => {
-    it('should construct correct URL with model in path', async () => {
-      const provider = new CloudflareGatewayOpenAiProvider(
-        'workers-ai',
-        '@cf/meta/llama-3.1-8b-instruct',
-        {
-          config: minimumConfig,
-        },
-      );
-
-      const responsePayload = {
-        choices: [{ message: { content: 'Test' } }],
-        usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 },
-      };
-      const mockResponse = {
-        ...defaultMockResponse,
-        text: vi.fn().mockResolvedValue(JSON.stringify(responsePayload)),
-        ok: true,
-      };
-      mockFetch.mockResolvedValue(mockResponse);
-
-      await provider.callApi('Test prompt');
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'https://gateway.ai.cloudflare.com/v1/testAccountId/testGatewayId/workers-ai/@cf/meta/llama-3.1-8b-instruct',
-        ),
-        expect.any(Object),
-      );
-    });
-
-    it('should return correct id for workers-ai provider', () => {
-      const provider = new CloudflareGatewayOpenAiProvider(
-        'workers-ai',
-        '@cf/meta/llama-3.1-8b-instruct',
-        {
-          config: minimumConfig,
-        },
-      );
-
-      expect(provider.id()).toBe('cloudflare-gateway:workers-ai:@cf/meta/llama-3.1-8b-instruct');
     });
   });
 });

--- a/test/providers/cloudflare-gateway.test.ts
+++ b/test/providers/cloudflare-gateway.test.ts
@@ -692,13 +692,17 @@ describe('CloudflareGateway Provider', () => {
       'replicate',
     ];
 
+    // Matching an Error instance compares the message exactly, which also pins the
+    // supported-provider list in the error to the one exercised above.
     it.each(unsupportedProviders)('should reject %s provider', (providerName) => {
       expect(() =>
         createCloudflareGatewayProvider(`cloudflare-gateway:${providerName}:test-model`, {
           config: minimumConfig,
         }),
       ).toThrow(
-        `Unsupported Cloudflare AI Gateway provider: "${providerName}". Supported providers: ${supportedProviders.join(', ')}`,
+        new Error(
+          `Unsupported Cloudflare AI Gateway provider: "${providerName}". Supported providers: ${supportedProviders.join(', ')}`,
+        ),
       );
     });
   });


### PR DESCRIPTION
## Summary

`PROVIDER_CONFIGS` in `src/providers/cloudflare-gateway.ts` still advertised five routes — `google-ai-studio`, `cohere`, `workers-ai`, `huggingface`, `replicate` — that the provider's own documentation already declares broken. Each builds an OpenAI Chat Completions request against a native Cloudflare gateway endpoint that does not accept that payload, so a user who selected one got a confusing upstream error rather than a fast, actionable failure. Only `mistral` was repaired in #10734; the rest were left in the surface area.

Reconciled code with docs by **deleting** the broken routes rather than adding new special cases:

- Removed the five entries from `PROVIDER_CONFIGS`. `createCloudflareGatewayProvider` already fails fast with `Unsupported Cloudflare AI Gateway provider: "<name>". Supported providers: …`, so removal is the whole fix — no new error path.
- Deleted the now-dead `workers-ai` branch in `buildGatewayUrl`, and with it the `modelName` parameter that branch was the only user of (plus its call-site argument and JSDoc line).
- Tightened the `PROVIDER_CONFIGS` doc comment to state the actual rule (routes must speak OpenAI Chat Completions or Anthropic Messages) instead of listing per-provider URL quirks.
- Updated `site/docs/providers/cloudflare-gateway.md` so the note says these routes are rejected with an error, matching the new behavior. The supported-providers table already listed only the seven working routes; the Workers AI section already points at the OpenAI-compatible REST API and is unchanged.

Test side: replaced the `workers-ai` URL/id tests (which asserted the broken shape) and the single bedrock rejection test with a table-driven rejection test covering all six unsupported routes, asserting the full error message — which also pins the supported-provider list in the error to the list the suite claims is supported.

Net **-49 lines**.

## Test plan

```
npx vitest run test/providers/cloudflare-gateway.test.ts test/providers/cloudflare-native-path.test.ts \
  test/providers/cloudflare-ai.test.ts test/providers/registry.test.ts
  → Test Files 4 passed (4), Tests 268 passed (268)

# regression check: stash only the src change, rerun
git stash push src/providers/cloudflare-gateway.ts && npx vitest run test/providers/cloudflare-gateway.test.ts
  → 6 failed (the six unsupported routes constructed a provider instead of throwing)

npx tsc --noEmit -p tsconfig.json          → clean
npx biome check src/providers/cloudflare-gateway.ts test/providers/cloudflare-gateway.test.ts → clean
npx prettier --check site/docs/providers/cloudflare-gateway.md → unchanged
```