### PR TITLE
test: stop loading the developer .env during tests

### DIFF
--- a/src/envars.ts
+++ b/src/envars.ts
@@ -5,8 +5,12 @@ import type { EnvOverrides } from './types/env';
 
 // Never load the developer's `.env` inside a test run: unit tests would silently pick up
 // real credentials and behave differently from CI, which has none. Mirrors the guard on
-// the default database path in src/database/index.ts.
-if (process.env.VITEST !== 'true') {
+// the default database path in src/database/index.ts, including its runner-owned global:
+// helpers that wipe process.env drop VITEST, but the global survives them.
+const isTestProcess =
+  process.env.VITEST === 'true' ||
+  Object.prototype.hasOwnProperty.call(globalThis, '__vitest_worker__');
+if (!isTestProcess) {
   dotenv.config({ quiet: true });
 }
 

--- a/src/envars.ts
+++ b/src/envars.ts
@@ -3,7 +3,12 @@ import { getEnvOverrides } from './envOverrides';
 
 import type { EnvOverrides } from './types/env';
 
-dotenv.config({ quiet: true });
+// Never load the developer's `.env` inside a test run: unit tests would silently pick up
+// real credentials and behave differently from CI, which has none. Mirrors the guard on
+// the default database path in src/database/index.ts.
+if (process.env.VITEST !== 'true') {
+  dotenv.config({ quiet: true });
+}
 
 // Define the supported environment variables and their types
 type EnvVars = {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,13 +1,9 @@
-import compression from 'compression';
-import cors from 'cors';
-import dotenv from 'dotenv';
-
-dotenv.config({ quiet: true });
-
 import fs from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
 
+import compression from 'compression';
+import cors from 'cors';
 import express from 'express';
 import { Server as SocketIOServer } from 'socket.io';
 import { getDefaultPort, VERSION } from '../constants';

--- a/test/envars.test.ts
+++ b/test/envars.test.ts
@@ -171,9 +171,13 @@ describe('envars', () => {
   describe('dotenv loading', () => {
     // A developer's gitignored .env must never reach the suite: tests would pick up
     // real credentials and diverge from CI, which has none.
+    // Resolved up front because os.tmpdir() reads TEMP/TMP, which the cleared-environment
+    // case below wipes: on Windows that yields the unusable path "undefined\temp".
+    const tmpRoot = os.tmpdir();
+
     async function reimportEnvarsBesideDotenv(): Promise<void> {
       const originalCwd = process.cwd();
-      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-dotenv-'));
+      const dir = fs.mkdtempSync(path.join(tmpRoot, 'promptfoo-dotenv-'));
       fs.writeFileSync(path.join(dir, '.env'), 'PROMPTFOO_DOTENV_PROBE=leaked\n');
 
       try {

--- a/test/envars.test.ts
+++ b/test/envars.test.ts
@@ -169,9 +169,9 @@ describe('envars', () => {
   });
 
   describe('dotenv loading', () => {
-    it('does not load a .env file into a test process', async () => {
-      // A developer's gitignored .env must never reach the suite: tests would pick up
-      // real credentials and diverge from CI, which has none.
+    // A developer's gitignored .env must never reach the suite: tests would pick up
+    // real credentials and diverge from CI, which has none.
+    async function reimportEnvarsBesideDotenv(): Promise<void> {
       const originalCwd = process.cwd();
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-dotenv-'));
       fs.writeFileSync(path.join(dir, '.env'), 'PROMPTFOO_DOTENV_PROBE=leaked\n');
@@ -180,11 +180,29 @@ describe('envars', () => {
         process.chdir(dir);
         vi.resetModules();
         await import('../src/envars');
-
-        expect(process.env.PROMPTFOO_DOTENV_PROBE).toBeUndefined();
       } finally {
         process.chdir(originalCwd);
         fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+
+    it('does not load a .env file into a test process', async () => {
+      await reimportEnvarsBesideDotenv();
+
+      expect(process.env.PROMPTFOO_DOTENV_PROBE).toBeUndefined();
+    });
+
+    it('does not load a .env file after a test clears process.env', async () => {
+      // Clearing process.env drops VITEST, so the guard has to fall back to the
+      // runner-owned global. Assert before restoring: the restore would erase the leak.
+      const restoreEnv = mockProcessEnv({}, { clear: true });
+
+      try {
+        await reimportEnvarsBesideDotenv();
+
+        expect(process.env.PROMPTFOO_DOTENV_PROBE).toBeUndefined();
+      } finally {
+        restoreEnv();
       }
     });
   });

--- a/test/envars.test.ts
+++ b/test/envars.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import cliState from '../src/cliState';
 import {
@@ -161,6 +165,27 @@ describe('envars', () => {
       dynCliState.default.config = { env: { OPENAI_API_KEY: 'wired-key' } };
 
       expect(dynEnvOverrides.getEnvOverrides()).toEqual({ OPENAI_API_KEY: 'wired-key' });
+    });
+  });
+
+  describe('dotenv loading', () => {
+    it('does not load a .env file into a test process', async () => {
+      // A developer's gitignored .env must never reach the suite: tests would pick up
+      // real credentials and diverge from CI, which has none.
+      const originalCwd = process.cwd();
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'promptfoo-dotenv-'));
+      fs.writeFileSync(path.join(dir, '.env'), 'PROMPTFOO_DOTENV_PROBE=leaked\n');
+
+      try {
+        process.chdir(dir);
+        vi.resetModules();
+        await import('../src/envars');
+
+        expect(process.env.PROMPTFOO_DOTENV_PROBE).toBeUndefined();
+      } finally {
+        process.chdir(originalCwd);
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -25,6 +25,12 @@ describe('GoogleInteractionsProvider', () => {
     vi.stubEnv('VERTEX_API_HOST', '');
     vi.stubEnv('GOOGLE_API_HOST', '');
     vi.stubEnv('PALM_API_HOST', '');
+    // Likewise for credentials: an ambient key satisfies the auth check the
+    // missing-key tests assert on, and outranks the fixtures asserted on the wire.
+    vi.stubEnv('GOOGLE_API_KEY', '');
+    vi.stubEnv('GEMINI_API_KEY', '');
+    vi.stubEnv('PALM_API_KEY', '');
+    vi.stubEnv('VERTEX_API_KEY', '');
     mockStoreBlob.mockResolvedValue({
       ref: { uri: 'blob://video/omni', hash: 'omni', mimeType: 'video/mp4', sizeBytes: 5 },
       deduplicated: false,
@@ -712,7 +718,6 @@ describe('GoogleInteractionsProvider', () => {
   it('requires a Gemini API key', async () => {
     const provider = new GoogleInteractionsProvider('gemini-omni-flash-preview', {
       config: {},
-      env: { GOOGLE_API_KEY: undefined, GEMINI_API_KEY: undefined },
     });
 
     await expect(provider.callApi('A city at dusk')).resolves.toMatchObject({
@@ -839,7 +844,6 @@ describe('GoogleInteractionsProvider', () => {
       config: {
         passthrough: { previous_interaction_id: 'interaction-0' },
       },
-      env: { GOOGLE_API_KEY: undefined, GEMINI_API_KEY: undefined },
     });
 
     const result = await provider.callApi('Make it brighter');

--- a/test/providers/google/interactions.test.ts
+++ b/test/providers/google/interactions.test.ts
@@ -30,7 +30,7 @@ describe('GoogleInteractionsProvider', () => {
     vi.stubEnv('GOOGLE_API_KEY', '');
     vi.stubEnv('GEMINI_API_KEY', '');
     vi.stubEnv('PALM_API_KEY', '');
-    vi.stubEnv('VERTEX_API_KEY', '');
+    vi.stubEnv('GOOGLE_GENERATIVE_AI_API_KEY', '');
     mockStoreBlob.mockResolvedValue({
       ref: { uri: 'blob://video/omni', hash: 'omni', mimeType: 'video/mp4', sizeBytes: 5 },
       deduplicated: false,


### PR DESCRIPTION
## Summary

`src/envars.ts` calls `dotenv.config()` at import time, so every vitest worker inherited the repo's gitignored `.env`. Any contributor with real credentials there ran a different test suite than CI does — and three tests in `test/providers/google/interactions.test.ts` failed outright:

```
> requires a Gemini API key
    Expected: "requires an API key"
    Received: "Gemini Interactions API error: TypeError: Cannot destructure property 'data' ..."
> does not reject an AI Studio Omni follow-up supplied through passthrough
> preserves a configured provider id and supports the legacy PALM API key
    x-goog-api-key received the developer's real key instead of the fixture's 'legacy-palm-key'
```

The two "requires an API key" cases were silently satisfied by the ambient `GEMINI_API_KEY` (their `env: { GOOGLE_API_KEY: undefined, GEMINI_API_KEY: undefined }` overrides never suppressed `process.env`), and the legacy-PALM case asserted a real credential on the wire. CI was green only because CI has no `.env`.

Changes:

- **`src/envars.ts`** — skip the `.env` load inside a test process, detected the same way `getDbPath()` in `src/database/index.ts` already does it: `VITEST`, or the runner-owned `__vitest_worker__` global for the case where a test wiped `process.env` (`mockProcessEnv({}, { clear: true })`) before a module reaching `envars` is re-imported. This immunises the whole backend suite (every vendor, not just Google) rather than patching one file.
- **`src/server/server.ts`** — deleted the redundant `dotenv` import and `dotenv.config()`. ESM hoisting means it already ran via `../constants` → `./envars` before that statement executes, so it was dead code that also reopened the leak for server tests.
- **`test/providers/google/interactions.test.ts`** — clear the Google credential env vars (`GOOGLE_API_KEY`, `GEMINI_API_KEY`, `PALM_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY` — every key the AI Studio path actually consults) in the existing `beforeEach` stub block, next to the host vars it already stubs for the same reason. The tests are now hermetic against shell-exported keys too, not just `.env`, which let the two ineffective `env: { ... undefined }` overrides be deleted.
- **`test/envars.test.ts`** — two regression tests: chdir into a temp dir containing a `.env`, re-import `src/envars`, assert the probe variable did not reach `process.env` — once normally, once with `process.env` cleared first. Deterministic in CI, not dependent on a local `.env` existing.

## Test plan

All run with the developer `.env` present (the failing condition), on Node 24.20.0:

- `npx vitest run test/envars.test.ts test/providers/google/interactions.test.ts` → 130 passed (was `3 failed | 40 passed` for the interactions file)
- Regression check, `src/envars.ts` fix stashed: `npx vitest run test/envars.test.ts -t "does not load a .env"` → failed, as expected; with only the `VITEST` half of the guard, the cleared-`process.env` case still failed
- Hermeticity check: `GEMINI_API_KEY=… GOOGLE_API_KEY=… PALM_API_KEY=… VERTEX_API_KEY=… GOOGLE_GENERATIVE_AI_API_KEY=shell-leaked npx vitest run test/providers/google/interactions.test.ts` → 43 passed (3 failed with the test change stashed; 2 failed on `GOOGLE_GENERATIVE_AI_API_KEY` alone before it was added to the stub list)
- `npx vitest run test/providers/google test/server test/hygiene test/test-hygiene.test.ts test/util/env.test.ts` → 44 files, 1553 passed
- `npx vitest run` (full backend suite) → 849 passed | 1 skipped, 24883 tests passed
- Same targeted runs with `.env` absent → pass
- `npx tsc --noEmit -p tsconfig.json` → clean
- `npx biome check` on the four changed files → clean
- `npm run architecture:check` → boundaries passed
