### PR TITLE
fix(providers): preserve WatsonX caller cancellation

### DIFF
--- a/site/docs/providers/watsonx.md
+++ b/site/docs/providers/watsonx.md
@@ -232,7 +232,7 @@ providers:
 
 ### Cost estimates
 
-Cost estimates use pricing metadata for the configured service and account. If metadata is unavailable or a pricing tier is unrecognized, the response omits `cost` and still returns the generated output.
+Cost estimates use pricing metadata for the configured service and account. If required metadata is unavailable or a required pricing tier is unrecognized, the response omits `cost` and still returns the generated output. A token category with a reported count of zero does not require a price.
 
 For account-specific pricing, set `inputCost` and `outputCost` in USD per token, or set `cost` for a shared input/output rate. These values override the built-in tier prices; an explicit zero is supported. Estimates do not determine whether your account can use a model.
 

--- a/src/providers/watsonx.ts
+++ b/src/providers/watsonx.ts
@@ -5,7 +5,6 @@ import { getCache, isCacheEnabled } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
-import { isAbortError } from '../util/fetch/errors';
 import invariant from '../util/invariant';
 import { createEmptyTokenUsage } from '../util/tokenUsageUtils';
 import { getRequestTimeoutMs, parseChatPrompt } from './shared';
@@ -769,9 +768,6 @@ export class WatsonXProvider implements ApiProvider {
       return providerResponse;
     } catch (err) {
       throwIfAborted(signal);
-      if (isAbortError(err)) {
-        throw err;
-      }
       logger.error(`Watsonx: API call error: ${String(err)}`);
 
       return {
@@ -865,9 +861,6 @@ export class WatsonXChatProvider extends WatsonXProvider {
       return providerResponse;
     } catch (err) {
       throwIfAborted(signal);
-      if (isAbortError(err)) {
-        throw err;
-      }
       logger.error(`Watsonx Chat: API call error: ${String(err)}`);
 
       return {

--- a/src/providers/watsonx.ts
+++ b/src/providers/watsonx.ts
@@ -5,6 +5,7 @@ import { getCache, isCacheEnabled } from '../cache';
 import { getEnvString } from '../envars';
 import logger from '../logger';
 import { type GenAISpanContext, type GenAISpanResult, withGenAISpan } from '../tracing/genaiTracer';
+import { isAbortError } from '../util/fetch/errors';
 import invariant from '../util/invariant';
 import { createEmptyTokenUsage } from '../util/tokenUsageUtils';
 import { getRequestTimeoutMs, parseChatPrompt } from './shared';
@@ -16,6 +17,7 @@ import type { EnvOverrides } from '../types/env';
 import type {
   ApiProvider,
   CallApiContextParams,
+  CallApiOptionsParams,
   ProviderResponse,
   TokenUsage,
 } from '../types/index';
@@ -45,6 +47,7 @@ interface TextGenRequestParams {
   modelId: string;
   projectId: string;
   parameters: TextGenRequestParametersModel;
+  signal?: AbortSignal;
 }
 
 const ConfigSchema = z.object({
@@ -236,12 +239,49 @@ function createWatsonXAuthCacheHash(authSelection: WatsonXAuthSelection): string
   });
 }
 
+function createAbortError(): Error {
+  const error = new Error('Request aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+}
+
+async function waitWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(createAbortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
+  try {
+    return await Promise.race([promise, aborted]);
+  } catch (error) {
+    throwIfAborted(signal);
+    throw error;
+  } finally {
+    if (onAbort) {
+      signal.removeEventListener('abort', onAbort);
+    }
+  }
+}
+
 // A client binds the service URL, API version and authenticator. Keep metadata
 // in memory per client so different regions/accounts never share model prices.
-let modelSpecsCache = new WeakMap<
-  WatsonXAIClient,
-  Map<string, { expiresAt: number; cost: WatsonXModelCost }>
->();
+type ModelSpecsCacheEntry =
+  | { expiresAt: number; cost: WatsonXModelCost }
+  | { pending: Promise<WatsonXModelCost | undefined> };
+let modelSpecsCache = new WeakMap<WatsonXAIClient, Map<string, ModelSpecsCacheEntry>>();
 const MODEL_SPECS_CACHE_TTL_MS = 5 * 60 * 1000;
 
 function getPricingTierCost(tier: unknown): number | undefined {
@@ -261,11 +301,42 @@ async function getModelCost(
   client: WatsonXAIClient,
   modelId: string,
 ): Promise<WatsonXModelCost | undefined> {
-  const cached = modelSpecsCache.get(client)?.get(modelId);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.cost;
+  let clientCache = modelSpecsCache.get(client);
+  if (!clientCache) {
+    clientCache = new Map();
+    modelSpecsCache.set(client, clientCache);
+  }
+  const cached = clientCache.get(modelId);
+  if (cached) {
+    if ('pending' in cached) {
+      return cached.pending;
+    }
+    if (cached.expiresAt > Date.now()) {
+      return cached.cost;
+    }
   }
 
+  const pending = fetchModelCost(client, modelId)
+    .then((cost) => {
+      if (cost) {
+        clientCache.set(modelId, { expiresAt: Date.now() + MODEL_SPECS_CACHE_TTL_MS, cost });
+      }
+      return cost;
+    })
+    .finally(() => {
+      if (clientCache.get(modelId) === entry) {
+        clientCache.delete(modelId);
+      }
+    });
+  const entry = { pending };
+  clientCache.set(modelId, entry);
+  return pending;
+}
+
+async function fetchModelCost(
+  client: WatsonXAIClient,
+  modelId: string,
+): Promise<WatsonXModelCost | undefined> {
   const controller = new AbortController();
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_resolve, reject) => {
@@ -291,20 +362,13 @@ async function getModelCost(
     if (!spec) {
       return undefined;
     }
-    const cost = {
+    return {
       input: getPricingTierCost(spec.input_tier),
       output: getPricingTierCost(spec.output_tier),
     };
-    let clientCache = modelSpecsCache.get(client);
-    if (!clientCache) {
-      clientCache = new Map();
-      modelSpecsCache.set(client, clientCache);
-    }
-    clientCache.set(modelId, { expiresAt: Date.now() + MODEL_SPECS_CACHE_TTL_MS, cost });
-    return cost;
   } catch (error) {
     logger.debug('[WatsonX] Model pricing metadata is unavailable', { error });
-    // Do not cache failures: a later response can retry after recovery.
+    // Do not cache failures: a later uncached response can retry after recovery.
     return undefined;
   } finally {
     clearTimeout(timeout);
@@ -317,6 +381,7 @@ async function calculateWatsonXCost(
   config: z.infer<typeof ConfigSchema>,
   promptTokens?: number,
   completionTokens?: number,
+  signal?: AbortSignal,
 ): Promise<number | undefined> {
   if (
     promptTokens == null ||
@@ -332,11 +397,11 @@ async function calculateWatsonXCost(
   const inputOverride = config.inputCost ?? config.cost;
   const outputOverride = config.outputCost ?? config.cost;
   const modelCost =
-    inputOverride == null || outputOverride == null
-      ? await getModelCost(client, modelId)
+    (promptTokens > 0 && inputOverride == null) || (completionTokens > 0 && outputOverride == null)
+      ? await waitWithAbort(getModelCost(client, modelId), signal)
       : undefined;
-  const inputCost = inputOverride ?? modelCost?.input;
-  const outputCost = outputOverride ?? modelCost?.output;
+  const inputCost = promptTokens === 0 ? 0 : (inputOverride ?? modelCost?.input);
+  const outputCost = completionTokens === 0 ? 0 : (outputOverride ?? modelCost?.output);
   if (
     inputCost == null ||
     outputCost == null ||
@@ -357,6 +422,7 @@ export class WatsonXProvider implements ApiProvider {
   client?: WatsonXAIClient;
   config: z.infer<typeof ConfigSchema>;
   private authCacheHash?: string;
+  private clientPromise?: Promise<WatsonXAIClient>;
 
   constructor(modelName: string, options: ProviderOptions) {
     const validationResult = ConfigSchema.safeParse(options.config);
@@ -518,6 +584,15 @@ export class WatsonXProvider implements ApiProvider {
       return this.client;
     }
 
+    if (!this.clientPromise) {
+      this.clientPromise = this.initializeClient().finally(() => {
+        this.clientPromise = undefined;
+      });
+    }
+    return this.clientPromise;
+  }
+
+  private async initializeClient(): Promise<WatsonXAIClient> {
     const authenticator = await this.getAuth();
 
     try {
@@ -536,7 +611,11 @@ export class WatsonXProvider implements ApiProvider {
     }
   }
 
-  async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
     // Set up tracing context
     const spanContext: GenAISpanContext = {
       system: 'watsonx',
@@ -563,14 +642,22 @@ export class WatsonXProvider implements ApiProvider {
       return result;
     };
 
-    return withGenAISpan(spanContext, () => this.callApiInternal(prompt, context), resultExtractor);
+    return withGenAISpan(
+      spanContext,
+      () => this.callApiInternal(prompt, context, options),
+      resultExtractor,
+    );
   }
 
   private async callApiInternal(
     prompt: string,
     context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
   ): Promise<ProviderResponse> {
-    const client = await this.getClient();
+    const signal = options?.abortSignal;
+    throwIfAborted(signal);
+    const client = await waitWithAbort(this.getClient(), signal);
+    throwIfAborted(signal);
 
     // Merge configs: provider config -> prompt-level config
     const config = {
@@ -587,7 +674,8 @@ export class WatsonXProvider implements ApiProvider {
     const cacheKey = `watsonx:${WATSONX_RESPONSE_CACHE_VERSION}:${this.modelName}:${configHash}:${authHash}:${generatePromptHash(prompt)}`;
     const cacheEnabled = isCacheEnabled();
     if (cacheEnabled) {
-      const cachedResponse = await cache.get(cacheKey);
+      const cachedResponse = await waitWithAbort(cache.get(cacheKey), signal);
+      throwIfAborted(signal);
       if (cachedResponse) {
         logger.debug('Watsonx: Returning cached response', {
           model: this.modelName,
@@ -636,9 +724,11 @@ export class WatsonXProvider implements ApiProvider {
         modelId,
         projectId,
         parameters,
+        ...(signal && { signal }),
       };
 
-      const apiResponse = await client.generateText(params);
+      const apiResponse = await waitWithAbort(client.generateText(params), signal);
+      throwIfAborted(signal);
       const parsedResponse = TextGenResponseSchema.safeParse(apiResponse.result);
 
       if (!parsedResponse.success) {
@@ -667,14 +757,21 @@ export class WatsonXProvider implements ApiProvider {
         config,
         textGenResult.input_token_count,
         textGenResult.generated_token_count,
+        signal,
       );
 
+      throwIfAborted(signal);
       if (isCacheEnabled()) {
-        await cache.set(cacheKey, JSON.stringify(providerResponse));
+        await waitWithAbort(cache.set(cacheKey, JSON.stringify(providerResponse)), signal);
+        throwIfAborted(signal);
       }
 
       return providerResponse;
     } catch (err) {
+      throwIfAborted(signal);
+      if (isAbortError(err)) {
+        throw err;
+      }
       logger.error(`Watsonx: API call error: ${String(err)}`);
 
       return {
@@ -690,8 +787,15 @@ export class WatsonXProvider implements ApiProvider {
  * WatsonX Chat Provider using the textChat API for messages-based interactions.
  */
 export class WatsonXChatProvider extends WatsonXProvider {
-  async callApi(prompt: string, context?: CallApiContextParams): Promise<ProviderResponse> {
-    const client = await this.getClient();
+  async callApi(
+    prompt: string,
+    context?: CallApiContextParams,
+    options?: CallApiOptionsParams,
+  ): Promise<ProviderResponse> {
+    const signal = options?.abortSignal;
+    throwIfAborted(signal);
+    const client = await waitWithAbort(this.getClient(), signal);
+    throwIfAborted(signal);
 
     // Merge configs: provider config -> prompt-level config
     const config = {
@@ -708,7 +812,8 @@ export class WatsonXChatProvider extends WatsonXProvider {
     const cacheKey = `watsonx:chat:${WATSONX_RESPONSE_CACHE_VERSION}:${this.modelName}:${configHash}:${authHash}:${generatePromptHash(prompt)}`;
     const cacheEnabled = isCacheEnabled();
     if (cacheEnabled) {
-      const cachedResponse = await cache.get(cacheKey);
+      const cachedResponse = await waitWithAbort(cache.get(cacheKey), signal);
+      throwIfAborted(signal);
       if (cachedResponse) {
         logger.debug(
           `Watsonx Chat: Returning cached response for prompt with config "${configHash}"`,
@@ -732,10 +837,12 @@ export class WatsonXChatProvider extends WatsonXProvider {
         ...(config.topP !== undefined && { topP: config.topP }),
         ...(config.stopSequences?.length && { stop: config.stopSequences }),
         ...(config.randomSeed !== undefined && { seed: config.randomSeed }),
+        ...(signal && { signal }),
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const response = await (client as any).textChat(params);
+      const response: any = await waitWithAbort((client as any).textChat(params), signal);
+      throwIfAborted(signal);
       const result = response.result as any;
 
       const providerResponse = this.convertChatResponse(result);
@@ -746,14 +853,21 @@ export class WatsonXChatProvider extends WatsonXProvider {
         config,
         providerResponse.tokenUsage?.prompt,
         providerResponse.tokenUsage?.completion,
+        signal,
       );
 
+      throwIfAborted(signal);
       if (isCacheEnabled()) {
-        await cache.set(cacheKey, JSON.stringify(providerResponse));
+        await waitWithAbort(cache.set(cacheKey, JSON.stringify(providerResponse)), signal);
+        throwIfAborted(signal);
       }
 
       return providerResponse;
     } catch (err) {
+      throwIfAborted(signal);
+      if (isAbortError(err)) {
+        throw err;
+      }
       logger.error(`Watsonx Chat: API call error: ${String(err)}`);
 
       return {

--- a/test/providers/watsonx-cost.test.ts
+++ b/test/providers/watsonx-cost.test.ts
@@ -1,3 +1,5 @@
+import { getEventListeners } from 'node:events';
+
 import { WatsonXAI } from '@ibm-cloud/watsonx-ai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCache, getCache, isCacheEnabled } from '../../src/cache';
@@ -38,9 +40,15 @@ const chatResult = {
     usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
   },
 };
-function metadata(inputTier: unknown = 'class_c1', outputTier: unknown = 'class_9') {
+function metadata(
+  inputTier: unknown = 'class_c1',
+  outputTier: unknown = 'class_9',
+  effectiveModelId = modelId,
+) {
   return {
-    result: { resources: [{ model_id: modelId, input_tier: inputTier, output_tier: outputTier }] },
+    result: {
+      resources: [{ model_id: effectiveModelId, input_tier: inputTier, output_tier: outputTier }],
+    },
   };
 }
 function client(inputTier: unknown = 'class_c1', outputTier: unknown = 'class_9') {
@@ -64,6 +72,51 @@ function provider(chat = false, config: Record<string, unknown> = {}) {
   });
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function expectCallerAbort(observed: Promise<unknown>) {
+  const stillPending = new Promise<undefined>((resolve) => setTimeout(resolve, 1));
+  const outcome = Promise.race([observed, stillPending]);
+  await vi.advanceTimersByTimeAsync(1);
+  const error = await outcome;
+  expect(error).toBeInstanceOf(Error);
+  expect(error).toMatchObject({ name: 'AbortError', message: expect.stringMatching(/abort/i) });
+  expect(error).not.toHaveProperty('message', expect.stringMatching(/timeout|network/i));
+}
+
+function setTokenCounts(
+  regionalClient: ReturnType<typeof client>,
+  input: number | undefined,
+  output: number | undefined,
+) {
+  regionalClient.generateText.mockResolvedValue({
+    result: {
+      ...textResult.result,
+      results: [
+        { generated_text: 'Hello', input_token_count: input, generated_token_count: output },
+      ],
+    },
+  });
+  regionalClient.textChat.mockResolvedValue({
+    result: {
+      ...chatResult.result,
+      usage: {
+        prompt_tokens: input,
+        completion_tokens: output,
+        total_tokens: (input ?? 0) + (output ?? 0),
+      },
+    },
+  });
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
   clearModelSpecsCache();
@@ -81,6 +134,176 @@ afterEach(() => {
 });
 
 describe.each([false, true])('WatsonX regional cost (chat=%s)', (chat) => {
+  it('shares one client and metadata request across a cold concurrent batch', async () => {
+    vi.useFakeTimers();
+    const regionalClient = client();
+    const lookup = deferred<ReturnType<typeof metadata>>();
+    const started = deferred<void>();
+    regionalClient.listFoundationModelSpecs.mockImplementation(() => {
+      started.resolve();
+      return lookup.promise;
+    });
+    vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+    const instance = provider(chat);
+    const pending = Promise.all(
+      ['First', 'Second', 'Third', 'Fourth'].map((prompt) => instance.callApi(prompt)),
+    );
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(0);
+    lookup.resolve(metadata());
+    const results = await pending;
+
+    expect(WatsonXAI.newInstance).toHaveBeenCalledTimes(1);
+    expect(chat ? regionalClient.textChat : regionalClient.generateText).toHaveBeenCalledTimes(4);
+    expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+    for (const result of results) {
+      expect(result.output).toBe('Hello');
+      expect(result.error).toBeUndefined();
+      expect(result.cost).toBeCloseTo((10 * 0.106 + 20 * 0.371) / 1e6, 12);
+    }
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('retries client initialization after a shared failure', async () => {
+    const regionalClient = client();
+    vi.mocked(WatsonXAI.newInstance)
+      .mockImplementationOnce(() => {
+        throw new Error('Client initialization failed');
+      })
+      .mockReturnValue(regionalClient as any);
+    const instance = provider(chat);
+    const results = await Promise.allSettled([
+      instance.callApi('First'),
+      instance.callApi('Second'),
+    ]);
+    expect(results.map((result) => result.status)).toEqual(['rejected', 'rejected']);
+    expect(WatsonXAI.newInstance).toHaveBeenCalledTimes(1);
+    expect(regionalClient.listFoundationModelSpecs).not.toHaveBeenCalled();
+
+    expect((await instance.callApi('Recovered')).output).toBe('Hello');
+    expect(WatsonXAI.newInstance).toHaveBeenCalledTimes(2);
+    expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the initialized client and response cache bound to the same account', async () => {
+    const firstClient = client('class_c1', 'class_c1');
+    const secondClient = client('class_9', 'class_9');
+    secondClient.generateText.mockResolvedValue({
+      result: {
+        ...textResult.result,
+        results: [{ ...textResult.result.results[0], generated_text: 'Other account' }],
+      },
+    });
+    secondClient.textChat.mockResolvedValue({
+      result: { ...chatResult.result, choices: [{ message: { content: 'Other account' } }] },
+    });
+    const responses = new Map<string, string>();
+    vi.mocked(isCacheEnabled).mockReturnValue(true);
+    vi.mocked(getCache).mockReturnValue({
+      get: vi.fn(async (key: string) => responses.get(key)),
+      set: vi.fn(async (key: string, value: string) => responses.set(key, value)),
+    } as any);
+    const instance = provider(chat);
+    let overlappingClient: ReturnType<WatsonXProvider['getClient']> | undefined;
+    vi.mocked(WatsonXAI.newInstance)
+      .mockImplementationOnce(() => {
+        // Overlap initialization before the first SDK client has been assigned.
+        instance.config.apiBearerToken = 'other-account-token';
+        overlappingClient = instance.getClient();
+        return firstClient as any;
+      })
+      .mockReturnValue(secondClient as any);
+    await instance.getClient();
+    await overlappingClient;
+    await instance.callApi('Shared prompt');
+
+    vi.mocked(WatsonXAI.newInstance).mockReturnValue(firstClient as any);
+    const replay = await provider(chat).callApi('Shared prompt');
+    expect(replay).toMatchObject({ cached: true, output: 'Hello' });
+    expect(replay.cost).toBeCloseTo((30 * 0.106) / 1e6, 12);
+    expect(chat ? secondClient.textChat : secondClient.generateText).not.toHaveBeenCalled();
+  });
+
+  it('shares a metadata refresh after the successful entry expires', async () => {
+    vi.useFakeTimers();
+    const regionalClient = client();
+    vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+    const instance = provider(chat);
+    await instance.callApi('Initial');
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    const lookup = deferred<ReturnType<typeof metadata>>();
+    const started = deferred<void>();
+    regionalClient.listFoundationModelSpecs.mockImplementation(() => {
+      started.resolve();
+      return lookup.promise;
+    });
+    const pending = Promise.all(
+      ['First', 'Second', 'Third'].map((prompt) => instance.callApi(prompt)),
+    );
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(0);
+    lookup.resolve(metadata('class_9', 'class_9'));
+    const results = await pending;
+
+    expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(2);
+    for (const result of results) {
+      expect(result.cost).toBeCloseTo((30 * 0.371) / 1e6, 12);
+    }
+    await instance.callApi('Still fresh');
+    expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each(['failure', 'timeout'])(
+    'releases all shared metadata waiters after %s and permits recovery',
+    async (failure) => {
+      vi.useFakeTimers();
+      vi.stubEnv('REQUEST_TIMEOUT_MS', '50');
+      const regionalClient = client();
+      const lookup = deferred<ReturnType<typeof metadata>>();
+      const started = deferred<void>();
+      regionalClient.listFoundationModelSpecs.mockImplementation(() => {
+        started.resolve();
+        return lookup.promise;
+      });
+      vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+      const instance = provider(chat);
+      await instance.getClient();
+      const pending = Promise.all(
+        ['First', 'Second', 'Third'].map((prompt) => instance.callApi(prompt)),
+      );
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(0);
+      const signal = regionalClient.listFoundationModelSpecs.mock.calls[0][0].signal;
+      if (failure === 'timeout') {
+        await vi.advanceTimersByTimeAsync(50);
+      } else {
+        lookup.reject(new Error('Metadata unavailable'));
+      }
+      const results = await pending;
+
+      expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+      expect(signal.aborted).toBe(failure === 'timeout');
+      for (const result of results) {
+        expect(result.output).toBe('Hello');
+        expect(result.error).toBeUndefined();
+        expect(result.cost).toBeUndefined();
+      }
+      expect(vi.getTimerCount()).toBe(0);
+
+      regionalClient.listFoundationModelSpecs.mockResolvedValue(metadata());
+      const recovered = await instance.callApi('Recovered');
+      expect(recovered.cost).toBeCloseTo((10 * 0.106 + 20 * 0.371) / 1e6, 12);
+      if (failure === 'timeout') {
+        lookup.resolve(metadata('class_1', 'class_1'));
+        expect((await instance.callApi('After late response')).cost).toBe(recovered.cost);
+      }
+      expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
   it('uses the generation client and effective model ID for authenticated regional metadata', async () => {
     const regionalClient = client();
     vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
@@ -263,6 +486,95 @@ describe.each([false, true])('WatsonX regional cost (chat=%s)', (chat) => {
     );
   });
 
+  it.each([
+    {
+      name: 'unknown output tier',
+      input: 10,
+      output: 0,
+      inputTier: 'class_c1',
+      outputTier: 'unknown',
+      expected: (10 * 0.106) / 1e6,
+    },
+    {
+      name: 'missing output tier',
+      input: 10,
+      output: 0,
+      inputTier: 'class_c1',
+      outputTier: null,
+      expected: (10 * 0.106) / 1e6,
+    },
+    {
+      name: 'unknown input tier',
+      input: 0,
+      output: 20,
+      inputTier: 'unknown',
+      outputTier: 'class_9',
+      expected: (20 * 0.371) / 1e6,
+    },
+    {
+      name: 'missing input tier',
+      input: 0,
+      output: 20,
+      inputTier: null,
+      outputTier: 'class_9',
+      expected: (20 * 0.371) / 1e6,
+    },
+  ])(
+    'ignores an unused $name for reported zero tokens',
+    async ({ input, output, inputTier, outputTier, expected }) => {
+      const regionalClient = client(inputTier, outputTier);
+      setTokenCounts(regionalClient, input, output);
+      vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+      const result = await provider(chat).callApi('Hello');
+
+      expect(result.output).toBe('Hello');
+      expect(result.error).toBeUndefined();
+      expect(result.cost).toBeCloseTo(expected, 12);
+      expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    { name: 'input override', input: 10, output: 0, config: { inputCost: 0.01 }, expected: 0.1 },
+    { name: 'output override', input: 0, output: 20, config: { outputCost: 0.02 }, expected: 0.4 },
+    { name: 'both counts zero', input: 0, output: 0, config: {}, expected: 0 },
+  ])(
+    'skips metadata when $name supplies every required price',
+    async ({ input, output, config, expected }) => {
+      const regionalClient = client('unknown', 'unknown');
+      setTokenCounts(regionalClient, input, output);
+      vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+      const result = await provider(chat, config).callApi('Hello');
+
+      expect(result.output).toBe('Hello');
+      expect(result.error).toBeUndefined();
+      expect(result.cost).toBeCloseTo(expected, 12);
+      expect(regionalClient.listFoundationModelSpecs).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { name: 'missing input', input: undefined, output: 0 },
+    { name: 'missing output', input: 0, output: undefined },
+    { name: 'negative input', input: -1, output: 0 },
+    { name: 'negative output', input: 0, output: -1 },
+    { name: 'NaN input', input: Number.NaN, output: 0 },
+    { name: 'NaN output', input: 0, output: Number.NaN },
+    { name: 'infinite input', input: Number.POSITIVE_INFINITY, output: 0 },
+    { name: 'infinite output', input: 0, output: Number.POSITIVE_INFINITY },
+  ])(
+    'keeps cost unknown for $name despite a reported zero counterpart',
+    async ({ input, output }) => {
+      const regionalClient = client();
+      setTokenCounts(regionalClient, input, output);
+      vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+      const result = await provider(chat, { cost: 0.01 }).callApi('Hello');
+
+      expect(result.cost).toBeUndefined();
+      expect(regionalClient.listFoundationModelSpecs).not.toHaveBeenCalled();
+    },
+  );
+
   it('does not replay old cached responses with fabricated zero costs', async () => {
     const regionalClient = client('unknown', 'unknown');
     vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
@@ -284,36 +596,443 @@ describe.each([false, true])('WatsonX regional cost (chat=%s)', (chat) => {
   });
 });
 
+describe.each([false, true])('WatsonX caller cancellation (chat=%s)', (chat) => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv('REQUEST_TIMEOUT_MS', '50');
+    vi.mocked(isCacheEnabled).mockReturnValue(true);
+  });
+
+  it('rejects pre-aborted calls before initializing the SDK or reading the response cache', async () => {
+    const regionalClient = client();
+    vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+    const controller = new AbortController();
+    controller.abort(new Error('Caller network timeout'));
+    const cache = getCache();
+    const observed = provider(chat)
+      .callApi('Never dispatched', undefined, { abortSignal: controller.signal })
+      .catch((error) => error);
+
+    try {
+      await expectCallerAbort(observed);
+      expect(WatsonXAI.newInstance).not.toHaveBeenCalled();
+      expect(regionalClient.generateText).not.toHaveBeenCalled();
+      expect(regionalClient.textChat).not.toHaveBeenCalled();
+      expect(regionalClient.listFoundationModelSpecs).not.toHaveBeenCalled();
+      expect(cache.get).not.toHaveBeenCalled();
+      expect(cache.set).not.toHaveBeenCalled();
+      expect(getEventListeners(controller.signal, 'abort')).toEqual([]);
+    } finally {
+      await observed;
+    }
+  });
+
+  it('detaches during shared client initialization while a surviving caller completes', async () => {
+    const regionalClient = client();
+    vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+    const instance = provider(chat);
+    const originalGetAuth = instance.getAuth.bind(instance);
+    const started = deferred<void>();
+    const release = deferred<void>();
+    const auth = vi.spyOn(instance, 'getAuth').mockImplementation(async () => {
+      const authenticator = await originalGetAuth();
+      started.resolve();
+      await release.promise;
+      return authenticator;
+    });
+    const canceled = new AbortController();
+    const surviving = new AbortController();
+    const cache = getCache();
+    const observed = instance
+      .callApi('Canceled', undefined, { abortSignal: canceled.signal })
+      .catch((error) => error);
+    const survivor = instance.callApi('Survivor', undefined, { abortSignal: surviving.signal });
+    try {
+      await started.promise;
+      canceled.abort();
+      await expectCallerAbort(observed);
+      expect(WatsonXAI.newInstance).not.toHaveBeenCalled();
+      expect(regionalClient.generateText).not.toHaveBeenCalled();
+      expect(regionalClient.textChat).not.toHaveBeenCalled();
+      expect(cache.set).not.toHaveBeenCalled();
+
+      release.resolve();
+      expect((await survivor).output).toBe('Hello');
+      expect(auth).toHaveBeenCalledTimes(1);
+      expect(WatsonXAI.newInstance).toHaveBeenCalledTimes(1);
+      expect(chat ? regionalClient.textChat : regionalClient.generateText).toHaveBeenCalledTimes(1);
+      expect(cache.set).toHaveBeenCalledTimes(1);
+      expect(surviving.signal.aborted).toBe(false);
+      expect(getEventListeners(canceled.signal, 'abort')).toEqual([]);
+      expect(getEventListeners(surviving.signal, 'abort')).toEqual([]);
+    } finally {
+      release.resolve();
+      await Promise.allSettled([observed, survivor]);
+    }
+  });
+
+  it.each(['late success', 'late failure', 'SDK cancellation'])(
+    'detaches from pending SDK work and ignores %s',
+    async (settlement) => {
+      const regionalClient = client();
+      const generation = chat ? regionalClient.textChat : regionalClient.generateText;
+      const response = chat ? chatResult : textResult;
+      const started = deferred<void>();
+      const held = deferred<unknown>();
+      generation.mockImplementation(({ signal }: { signal?: AbortSignal }) => {
+        started.resolve();
+        if (settlement === 'SDK cancellation') {
+          signal?.addEventListener(
+            'abort',
+            () => held.reject(new Error('Network timeout: SDK request canceled')),
+            { once: true },
+          );
+        }
+        return held.promise;
+      });
+      vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+      const instance = provider(chat);
+      expect(await instance.getClient()).toBe(regionalClient);
+      const controller = new AbortController();
+      const cache = getCache();
+      const observed = instance
+        .callApi('Canceled SDK call', undefined, { abortSignal: controller.signal })
+        .catch((error) => error);
+      try {
+        await started.promise;
+        controller.abort(new Error('Caller network timeout'));
+        await expectCallerAbort(observed);
+        expect(generation).toHaveBeenCalledWith(
+          expect.objectContaining({ signal: controller.signal }),
+        );
+        expect(regionalClient.listFoundationModelSpecs).not.toHaveBeenCalled();
+        expect(cache.set).not.toHaveBeenCalled();
+
+        if (settlement === 'late failure') {
+          held.reject(new Error('Late SDK failure'));
+        } else if (settlement === 'late success') {
+          held.resolve(response);
+        }
+        await vi.advanceTimersByTimeAsync(0);
+        expect(regionalClient.listFoundationModelSpecs).not.toHaveBeenCalled();
+        expect(cache.set).not.toHaveBeenCalled();
+        expect(getEventListeners(controller.signal, 'abort')).toEqual([]);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        held.resolve(response);
+        await observed;
+        await vi.advanceTimersByTimeAsync(0);
+      }
+    },
+  );
+
+  it('cancels one metadata waiter while preserving the survivor and shared cached prices', async () => {
+    const regionalClient = client();
+    const lookup = deferred<ReturnType<typeof metadata>>();
+    const started = deferred<void>();
+    regionalClient.listFoundationModelSpecs.mockImplementation(() => {
+      started.resolve();
+      return lookup.promise;
+    });
+    vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+    const instance = provider(chat);
+    expect(await instance.getClient()).toBe(regionalClient);
+    const canceled = new AbortController();
+    const surviving = new AbortController();
+    const cache = getCache();
+    const observed = instance
+      .callApi('Canceled', undefined, { abortSignal: canceled.signal })
+      .catch((error) => error);
+    const survivor = instance.callApi('Survivor', undefined, { abortSignal: surviving.signal });
+    try {
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(0);
+      canceled.abort();
+      await expectCallerAbort(observed);
+      const metadataSignal = regionalClient.listFoundationModelSpecs.mock.calls[0][0].signal;
+      expect(metadataSignal).not.toBe(canceled.signal);
+      expect(metadataSignal).not.toBe(surviving.signal);
+      expect(metadataSignal.aborted).toBe(false);
+      expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+      expect(cache.set).not.toHaveBeenCalled();
+
+      lookup.resolve(metadata());
+      const result = await survivor;
+      expect(result.output).toBe('Hello');
+      expect(result.cost).toBeCloseTo((10 * 0.106 + 20 * 0.371) / 1e6, 12);
+      expect(cache.set).toHaveBeenCalledTimes(1);
+      expect((await instance.callApi('Future caller')).cost).toBe(result.cost);
+      expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
+      expect(surviving.signal.aborted).toBe(false);
+      expect(getEventListeners(canceled.signal, 'abort')).toEqual([]);
+      expect(getEventListeners(surviving.signal, 'abort')).toEqual([]);
+    } finally {
+      lookup.resolve(metadata());
+      await Promise.allSettled([observed, survivor]);
+    }
+  });
+
+  it.each(['success', 'deadline'])(
+    'preserves the shared metadata %s after every caller cancels',
+    async (settlement) => {
+      const regionalClient = client();
+      const lookup = deferred<ReturnType<typeof metadata>>();
+      const started = deferred<void>();
+      regionalClient.listFoundationModelSpecs.mockImplementation(() => {
+        started.resolve();
+        return lookup.promise;
+      });
+      vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+      const instance = provider(chat);
+      expect(await instance.getClient()).toBe(regionalClient);
+      const controllers = [new AbortController(), new AbortController()];
+      const cache = getCache();
+      const observed = controllers.map((controller, index) =>
+        instance
+          .callApi(`Canceled ${index}`, undefined, { abortSignal: controller.signal })
+          .catch((error) => error),
+      );
+      try {
+        await started.promise;
+        await vi.advanceTimersByTimeAsync(0);
+        controllers.forEach((controller) => controller.abort());
+        for (const result of observed) {
+          await expectCallerAbort(result);
+        }
+        const metadataSignal = regionalClient.listFoundationModelSpecs.mock.calls[0][0].signal;
+        expect(metadataSignal.aborted).toBe(false);
+        expect(vi.getTimerCount()).toBe(1);
+        expect(cache.set).not.toHaveBeenCalled();
+
+        if (settlement === 'success') {
+          lookup.resolve(metadata());
+          await vi.advanceTimersByTimeAsync(0);
+        } else {
+          await vi.advanceTimersByTimeAsync(50);
+          regionalClient.listFoundationModelSpecs.mockResolvedValue(metadata());
+        }
+        expect(metadataSignal.aborted).toBe(settlement === 'deadline');
+        expect(vi.getTimerCount()).toBe(0);
+        expect(cache.set).not.toHaveBeenCalled();
+        const future = await instance.callApi('Future caller');
+        expect(future.cost).toBeCloseTo((10 * 0.106 + 20 * 0.371) / 1e6, 12);
+        expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(
+          settlement === 'success' ? 1 : 2,
+        );
+        for (const controller of controllers) {
+          expect(getEventListeners(controller.signal, 'abort')).toEqual([]);
+        }
+      } finally {
+        lookup.resolve(metadata());
+        await Promise.allSettled(observed);
+        await vi.advanceTimersByTimeAsync(0);
+      }
+    },
+  );
+
+  it.each([false, true])(
+    'detaches from a held response-cache read without continuing after abort (hit=%s)',
+    async (hit) => {
+      const regionalClient = client();
+      vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+      const instance = provider(chat);
+      expect(await instance.getClient()).toBe(regionalClient);
+      const read = deferred<string | undefined>();
+      const started = deferred<void>();
+      const cache = {
+        get: vi.fn(() => {
+          started.resolve();
+          return read.promise;
+        }),
+        set: vi.fn(),
+      };
+      vi.mocked(getCache).mockReturnValue(cache as any);
+      const controller = new AbortController();
+      const observed = instance
+        .callApi('Held cache read', undefined, { abortSignal: controller.signal })
+        .catch((error) => error);
+      const cached = hit ? JSON.stringify({ output: 'Cached response', cost: 0.25 }) : undefined;
+      try {
+        await started.promise;
+        controller.abort();
+        await expectCallerAbort(observed);
+        read.resolve(cached);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(regionalClient.generateText).not.toHaveBeenCalled();
+        expect(regionalClient.textChat).not.toHaveBeenCalled();
+        expect(regionalClient.listFoundationModelSpecs).not.toHaveBeenCalled();
+        expect(cache.set).not.toHaveBeenCalled();
+        expect(getEventListeners(controller.signal, 'abort')).toEqual([]);
+      } finally {
+        read.resolve(cached);
+        await observed;
+      }
+    },
+  );
+
+  it('does not write a response when cancellation wins as pricing completes', async () => {
+    const regionalClient = client();
+    const lookup = deferred<ReturnType<typeof metadata>>();
+    const started = deferred<void>();
+    regionalClient.listFoundationModelSpecs.mockImplementation(() => {
+      started.resolve();
+      return lookup.promise;
+    });
+    vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+    const instance = provider(chat);
+    expect(await instance.getClient()).toBe(regionalClient);
+    const controller = new AbortController();
+    const cache = getCache();
+    const observed = instance
+      .callApi('Canceled before cache write', undefined, { abortSignal: controller.signal })
+      .catch((error) => error);
+    try {
+      await started.promise;
+      lookup.resolve(metadata());
+      controller.abort();
+      await expectCallerAbort(observed);
+      expect(cache.set).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+      expect(getEventListeners(controller.signal, 'abort')).toEqual([]);
+    } finally {
+      lookup.resolve(metadata());
+      await observed;
+    }
+  });
+
+  it.each([false, true])(
+    'removes caller listeners after ordinary settlement (failure=%s)',
+    async (fails) => {
+      const regionalClient = client();
+      if (fails) {
+        (chat ? regionalClient.textChat : regionalClient.generateText).mockRejectedValueOnce(
+          new Error('Generation unavailable'),
+        );
+      }
+      vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+      const controller = new AbortController();
+      const result = await provider(chat).callApi('Ordinary call', undefined, {
+        abortSignal: controller.signal,
+      });
+      if (fails) {
+        expect(result.error).toContain('Generation unavailable');
+      } else {
+        expect(result.output).toBe('Hello');
+        expect(result.cost).toBeDefined();
+      }
+      expect(controller.signal.aborted).toBe(false);
+      expect(getEventListeners(controller.signal, 'abort')).toEqual([]);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+});
+
 describe('WatsonX metadata cache boundaries', () => {
   it.each([
     ['different regions', { serviceUrl: 'https://jp-tok.ml.cloud.ibm.com' }],
     ['different accounts in the same region', { apiBearerToken: 'other-account-token' }],
     ['different API versions', { version: '2025-01-01' }],
   ])('isolates %s', async (_name, config) => {
+    vi.useFakeTimers();
     const firstClient = client('class_c1', 'class_c1');
     const secondClient = client('class_9', 'class_9');
+    const firstLookup = deferred<ReturnType<typeof metadata>>();
+    const secondLookup = deferred<ReturnType<typeof metadata>>();
+    const firstStarted = deferred<void>();
+    const secondStarted = deferred<void>();
+    firstClient.listFoundationModelSpecs.mockImplementation(() => {
+      firstStarted.resolve();
+      return firstLookup.promise;
+    });
+    secondClient.listFoundationModelSpecs.mockImplementation(() => {
+      secondStarted.resolve();
+      return secondLookup.promise;
+    });
     vi.mocked(WatsonXAI.newInstance)
       .mockReturnValueOnce(firstClient as any)
       .mockReturnValueOnce(secondClient as any);
     const first = provider();
     const second = provider(false, config);
-    expect((await first.callApi('Hello')).cost).toBeCloseTo((30 * 0.106) / 1e6, 12);
-    expect((await second.callApi('Hello')).cost).toBeCloseTo((30 * 0.371) / 1e6, 12);
+    expect(await first.getClient()).toBe(firstClient);
+    expect(await second.getClient()).toBe(secondClient);
+    const pending = Promise.all([first.callApi('Hello'), second.callApi('Hello')]);
+    await Promise.all([firstStarted.promise, secondStarted.promise]);
+    firstLookup.resolve(metadata('class_c1', 'class_c1'));
+    secondLookup.resolve(metadata('class_9', 'class_9'));
+    const [firstResult, secondResult] = await pending;
+    expect(firstResult.error).toBeUndefined();
+    expect(secondResult.error).toBeUndefined();
+    expect(firstResult.cost).toBeCloseTo((30 * 0.106) / 1e6, 12);
+    expect(secondResult.cost).toBeCloseTo((30 * 0.371) / 1e6, 12);
     await first.callApi('Again');
     expect(firstClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
     expect(secondClient.listFoundationModelSpecs).toHaveBeenCalledTimes(1);
   });
 
-  it('refreshes expired metadata', async () => {
-    const now = vi.spyOn(Date, 'now').mockReturnValue(1000);
+  it('isolates simultaneous metadata lookups for different models on one client', async () => {
+    vi.useFakeTimers();
+    const otherModelId = 'account/other-model';
     const regionalClient = client();
+    const firstLookup = deferred<ReturnType<typeof metadata>>();
+    const secondLookup = deferred<ReturnType<typeof metadata>>();
+    const firstStarted = deferred<void>();
+    const secondStarted = deferred<void>();
+    regionalClient.listFoundationModelSpecs.mockImplementation(
+      ({ filters }: { filters: string }) => {
+        if (filters === `modelid_${modelId}`) {
+          firstStarted.resolve();
+          return firstLookup.promise;
+        }
+        secondStarted.resolve();
+        return secondLookup.promise;
+      },
+    );
+    vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+    const first = provider();
+    const second = provider(false, { modelId: otherModelId });
+    expect(await first.getClient()).toBe(regionalClient);
+    expect(await second.getClient()).toBe(regionalClient);
+    const pending = Promise.all([first.callApi('First'), second.callApi('Second')]);
+    await Promise.all([firstStarted.promise, secondStarted.promise]);
+    firstLookup.resolve(metadata('class_c1', 'class_c1'));
+    secondLookup.resolve(metadata('class_9', 'class_9', otherModelId));
+    const [firstResult, secondResult] = await pending;
+    expect(firstResult.error).toBeUndefined();
+    expect(secondResult.error).toBeUndefined();
+    expect(firstResult.cost).toBeCloseTo((30 * 0.106) / 1e6, 12);
+    expect(secondResult.cost).toBeCloseTo((30 * 0.371) / 1e6, 12);
+    expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledWith({
+      filters: `modelid_${otherModelId}`,
+      signal: expect.any(AbortSignal),
+    });
+    await Promise.all([first.callApi('First again'), second.callApi('Second again')]);
+    expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let a pending lookup repopulate a cleared metadata cache', async () => {
+    vi.useFakeTimers();
+    const regionalClient = client();
+    const oldLookup = deferred<ReturnType<typeof metadata>>();
+    const started = deferred<void>();
+    regionalClient.listFoundationModelSpecs.mockImplementationOnce(() => {
+      started.resolve();
+      return oldLookup.promise;
+    });
     vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
     const instance = provider();
-    await instance.callApi('First');
-    now.mockReturnValue(1000 + 5 * 60 * 1000);
+    const pending = instance.callApi('Before clearing metadata');
+    await started.promise;
+    clearModelSpecsCache();
+
     regionalClient.listFoundationModelSpecs.mockResolvedValue(metadata('class_9', 'class_9'));
-    expect((await instance.callApi('Second')).cost).toBeCloseTo((30 * 0.371) / 1e6, 12);
+    const fresh = await instance.callApi('After clearing metadata');
+    expect(fresh.cost).toBeCloseTo((30 * 0.371) / 1e6, 12);
+    oldLookup.resolve(metadata('class_1', 'class_1'));
+    expect((await pending).cost).toBeCloseTo((30 * 0.636) / 1e6, 12);
+
+    expect((await instance.callApi('After old lookup settles')).cost).toBe(fresh.cost);
     expect(regionalClient.listFoundationModelSpecs).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it.each([

--- a/test/providers/watsonx-cost.test.ts
+++ b/test/providers/watsonx-cost.test.ts
@@ -8,6 +8,7 @@ import {
   WatsonXChatProvider,
   WatsonXProvider,
 } from '../../src/providers/watsonx';
+import { createEmptyTokenUsage } from '../../src/util/tokenUsageUtils';
 
 vi.mock('@ibm-cloud/watsonx-ai', () => ({ WatsonXAI: { newInstance: vi.fn() } }));
 vi.mock('../../src/envars', async (importOriginal) => ({
@@ -83,10 +84,11 @@ function deferred<T>() {
 }
 
 async function expectCallerAbort(observed: Promise<unknown>) {
-  const stillPending = new Promise<undefined>((resolve) => setTimeout(resolve, 1));
-  const outcome = Promise.race([observed, stillPending]);
-  await vi.advanceTimersByTimeAsync(1);
-  const error = await outcome;
+  const onSettled = vi.fn();
+  void observed.then(onSettled);
+  await vi.advanceTimersByTimeAsync(0);
+  expect(onSettled).toHaveBeenCalledTimes(1);
+  const error = onSettled.mock.calls[0][0];
   expect(error).toBeInstanceOf(Error);
   expect(error).toMatchObject({ name: 'AbortError', message: expect.stringMatching(/abort/i) });
   expect(error).not.toHaveProperty('message', expect.stringMatching(/timeout|network/i));
@@ -602,6 +604,40 @@ describe.each([false, true])('WatsonX caller cancellation (chat=%s)', (chat) => 
     vi.stubEnv('REQUEST_TIMEOUT_MS', '50');
     vi.mocked(isCacheEnabled).mockReturnValue(true);
   });
+
+  it.each([false, true])(
+    'returns SDK AbortErrors as ordinary failures when the caller did not cancel (signal=%s)',
+    async (withSignal) => {
+      const regionalClient = client();
+      const generation = chat ? regionalClient.textChat : regionalClient.generateText;
+      const sdkError = Object.assign(new Error('SDK request timed out'), { name: 'AbortError' });
+      generation.mockRejectedValueOnce(sdkError);
+      vi.mocked(WatsonXAI.newInstance).mockReturnValue(regionalClient as any);
+      const signal = withSignal ? new AbortController().signal : undefined;
+      const cache = getCache();
+
+      await expect(
+        provider(chat).callApi(
+          'SDK failure',
+          undefined,
+          signal ? { abortSignal: signal } : undefined,
+        ),
+      ).resolves.toEqual({
+        error: 'API call error: AbortError: SDK request timed out',
+        output: '',
+        tokenUsage: createEmptyTokenUsage(),
+      });
+      expect(generation).toHaveBeenCalledTimes(1);
+      expect(generation.mock.calls[0][0].signal).toBe(signal);
+      expect(regionalClient.listFoundationModelSpecs).not.toHaveBeenCalled();
+      expect(cache.set).not.toHaveBeenCalled();
+      if (signal) {
+        expect(signal.aborted).toBe(false);
+        expect(getEventListeners(signal, 'abort')).toEqual([]);
+      }
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
 
   it('rejects pre-aborted calls before initializing the SDK or reading the response cache', async () => {
     const regionalClient = client();


### PR DESCRIPTION
Concurrent WatsonX calls now share client initialization and pricing metadata lookups. Canceling one caller releases its wait and cancels its generation request while other callers can finish. SDK abort errors unrelated to caller cancellation retain the normal provider error response.

Cached output keeps its original unknown cost on replay; a later uncached generation can retry unavailable pricing metadata. Zero-token categories no longer require unused pricing rates. This follows up #10802.

## Validation

- 301 affected tests across four suites passed, including test hygiene and four non-caller SDK abort regressions. Timer-dependent synchronization was replaced with a deterministic barrier.
- Root and app type checks, architecture checks, core and UI builds, postbuild, lint/format, and normal hooks passed.
- 22 actual IBM SDK loopback CLI cases passed, covering generation, metadata lookup/cancellation, and cache behavior. Exported successes and expected errors were inspected.
- Local checks used a qualified existing dependency tree because Socket blocks the locked Joi package. No vendor inference or live pricing calls were made.
