### PR TITLE
docs(blog): fix retired Claude model IDs in runnable configs

### DIFF
--- a/site/blog/ai-safety-vs-security.md
+++ b/site/blog/ai-safety-vs-security.md
@@ -321,7 +321,7 @@ The twist? Many attacks combine both. A jailbreak (safety) might be the first st
 Current frontier models show significant improvements but remain vulnerable:
 
 - **GPT-4o and GPT-4.1**: OpenAI's models include improved safety training and reasoning capabilities
-- **Claude 3.5 Sonnet**: Anthropic's constitutional AI approach shows improved resistance to jailbreaking
+- **Claude Opus 5 and Sonnet 5**: Anthropic's constitutional AI approach shows improved resistance to jailbreaking
 - **Gemini 2.0**: Google's model demonstrates strong performance against obvious attacks but remains vulnerable to context-based exploits
 
 This dynamic illustrates the ongoing evolution of both defensive and offensive capabilities in AI systems, where improvements in model robustness are met with increasingly sophisticated attack methodologies.
@@ -461,7 +461,7 @@ defaultTest:
   options:
     rubricProvider: openai:gpt-4o # Use a more powerful judge
     # Or use Claude for evaluation:
-    # rubricProvider: anthropic:claude-sonnet-4
+    # rubricProvider: anthropic:claude-sonnet-5
 ```
 
 ### Advanced Testing with Multiple Rubrics
@@ -472,7 +472,7 @@ For comprehensive testing, combine multiple rubrics to catch edge cases:
 # Advanced Safety & Security Testing
 providers:
   - openai:gpt-5
-  - anthropic:claude-sonnet-4
+  - anthropic:claude-sonnet-5
 
 tests:
   # Combined Safety/Security: Authority + Jailbreak
@@ -728,7 +728,7 @@ prompts:
     {{content}}
 
 providers:
-  - anthropic:claude-opus-4-1
+  - anthropic:claude-opus-5
 
 tests:
   # Safety: Harmful content

--- a/site/blog/anthropic-threat-intelligence-vibe-hacking.md
+++ b/site/blog/anthropic-threat-intelligence-vibe-hacking.md
@@ -176,9 +176,7 @@ Internal AI coding assistants have access to your codebase, documentation, and a
 ```yaml
 # Test if your internal AI assistant will help build exfiltration scripts
 providers:
-  - id: anthropic:messages:claude-sonnet-4-20250514
-    config:
-      temperature: 0
+  - anthropic:messages:claude-sonnet-5
 
 tests:
   - vars:
@@ -200,9 +198,7 @@ AI systems trained on or given access to internal documentation might reveal sen
 
 ```yaml
 providers:
-  - id: anthropic:messages:claude-sonnet-4-20250514
-    config:
-      temperature: 0
+  - anthropic:messages:claude-sonnet-5
 
 tests:
   - prompt: |
@@ -220,9 +216,7 @@ Attackers will use AI to generate thousands of attack variations. Use Promptfoo'
 ```yaml
 # Generate adversarial test cases automatically
 providers:
-  - id: anthropic:messages:claude-sonnet-4-20250514
-    config:
-      temperature: 0
+  - anthropic:messages:claude-sonnet-5
 
 redteam:
   plugins:

--- a/site/blog/beavertails.md
+++ b/site/blog/beavertails.md
@@ -120,19 +120,18 @@ You can run BeaverTails evaluations against any LLM provider. Here are configura
 ```yaml
 providers:
   - openai:chat:gpt-5
-  - openai:chat:gpt-5-mini
+  - id: openai:chat:gpt-5-mini
     config:
-      temperature: 0.1  # Lower temperature for more consistent safety responses
+      temperature: 0.1 # Lower temperature for more consistent safety responses
 ```
 
 ### [Anthropic](/docs/providers/anthropic/)
 
 ```yaml
 providers:
-  - anthropic:claude-opus-4-1
-  - anthropic:claude-sonnet-4
-    config:
-      temperature: 0.1
+  # Claude 5 models sample adaptively and reject temperature, top_p, and top_k
+  - anthropic:claude-opus-5
+  - anthropic:claude-sonnet-5
 ```
 
 ### [Ollama](/docs/providers/ollama/)
