### PR TITLE
fix(providers): stop leaking local config into request bodies

### DIFF
--- a/src/providers/cerebras.ts
+++ b/src/providers/cerebras.ts
@@ -1,4 +1,5 @@
 import { OpenAiChatCompletionProvider } from './openai/chat';
+import { splitLocalOptions } from './openai/util';
 
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderOptions } from '../types/index';
@@ -22,8 +23,10 @@ export function createCerebrasProvider(
   const splits = providerPath.split(':');
   const modelName = splits.slice(1).join(':');
 
-  // Filter out basePath from config to avoid passing it to the API
-  const { basePath: _, ...configWithoutBasePath } = options.config?.config || {};
+  const config = options.config?.config || {};
+  // Only genuine model parameters belong in the request body; promptfoo's own settings
+  // (credentials, headers, cost overrides, basePath) stay local.
+  const { localOptions, modelParameters } = splitLocalOptions(config);
 
   // Create a custom provider class that overrides the getOpenAiBody method
   class CerebrasProvider extends OpenAiChatCompletionProvider {
@@ -48,11 +51,10 @@ export function createCerebrasProvider(
   const cerebrasConfig = {
     ...options,
     config: {
-      apiBaseUrl: 'https://api.cerebras.ai/v1',
-      apiKeyEnvar: 'CEREBRAS_API_KEY',
-      passthrough: {
-        ...configWithoutBasePath,
-      },
+      ...localOptions,
+      apiBaseUrl: localOptions.apiBaseUrl || 'https://api.cerebras.ai/v1',
+      apiKeyEnvar: localOptions.apiKeyEnvar || 'CEREBRAS_API_KEY',
+      passthrough: { ...modelParameters, ...config.passthrough },
     },
   };
 

--- a/src/providers/cerebras.ts
+++ b/src/providers/cerebras.ts
@@ -1,5 +1,5 @@
 import { OpenAiChatCompletionProvider } from './openai/chat';
-import { splitLocalOptions } from './openai/util';
+import { splitLocalOptions } from './openai/localOptions';
 
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderOptions } from '../types/index';

--- a/src/providers/cloudflare-ai.ts
+++ b/src/providers/cloudflare-ai.ts
@@ -3,6 +3,7 @@ import invariant from '../util/invariant';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
+import { splitLocalOptions } from './openai/util';
 
 import type { EnvVarKey } from '../envars';
 import type { EnvOverrides } from '../types/env';
@@ -70,28 +71,18 @@ function getApiBaseUrl(config?: CloudflareAiConfig, env?: EnvOverrides): string 
   return `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/v1`;
 }
 
-function getPassthroughConfig(config?: CloudflareAiConfig) {
-  // Extract Cloudflare-specific config keys that shouldn't be passed through
-  const {
-    accountId: _accountId,
-    accountIdEnvar: _accountIdEnvar,
-    apiKey: _apiKey,
-    apiKeyEnvar: _apiKeyEnvar,
-    apiBaseUrl: _apiBaseUrl,
-    ...passthrough
-  } = config || {};
-  return passthrough;
-}
-
 function getOpenAiConfig(providerOptions: CloudflareAiProviderOptions): OpenAiCompletionOptions {
-  const apiBaseUrl = getApiBaseUrl(providerOptions.config, providerOptions.env);
-  const passthrough = getPassthroughConfig(providerOptions.config);
+  const config = providerOptions.config || {};
+  const apiBaseUrl = getApiBaseUrl(config, providerOptions.env);
+  // Only genuine model parameters belong in the request body; promptfoo's own settings
+  // (credentials, headers, cost overrides, basePath) stay local.
+  const { modelParameters } = splitLocalOptions(config, ['accountId', 'accountIdEnvar']);
 
   return {
-    ...providerOptions.config,
+    ...config,
     apiKeyEnvar: 'CLOUDFLARE_API_KEY',
     apiBaseUrl,
-    passthrough,
+    passthrough: { ...modelParameters, ...config.passthrough },
   };
 }
 

--- a/src/providers/cloudflare-ai.ts
+++ b/src/providers/cloudflare-ai.ts
@@ -3,7 +3,7 @@ import invariant from '../util/invariant';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
-import { splitLocalOptions } from './openai/util';
+import { splitLocalOptions } from './openai/localOptions';
 
 import type { EnvVarKey } from '../envars';
 import type { EnvOverrides } from '../types/env';

--- a/src/providers/nscale.ts
+++ b/src/providers/nscale.ts
@@ -3,7 +3,7 @@ import { createNscaleImageProvider } from './nscale/image';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
-import { splitLocalOptions } from './openai/util';
+import { splitLocalOptions } from './openai/localOptions';
 
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderOptions } from '../types/index';

