### PR TITLE
docs: add Lintspace score verification badge (82/100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <a href="https://npmjs.com/package/promptfoo"><img src="https://img.shields.io/npm/v/promptfoo" alt="npm"></a>
   <a href="https://npmjs.com/package/promptfoo"><img src="https://img.shields.io/npm/dm/promptfoo" alt="npm"></a>
   <a href="https://github.com/promptfoo/promptfoo/actions/workflows/main.yml"><img src="https://img.shields.io/github/actions/workflow/status/promptfoo/promptfoo/main.yml" alt="GitHub Workflow Status"></a>
+  <a href="https://lintspace.com/verdict/6270f418-bef1-4ace-a20f-cdcef0ea590c"><img src="https://lintspace.com/api/badge/6270f418-bef1-4ace-a20f-cdcef0ea590c.svg" alt="Lintspace Score"></a>
   <a href="https://github.com/promptfoo/promptfoo/blob/main/LICENSE"><img src="https://img.shields.io/github/license/promptfoo/promptfoo" alt="MIT license"></a>
   <a href="https://discord.gg/promptfoo"><img src="https://img.shields.io/discord/1146610656779440188?logo=discord&label=promptfoo" alt="Discord"></a>
 </p>


### PR DESCRIPTION
Hi @ian-whitestone @typpo and the Promptfoo team! 👋

Lintspace recently evaluated `promptfoo` across architectural maturity, documentation quality, release cadence, and production readiness, scoring it **82/100 (Production Ready)**.

Proposing to add the live Lintspace verification badge to the header badge row in the README:

```html
<a href="https://lintspace.com/verdict/6270f418-bef1-4ace-a20f-cdcef0ea590c"><img src="https://lintspace.com/api/badge/6270f418-bef1-4ace-a20f-cdcef0ea590c.svg" alt="Lintspace Score"></a>
```

Full evaluation breakdown and metrics: https://lintspace.com/verdict/6270f418-bef1-4ace-a20f-cdcef0ea590c