### PR TITLE
fix(providers): finish the GitHub Models retirement

### DIFF
--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.test.tsx
@@ -1345,6 +1345,19 @@ describe('ProviderConfigEditor', () => {
     expect(screen.queryByTestId('custom-config')).not.toBeInTheDocument();
   });
 
+  it('should explain the retirement instead of editing a saved GitHub Models target', () => {
+    renderWithProviders(
+      <ProviderConfigEditor
+        provider={{ id: 'github:openai/gpt-5', config: {} }}
+        setProvider={vi.fn()}
+        providerType="github"
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent('GitHub retired GitHub Models');
+    expect(screen.queryByTestId('custom-config')).not.toBeInTheDocument();
+  });
+
   it('should render the raw provider editor for Open Interpreter targets', () => {
     renderWithProviders(
       <ProviderConfigEditor

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderConfigEditor.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { Alert, AlertContent, AlertDescription } from '@app/components/ui/alert';
 import deepEqual from 'fast-deep-equal';
+import { AlertTriangle } from 'lucide-react';
 import { useRedTeamConfig } from '../../hooks/useRedTeamConfig';
 import { useRedTeamTargetConfigValidation } from '../../hooks/useRedTeamTargetConfigValidation';
 import A2AEndpointConfiguration from './A2AEndpointConfiguration';
@@ -687,10 +689,31 @@ function ProviderConfigEditor({
         />
       )}
 
+      {/* Retired providers - no configuration can make them run again */}
+      {providerType === 'github' && (
+        <Alert variant="warning">
+          <AlertTriangle className="size-4" />
+          <AlertContent>
+            <AlertDescription>
+              GitHub retired GitHub Models, including its inference API, on July 30, 2026, so{' '}
+              <code>github:</code> targets no longer run. Pick another provider and configure its
+              own endpoint and credentials — see the{' '}
+              <a
+                href="https://www.promptfoo.dev/docs/providers/github"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                GitHub Models documentation
+              </a>
+              .
+            </AlertDescription>
+          </AlertContent>
+        </Alert>
+      )}
+
       {/* Specialized providers - use custom config for now */}
-      {['github', 'xai', 'ai21', 'aimlapi', 'hyperbolic', 'fal', 'voyage'].includes(
-        providerType || '',
-      ) && (
+      {['xai', 'ai21', 'aimlapi', 'hyperbolic', 'fal', 'voyage'].includes(providerType || '') && (
         <CustomTargetConfiguration
           selectedTarget={provider}
           updateCustomTarget={updateCustomTarget}

--- a/src/app/src/pages/redteam/setup/components/Targets/providerDocumentationMap.test.ts
+++ b/src/app/src/pages/redteam/setup/components/Targets/providerDocumentationMap.test.ts
@@ -29,6 +29,10 @@ describe('hasSpecificDocumentation', () => {
     expect(result).toBe(false);
   });
 
+  it('should return false for the retired GitHub Models provider', () => {
+    expect(hasSpecificDocumentation('github')).toBe(false);
+  });
+
   it('should return false when providerType is not a key in PROVIDER_DOCUMENTATION_MAP', () => {
     const providerType = 'notarealprovider';
 

--- a/src/app/src/pages/redteam/setup/components/Targets/providerDocumentationMap.ts
+++ b/src/app/src/pages/redteam/setup/components/Targets/providerDocumentationMap.ts
@@ -62,7 +62,6 @@ export const PROVIDER_DOCUMENTATION_MAP: Record<string, string> = {
 
   // Third-Party Providers
   openrouter: `${BASE_DOCS_URL}/openrouter`,
-  github: `${BASE_DOCS_URL}/github`,
   ai21: `${BASE_DOCS_URL}/ai21`,
   aimlapi: `${BASE_DOCS_URL}/aimlapi`,
   hyperbolic: `${BASE_DOCS_URL}/hyperbolic`,

--- a/src/commands/exampleAliases.ts
+++ b/src/commands/exampleAliases.ts
@@ -216,10 +216,20 @@ export const REMOVED_EXAMPLES: Record<
     legacyRef: '0.120.26',
     reason: 'gemma-vs-mistral was removed because the underlying model is no longer available.',
   },
+  'github-models': {
+    legacyRef: '0.120.26',
+    reason:
+      'github-models was removed because GitHub retired GitHub Models, including its inference API, on July 30, 2026.',
+  },
   'openai-deep-research': {
     legacyRef: '31b566872971532e6d428c0cbad4487d22d936c5',
     reason:
       'This historical example uses retired OpenAI deep-research models and cannot run against the current OpenAI API.',
+  },
+  'provider-github-models': {
+    legacyRef: '31b566872971532e6d428c0cbad4487d22d936c5',
+    reason:
+      'provider-github-models was removed because GitHub retired GitHub Models, including its inference API, on July 30, 2026.',
   },
   'redteam-dalle': {
     legacyRef: '31b566872971532e6d428c0cbad4487d22d936c5',

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -394,6 +394,28 @@ describe('init command', () => {
         },
       );
 
+      it.each([
+        { example: 'github-models', ref: '0.120.26' },
+        { example: 'provider-github-models', ref: '31b566872971532e6d428c0cbad4487d22d936c5' },
+      ])(
+        'pins the retired GitHub Models example $example and explains the retirement',
+        async ({ example, ref }) => {
+          mockFetchWithProxy.mockResolvedValue(
+            createMockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+          );
+          vi.mocked(confirm).mockResolvedValue(false);
+
+          expect(await init.handleExampleDownload('.', example)).toBe(example);
+          expect(mockFetchWithProxy).toHaveBeenCalledTimes(1);
+          expect(mockFetchWithProxy.mock.calls[0][0]).toContain(
+            `/repos/promptfoo/promptfoo/contents/examples/${example}?ref=${ref}`,
+          );
+          expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('GitHub retired GitHub Models'),
+          );
+        },
+      );
+
       it('should reset to default refs when retrying after legacy example failure', async () => {
         const mockLegacyFailure = createMockResponse({
           ok: false,


### PR DESCRIPTION
## Summary

[#10746](https://github.com/promptfoo/promptfoo/pull/10746) retired the `github:` provider (`createGitHubProvider` now throws `GITHUB_MODELS_RETIREMENT_MESSAGE`, and `GITHUB_TOKEN` no longer selects a default grader), but two surfaces still told users it works.

**`promptfoo init --example github-models`** — the example was deleted from `examples/` and dropped from `EXAMPLE_ALIASES`, but never added to `REMOVED_EXAMPLES`, so it failed with a generic "not found" instead of the retirement note that mechanism exists to print. Added both the pre-reorg (`github-models`) and post-reorg (`provider-github-models`) names, each pinned to a ref where that directory actually exists — `0.120.26` and `31b5668…`, the same historical ref the two sibling entries use.

**Red team setup UI** — `github` was still in `ProviderConfigEditor`'s specialized-provider list, so a saved `github:` target rendered a fully editable raw-config panel, plus a "Need help configuring…? View the documentation" alert from `providerDocumentationMap`. A retired provider has no configuration that can make it run again, so both were removed and replaced with a warning that states the retirement and points at the (already-rewritten) provider docs page.

Net: `github` deleted from two provider lists; the only addition is the notice that replaces the dead editor, plus the two data entries.

## Test plan

- `npx vitest run test/commands/init.test.ts` → 30 passed. Reverting only `exampleAliases.ts` fails the two new cases (fetch goes to the default refs, not the pinned one), confirming the regression test bites.
- `npx vitest run test/commands` → 39 files, 780 passed.
- `npm run test:app -- src/pages/redteam/setup/components/Targets --run` → 25 files, 494 passed (includes the new `ProviderConfigEditor` and `providerDocumentationMap` cases).
- `npx tsc --noEmit -p tsconfig.json` and `npx tsc --noEmit -p src/app/tsconfig.json` → clean.
- `npx biome ci` on the changed files → exit 0 (the three `noExcessiveCognitiveComplexity` warnings on `ProviderConfigEditor.tsx` are pre-existing; verified the same three appear on `HEAD`).
- Live CLI check against GitHub, both names resolving and downloading:

```
$ promptfoo init <tmp> --example github-models --no-interactive
Note: github-models was removed because GitHub retired GitHub Models, including its inference API, on July 30, 2026.
Downloading the legacy 'github-models' example from promptfoo@0.120.26.
✅ Example project 'github-models' written to: <tmp>/github-models

$ promptfoo init <tmp> --example provider-github-models --no-interactive
Note: provider-github-models was removed because GitHub retired GitHub Models, including its inference API, on July 30, 2026.
Downloading the legacy 'provider-github-models' example from promptfoo@31b566872971532e6d428c0cbad4487d22d936c5.
✅ Example project 'provider-github-models' written to: <tmp>/provider-github-models
```