--- a/src/providers/nscale.ts
+++ b/src/providers/nscale.ts
@@ -3,6 +3,7 @@ import { createNscaleImageProvider } from './nscale/image';
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
+import { splitLocalOptions } from './openai/util';
 
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderOptions } from '../types/index';
@@ -15,34 +16,6 @@ import type { ApiProvider, ProviderOptions } from '../types/index';
  *
  * Documentation: https://docs.nscale.com/
  */
-/**
- * Config keys promptfoo consumes itself rather than forwarding to the model.
- *
- * `passthrough` is serialized verbatim into the request body, so anything spread
- * into it is sent to Nscale as a model parameter. Spreading the whole user config
- * put `apiKey` — the raw service token — into the JSON body, and diverted
- * `headers` there too so custom headers never became HTTP headers.
- *
- * Mirrors `OpenAiSharedOptions` in `./openai/types`.
- */
-const NSCALE_PROVIDER_LEVEL_OPTIONS = new Set([
-  'apiKey',
-  'apiKeyEnvar',
-  'apiKeyRequired',
-  'useDefaultApiKey',
-  'apiHost',
-  'apiBaseUrl',
-  'organization',
-  'headers',
-  'maxRetries',
-  'cost',
-  'inputCost',
-  'outputCost',
-  'audioCost',
-  'audioInputCost',
-  'audioOutputCost',
-]);
-
 export function createNscaleProvider(
   providerPath: string,
   options: {
@@ -54,20 +27,7 @@ export function createNscaleProvider(
   const splits = providerPath.split(':');
 
   const config = options.config?.config || {};
-
-  // Split the user's config into settings promptfoo handles (auth, routing,
-  // headers, cost overrides) and genuine model parameters, so only the latter
-  // reach the request body.
-  const { passthrough: explicitPassthrough, ...configOptions } = config;
-  const providerLevelOptions: Record<string, any> = {};
-  const modelParameters: Record<string, any> = {};
-  for (const [key, value] of Object.entries(configOptions)) {
-    if (NSCALE_PROVIDER_LEVEL_OPTIONS.has(key)) {
-      providerLevelOptions[key] = value;
-    } else {
-      modelParameters[key] = value;
-    }
-  }
+  const { localOptions, modelParameters } = splitLocalOptions(config);
 
   const getApiKeyEnvar = () => {
     if (config.apiKeyEnvar) {
@@ -85,15 +45,12 @@ export function createNscaleProvider(
   const nscaleConfig = {
     ...options,
     config: {
-      ...providerLevelOptions,
+      ...localOptions,
       apiKeyEnvar: getApiKeyEnvar(),
       // Honor an explicit apiBaseUrl (private/regional Nscale endpoints) instead
       // of silently ignoring it while still shipping it in the request body.
-      apiBaseUrl: providerLevelOptions.apiBaseUrl || 'https://inference.api.nscale.com/v1',
-      passthrough: {
-        ...modelParameters,
-        ...explicitPassthrough,
-      },
+      apiBaseUrl: localOptions.apiBaseUrl || 'https://inference.api.nscale.com/v1',
+      passthrough: { ...modelParameters, ...config.passthrough },
     },
   };
 

--- a/src/providers/openai/localOptions.ts
+++ b/src/providers/openai/localOptions.ts
@@ -1,0 +1,56 @@
+import type { OpenAiCompletionOptions, OpenAiSharedOptions } from './types';
+
+/**
+ * Config keys promptfoo or its transport consumes, rather than model parameters that belong
+ * in the request body. Requiring every shared option keeps future connection settings — and
+ * promptfoo bookkeeping such as `basePath` — out of `passthrough`, where they would be
+ * serialized verbatim into the JSON body of every request.
+ */
+const LOCAL_OPTIONS = {
+  apiKey: true,
+  apiKeyEnvar: true,
+  apiKeyRequired: true,
+  useDefaultApiKey: true,
+  apiHost: true,
+  apiBaseUrl: true,
+  organization: true,
+  headers: true,
+  maxRetries: true,
+  cost: true,
+  inputCost: true,
+  outputCost: true,
+  audioCost: true,
+  audioInputCost: true,
+  audioOutputCost: true,
+  passthrough: true,
+  mcp: true,
+  functionToolCallbacks: true,
+  showThinking: true,
+  omitDefaults: true,
+  basePath: true,
+  linkedTargetId: true,
+} satisfies Record<keyof OpenAiSharedOptions, boolean> &
+  Partial<Record<keyof OpenAiCompletionOptions | 'basePath' | 'linkedTargetId', boolean>>;
+
+const LOCAL_OPTION_NAMES = new Set<string>(Object.keys(LOCAL_OPTIONS));
+
+/**
+ * Splits an OpenAI-compatible provider config into the settings promptfoo handles itself
+ * (auth, routing, headers, cost overrides) and genuine model parameters, so that only the
+ * latter reach the request body via `passthrough`.
+ *
+ * `extraLocalKeys` lets a provider keep its own vendor-specific settings local too.
+ */
+export function splitLocalOptions(
+  config: Record<string, any> = {},
+  extraLocalKeys: string[] = [],
+): { localOptions: Record<string, any>; modelParameters: Record<string, any> } {
+  const localOptions: Record<string, any> = {};
+  const modelParameters: Record<string, any> = {};
+  for (const [key, value] of Object.entries(config)) {
+    const target =
+      LOCAL_OPTION_NAMES.has(key) || extraLocalKeys.includes(key) ? localOptions : modelParameters;
+    target[key] = value;
+  }
+  return { localOptions, modelParameters };
+}

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -6,6 +6,7 @@ import { calculateCost } from '../shared';
 
 import type { TokenUsage, VarValue } from '../../types/index';
 import type { ProviderConfig } from '../shared';
+import type { OpenAiCompletionOptions, OpenAiSharedOptions } from './types';
 
 const ajv = getAjv();
 
@@ -1092,4 +1093,59 @@ export function formatOpenAiError(data: {
   }
   errorMessage += '\n\n' + safeJsonStringify(data, true /* prettyPrint */);
   return errorMessage;
+}
+
+/**
+ * Config keys promptfoo or its transport consumes, rather than model parameters that belong
+ * in the request body. Requiring every shared option keeps future connection settings — and
+ * promptfoo bookkeeping such as `basePath` — out of `passthrough`, where they would be
+ * serialized verbatim into the JSON body of every request.
+ */
+const LOCAL_OPTIONS = {
+  apiKey: true,
+  apiKeyEnvar: true,
+  apiKeyRequired: true,
+  useDefaultApiKey: true,
+  apiHost: true,
+  apiBaseUrl: true,
+  organization: true,
+  headers: true,
+  maxRetries: true,
+  cost: true,
+  inputCost: true,
+  outputCost: true,
+  audioCost: true,
+  audioInputCost: true,
+  audioOutputCost: true,
+  passthrough: true,
+  mcp: true,
+  functionToolCallbacks: true,
+  showThinking: true,
+  omitDefaults: true,
+  basePath: true,
+  linkedTargetId: true,
+} satisfies Record<keyof OpenAiSharedOptions, boolean> &
+  Partial<Record<keyof OpenAiCompletionOptions | 'basePath' | 'linkedTargetId', boolean>>;
+
+const LOCAL_OPTION_NAMES = new Set<string>(Object.keys(LOCAL_OPTIONS));
+
+/**
+ * Splits an OpenAI-compatible provider config into the settings promptfoo handles itself
+ * (auth, routing, headers, cost overrides) and genuine model parameters, so that only the
+ * latter reach the request body via `passthrough`.
+ *
+ * `extraLocalKeys` lets a provider keep its own vendor-specific settings local too.
+ */
+export function splitLocalOptions(
+  config: Record<string, any> = {},
+  extraLocalKeys: string[] = [],
+): { localOptions: Record<string, any>; modelParameters: Record<string, any> } {
+  const localOptions: Record<string, any> = {};
+  const modelParameters: Record<string, any> = {};
+  for (const [key, value] of Object.entries(config)) {
+    const target =
+      LOCAL_OPTION_NAMES.has(key) || extraLocalKeys.includes(key) ? localOptions : modelParameters;
+    target[key] = value;
+  }
+  return { localOptions, modelParameters };
 }

--- a/src/providers/openai/util.ts
+++ b/src/providers/openai/util.ts
@@ -6,7 +6,6 @@ import { calculateCost } from '../shared';
 
 import type { TokenUsage, VarValue } from '../../types/index';
 import type { ProviderConfig } from '../shared';
-import type { OpenAiCompletionOptions, OpenAiSharedOptions } from './types';
 
 const ajv = getAjv();
 
@@ -1093,59 +1092,4 @@ export function formatOpenAiError(data: {
   }
   errorMessage += '\n\n' + safeJsonStringify(data, true /* prettyPrint */);
   return errorMessage;
-}
-
-/**
- * Config keys promptfoo or its transport consumes, rather than model parameters that belong
- * in the request body. Requiring every shared option keeps future connection settings — and
- * promptfoo bookkeeping such as `basePath` — out of `passthrough`, where they would be
- * serialized verbatim into the JSON body of every request.
- */
-const LOCAL_OPTIONS = {
-  apiKey: true,
-  apiKeyEnvar: true,
-  apiKeyRequired: true,
-  useDefaultApiKey: true,
-  apiHost: true,
-  apiBaseUrl: true,
-  organization: true,
-  headers: true,
-  maxRetries: true,
-  cost: true,
-  inputCost: true,
-  outputCost: true,
-  audioCost: true,
-  audioInputCost: true,
-  audioOutputCost: true,
-  passthrough: true,
-  mcp: true,
-  functionToolCallbacks: true,
-  showThinking: true,
-  omitDefaults: true,
-  basePath: true,
-  linkedTargetId: true,
-} satisfies Record<keyof OpenAiSharedOptions, boolean> &
-  Partial<Record<keyof OpenAiCompletionOptions | 'basePath' | 'linkedTargetId', boolean>>;
-
-const LOCAL_OPTION_NAMES = new Set<string>(Object.keys(LOCAL_OPTIONS));
-
-/**
- * Splits an OpenAI-compatible provider config into the settings promptfoo handles itself
- * (auth, routing, headers, cost overrides) and genuine model parameters, so that only the
- * latter reach the request body via `passthrough`.
- *
- * `extraLocalKeys` lets a provider keep its own vendor-specific settings local too.
- */
-export function splitLocalOptions(
-  config: Record<string, any> = {},
-  extraLocalKeys: string[] = [],
-): { localOptions: Record<string, any>; modelParameters: Record<string, any> } {
-  const localOptions: Record<string, any> = {};
-  const modelParameters: Record<string, any> = {};
-  for (const [key, value] of Object.entries(config)) {
-    const target =
-      LOCAL_OPTION_NAMES.has(key) || extraLocalKeys.includes(key) ? localOptions : modelParameters;
-    target[key] = value;
-  }
-  return { localOptions, modelParameters };
 }

--- a/src/providers/togetherai.ts
+++ b/src/providers/togetherai.ts
@@ -1,7 +1,7 @@
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
-import { splitLocalOptions } from './openai/util';
+import { splitLocalOptions } from './openai/localOptions';
 
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderOptions } from '../types/index';

--- a/src/providers/togetherai.ts
+++ b/src/providers/togetherai.ts
@@ -1,39 +1,10 @@
 import { OpenAiChatCompletionProvider } from './openai/chat';
 import { OpenAiCompletionProvider } from './openai/completion';
 import { OpenAiEmbeddingProvider } from './openai/embedding';
+import { splitLocalOptions } from './openai/util';
 
 import type { EnvOverrides } from '../types/env';
 import type { ApiProvider, ProviderOptions } from '../types/index';
-import type { OpenAiCompletionOptions, OpenAiSharedOptions } from './openai/types';
-
-// These are consumed by promptfoo or its transport, not TogetherAI's model endpoint.
-// Requiring every shared option here keeps future connection settings out of passthrough.
-const localOptions = {
-  apiKey: true,
-  apiKeyEnvar: true,
-  apiKeyRequired: true,
-  useDefaultApiKey: true,
-  apiHost: true,
-  apiBaseUrl: true,
-  organization: true,
-  headers: true,
-  maxRetries: true,
-  cost: true,
-  inputCost: true,
-  outputCost: true,
-  audioCost: true,
-  audioInputCost: true,
-  audioOutputCost: true,
-  passthrough: true,
-  mcp: true,
-  functionToolCallbacks: true,
-  showThinking: true,
-  omitDefaults: true,
-  basePath: true,
-  linkedTargetId: true,
-} satisfies Record<keyof OpenAiSharedOptions, boolean> &
-  Partial<Record<keyof OpenAiCompletionOptions | 'basePath' | 'linkedTargetId', boolean>>;
-const localOptionNames = new Set(Object.keys(localOptions));
 
 /**
  * Creates a TogetherAI provider using OpenAI-compatible endpoints
@@ -52,9 +23,7 @@ export function createTogetherAiProvider(
   const splits = providerPath.split(':');
 
   const config = options.config?.config || {};
-  const modelParameters = Object.fromEntries(
-    Object.entries(config).filter(([key]) => !localOptionNames.has(key)),
-  );
+  const { modelParameters } = splitLocalOptions(config);
   const togetherAiConfig = {
     ...options.config,
     id: options.id ?? options.config?.id,

--- a/test/providers/cerebras.test.ts
+++ b/test/providers/cerebras.test.ts
@@ -145,6 +145,26 @@ describe('Cerebras provider', () => {
       ).toBeUndefined();
     });
 
+    it('should keep credentials and headers out of passthrough', async () => {
+      // Regression: the whole config was spread into `passthrough`, so a configured
+      // apiKey was serialized into the request body and custom headers never became
+      // HTTP headers.
+      const provider = createCerebrasProvider('cerebras:llama3.1-8b', {
+        config: {
+          config: {
+            apiKey: 'CEREBRAS-SECRET',
+            headers: { 'X-Tenant': 'acme' },
+            temperature: 0.5,
+          },
+        },
+      });
+
+      const config = (provider as OpenAiChatCompletionProvider).config;
+      expect(config.passthrough).toEqual({ temperature: 0.5 });
+      expect(config.apiKey).toBe('CEREBRAS-SECRET');
+      expect(config.headers).toEqual({ 'X-Tenant': 'acme' });
+    });
+
     it('should pass through arbitrary passthrough config', async () => {
       const provider = createCerebrasProvider('cerebras:llama3.1-8b', {
         config: {

--- a/test/providers/cloudflare-ai.test.ts
+++ b/test/providers/cloudflare-ai.test.ts
@@ -345,6 +345,40 @@ describe('CloudflareAi Provider', () => {
       expect(requestBody.apiBaseUrl).toBeUndefined();
     });
 
+    it('Should keep promptfoo local options out of the request body', async () => {
+      // Regression: every config key that was not Cloudflare-specific went into
+      // `passthrough`, so promptfoo's own settings — including the local config
+      // directory in `basePath` — were serialized into the JSON body, and custom
+      // `headers` were sent as model parameters instead of HTTP headers.
+      const provider = new CloudflareAiChatCompletionProvider(testModelName, {
+        config: {
+          accountId: 'test-account',
+          apiKey: 'test-key',
+          basePath: '/Users/someone/secret-project',
+          headers: { 'X-Tenant': 'acme' },
+          maxRetries: 0,
+          temperature: 0.8,
+        } as CloudflareAiConfig,
+      });
+
+      mockFetch.mockResolvedValue({
+        ...defaultMockResponse,
+        text: vi
+          .fn()
+          .mockResolvedValue(JSON.stringify({ choices: [{ message: { content: 'x' } }] })),
+        ok: true,
+      });
+      await provider.callApi('Test local options');
+
+      const [, request] = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(request.body);
+      expect(requestBody).not.toHaveProperty('basePath');
+      expect(requestBody).not.toHaveProperty('headers');
+      expect(requestBody).not.toHaveProperty('maxRetries');
+      expect(requestBody.temperature).toBe(0.8);
+      expect(request.headers).toMatchObject({ 'X-Tenant': 'acme' });
+    });
+
     it('Should return proper provider identification methods', () => {
       const provider = new CloudflareAiChatCompletionProvider(testModelName, {
         config: cloudflareMinimumConfig,

--- a/test/providers/nscaleRequest.test.ts
+++ b/test/providers/nscaleRequest.test.ts
@@ -99,6 +99,19 @@ describe('Nscale request construction', () => {
     expect(body).not.toHaveProperty('apiBaseUrl');
   });
 
+  it('does not send promptfoo bookkeeping in the request body', async () => {
+    // Regression: `loadApiProvider` merges the loaded config file's directory into
+    // every provider config as `basePath`, and the allowlist of local options did
+    // not cover it, so the local filesystem path was shipped to the model.
+    const { body } = await callWithConfig({
+      apiKey: 'tok',
+      basePath: '/Users/someone/secret-project',
+    });
+
+    expect(body).not.toHaveProperty('basePath');
+    expect(JSON.stringify(body)).not.toContain('secret-project');
+  });
+
   it('defaults to the public Nscale endpoint', async () => {
     const { url } = await callWithConfig({ apiKey: 'tok' });
 


### PR DESCRIPTION
## Summary

`loadApiProvider` merges the loaded config file's directory into **every** provider config as `basePath`. Providers that iterate their config into `passthrough` — which the shared OpenAI transport serializes verbatim into the request body — need an allowlist of the keys promptfoo consumes itself. Three providers hand-maintained their own copy of that list, and two of them were incomplete.

Captured against a local HTTP echo server with the built CLI (`node dist/src/main.js eval …`), before this change:

```json
{"model":"meta-llama/Llama-3.3-70B-Instruct","messages":[…],"max_tokens":1024,"temperature":0,"basePath":"/private/tmp/…/wire"}
{"model":"@cf/meta/llama-3.1-8b-instruct","messages":[…],"max_tokens":1024,"temperature":0,"basePath":"/private/tmp/…/wire"}
```

Three bugs, one root cause:

- **nscale** — `NSCALE_PROVIDER_LEVEL_OPTIONS` covered `OpenAiSharedOptions` but not `basePath`, so the local path went to the model.
- **cloudflare-ai** — `getPassthroughConfig` destructured only the five Cloudflare-specific keys, so `basePath`, `headers`, `maxRetries`, cost overrides and an explicit `passthrough` (nested one level deep!) all became model parameters.
- **cerebras** — filtered `basePath` but spread everything else into `passthrough`, so a configured `apiKey` was transmitted in the request body and custom `headers` never became HTTP headers. It also hardcoded `apiBaseUrl`, so a configured one was silently ignored *and* shipped in the body — in the pre-fix wire run its request went to the real `api.cerebras.ai` and returned 401 instead of the configured endpoint.

This is the same class of bug fixed for Portkey in #10536.

### What changed

Rather than adding `basePath` to three lists, this deletes two of them. `togetherai.ts` had the only complete version, typed `satisfies Record<keyof OpenAiSharedOptions, boolean> & …` so a newly added shared option fails the build instead of leaking. That list and the split it drives move to `splitLocalOptions` in `src/providers/openai/util.ts`, and all four providers import it; `extraLocalKeys` lets Cloudflare keep `accountId`/`accountIdEnvar` local without redefining the set.

Also deleted along the way: nscale's bespoke split loop, cloudflare's `getPassthroughConfig` destructure, cerebras's `basePath` filter. `src/` is net **-40 lines** (80 added, 105 removed) with one shared definition instead of three.

I checked the other providers that build `passthrough` (openrouter, orcarouter, snowflake, databricks, llamaApi): they use explicit per-key allowlists and never iterate the config, so they are unaffected. `envoy.ts` spreads config into `config`, not `passthrough`, so nothing reaches the body.

Behavior changes worth calling out: cerebras now honors a configured `apiBaseUrl` and `apiKeyEnvar` (previously ignored), and cloudflare-ai now merges an explicit `config.passthrough` into the body instead of nesting it under a `passthrough` key.

## Test plan

Three regression tests, each verified failing on the pre-fix source and passing after:

- `test/providers/nscaleRequest.test.ts` — wire-level (real OpenAI provider, mocked transport): body has no `basePath`.
- `test/providers/cloudflare-ai.test.ts` — wire-level via `mockFetch`: body has no `basePath`/`headers`/`maxRetries`, `temperature` survives, `X-Tenant` is sent as an HTTP header.
- `test/providers/cerebras.test.ts` — `apiKey` and `headers` stay out of `passthrough` and land in config.

```
npx vitest run test/providers/            → 240 passed | 1 skipped (241 files), 9743 tests passed
npx vitest run test/test-hygiene.test.ts  → 115 passed
npx tsc --noEmit -p tsconfig.json         → clean
npx biome ci <changed files>              → clean
npm run architecture:check                → Architecture boundaries passed
```

End-to-end on the wire, `npm run build` then the built CLI against a local node http echo server, one config file in a subdirectory (so `basePath` is non-empty), all four providers pointed at it:

```
node dist/src/main.js eval -c <scratch>/wire/promptfooconfig.yaml --no-cache -o out.json
→ 4 passed (100%), 0 errors
```

Captured bodies after the fix — `basePath` gone, everything else unchanged, credentials only in the `Authorization` header:

```json
{"model":"meta-llama/Llama-3.3-70B-Instruct","messages":[{"role":"user","content":"Say hi"}],"max_tokens":1024,"temperature":0} |auth= Bearer wire-token
{"model":"@cf/meta/llama-3.1-8b-instruct","messages":[{"role":"user","content":"Say hi"}],"max_tokens":1024,"temperature":0}    |auth= Bearer wire-token
{"model":"meta-llama/Llama-3-8b-chat-hf","messages":[{"role":"user","content":"Say hi"}],"max_tokens":1024,"temperature":0}     |auth= Bearer wire-token
{"model":"llama3.1-8b","messages":[{"role":"user","content":"Say hi"}],"max_tokens":1024,"temperature":0}                       |auth= Bearer wire-token
```
