### PR TITLE
refactor(cli): return model-audit args directly

### DIFF
--- a/src/commands/modelScan.ts
+++ b/src/commands/modelScan.ts
@@ -284,10 +284,7 @@ function hasPersistedScannerSelection(metadata: ModelAudit['metadata']): boolean
  * Parse CLI options through Zod, logging validation errors to the CLI.
  * Returns null when validation fails (and sets process.exitCode to 1).
  */
-function buildCliArgs(
-  paths: string[],
-  cliOptions: Record<string, unknown>,
-): { args: string[]; unsupportedOptions: string[] } | null {
+function buildCliArgs(paths: string[], cliOptions: Record<string, unknown>): string[] | null {
   try {
     return parseModelAuditArgs(paths, cliOptions);
   } catch (error) {
@@ -925,16 +922,16 @@ export function modelScanCommand(program: Command): void {
       };
 
       if (options.listScanners) {
-        const parsed = buildCliArgs(paths || [], {
+        const args = buildCliArgs(paths || [], {
           ...options,
           format: options.format || 'text',
           output: options.output,
           timeout: undefined,
         });
-        if (!parsed) {
+        if (!args) {
           return;
         }
-        await runPassthroughModelAudit(parsed.args, delegationEnv);
+        await runPassthroughModelAudit(args, delegationEnv);
         return;
       }
 
@@ -960,16 +957,15 @@ export function modelScanCommand(program: Command): void {
 
       // Parse CLI arguments
       const outputFormat = saveToDatabase ? 'json' : options.format || 'text';
-      const parsed = buildCliArgs(paths, {
+      const args = buildCliArgs(paths, {
         ...options,
         format: outputFormat,
         output: options.output && !saveToDatabase ? options.output : undefined,
         timeout: options.timeout ? parseInt(options.timeout, 10) : undefined,
       });
-      if (!parsed) {
+      if (!args) {
         return;
       }
-      const args = parsed.args;
 
       if (saveToDatabase || outputFormat === 'text') {
         logger.info(`Running model scan on: ${paths.join(', ')}`);

--- a/src/server/routes/modelAudit.ts
+++ b/src/server/routes/modelAudit.ts
@@ -23,7 +23,7 @@ export const modelAuditRouter = Router();
 const LIST_SCANNERS_ARGS = parseModelAuditArgs([], {
   listScanners: true,
   format: 'json',
-}).args;
+});
 
 function getModelAuditDelegationEnv(): NodeJS.ProcessEnv {
   return {
@@ -257,7 +257,7 @@ modelAuditRouter.post('/scan', async (req: Request, res: Response): Promise<void
     // Use the centralized CLI parser to build command arguments
     const effectiveVerbose = normalizedOptions.verbose !== false;
     const effectiveTimeout = normalizedOptions.timeout || 3600;
-    const { args } = parseModelAuditArgs(resolvedPaths, {
+    const args = parseModelAuditArgs(resolvedPaths, {
       ...normalizedOptions,
       // Force JSON format for API responses (required for parsing)
       format: 'json',

--- a/src/util/modelAuditCliParser.ts
+++ b/src/util/modelAuditCliParser.ts
@@ -76,10 +76,7 @@ const CLI_ARG_MAP: Partial<
 /**
  * Elegant, configuration-driven CLI argument parser
  */
-export function parseModelAuditArgs(
-  paths: string[],
-  options: unknown,
-): { args: string[]; unsupportedOptions: string[] } {
+export function parseModelAuditArgs(paths: string[], options: unknown): string[] {
   const validatedOptions = ModelAuditCliOptionsSchema.parse(options);
   const args: string[] = ['scan', ...paths];
 
@@ -118,5 +115,5 @@ export function parseModelAuditArgs(
     }
   }
 
-  return { args, unsupportedOptions: [] };
+  return args;
 }

--- a/test/utils/modelAuditCliParser.test.ts
+++ b/test/utils/modelAuditCliParser.test.ts
@@ -2,17 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { parseModelAuditArgs } from '../../src/util/modelAuditCliParser';
 
 describe('parseModelAuditArgs', () => {
-  it('should parse basic options and preserve the return shape', () => {
+  it('should parse basic options', () => {
     const result = parseModelAuditArgs(['model.pkl'], {
       format: 'json',
       verbose: true,
       timeout: 300,
     });
 
-    expect(result).toEqual({
-      args: ['scan', 'model.pkl', '--format', 'json', '--verbose', '--timeout', '300'],
-      unsupportedOptions: [],
-    });
+    expect(result).toEqual([
+      'scan',
+      'model.pkl',
+      '--format',
+      'json',
+      '--verbose',
+      '--timeout',
+      '300',
+    ]);
   });
 
   it('should handle multiple blacklist patterns', () => {
@@ -20,7 +25,7 @@ describe('parseModelAuditArgs', () => {
       blacklist: ['pattern1', 'pattern2', 'pattern3'],
     });
 
-    expect(result.args).toEqual([
+    expect(result).toEqual([
       'scan',
       'model.pkl',
       '--blacklist',
@@ -37,14 +42,7 @@ describe('parseModelAuditArgs', () => {
       format: 'sarif',
     });
 
-    expect(result.args).toEqual([
-      'scan',
-      'model1.pkl',
-      'model2.h5',
-      'model3.onnx',
-      '--format',
-      'sarif',
-    ]);
+    expect(result).toEqual(['scan', 'model1.pkl', 'model2.h5', 'model3.onnx', '--format', 'sarif']);
   });
 
   it('should handle all supported options', () => {
@@ -64,7 +62,7 @@ describe('parseModelAuditArgs', () => {
       stream: true,
     });
 
-    expect(result.args).toEqual([
+    expect(result).toEqual([
       'scan',
       'model.pkl',
       '--blacklist',
@@ -99,7 +97,7 @@ describe('parseModelAuditArgs', () => {
       stream: false,
     });
 
-    expect(result.args).toEqual(['scan', 'model.pkl']);
+    expect(result).toEqual(['scan', 'model.pkl']);
   });
 
   it('should reject invalid format and timeout options', () => {
@@ -128,7 +126,7 @@ describe('parseModelAuditArgs', () => {
       excludeScanner: ['weight_distribution'],
     });
 
-    expect(result.args).toEqual([
+    expect(result).toEqual([
       'scan',
       'model.pkl',
       '--scanners',
@@ -146,6 +144,6 @@ describe('parseModelAuditArgs', () => {
       format: 'json',
     });
 
-    expect(result.args).toEqual(['scan', '--format', 'json', '--list-scanners']);
+    expect(result).toEqual(['scan', '--format', 'json', '--list-scanners']);
   });
 });


### PR DESCRIPTION
## Summary

`parseModelAuditArgs` returned `{ args: string[]; unsupportedOptions: string[] }`, but `unsupportedOptions` was hard-coded to `[]` and no caller ever read it — dead surface left behind when option validation moved into the Zod schema (`ModelAuditCliOptionsSchema.parse` now throws on bad input instead of collecting names).

Removing it leaves a single-field wrapper object with no reason to exist, so `parseModelAuditArgs` and `buildCliArgs` now return the argv array itself and the three call sites drop their destructuring. `src/commands/modelScan.ts` also loses a `const args = parsed;` alias that only existed to unwrap the object.

No behavior change — `args` was already the only field anyone used.

## Test plan

- `npx vitest run test/utils/modelAuditCliParser.test.ts test/commands/modelScan.test.ts test/server/routes/modelAudit.test.ts` — 119 passed
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx biome check` — clean (the three cognitive-complexity warnings are pre-existing on `main`)

Net −9 lines.