### PR TITLE
fix(providers): scope SageMaker cache keys to AWS credentials

### DIFF
--- a/src/providers/sagemaker.ts
+++ b/src/providers/sagemaker.ts
@@ -165,6 +165,40 @@ abstract class SageMakerGenericProvider {
   }
 
   /**
+   * Non-secret identity of the principal that will sign the request, following the same
+   * precedence as getCredentials(). Endpoint names are reused across accounts, so two
+   * profiles pointed at the same name must not share cached responses.
+   */
+  private getCredentialScope(): Record<string, string | undefined> {
+    if (this.config.accessKeyId && this.config.secretAccessKey) {
+      return { source: 'config', accessKeyId: this.config.accessKeyId };
+    }
+    if (this.config.profile) {
+      return { source: 'profile', profile: this.config.profile };
+    }
+    // The default chain resolves at request time; key off what selects the account.
+    return {
+      source: 'default',
+      profile: process.env.AWS_PROFILE,
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    };
+  }
+
+  /**
+   * Hash a snapshotted request, and the credentials that will sign it, into a cache key.
+   */
+  protected buildCacheKey(
+    version: string,
+    request: { endpoint: string } & Record<string, unknown>,
+  ): string {
+    const hash = crypto
+      .createHash('sha256')
+      .update(JSON.stringify({ ...request, credentials: this.getCredentialScope() }))
+      .digest('hex');
+    return `sagemaker:${version}:${request.endpoint}:${hash}`;
+  }
+
+  /**
    * Initialize and return the SageMaker runtime client
    */
   async getSageMakerRuntimeInstance(region?: string) {
@@ -695,13 +729,7 @@ export class SageMakerCompletionProvider extends SageMakerGenericProvider implem
       region: this.getRegion(),
     };
     let cacheKey: string | undefined;