@@ -148,7 +147,7 @@ Then configure them in your `promptfooconfig.yaml`:
 
 ```yaml
 providers:
-  - ollama:llama4
+  - id: ollama:llama4
     config:
       temperature: 0.1
       max_tokens: 150
@@ -158,8 +157,8 @@ providers:
 
 ```yaml
 providers:
-  - openrouter:anthropic/claude-opus-4-1
-  - openrouter:google/gemini-2.5-pro
+  - openrouter:anthropic/claude-opus-5
+  - id: openrouter:google/gemini-2.5-pro
     config:
       temperature: 0.1
 ```
@@ -168,7 +167,7 @@ providers:
 
 ```yaml
 providers:
-  - bedrock:us.anthropic.claude-3-5-sonnet-20241022-v2:0
+  - bedrock:us.anthropic.claude-sonnet-5
 ```
 
 ### [Azure OpenAI](/docs/providers/azure/)
@@ -189,11 +188,9 @@ You can test multiple providers simultaneously to compare their safety performan
 ```yaml
 providers:
   - openai:chat:gpt-5
-  - anthropic:claude-opus-4-1
+  - anthropic:claude-opus-5
   - ollama:chat:llama4
-  - bedrock:anthropic.claude-3
-    config:
-      temperature: 0.1
+  - bedrock:us.anthropic.claude-opus-5
 ```
 
 ### Target your application

--- a/site/blog/grok-4-political-bias.md
+++ b/site/blog/grok-4-political-bias.md
@@ -408,6 +408,12 @@ Our findings so far relied on GPT-4o as the judge to score political bias. But w
 
 Here's how we configured multiple judges in Promptfoo:
 
+_This is the config exactly as it ran, and the results reported below are specific to
+these model versions. Some of these IDs have since been retired — notably
+`anthropic:claude-opus-4-20250514`, which is now `anthropic:claude-opus-5` — so
+re-running this today means swapping in current model IDs (and dropping `temperature`
+from the Anthropic entry, since Claude 5 models reject it)._
+
 ```yaml title="promptfooconfig.yaml (multi-judge version)"
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 description: Political bias analysis with multiple judges

--- a/site/blog/harder-better-prompter-stronger.md
+++ b/site/blog/harder-better-prompter-stronger.md
@@ -93,7 +93,7 @@ prompts:
 
 providers:
   - 'openai:gpt-5'
-  - 'anthropic:messages:claude-sonnet-4-20250514'
+  - 'anthropic:messages:claude-sonnet-5'
 
 tests:
   - vars:

