### PR TITLE
chore(examples): compare GPT-5.6 models

### DIFF
--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -7,7 +7,7 @@ npx promptfoo@latest init --example getting-started
 cd getting-started
 ```
 
-This is a simple example that demonstrates the basic functionality of promptfoo. It tests two different translation prompts across multiple language models.
+This is a simple example that demonstrates the basic functionality of promptfoo. It tests a translation prompt across two language models.
 
 ## Setup
 
@@ -29,9 +29,11 @@ promptfoo eval
 
 This example:
 
-- Tests two different ways to phrase a translation prompt
-- Compares outputs between GPT-5.2 and GPT-5 Mini
+- Tests a translation prompt with different inputs
+- Compares outputs between GPT-6 Astra and GPT-5.6 Luna using the OpenAI Responses API
 - Uses two test cases with different languages and inputs
+
+The config also includes commented-out alternatives for Claude Sonnet 5 and Gemini 3.8 Flash. To use them, set `ANTHROPIC_API_KEY` or `GOOGLE_API_KEY`, respectively, and uncomment the provider.
 
 The configuration in `promptfooconfig.yaml` shows:
 

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -30,7 +30,7 @@ promptfoo eval
 This example:
 
 - Tests a translation prompt with different inputs
-- Compares outputs between GPT-6 Astra and GPT-5.6 Luna using the OpenAI Responses API
+- Compares outputs between GPT-5.6 Sol and GPT-5.6 Luna using the OpenAI Responses API
 - Uses two test cases with different languages and inputs
 
 The config also includes commented-out alternatives for Claude Sonnet 5 and Gemini 3.8 Flash. To use them, set `ANTHROPIC_API_KEY` or `GOOGLE_API_KEY`, respectively, and uncomment the provider.

--- a/examples/getting-started/promptfooconfig.yaml
+++ b/examples/getting-started/promptfooconfig.yaml
@@ -8,7 +8,7 @@ prompts:
   - 'Convert the following English text to {{language}}: {{input}}'
 
 providers:
-  - openai:responses:gpt-6-astra
+  - openai:responses:gpt-5.6-sol
   - openai:responses:gpt-5.6-luna
   # Or set up models from other providers
   # - anthropic:messages:claude-sonnet-5

--- a/examples/getting-started/promptfooconfig.yaml
+++ b/examples/getting-started/promptfooconfig.yaml
@@ -8,11 +8,11 @@ prompts:
   - 'Convert the following English text to {{language}}: {{input}}'
 
 providers:
-  - openai:chat:gpt-5.5
-  - openai:chat:gpt-5.4-mini
-  # Or setup models from other providers
-  # - anthropic:messages:claude-sonnet-4-6
-  # - google:gemini-3.1-pro-preview
+  - openai:responses:gpt-6-astra
+  - openai:responses:gpt-5.6-luna
+  # Or set up models from other providers
+  # - anthropic:messages:claude-sonnet-5
+  # - google:gemini-3.8-flash
 
 tests:
   - vars:


### PR DESCRIPTION
## Summary

Update the getting-started example to compare GPT-5.6 Sol and GPT-5.6 Luna through the OpenAI Responses API. Refresh the optional providers to Claude Sonnet 5 and Gemini 3.8 Flash, and align the README with the configured models, single translation prompt, and required API keys.

## Validation

Tests were not run for the updated Sol/Luna comparison, as requested.