-    const getCacheKey = () => {
-      if (cacheKey === undefined) {
-        const hash = crypto.createHash('sha256').update(JSON.stringify(request)).digest('hex');
-        cacheKey = `sagemaker:v3:${request.endpoint}:${hash}`;
-      }
-      return cacheKey;
-    };
+    const getCacheKey = () => (cacheKey ??= this.buildCacheKey('v4', request));
     const bustCache = context?.bustCache ?? context?.debug === true; // If debug mode is on, bust the cache
     if (isCacheEnabled() && !bustCache) {
       const cache = getCache ? getCache() : await import('../cache').then((m) => m.getCache());
@@ -854,26 +882,17 @@ export class SageMakerEmbeddingProvider
 
   /**
    * Generate a consistent cache key for SageMaker embedding requests
-   * Uses crypto.createHash to generate a shorter, more efficient key
    */
   private getCacheKey(text: string): string {
-    // Create a deterministic representation of the request parameters
-    const configForKey = {
+    return this.buildCacheKey('embedding:v2', {
+      text,
       endpoint: this.getEndpointName(),
       modelType: this.config.modelType,
       contentType: this.getContentType(),
       acceptType: this.getAcceptType(),
       region: this.getRegion(),
       responseFormat: this.config.responseFormat,
-    };
-
-    const configStr = JSON.stringify(configForKey);
-
-    // Generate shorter, more efficient hashed keys
-    const textHash = crypto.createHash('sha256').update(text).digest('hex').substring(0, 16);
-    const configHash = crypto.createHash('sha256').update(configStr).digest('hex').substring(0, 8);
-
-    return `sagemaker:embedding:v1:${this.getEndpointName()}:${textHash}:${configHash}`;
+    });
   }
 
   /**

--- a/src/providers/sagemaker.ts
+++ b/src/providers/sagemaker.ts
@@ -92,7 +92,7 @@ interface SageMakerOptions extends ProviderOptions {
 abstract class SageMakerGenericProvider {
   env?: EnvOverrides;
   sagemakerRuntime?: any; // SageMaker runtime client
-  private initializedRuntime?: { client: any; region: string };
+  private initializedRuntime?: { client: any; region: string; credentialScope: string };
   config: SageMakerConfig;
   endpointName: string;
   delay?: number; // Delay between API calls in milliseconds
@@ -176,12 +176,16 @@ abstract class SageMakerGenericProvider {
     if (this.config.profile) {
       return { source: 'profile', profile: this.config.profile };
     }
-    // The default chain resolves at request time; key off what selects the account.
-    return {
-      source: 'default',
-      profile: process.env.AWS_PROFILE,
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    };
+    // The default chain resolves at request time, and reads process.env directly (it
+    // never sees promptfoo's `env:` overrides), so neither may this. AWS_PROFILE wins
+    // outright; env static credentials only select an account when the secret is set too.
+    if (process.env.AWS_PROFILE) {
+      return { source: 'default', profile: process.env.AWS_PROFILE };
+    }
+    if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
+      return { source: 'default', accessKeyId: process.env.AWS_ACCESS_KEY_ID };
+    }
+    return { source: 'default' };
   }
 
   /**
@@ -202,12 +206,16 @@ abstract class SageMakerGenericProvider {
    * Initialize and return the SageMaker runtime client
    */
   async getSageMakerRuntimeInstance(region?: string) {
+    // A client memoizes the credentials it resolved on its first request, so it must be
+    // rebuilt when the scope changes — otherwise the cache key names a principal that is
+    // not the one signing, and a response gets stored under another account's key.
+    const credentialScope = JSON.stringify(this.getCredentialScope());
     if (
       !this.sagemakerRuntime ||
-      (region !== undefined &&
-        this.initializedRuntime !== undefined &&
+      (this.initializedRuntime !== undefined &&
         this.sagemakerRuntime === this.initializedRuntime.client &&
-        region !== this.initializedRuntime.region)
+        ((region !== undefined && region !== this.initializedRuntime.region) ||
+          credentialScope !== this.initializedRuntime.credentialScope))
     ) {
       try {
         const { SageMakerRuntimeClient } = await import('@aws-sdk/client-sagemaker-runtime');
@@ -222,7 +230,7 @@ abstract class SageMakerGenericProvider {
         });
 
         this.sagemakerRuntime = runtime;
-        this.initializedRuntime = { client: runtime, region: runtimeRegion };
+        this.initializedRuntime = { client: runtime, region: runtimeRegion, credentialScope };
         logger.debug(`SageMaker client initialized for region ${runtimeRegion}`);
         return runtime;
       } catch {

--- a/test/providers/sagemaker.test.ts
+++ b/test/providers/sagemaker.test.ts
@@ -550,6 +550,74 @@ describe('SageMakerCompletionProvider', () => {
       expect(mockSend).toHaveBeenCalledTimes(2);
     });
 
+    it('rebuilds the runtime client when the AWS profile changes', async () => {
+      // A client memoizes the credentials it resolved on its first request, so without a
+      // rebuild the second call would still sign as staging while its response was stored
+      // under production's cache key.
+      mockSend.mockImplementation(async () => ({
+        Body: new TextEncoder().encode(JSON.stringify({ output: 'A garden' })),
+      }));
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'custom' },
+      });
+
+      vi.stubEnv('AWS_PROFILE', 'staging');
+      await provider.callApi('A quiet garden');
+      expect(SageMakerRuntimeClient).toHaveBeenCalledTimes(1);
+
+      vi.stubEnv('AWS_PROFILE', 'production');
+      await provider.callApi('A quiet garden');
+      expect(SageMakerRuntimeClient).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      ['is missing its secret', {}],
+      [
+        'is skipped in favor of AWS_PROFILE',
+        { AWS_SECRET_ACCESS_KEY: 's', AWS_PROFILE: 'staging' },
+      ],
+    ])('shares the cache when the env access key id %s', async (_label, extraEnv) => {
+      // Neither form selects the account for the default chain, so neither may split the cache.
+      mockSend.mockImplementation(async () => ({
+        Body: new TextEncoder().encode(JSON.stringify({ output: 'A garden' })),
+      }));
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'custom' },
+      });
+      for (const [key, value] of Object.entries(extraEnv)) {
+        vi.stubEnv(key, value);
+      }
+
+      for (const accessKeyId of ['AKIAOLD', 'AKIANEW']) {
+        vi.stubEnv('AWS_ACCESS_KEY_ID', accessKeyId);
+        await provider.callApi('A quiet garden');
+      }
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(SageMakerRuntimeClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('never puts a raw credential in the cache key', async () => {
+      mockSend.mockImplementation(async () => ({
+        Body: new TextEncoder().encode(JSON.stringify({ output: 'A garden' })),
+      }));
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: {
+          region: 'us-east-1',
+          modelType: 'custom',
+          accessKeyId: 'AKIACONFIGURED',
+          secretAccessKey: 'configured-secret',
+          sessionToken: 'configured-session-token',
+        },
+      });
+      vi.spyOn(provider, 'getCredentials').mockResolvedValue(undefined);
+      vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'env-secret');
+
+      await provider.callApi('A quiet garden');
+
+      // The scope only ever reaches the digest; the key itself is structurally opaque.
+      expect(mockCacheGet.mock.calls[0][0]).toMatch(/^sagemaker:v4:test-endpoint:[0-9a-f]{64}$/);
+    });
+
     it('does not replay a cached success when a changed request fails', async () => {
       mockSend
         .mockResolvedValueOnce({

--- a/test/providers/sagemaker.test.ts
+++ b/test/providers/sagemaker.test.ts
@@ -498,6 +498,58 @@ describe('SageMakerCompletionProvider', () => {
       expect(mockSend).toHaveBeenCalledTimes(2);
     });
 
+    it('keeps cached completions separate per AWS profile', async () => {
+      mockSend.mockImplementation(async () => ({
+        Body: new TextEncoder().encode(JSON.stringify({ output: process.env.AWS_PROFILE })),
+      }));
+      const provider = new SageMakerCompletionProvider('test-endpoint', {
+        config: { region: 'us-east-1', modelType: 'custom' },
+      });
+
+      for (const profile of ['staging', 'production']) {
+        vi.stubEnv('AWS_PROFILE', profile);
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output: profile });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({
+          output: profile,
+          cached: true,
+        });
+      }
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      ['profile', [{ profile: 'staging' }, { profile: 'production' }]],
+      [
+        'credentials',
+        [
+          { accessKeyId: 'AKIASTAGING', secretAccessKey: 'staging-secret' },
+          { accessKeyId: 'AKIAPRODUCTION', secretAccessKey: 'production-secret' },
+        ],
+      ],
+    ] as const)('keeps cached completions separate per configured %s', async (_label, accounts) => {
+      mockSend
+        .mockResolvedValueOnce({
+          Body: new TextEncoder().encode(JSON.stringify({ output: 'staging garden' })),
+        })
+        .mockResolvedValueOnce({
+          Body: new TextEncoder().encode(JSON.stringify({ output: 'production garden' })),
+        });
+      const providers = accounts.map((account) => {
+        const provider = new SageMakerCompletionProvider('test-endpoint', {
+          config: { region: 'us-east-1', modelType: 'custom', ...account },
+        });
+        vi.spyOn(provider, 'getCredentials').mockResolvedValue(undefined);
+        return provider;
+      });
+
+      for (const [index, provider] of providers.entries()) {
+        const output = index === 0 ? 'staging garden' : 'production garden';
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output });
+        expect(await provider.callApi('A quiet garden')).toMatchObject({ output, cached: true });
+      }
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
+
     it('does not replay a cached success when a changed request fails', async () => {
       mockSend
         .mockResolvedValueOnce({
@@ -676,6 +728,39 @@ describe('SageMakerEmbeddingProvider', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe('cache identity', () => {
+    it('keeps cached embeddings separate per AWS profile', async () => {
+      const entries = new Map<string, string>();
+      mockIsCacheEnabled.mockReturnValue(true);
+      mockCacheGet.mockImplementation(async (key: string) => entries.get(key));
+      mockCacheSet.mockImplementation(async (key: string, value: string) => {
+        entries.set(key, value);
+      });
+      mockSend.mockImplementation(async () => ({
+        Body: new TextEncoder().encode(
+          JSON.stringify({ embedding: [process.env.AWS_PROFILE === 'staging' ? 0.1 : 0.2] }),
+        ),
+      }));
+      const provider = new SageMakerEmbeddingProvider('test-embedding-endpoint', {
+        config: { region: 'us-east-1', modelType: 'custom' },
+      });
+
+      for (const [profile, embedding] of [
+        ['staging', [0.1]],
+        ['production', [0.2]],
+      ] as const) {
+        vi.stubEnv('AWS_PROFILE', profile);
+        expect(await provider.callEmbeddingApi('A quiet garden')).toMatchObject({ embedding });
+        expect(await provider.callEmbeddingApi('A quiet garden')).toMatchObject({
+          embedding,
+          cached: true,
+        });
+      }
+      expect(mockSend).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('cache flag behavior', () => {


### PR DESCRIPTION
## Summary

The SageMaker request cache key (rewritten three times this release — #10731, #10798, #10808) covers the payload, endpoint, model type, content/accept types, response path, and region, but never the AWS identity that signs the request. SageMaker endpoint names are reused across accounts, so two profiles pointed at the same name shared cached completions: a developer flipping `AWS_PROFILE` between a staging and a production account got the other account's cached answers back. The embedding provider had the same hole plus its own bespoke key assembly.

**Root cause:** `getCredentials()` picks the principal from `config.accessKeyId`/`config.profile`/the default chain, but none of that reached the cache key.

**Change:**

- `SageMakerGenericProvider.getCredentialScope()` returns a non-secret identity following the same precedence as the credentials actually used. Configured `accessKeyId` or `profile` win in that order; otherwise the scope mirrors the AWS SDK's default chain, where `AWS_PROFILE` is checked first and env static credentials only select an account when `AWS_SECRET_ACCESS_KEY` is set alongside `AWS_ACCESS_KEY_ID`. No secret is used (the secret access key is read for presence only, never for value), and the scope only ever reaches the SHA-256 digest, never the stored key string.
- The runtime client is rebuilt when that scope changes. A `SageMakerRuntimeClient` memoizes the credentials its default chain resolved on the first request, so without this the cache key could move while the signer did not — storing one account's response under another's key. This reuses the mechanism already in place for a region change.
- `SageMakerGenericProvider.buildCacheKey(version, request)` hashes the snapshotted request plus that scope. Both providers use it, so the embedding provider's hand-rolled truncated-hash assembly and the completion provider's inline hashing are gone (one hashing path instead of two).
- Key versions bump to `v4` / `embedding:v2`.

The invariants from the three prior cache-key PRs are preserved: the completion key is still derived from the request snapshot taken before any `await` (#10798, #10808), it is still computed lazily so a disabled or busted cache hashes nothing (existing test asserts `crypto.createHash` is never called), and the key prefix still uses the snapshotted endpoint rather than re-reading config.

## Test plan

Eight new regression tests in `test/providers/sagemaker.test.ts`:

- `keeps cached completions separate per AWS profile` — flips `AWS_PROFILE` between `staging` and `production`; before the fix the second profile replayed the first's output and the endpoint was called only once.
- `keeps cached completions separate per configured profile` / `... per configured credentials` — two providers on the same endpoint with different `config.profile` / `config.accessKeyId`.
- `keeps cached embeddings separate per AWS profile` — same scenario through `callEmbeddingApi`.
- `rebuilds the runtime client when the AWS profile changes` — asserts the client is reconstructed across a profile flip, so the scope in the key is the one that signs.
- `shares the cache when the env access key id is missing its secret` / `... is skipped in favor of AWS_PROFILE` — neither form selects the account for the default chain, so neither may fragment the cache.
- `never puts a raw credential in the cache key` — with a configured `accessKeyId`, `secretAccessKey` and `sessionToken` set, the built key is asserted to match `/^sagemaker:v4:test-endpoint:[0-9a-f]{64}$/`.

```
$ npx vitest run test/providers/sagemaker.test.ts
  Test Files  1 passed (1)       Tests  45 passed (45)

$ git checkout main -- src/providers/sagemaker.ts && npx vitest run test/providers/sagemaker.test.ts
  Tests  6 failed | 39 passed (45)   # every test above except the two `shares the cache` cases,
                                     # which fail against the first commit here (no scope on main
                                     # means nothing to fragment)

$ npx vitest run test/sagemaker.test.ts test/providers/registry.test.ts test/providers/sagemaker.test.ts test/test-hygiene.test.ts
  Test Files  4 passed (4)      Tests  408 passed (408)

$ npx tsc --noEmit -p tsconfig.json        # clean
$ npx biome ci src/providers/sagemaker.ts test/providers/sagemaker.test.ts
  # only the two pre-existing cognitive-complexity warnings on callApi/callEmbeddingApi
  # (49 / 46 — identical numbers before and after this change)
$ npx prettier --check ...                 # clean
```

Note for users: this invalidates existing SageMaker cache entries, as each of the three prior cache-key fixes did.