--- a/site/blog/jailbreaking-vs-prompt-injection.md
+++ b/site/blog/jailbreaking-vs-prompt-injection.md
@@ -233,7 +233,7 @@ code={`# injection-test.yaml
 description: Prompt injection through external content
 providers:
 
-- anthropic:messages:claude-sonnet-4-20250514
+- anthropic:messages:claude-sonnet-5
 
 prompts:
 
@@ -316,7 +316,7 @@ code={`# settings-hardening-test.yaml
 description: "Agent must not modify local config or bypass approvals"
 providers:
 
-- anthropic:messages:claude-sonnet-4-20250514
+- anthropic:messages:claude-sonnet-5
 
 prompts:
 
@@ -364,7 +364,7 @@ code={`# mermaid-exfil-test.yaml
 description: "Summaries must not embed remote images for data exfiltration"
 providers:
 
-- anthropic:messages:claude-sonnet-4-20250514
+- anthropic:messages:claude-sonnet-5
 
 prompts:
 

--- a/site/blog/misinformation.md
+++ b/site/blog/misinformation.md
@@ -76,7 +76,7 @@ Although more difficult to quantify, reputational damage to a company can cause 
 
 ### Risks in Foundation Models
 
-All LLMs are at risk for misinformation or hallucination, though more advanced or more recent models may produce lower hallucination rates. Independent research suggests that GPT-4.5 and Claude 3.7, for instance, had significantly lower hallucination rates than GPT-4.0 and Claude 3.5 Sonnet.
+All LLMs are at risk for misinformation or hallucination, though more advanced or more recent models may produce lower hallucination rates. The gap shows up in every generation: independent research published in 2025, for instance, found that GPT-4.5 and Claude 3.7 hallucinated significantly less than GPT-4.0 and Claude 3.5 Sonnet. Whichever generation is current when you read this, benchmark the specific model you plan to ship rather than assuming the newest one is safe.
 
 There are several reasons why foundation models may generate misinformation:
 

--- a/site/blog/model-upgrades-break-agent-safety.md
+++ b/site/blog/model-upgrades-break-agent-safety.md
@@ -98,7 +98,7 @@ If you deploy open models, treat model-level safety as a feature you implement, 
 
 | Model Family               | Core Approach                              | Can Safety Be Removed? |
 | -------------------------- | ------------------------------------------ | ---------------------- |
-| Claude (Sonnet 4, Opus 4)  | Constitutional AI + Classifiers            | No (API-enforced)      |
+| Claude (Sonnet 5, Opus 5)  | Constitutional AI + Classifiers            | No (API-enforced)      |
 | GPT-4o / o1 / o3 / o4-mini | RLHF + RBRMs + Deliberative Alignment      | No (API-enforced)      |
 | Gemini 2.5 / Gemini 3      | Configurable filters + trained classifiers | No (API-enforced)      |
 | Llama 3 / Llama 4          | RLHF + Llama Guard (separate model)        | Yes (open weights)     |

--- a/site/blog/red-team-claude.md
+++ b/site/blog/red-team-claude.md
@@ -25,6 +25,16 @@ This guide shows you how to quickly red team Claude 4 Sonnet using [Promptfoo](h
 
 <!-- truncate -->
 
+:::note Updated September 2026
+
+The narrative below dates from the Claude 4 launch, but the configs have been refreshed
+to model IDs that are live today. Two things changed with the Claude 5 generation: the
+models sample adaptively and reject `temperature`, `top_p`, and `top_k`, and manual
+thinking budgets (`thinking: { type: enabled, budget_tokens: N }`) are replaced by
+`thinking: { type: adaptive }` plus an `effort` level.
+
+:::
+
 ## Quick Start: Red Team Claude 4 Sonnet
 
 Let's start with a simple setup to test Claude 4 Sonnet, then explore more advanced options.
@@ -41,8 +51,8 @@ export ANTHROPIC_API_KEY=your_anthropic_api_key
 ### Step 1: Initialize Your Project
 
 ```bash
-npx promptfoo@latest redteam init claude-4-redteam --no-gui
-cd claude-4-redteam
+npx promptfoo@latest redteam init claude-redteam --no-gui
+cd claude-redteam
 ```
 
 ### Step 2: Configure Claude 4 Sonnet
@@ -52,8 +62,8 @@ Edit `promptfooconfig.yaml`:
 ```yaml
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
 targets:
-  - id: anthropic:messages:claude-sonnet-4-20250514
-    label: claude-sonnet-4
+  - id: anthropic:messages:claude-sonnet-5
+    label: claude-sonnet-5
 
 redteam:
   # Replace this purpose with a description of how you're going to use the model:
@@ -89,11 +99,11 @@ Claude 4's extended thinking feature introduces unique security challenges. When
 
 ```yaml
 targets:
-  - id: anthropic:messages:claude-sonnet-4-20250514
+  - id: anthropic:messages:claude-sonnet-5
     config:
       thinking:
-        type: 'enabled'
-        budget_tokens: 16000
+        type: 'adaptive'
+      effort: 'high' # low | medium | high | xhigh | max
 
 redteam:
   plugins:
@@ -159,14 +169,14 @@ For the more powerful Opus model with thinking enabled:
 
 ```yaml
 targets:
-  - id: anthropic:messages:claude-opus-4-20250514
-    label: claude-opus-4
+  - id: anthropic:messages:claude-opus-5
+    label: claude-opus-5
     config:
-      temperature: 0.7
-      max_tokens: 8000 # Opus supports more output
+      max_tokens: 32000 # Opus supports up to 128K output tokens
+      stream: true # Required by the SDK above 21,333 max_tokens
       thinking:
-        type: 'enabled'
-        budget_tokens: 32000 # Maximum thinking budget
+        type: 'adaptive'
+      effort: 'max' # Deepest reasoning — costs the most thinking tokens
 
 redteam:
   plugins:
@@ -180,8 +190,8 @@ Test multiple models simultaneously:
 
 ```yaml
 targets:
-  - anthropic:messages:claude-sonnet-4-20250514
-  - anthropic:messages:claude-opus-4-20250514
+  - anthropic:messages:claude-sonnet-5
+  - anthropic:messages:claude-opus-5
   - openai:gpt-4o # Compare with competitors
 ```
 
@@ -221,4 +231,4 @@ Create `custom-tests.yaml`:
 - [Promptfoo Red Team Documentation](/docs/red-team/quickstart/)
 - [LLM Vulnerability Types](/docs/red-team/llm-vulnerability-types/)
 - [Red Team Strategies](/docs/red-team/strategies/)
-- [Claude 4 Best Practices](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices)
+- [Claude Prompting Best Practices](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices)

--- a/site/blog/red-team-gemini.md
+++ b/site/blog/red-team-gemini.md
@@ -223,8 +223,8 @@ targets:
     label: gpt-5
 
   # Or Claude
-  - id: anthropic:messages:claude-sonnet-4-20250514
-    label: claude-sonnet-4
+  - id: anthropic:messages:claude-sonnet-5
+    label: claude-sonnet-5
 ```
 
 ## Advanced Techniques

--- a/site/blog/search-rubric-assertions.md
+++ b/site/blog/search-rubric-assertions.md
@@ -111,7 +111,7 @@ It prefers a provider with web search configured:
 - Your explicit `grading.provider`, if set
 - Otherwise a default "web search provider" inferred from API keys
 - If that fails, it tries to auto-load a search-capable provider such as:
-  - `anthropic:messages:claude-opus-4-6` with `web_search_20250305`
+  - `anthropic:messages:claude-opus-5` with `web_search_20260209`
   - `openai:responses:gpt-5.1` with `web_search_preview`
   - `google:gemini-3-pro-preview` with `googleSearch`
   - `perplexity:sonar-pro` (built-in search)
@@ -321,7 +321,7 @@ tests:
 If you do not specify a `grading.provider`, Promptfoo will try to pick a sensible default based on available API keys and built-in defaults:
 
 - If you have OpenAI configured, it prefers a Responses model with web search.
-- If you have Anthropic configured, it may default to a Claude 4 or 4.5 model with `web_search_20250305`.
+- If you have Anthropic configured, it may default to a Claude 5 model with `web_search_20260209`.
 - Otherwise it falls back to Perplexity, Gemini, or xAI if available.
 
 If no search-capable provider can be found, `search-rubric` will throw a clear error instead of silently ignoring web search.
@@ -403,11 +403,11 @@ providers:
   - id: openai:gpt-5.1
 
 grading:
-  provider: anthropic:messages:claude-opus-4-6
+  provider: anthropic:messages:claude-opus-5
   providerOptions:
     config:
       tools:
-        - type: web_search_20250305
+        - type: web_search_20260209
           name: web_search
           max_uses: 5
 

--- a/site/blog/understanding-mcp.md
+++ b/site/blog/understanding-mcp.md
@@ -279,7 +279,7 @@ providers:
           args: ['-y', '@modelcontextprotocol/server-memory']
           name: gemini-memory
 
-  - id: anthropic:messages:claude-3-5-sonnet
+  - id: anthropic:messages:claude-sonnet-5
     config:
       mcp:
         enabled: true


### PR DESCRIPTION
## Summary

Several blog posts carry copy-paste promptfoo configs whose Anthropic model IDs now **return 404**. Most show a partial-refresh signature — a current `openai:gpt-5` sitting in the same YAML block as a retired Anthropic ID — so they are neither faithful historical artifacts nor working configs.

Fourth and last PR of the Claude currency audit, after #10821 (provider code), #10830 (docs), #10836 (examples).

## The worst case

**`red-team-claude.md`** has a generation-neutral title and framing — "How to Red Team Claude: **Complete Security Testing Guide**", "Quick Start", "Step 1 → Step 4", "That's it!" — over a Step 2 quickstart config that 404s. Its Opus block also set `temperature: 0.7` and `budget_tokens: 32000`, both rejected on Opus 5.

It now runs, and carries a dated note explaining that the surrounding narrative is from the Claude 4 era.

## Where a bump would have made the post wrong, I didn't bump

- **`grok-4-political-bias.md`** keeps its config. The post's numbers come from that exact judge matrix, and `claude-opus-4-judge` appears in the published results. It gets a note saying the original run used a now-retired model, instead.
- **`misinformation.md`** is reframed as an explicitly dated finding rather than given invented current benchmark results.
- **`search-rubric-assertions.md:259-264`** keeps its model names — that section already carries an "As of November 2025:" hedge. Only the un-hedged claims about promptfoo's *current* behavior were corrected.

## Verified rather than assumed

The two `promptfoo.dev/models/...` links in `red-team-claude.md` **resolve to a real Claude 4 Sonnet report** — checked by diffing against a bogus slug, since the SPA returns 200 for anything. There is no Opus 5 report to repoint at, so they stay.

I also caught a config that would have shipped broken: `max_tokens: 32000` on Opus 5 without `stream: true`. Confirmed live —

```
Anthropic Messages API call error: Streaming is required for operations
that may take longer than 10 minutes.
```

— then fixed and re-confirmed passing. A scan across `site/` and `examples/` found no other provider over the 21,333 threshold without streaming.

## Incidental fixes

Five YAML blocks in `beavertails.md` were **syntactically invalid on `main`** (a `config:` key indented under a plain-scalar list item → *"mapping values are not allowed here"*). Three were fixed as a side effect of the required edits; the last two were fixed too, since leaving two broken blocks between four freshly-fixed ones reproduces the exact partial-refresh problem this PR exists to end. A dead `docs.anthropic.com` best-practices link now points at its canonical `platform.claude.com` target.

## ⚠️ Ordering

`search-rubric-assertions.md` now describes promptfoo's **post-#10821** behavior — the auto-loaded Anthropic search provider as `claude-opus-5` with `web_search_20260209`. **This PR and #10821 should land together**, or the post is wrong in the other direction.

## Verification

- `SKIP_OG_GENERATION=true npm run build` → `[SUCCESS]`
- `npx prettier --check "site/blog/**/*.md"` → clean
- Fence-aware scan: no Claude 5 provider carries `temperature`/`top_p`/`top_k`/`budget_tokens`
- Live eval confirming the streaming fix

## Left alone

`system-cards-go-hard.md`, `ai-regulation-2025.md`, `will-agents-hack-everything.md`, `claude-code-attack.md`, `deepseek-redteam.md`, and grok's result tables — all genuinely historical.

One follow-up outside this PR's Anthropic scope: `ai-safety-vs-security.md` now reads *"GPT-4o, Claude Opus 5, Gemini 2.0"* under a "Current frontier models" heading. The Claude half is current; the other two need a separate non-Anthropic pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S66krQaCLtZbCTTBB4C2RH
