### PR TITLE
fix(providers): update OpenAI models and defaults

### DIFF
--- a/examples/compare-openai-models/README.md
+++ b/examples/compare-openai-models/README.md
@@ -1,6 +1,6 @@
 # compare-openai-models (OpenAI Model Comparison)
 
-This example compares OpenAI's `gpt-5.4` with `gpt-5.4-mini` across various riddles and reasoning tasks.
+This example compares `gpt-5.6-luna`, `gpt-5.6-terra`, `gpt-5.6-sol`, and `gpt-6-astra` on riddles with the same `low` reasoning effort. Astra requires model access on your OpenAI account.
 
 You can run this example with:
 
@@ -49,13 +49,13 @@ cd compare-openai-models
    npx promptfoo@latest view
    ```
 
-   The expected output will include the responses from both models for the provided riddles, allowing you to compare their performance side by side.
+   The expected output will include the responses from all four models for the provided riddles, allowing you to compare their performance side by side.
 
 ## What this example demonstrates
 
-This example compares OpenAI's GPT-5.4 with GPT-5.4 Mini across various riddles and puzzles. It demonstrates:
+This example compares Luna, Terra, Sol, and Astra across various riddles and puzzles. It demonstrates:
 
-- **Model comparison**: Side-by-side evaluation of `gpt-5.4` vs `gpt-5.4-mini`
+- **Model comparison**: Side-by-side evaluation of Luna, Terra, Sol, and Astra
 - **Cost and latency assertions**: Ensuring responses meet performance thresholds
 - **Content validation**: Using `contains` assertions to verify specific answers
 - **LLM-based grading**: Using `llm-rubric` assertions for nuanced evaluation criteria

--- a/examples/compare-openai-models/promptfooconfig.yaml
+++ b/examples/compare-openai-models/promptfooconfig.yaml
@@ -1,21 +1,39 @@
 # yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
-description: Comparing OpenAI flagship models performance on riddles
+description: Comparing current OpenAI models on riddles
 
 prompts:
   - 'Solve this riddle: {{riddle}}'
 
 providers:
-  - openai:chat:gpt-5.4
-  - openai:chat:gpt-5.4-mini
+  - id: openai:responses:gpt-5.6-luna
+    config:
+      reasoning:
+        effort: low
+      max_output_tokens: 2048
+  - id: openai:responses:gpt-5.6-terra
+    config:
+      reasoning:
+        effort: low
+      max_output_tokens: 2048
+  - id: openai:responses:gpt-5.6-sol
+    config:
+      reasoning:
+        effort: low
+      max_output_tokens: 2048
+  - id: openai:responses:gpt-6-astra
+    config:
+      reasoning:
+        effort: low
+      max_output_tokens: 2048
 
 defaultTest:
   assert:
-    # Inference should always cost less than this (USD)
+    # Example per-response budget (USD)
     - type: cost
-      threshold: 0.01
-    # Inference should always be faster than this (milliseconds)
+      threshold: 0.15
+    # Example per-response latency budget (milliseconds)
     - type: latency
-      threshold: 10000
+      threshold: 60000
 
 tests:
   - vars:

--- a/examples/openai-agents-advanced/agents/support-agent.ts
+++ b/examples/openai-agents-advanced/agents/support-agent.ts
@@ -2,7 +2,7 @@ import { Agent } from '@openai/agents';
 
 export default new Agent({
   name: 'Support Agent',
-  model: 'gpt-5-mini',
+  model: 'gpt-5.6-luna',
   instructions: `You are a concise support agent.
 
 - Remember short code words the user gives you.

--- a/examples/openai-agents-advanced/agents/workspace-agent.ts
+++ b/examples/openai-agents-advanced/agents/workspace-agent.ts
@@ -6,7 +6,7 @@ const taskFilePath = fileURLToPath(new URL('../workspace/task.md', import.meta.u
 
 export default new SandboxAgent({
   name: 'Workspace Reviewer',
-  model: 'gpt-5-mini',
+  model: 'gpt-5.6-luna',
   modelSettings: {
     toolChoice: 'required',
   },

--- a/examples/openai-agents-basic/README.md
+++ b/examples/openai-agents-basic/README.md
@@ -107,7 +107,7 @@ export default new Agent({
   - Use check_inventory to see what items, equipment, and gold players have
   - Use check_character_stats to view player abilities, HP, AC, and level
   - Use describe_scene to paint vivid, atmospheric pictures of locations`,
-  model: 'gpt-5-mini',
+  model: 'gpt-5.6-luna',
   tools: gameTools,
 });
 ```

--- a/examples/openai-agents-basic/agents/dungeon-master-agent.ts
+++ b/examples/openai-agents-basic/agents/dungeon-master-agent.ts
@@ -32,6 +32,6 @@ When combat occurs:
 
 Keep responses punchy but atmospheric. Always roll dice for uncertain outcomes.
 Reference character abilities and inventory items when relevant. Make every moment memorable!`,
-  model: 'gpt-5-mini',
+  model: 'gpt-5.6-luna',
   tools: gameTools,
 });

--- a/examples/openai-agents/README.md
+++ b/examples/openai-agents/README.md
@@ -13,6 +13,8 @@ It demonstrates:
 
 The tracing path is important: the example installs a custom OpenAI Agents tracing processor that exports the SDK's spans to Promptfoo's built-in OTLP receiver. That is what makes the trajectory assertions and trace visualization work inside Promptfoo. The bridge maps SDK custom spans, including `sandbox.*` lifecycle spans and experimental Codex command spans, into normal OTLP attributes, and Promptfoo normalizes OpenAI Agents `exec_command` tool spans as command trajectory steps. The config accepts both OTLP JSON and protobuf because the SDK bridge emits JSON while the optional Python wrapper span uses protobuf by default.
 
+The example uses `gpt-5.6-luna`. Set `config.model` or `OPENAI_AGENT_MODEL` to use Terra, Sol, or Astra for more demanding tasks.
+
 ## Files
 
 - `agent_provider.py`: the Promptfoo Python provider and agent graph

--- a/examples/openai-agents/agent_provider.py
+++ b/examples/openai-agents/agent_provider.py
@@ -42,7 +42,7 @@ from agents.sandbox.entries import File
 from agents.sandbox.sandboxes.unix_local import UnixLocalSandboxClient
 from promptfoo_tracing import configure_promptfoo_tracing
 
-DEFAULT_MODEL = os.getenv("OPENAI_AGENT_MODEL", "gpt-5.4-mini")
+DEFAULT_MODEL = os.getenv("OPENAI_AGENT_MODEL", "gpt-5.6-luna")
 SESSION_DB_PATH = Path(__file__).with_name(".promptfoo-openai-agents.sqlite3")
 EXAMPLE_DIR = Path(__file__).resolve().parent
 DISCOUNT_REVIEW_SKILL_DIR = EXAMPLE_DIR / "skills" / "discount-review"
@@ -477,7 +477,7 @@ def _build_agents(model: str) -> Agent[AirlineContext]:
     faq_agent = Agent[AirlineContext](
         name="FAQ Agent",
         model=model,
-        model_settings=ModelSettings(include_usage=True, temperature=0),
+        model_settings=ModelSettings(include_usage=True),
         instructions=(
             "You answer airline policy questions. "
             "Always call faq_lookup instead of using prior knowledge. "
@@ -491,7 +491,7 @@ def _build_agents(model: str) -> Agent[AirlineContext]:
     seat_agent = Agent[AirlineContext](
         name="Seat Booking Agent",
         model=model,
-        model_settings=ModelSettings(include_usage=True, temperature=0),
+        model_settings=ModelSettings(include_usage=True),
         instructions=(
             "You handle booking lookups and seat changes. "
             "If the conversation or shared context already includes a confirmation number, "
@@ -515,7 +515,7 @@ def _build_agents(model: str) -> Agent[AirlineContext]:
     triage_agent = Agent[AirlineContext](
         name="Triage Agent",
         model=model,
-        model_settings=ModelSettings(include_usage=True, temperature=0),
+        model_settings=ModelSettings(include_usage=True),
         instructions=(
             "You route each request to the best specialist. "
             "Use the FAQ Agent for airline policies and the Seat Booking Agent for "
@@ -681,7 +681,6 @@ def _build_sandbox_agent(model: str) -> SandboxAgent:
         default_manifest=_build_sandbox_manifest(),
         model_settings=ModelSettings(
             include_usage=True,
-            temperature=0,
             tool_choice="required",
         ),
     )
@@ -719,7 +718,6 @@ def _build_skill_agent(model: str) -> Agent[Any]:
         ],
         model_settings=ModelSettings(
             include_usage=True,
-            temperature=0,
             tool_choice="required",
         ),
     )

--- a/examples/openai-agents/promptfooconfig.redteam.coding.yaml
+++ b/examples/openai-agents/promptfooconfig.redteam.coding.yaml
@@ -8,7 +8,7 @@ targets:
   - id: file://agent_provider.py:call_sandbox_api
     label: sandbox-coding-agent-redteam
     config:
-      model: gpt-5.4-mini
+      model: gpt-5.6-luna
       max_turns: 10
       otlp_endpoint: http://localhost:4318
       return_transcript: false
@@ -32,7 +32,7 @@ defaultTest:
         max_count: 0
 
 redteam:
-  provider: openai:chat:gpt-5.4-mini
+  provider: openai:chat:gpt-5.6-luna
   injectVar: prompt
   numTests: 1
   maxConcurrency: 1

--- a/examples/openai-agents/promptfooconfig.redteam.yaml
+++ b/examples/openai-agents/promptfooconfig.redteam.yaml
@@ -8,7 +8,7 @@ targets:
   - id: file://agent_provider.py:call_api
     label: airline-agent-redteam
     config:
-      model: gpt-5.4-mini
+      model: gpt-5.6-luna
       max_turns: 12
       otlp_endpoint: http://localhost:4318
       return_transcript: false
@@ -36,7 +36,7 @@ defaultTest:
       value: faq_lookup
 
 redteam:
-  provider: openai:chat:gpt-5.4-mini
+  provider: openai:chat:gpt-5.6-luna
   injectVar: prompt
   numTests: 1
   maxConcurrency: 1

--- a/examples/openai-agents/promptfooconfig.yaml
+++ b/examples/openai-agents/promptfooconfig.yaml
@@ -8,19 +8,19 @@ providers:
   - id: file://agent_provider.py:call_api
     label: airline-workflow
     config:
-      model: gpt-5.4-mini
+      model: gpt-5.6-luna
       max_turns: 12
       otlp_endpoint: http://localhost:4318
   - id: file://agent_provider.py:call_sandbox_api
     label: sandbox-workflow
     config:
-      model: gpt-5.4-mini
+      model: gpt-5.6-luna
       max_turns: 8
       otlp_endpoint: http://localhost:4318
   - id: file://agent_provider.py:call_skill_api
     label: skill-workflow
     config:
-      model: gpt-5.4-mini
+      model: gpt-5.6-luna
       max_turns: 8
       otlp_endpoint: http://localhost:4318
 
@@ -98,7 +98,7 @@ tests:
         value:
           max_count: 0
       - type: trajectory:goal-success
-        provider: openai:chat:gpt-5.4-mini
+        provider: openai:chat:gpt-5.6-luna
         value: Move the passenger with confirmation ABC123 to seat 14C and answer the baggage policy question correctly.
 
   - description: FAQ-only request should not change the booking

--- a/examples/openai-chat-history/promptfooconfig.yaml
+++ b/examples/openai-chat-history/promptfooconfig.yaml
@@ -4,7 +4,7 @@ description: OpenAI chat with conversation history and context
 prompts:
   - file://prompt.json
 providers:
-  - openai:gpt-4.1-mini
+  - openai:chat:gpt-5.6-luna
 
 # Set up the conversation history
 defaultTest:

--- a/examples/openai-codex-app-server/approval-policy/promptfooconfig.yaml
+++ b/examples/openai-codex-app-server/approval-policy/promptfooconfig.yaml
@@ -8,7 +8,7 @@ prompts:
     Explain whether the command was allowed.
 
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       sandbox_mode: read-only
       approval_policy: on-request

--- a/examples/openai-codex-app-server/promptfooconfig.tracing.yaml
+++ b/examples/openai-codex-app-server/promptfooconfig.tracing.yaml
@@ -5,7 +5,7 @@ prompts:
   - 'Return a concise JSON summary of this workspace. Include the main purpose.'
 
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       sandbox_mode: read-only
       approval_policy: never

--- a/examples/openai-codex-app-server/promptfooconfig.yaml
+++ b/examples/openai-codex-app-server/promptfooconfig.yaml
@@ -5,7 +5,7 @@ prompts:
   - 'Return a concise JSON summary of this workspace. Include the main purpose and two likely maintenance risks.'
 
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       sandbox_mode: read-only
       approval_policy: never

--- a/examples/openai-codex-app-server/review-diff/promptfooconfig.yaml
+++ b/examples/openai-codex-app-server/review-diff/promptfooconfig.yaml
@@ -17,7 +17,7 @@ prompts:
     actionable comments, return an empty comments array.
 
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       sandbox_mode: read-only
       approval_policy: never

--- a/examples/openai-codex-app-server/skills/promptfooconfig.yaml
+++ b/examples/openai-codex-app-server/skills/promptfooconfig.yaml
@@ -5,7 +5,7 @@ prompts:
   - file://skill-input.json
 
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       sandbox_mode: read-only
       approval_policy: never

--- a/examples/openai-codex-sdk/skill-comparison/promptfooconfig.yaml
+++ b/examples/openai-codex-sdk/skill-comparison/promptfooconfig.yaml
@@ -39,7 +39,7 @@ x-review-schema: &reviewSchema
 # `working_dir` so v1/v2 read different `SKILL.md` files but everything else
 # (model, sandbox, schema) stays identical.
 x-codex-config: &codexConfig
-  model: gpt-5.5
+  model: gpt-5.6-sol
   skip_git_repo_check: true
   sandbox_mode: read-only
   enable_streaming: true

--- a/examples/openai-codex-sdk/skills/promptfooconfig.tracing.yaml
+++ b/examples/openai-codex-sdk/skills/promptfooconfig.tracing.yaml
@@ -7,7 +7,7 @@ prompts:
 providers:
   - id: openai:codex-sdk
     config:
-      model: gpt-5.2
+      model: gpt-5.6-terra
       # Relative working_dir values resolve from this config file's directory.
       # Codex resolves CODEX_HOME itself; set CODEX_HOME_OVERRIDE when running this config from another cwd.
       # sample-codex-home has no auth state; use an API key or point CODEX_HOME_OVERRIDE at ~/.codex.

--- a/examples/openai-codex-sdk/skills/promptfooconfig.yaml
+++ b/examples/openai-codex-sdk/skills/promptfooconfig.yaml
@@ -7,7 +7,7 @@ prompts:
 providers:
   - id: openai:codex-sdk
     config:
-      model: gpt-5.2
+      model: gpt-5.6-terra
       # Relative working_dir values resolve from this config file's directory.
       # Codex resolves CODEX_HOME itself; set CODEX_HOME_OVERRIDE when running this config from another cwd.
       # sample-codex-home has no auth state; use an API key or point CODEX_HOME_OVERRIDE at ~/.codex.

--- a/examples/openai-eval-factuality/promptfooconfig.yaml
+++ b/examples/openai-eval-factuality/promptfooconfig.yaml
@@ -5,7 +5,7 @@ prompts:
   - file://prompts/name_capitals_concise.txt
   - file://prompts/name_capitals_verbose.txt
 providers:
-  - openai:chat:gpt-5.4-mini
+  - openai:chat:gpt-5.6-luna
 tests:
   - vars:
       location: Sacramento

--- a/examples/openai-function-call/promptfooconfig.yaml
+++ b/examples/openai-function-call/promptfooconfig.yaml
@@ -5,13 +5,15 @@ prompts:
   - 'What is the weather like in {{city}}?'
 
 providers:
-  - id: 'openai:chat:gpt-4.1-mini'
+  - id: 'openai:chat:gpt-5.6-luna'
     label: 'functions-defined-in-external-file'
     config:
+      reasoning_effort: none
       functions: file://get_current_weather.yaml
-  - id: 'openai:chat:gpt-4.1-mini'
+  - id: 'openai:chat:gpt-5.6-luna'
     label: 'functions-defined-in-config'
     config:
+      reasoning_effort: none
       functions:
         [
           {

--- a/examples/openai-images/README.md
+++ b/examples/openai-images/README.md
@@ -7,7 +7,7 @@ npx promptfoo@latest init --example openai-images
 cd openai-images
 ```
 
-A simple example showing how to evaluate OpenAI's current image generation models (GPT Image 2, GPT Image 1.5, GPT Image 1, GPT Image 1 Mini) with promptfoo.
+Compare GPT Image 2.5 Flare and Sunburst with earlier OpenAI image models in promptfoo.
 
 ## Quick Start
 
@@ -27,7 +27,7 @@ promptfoo view
 
 ## What's in this Example
 
-- Compares GPT Image 2, GPT Image 1.5, GPT Image 1, and GPT Image 1 Mini outputs
+- Compares GPT Image 2.5 Flare and Sunburst with GPT Image 2, 1.5, 1, and 1 Mini
 - Uses text-to-image generation through the Image API generations endpoint
 - Tests artistic style prompts across different models
 - Configures different image sizes and quality settings
@@ -35,9 +35,29 @@ promptfoo view
 
 ## Supported Models
 
-### GPT Image 2 (Recommended)
+### GPT Image 2.5 Flare and Sunburst (Recommended)
 
-OpenAI's latest image generation model with flexible custom sizes and improved output controls.
+Use Flare for everyday image generation. Sunburst is designed for precise editing; this example compares its text-to-image output. Both support custom sizes, transparent backgrounds, and quality settings through `max`.
+
+```yaml
+providers:
+  - id: openai:image:gpt-image-2.5-flare
+    config:
+      size: 1536x1024
+      quality: high # low, medium, high, xhigh, max, auto
+      background: transparent
+      output_format: png # png or webp for transparent backgrounds
+  - id: openai:image:gpt-image-2.5-sunburst
+    config:
+      size: 1536x1024
+      quality: high
+      background: transparent
+      output_format: png
+```
+
+### GPT Image 2
+
+Earlier image model with flexible custom sizes and opaque backgrounds.
 
 ```yaml
 providers:
@@ -103,20 +123,31 @@ providers:
 
 ### DALL-E 3 and DALL-E 2
 
-`dall-e-3` and `dall-e-2` were [retired from the OpenAI API](https://developers.openai.com/api/docs/deprecations) on May 12, 2026. The provider retains compatibility for gateways that still expose them. Use `gpt-image-2`, `gpt-image-1.5`, `gpt-image-1`, or `gpt-image-1-mini` for new evals.
+`dall-e-3` and `dall-e-2` were [retired from the OpenAI API](https://developers.openai.com/api/docs/deprecations) on May 12, 2026. The provider retains compatibility for gateways that still expose them. Use `gpt-image-2.5-flare` or `gpt-image-2.5-sunburst` for new evals.
 
 Promptfoo's `openai:image` provider currently supports text-to-image generation. Image edits/reference inputs, variations, and streaming partial images are not part of this example and are rejected if configured.
 
 ## Pricing
+
+Flare and Sunburst share these [standard rates](https://developers.openai.com/api/docs/pricing), in USD per million tokens:
+
+| Input type | Input | Cached input | Output |
+| ---------- | ----- | ------------ | ------ |
+| Text       | $5    | $1.25        | —      |
+| Image      | $8    | $2           | $30    |
+
+Promptfoo calculates GPT Image 2.5 costs from returned usage. If usage is missing, cost stays unset. Equal token rates do not mean equal cost per image: each model and quality setting can use different token counts.
+
+Output-only estimates for earlier models:
 
 | Model            | Quality | Size      | Price per image |
 | ---------------- | ------- | --------- | --------------- |
 | GPT Image 2      | Low     | 1024x1024 | $0.006          |
 | GPT Image 2      | Medium  | 1024x1024 | $0.053          |
 | GPT Image 2      | High    | 1024x1024 | $0.211          |
-| GPT Image 1.5    | Low     | 1024x1024 | ~$0.064         |
-| GPT Image 1.5    | Medium  | 1024x1024 | ~$0.128         |
-| GPT Image 1.5    | High    | 1024x1024 | ~$0.192         |
+| GPT Image 1.5    | Low     | 1024x1024 | $0.009          |
+| GPT Image 1.5    | Medium  | 1024x1024 | $0.034          |
+| GPT Image 1.5    | High    | 1024x1024 | $0.133          |
 | GPT Image 1      | Low     | 1024x1024 | $0.011          |
 | GPT Image 1      | Medium  | 1024x1024 | $0.042          |
 | GPT Image 1      | High    | 1024x1024 | $0.167          |
@@ -124,7 +155,7 @@ Promptfoo's `openai:image` provider currently supports text-to-image generation.
 | GPT Image 1 Mini | Medium  | 1024x1024 | $0.011          |
 | GPT Image 1 Mini | High    | 1024x1024 | $0.036          |
 
-**Note:** Prices shown are 1024x1024 output image estimates and do not include input text tokens. For GPT Image 2 `auto` quality or custom sizes, promptfoo preserves OpenAI usage metadata and leaves `cost` unset instead of guessing.
+**Note:** The per-image estimates exclude input tokens. Promptfoo uses returned usage when available. Without usage, GPT Image 2 `auto` quality or custom sizes leave `cost` unset.
 
 ## Documentation
 

--- a/examples/openai-images/promptfooconfig.yaml
+++ b/examples/openai-images/promptfooconfig.yaml
@@ -5,7 +5,21 @@ prompts:
   - 'In the style of {{artist}}: {{subject}}'
 
 providers:
-  # GPT Image 2 - OpenAI's latest image generation model
+  # GPT Image 2.5 Flare - everyday image generation
+  - id: openai:image:gpt-image-2.5-flare
+    config:
+      size: 1024x1024
+      quality: low # low, medium, high, xhigh, max, auto
+      # background: transparent # transparent, opaque, auto; use png/webp for transparency
+      # output_format: webp # png, jpeg, webp
+
+  # GPT Image 2.5 Sunburst - compare on the same prompts
+  - id: openai:image:gpt-image-2.5-sunburst
+    config:
+      size: 1024x1024
+      quality: low
+
+  # Earlier models for comparison
   - id: openai:image:gpt-image-2
     config:
       size: 1024x1024 # Common sizes: 1024x1024, 1024x1536, 1536x1024, 2048x1152, 2048x2048, auto

--- a/examples/openai-mcp/promptfooconfig.approval.yaml
+++ b/examples/openai-mcp/promptfooconfig.approval.yaml
@@ -8,22 +8,25 @@ prompts:
 
 providers:
   # Provider with approval required (default behavior)
-  - id: openai:responses:gpt-4.1-2025-04-14
+  - id: openai:responses:gpt-5.6-terra
     label: 'With Approval Required'
     config:
+      reasoning:
+        effort: none
       tools:
         - type: mcp
           server_label: deepwiki
           server_url: https://mcp.deepwiki.com/mcp
           # require_approval is not specified, so approval is required by default
       max_output_tokens: 1000
-      temperature: 0.2
       instructions: 'You are a research assistant. When approval is required for MCP tools, explain what you would do if the tool were approved.'
 
   # Provider with selective approval
-  - id: openai:responses:gpt-4.1-2025-04-14
+  - id: openai:responses:gpt-5.6-terra
     label: 'Selective Approval'
     config:
+      reasoning:
+        effort: none
       tools:
         - type: mcp
           server_label: deepwiki
@@ -33,20 +36,20 @@ providers:
               tool_names: ['read_wiki_structure']
           # ask_question will still require approval, but read_wiki_structure won't
       max_output_tokens: 1000
-      temperature: 0.2
       instructions: 'You are a research assistant. Use the available tools to gather information.'
 
   # Provider with no approval required
-  - id: openai:responses:gpt-4.1-2025-04-14
+  - id: openai:responses:gpt-5.6-terra
     label: 'No Approval Required'
     config:
+      reasoning:
+        effort: none
       tools:
         - type: mcp
           server_label: deepwiki
           server_url: https://mcp.deepwiki.com/mcp
           require_approval: never
       max_output_tokens: 1000
-      temperature: 0.2
       instructions: 'You are a research assistant. Use the available MCP tools to search for information.'
 
 tests:

--- a/examples/openai-mcp/promptfooconfig.authenticated.yaml
+++ b/examples/openai-mcp/promptfooconfig.authenticated.yaml
@@ -8,8 +8,10 @@ prompts:
   - 'I need to {{action}} for customer ID {{customer_id}}. Please use the Stripe integration to fetch this data.'
 
 providers:
-  - id: openai:responses:gpt-4.1-2025-04-14
+  - id: openai:responses:gpt-5.6-terra
     config:
+      reasoning:
+        effort: none
       tools:
         - type: mcp
           server_label: stripe
@@ -19,7 +21,6 @@ providers:
           require_approval: never
           allowed_tools: ['create_payment_link', 'list_payment_methods']
       max_output_tokens: 1000
-      temperature: 0.1
       instructions: 'You are a payment processing assistant. Use the Stripe MCP tools to help with payment-related tasks. Always provide clear and accurate information about payment operations.'
 
 tests:

--- a/examples/openai-mcp/promptfooconfig.yaml
+++ b/examples/openai-mcp/promptfooconfig.yaml
@@ -8,8 +8,10 @@ prompts:
   - 'What are the main features of {{repo}}? Please provide a detailed overview.'
 
 providers:
-  - id: openai:responses:gpt-4.1-2025-04-14
+  - id: openai:responses:gpt-5.6-terra
     config:
+      reasoning:
+        effort: none
       tools:
         - type: mcp
           server_label: deepwiki
@@ -17,7 +19,6 @@ providers:
           require_approval: never
           allowed_tools: ['ask_question', 'read_wiki_structure']
       max_output_tokens: 1500
-      temperature: 0.3
       instructions: 'You are a helpful research assistant. Use the available MCP tools to search for accurate information about repositories and provide comprehensive answers.'
 
 tests:

--- a/examples/openai-multiline-yaml/promptfooconfig.yaml
+++ b/examples/openai-multiline-yaml/promptfooconfig.yaml
@@ -4,7 +4,7 @@ description: OpenAI evaluation with multiline YAML prompt formatting
 prompts:
   - file://prompt.yaml
 providers:
-  - openai:chat:gpt-4.1-mini
+  - openai:chat:gpt-5.6-luna
 
 tests:
   - vars:

--- a/examples/openai-responses/README.md
+++ b/examples/openai-responses/README.md
@@ -13,7 +13,7 @@ cd openai-responses
 
 ### Basic Responses API (`promptfooconfig.yaml`)
 
-Basic example showing how to use the Responses API with GPT-5.5, the GPT-5.4 family (`gpt-5.4-mini`, `gpt-5.4-nano`), and a GPT-4.1 comparison model.
+Basic example showing how to use the Responses API with GPT-5.6 Sol, Terra, and Luna, plus a GPT-4.1 comparison model.
 
 ### External Response Format (`promptfooconfig.external-format.yaml`)
 
@@ -48,7 +48,7 @@ Key differences from regular function calling:
 
 ### Reasoning Models (`promptfooconfig.reasoning.yaml`)
 
-Example showing how to use reasoning models (o1, o3, etc.) with specific configurations.
+Compare GPT-5.6 Sol, Terra, and Luna with GPT-6 Astra using explicit reasoning budgets.
 
 ### GPT-5.1 (`promptfooconfig.gpt-5.1.yaml`)
 
@@ -89,7 +89,7 @@ Example showing web search capabilities.
 
 ### Prompt Caching (`promptfooconfig.prompt-cache.yaml`)
 
-Example combining `prompt_cache_key`, `prompt_cache_retention`, and included
+Example combining `prompt_cache_key`, `prompt_cache_options`, and included
 `web_search_call.results` payloads in a Responses request.
 
 ### Codex Models (`promptfooconfig.codex.yaml`)

--- a/examples/openai-responses/promptfooconfig.external-format.yaml
+++ b/examples/openai-responses/promptfooconfig.external-format.yaml
@@ -4,10 +4,11 @@ prompts:
   - 'Extract information about the event: {{event}}'
 
 providers:
-  - id: openai:responses:gpt-4.1
+  - id: openai:responses:gpt-5.6-terra
     label: inline-json-schema
     config:
-      temperature: 0.7
+      reasoning:
+        effort: none
       instructions: 'You are a helpful AI assistant. Extract key details about the event.'
       response_format:
         type: 'json_schema'
@@ -35,17 +36,19 @@ providers:
           required: ['event_name', 'date', 'location', 'participants', 'description']
           additionalProperties: false
 
-  - id: openai:responses:gpt-4.1
+  - id: openai:responses:gpt-5.6-terra
     label: external-file-format
     config:
-      temperature: 0.7
+      reasoning:
+        effort: none
       instructions: 'You are a helpful AI assistant. Extract key details about the event.'
       response_format: file://response_format.json
 
-  - id: openai:responses:gpt-4.1
+  - id: openai:responses:gpt-5.6-terra
     label: nested-file-reference
     config:
-      temperature: 0.7
+      reasoning:
+        effort: none
       instructions: 'You are a helpful AI assistant. Extract key details about the event.'
       response_format: file://nested_response_format.json
 

--- a/examples/openai-responses/promptfooconfig.function-call.yaml
+++ b/examples/openai-responses/promptfooconfig.function-call.yaml
@@ -4,11 +4,12 @@ prompts:
   - 'What is the weather like in {{location}}?'
 
 providers:
-  - id: openai:responses:o1-pro
-    label: o1-pro
+  - id: openai:responses:gpt-6-astra
+    label: gpt-6-astra
     config:
-      temperature: 0.7
-      max_output_tokens: 300
+      reasoning:
+        effort: low
+      max_output_tokens: 4096
       tool_choice: auto
       tools:
         - type: function
@@ -25,11 +26,12 @@ providers:
                 enum: ['celsius', 'fahrenheit']
             required: ['location', 'unit']
 
-  - id: openai:responses:o3
-    label: o3
+  - id: openai:responses:gpt-5.6-terra
+    label: gpt-5.6-terra
     config:
-      reasoning_effort: 'medium'
-      max_output_tokens: 300
+      reasoning:
+        effort: medium
+      max_output_tokens: 4096
       tool_choice: auto
       tools:
         - type: function
@@ -46,11 +48,12 @@ providers:
                 enum: ['celsius', 'fahrenheit']
             required: ['location', 'unit']
 
-  - id: openai:responses:o4-mini
-    label: o4-mini
+  - id: openai:responses:gpt-5.6-luna
+    label: gpt-5.6-luna
     config:
-      reasoning_effort: 'low'
-      max_output_tokens: 300
+      reasoning:
+        effort: low
+      max_output_tokens: 4096
       tool_choice: auto
       tools:
         - type: function

--- a/examples/openai-responses/promptfooconfig.function-callback.yaml
+++ b/examples/openai-responses/promptfooconfig.function-callback.yaml
@@ -6,9 +6,10 @@ prompts:
   - 'What is {{a}} plus {{b}}?'
 
 providers:
-  - id: openai:responses:gpt-4o
+  - id: openai:responses:gpt-5.6-terra
     config:
-      temperature: 0
+      reasoning:
+        effort: none
       max_output_tokens: 100
       tool_choice: auto
       tools:

--- a/examples/openai-responses/promptfooconfig.image.yaml
+++ b/examples/openai-responses/promptfooconfig.image.yaml
@@ -4,9 +4,10 @@ prompts:
   - file://prompt.image.json
 
 providers:
-  - id: openai:responses:gpt-4.1-mini
+  - id: openai:responses:gpt-5.6-luna
     config:
-      temperature: 0.7
+      reasoning:
+        effort: none
       max_output_tokens: 300
 
 tests:

--- a/examples/openai-responses/promptfooconfig.mcp.yaml
+++ b/examples/openai-responses/promptfooconfig.mcp.yaml
@@ -6,8 +6,10 @@ prompts:
   - 'Can you search for information about {{topic}} in the {{repo}} repository?'
 
 providers:
-  - id: openai:responses:gpt-4.1-2025-04-14
+  - id: openai:responses:gpt-5.6-terra
     config:
+      reasoning:
+        effort: none
       tools:
         - type: mcp
           server_label: deepwiki
@@ -15,9 +17,10 @@ providers:
           require_approval: never
           allowed_tools: ['ask_question']
       max_output_tokens: 1000
-      temperature: 0.3
-  - id: openai:responses:gpt-5.4
+  - id: openai:responses:gpt-5.6-sol
     config:
+      reasoning:
+        effort: none
       tools:
         - type: mcp
           server_label: deepwiki
@@ -25,7 +28,6 @@ providers:
           require_approval: never
           allowed_tools: ['ask_question']
       max_output_tokens: 1000
-      temperature: 0.3
 
 tests:
   - vars:

--- a/examples/openai-responses/promptfooconfig.prompt-cache.yaml
+++ b/examples/openai-responses/promptfooconfig.prompt-cache.yaml
@@ -6,11 +6,15 @@ prompts:
     Include a cited source.
 
 providers:
-  - id: openai:responses:gpt-5.5
+  - id: openai:responses:gpt-5.6-sol
     config:
+      reasoning:
+        effort: none
       max_output_tokens: 300
       prompt_cache_key: recent-topic-update
-      prompt_cache_retention: 24h
+      prompt_cache_options:
+        mode: implicit
+        ttl: 30m
       include:
         - web_search_call.results
       tools:

--- a/examples/openai-responses/promptfooconfig.reasoning.yaml
+++ b/examples/openai-responses/promptfooconfig.reasoning.yaml
@@ -6,31 +6,31 @@ prompts:
     {{math_problem}}
 
 providers:
-  - id: openai:responses:o3-mini
-    label: o3-mini-reasoning
+  - id: openai:responses:gpt-5.6-sol
+    label: gpt-5.6-sol-reasoning
     config:
-      max_output_tokens: 1000
+      max_output_tokens: 4096
       reasoning:
         effort: 'high'
       user: 'math-student-001'
 
-  - id: openai:responses:o3-pro
-    label: o3-pro-reasoning
+  - id: openai:responses:gpt-6-astra
+    label: gpt-6-astra-reasoning
     config:
-      max_output_tokens: 2000
+      max_output_tokens: 8192
       reasoning:
         effort: 'high'
 
-  - id: openai:responses:o4-mini
-    label: o4-mini-reasoning
+  - id: openai:responses:gpt-5.6-terra
+    label: gpt-5.6-terra-reasoning
     config:
-      max_output_tokens: 1000
+      max_output_tokens: 4096
       reasoning:
         effort: 'medium'
-  - id: openai:responses:gpt-5.4
-    label: gpt-5.4-none-reasoning
+  - id: openai:responses:gpt-5.6-luna
+    label: gpt-5.6-luna-none-reasoning
     config:
-      max_output_tokens: 1000
+      max_output_tokens: 4096
       reasoning:
         effort: 'none'
 

--- a/examples/openai-responses/promptfooconfig.web-search.yaml
+++ b/examples/openai-responses/promptfooconfig.web-search.yaml
@@ -4,9 +4,10 @@ prompts:
   - 'Find me something fun or positive that happened recently in the news about {{topic}}. I want to hear about developments or stories from the past week. Make sure to cite your sources.'
 
 providers:
-  - id: openai:responses:gpt-4o
+  - id: openai:responses:gpt-5.6-terra
     config:
-      temperature: 0.7
+      reasoning:
+        effort: none
       max_output_tokens: 500
       tools:
         - type: web_search

--- a/examples/openai-responses/promptfooconfig.yaml
+++ b/examples/openai-responses/promptfooconfig.yaml
@@ -4,10 +4,12 @@ prompts:
   - 'Extract information about the event: {{event}}'
 
 providers:
-  # GPT-5 models showcasing latest capabilities
-  - id: openai:responses:gpt-5.6
-    label: gpt-5.6-json-schema
+  # GPT-5.6 tiers with structured output
+  - id: openai:responses:gpt-5.6-sol
+    label: gpt-5.6-sol-json-schema
     config:
+      reasoning:
+        effort: none
       instructions: 'You are a helpful AI assistant. Extract key details about the event.'
       response_format:
         type: 'json_schema'
@@ -32,9 +34,11 @@ providers:
           required: ['event_name', 'date', 'location', 'participants']
           additionalProperties: false
 
-  - id: openai:responses:gpt-5.4-nano
-    label: gpt-5.4-nano-json-schema
+  - id: openai:responses:gpt-5.6-luna
+    label: gpt-5.6-luna-json-schema
     config:
+      reasoning:
+        effort: none
       instructions: 'You are a helpful AI assistant. Extract key details about the event.'
       response_format:
         type: 'json_schema'
@@ -60,9 +64,11 @@ providers:
           additionalProperties: false
       store: true
 
-  - id: openai:responses:gpt-5.4-mini
-    label: gpt-5.4-mini-json-schema
+  - id: openai:responses:gpt-5.6-terra
+    label: gpt-5.6-terra-json-schema
     config:
+      reasoning:
+        effort: none
       instructions: 'You are a helpful AI assistant. Extract key details about the event.'
       response_format:
         type: 'json_schema'

--- a/examples/openai-structured-output/per-test-schema.yaml
+++ b/examples/openai-structured-output/per-test-schema.yaml
@@ -13,9 +13,9 @@ prompts:
   - 'Answer this question: {{question}}'
 
 providers:
-  - id: openai:gpt-4o-mini
+  - id: openai:chat:gpt-5.6-luna
     config:
-      temperature: 0
+      reasoning_effort: none
 
 # Parse JSON output so assertions can access properties directly
 defaultTest:

--- a/examples/openai-structured-output/promptfooconfig.chat.yaml
+++ b/examples/openai-structured-output/promptfooconfig.chat.yaml
@@ -4,17 +4,19 @@ prompts:
   - 'Analyze the following customer support query: "{{query}}" and respond with structured JSON data.'
 
 providers:
-  # GPT-5 models with structured output
-  - id: openai:chat:gpt-5.4-nano
-    label: GPT-5.4 Nano External Schema
+  # GPT-5.6 tiers with structured output
+  - id: openai:chat:gpt-5.6-luna
+    label: GPT-5.6 Luna External Schema
     config:
+      reasoning_effort: none
       max_completion_tokens: 800
       seed: 123456
       response_format: file://schema.chat.json # External schema file reference
 
-  - id: openai:chat:gpt-5.4-mini
-    label: GPT-5.4 Mini Inline Schema
+  - id: openai:chat:gpt-5.6-terra
+    label: GPT-5.6 Terra Inline Schema
     config:
+      reasoning_effort: none
       max_completion_tokens: 1000
       response_format:
         type: json_schema

--- a/examples/openai-structured-output/promptfooconfig.responses.yaml
+++ b/examples/openai-structured-output/promptfooconfig.responses.yaml
@@ -4,18 +4,19 @@ prompts:
   - 'Analyze the following customer support query: "{{query}}" and respond with structured JSON data.'
 
 providers:
-  - id: openai:responses:gpt-4.1-nano
+  - id: openai:responses:gpt-5.6-luna
     config:
-      temperature: 0.3
+      reasoning:
+        effort: none
       max_output_tokens: 600
-      top_p: 0.95
       instructions: 'You are an expert customer support analyst. Analyze the customer query and provide structured information following the exact JSON schema provided.'
       response_format: file://schema.responses.yaml # External schema file reference
 
-  - id: openai:responses:gpt-4.1-mini
+  - id: openai:responses:gpt-5.6-terra
     label: Responses API (Inline Schema)
     config:
-      temperature: 0.2
+      reasoning:
+        effort: none
       max_output_tokens: 800
       instructions: 'You are an expert customer support analyst. Analyze the customer query and provide structured information following the exact JSON schema provided.'
       response_format:

--- a/examples/openai-tools-call/promptfooconfig.yaml
+++ b/examples/openai-tools-call/promptfooconfig.yaml
@@ -5,7 +5,7 @@ prompts:
   - 'What is the weather like in {{city}}?'
 
 providers:
-  - id: openai:chat:gpt-5.4-mini
+  - id: openai:chat:gpt-5.6-luna
     config:
       verbosity: high
       tools:

--- a/examples/openai-vision/README.md
+++ b/examples/openai-vision/README.md
@@ -4,7 +4,7 @@ This example demonstrates how to use promptfoo to evaluate OpenAI's vision capab
 
 ## Features Demonstrated
 
-- Using OpenAI's GPT-4o with vision capabilities
+- Using OpenAI's GPT-5.6 Sol with vision capabilities
 - Incorporating images in prompts using JSON format
 - Passing image URLs as variables
 - Testing vision model responses against expected content

--- a/examples/openai-vision/promptfooconfig.yaml
+++ b/examples/openai-vision/promptfooconfig.yaml
@@ -4,7 +4,7 @@ description: OpenAI vision model image analysis and evaluation
 prompts:
   - file://prompt.json
 providers:
-  - openai:chat:gpt-5.4
+  - openai:chat:gpt-5.6-sol
 
 tests:
   - vars:

--- a/site/docs/providers/openai-agents.md
+++ b/site/docs/providers/openai-agents.md
@@ -38,7 +38,7 @@ providers:
     config:
       agent:
         name: Customer Support Agent
-        model: gpt-5-mini
+        model: gpt-5.6-luna
         instructions: You are a helpful customer support agent.
       maxTurns: 10
 ```
@@ -128,7 +128,7 @@ import { Agent } from '@openai/agents';
 
 export default new Agent({
   name: 'Support Agent',
-  model: 'gpt-5-mini',
+  model: 'gpt-5.6-luna',
   instructions: 'You are a helpful customer support agent.',
 });
 ```
@@ -163,12 +163,12 @@ providers:
     config:
       agent:
         name: Triage Agent
-        model: gpt-5-mini
+        model: gpt-5.6-luna
         instructions: Route questions to the appropriate specialist.
       handoffs:
         - agent:
             name: Technical Support
-            model: gpt-5-mini
+            model: gpt-5.6-luna
             instructions: Handle technical troubleshooting.
           description: Transfer for technical issues
 ```
@@ -474,7 +474,7 @@ tests:
 
       - type: trajectory:goal-success
         value: 'Determine whether order 123 shipped and tell the user the correct status'
-        provider: openai:gpt-5-mini
+        provider: openai:gpt-5.6-luna
 ```
 
 See [Tracing](/docs/tracing/) for the eval-level OTLP setup required when you want Promptfoo to ingest and evaluate these traces directly.

--- a/site/docs/providers/openai-codex-app-server.md
+++ b/site/docs/providers/openai-codex-app-server.md
@@ -98,7 +98,7 @@ The same notes as the [Codex SDK Bedrock setup](/docs/providers/openai-codex-sdk
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       sandbox_mode: read-only
       approval_policy: never
@@ -191,7 +191,7 @@ The app-server provider starts the `codex` binary on your PATH, or `codex_path_o
 
 ```yaml
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       approval_policy:
         granular:
@@ -206,12 +206,12 @@ providers:
 
 ```yaml
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       collaboration_mode:
         mode: plan
         settings:
-          model: gpt-5.5
+          model: gpt-5.6-sol
           reasoning_effort: none
           developer_instructions: null
 ```
@@ -224,7 +224,7 @@ Codex gates optional capabilities behind [feature flags](https://developers.open
 
 ```yaml
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       cli_config:
         features:
@@ -240,7 +240,7 @@ Configure deterministic responses when you intentionally want app-server approva
 
 ```yaml
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       sandbox_mode: workspace-write
       approval_policy: on-request
@@ -290,7 +290,7 @@ Legacy `execCommandApproval` and `applyPatchApproval` callbacks are also handled
 
 ```yaml title="promptfooconfig.yaml"
 providers:
-  - id: openai:codex-app-server:gpt-5.5
+  - id: openai:codex-app-server:gpt-5.6-sol
     config:
       sandbox_mode: read-only
       output_schema:

--- a/site/docs/providers/openai.md
+++ b/site/docs/providers/openai.md
@@ -122,7 +122,7 @@ Bare `openai:<model>` IDs default to Responses for GPT-5.6 and newer GPT models,
 
 Use `openai:chat:<model>` or `openai:responses:<model>` to select the endpoint explicitly, including for a compatible gateway. Existing bare GPT-5.6 configurations with Chat-specific options should either select `openai:chat:gpt-5.6` or switch to Responses options such as `reasoning.effort` and `max_output_tokens`.
 
-Bare `openai:chat` and `openai:responses` currently select `gpt-4.1-2025-04-14`. Specify a model ID, such as `openai:responses:gpt-5.6-luna`, to choose a newer model explicitly. Keeping the existing defaults avoids changing the model for configurations that omit it. When a model has dated snapshots, use one to hold the model version constant across runs. A fixed snapshot does not guarantee identical outputs.
+Bare `openai:chat` and `openai:responses` select `gpt-5.6-terra`. Built-in grading uses `gpt-5.6-sol`; suggestions and web search use `gpt-5.6-terra`. Specify a model ID to override these defaults. When a model has dated snapshots, use one to hold the model version constant across runs. A fixed snapshot does not guarantee identical outputs.
 
 `openai:embedding` and `openai:embeddings` default to `text-embedding-3-large`; both prefixes accept an explicit model. `openai:speech:` is an alias for `openai:tts:`.
 
@@ -265,6 +265,17 @@ Built-in OpenAI API requests include `X-OpenAI-Originator: promptfoo`. Override 
 ### Cost estimates
 
 Promptfoo uses returned token usage and its model pricing catalog to estimate costs. Estimates can be incomplete for new models, tools, or gateways that omit usage. Check [OpenAI's usage dashboard](https://platform.openai.com/usage) for billed usage.
+
+Current standard rates in USD per million tokens, for requests with up to 272,000 input tokens:
+
+| Model                         | Input | Cached input | Cache writes | Output |
+| ----------------------------- | ----- | ------------ | ------------ | ------ |
+| GPT-5.6 Luna                  | $0.20 | $0.02        | $0.25        | $1.20  |
+| GPT-5.6 Terra                 | $2    | $0.20        | $2.50        | $12    |
+| GPT-5.6 Sol (`gpt-5.6` alias) | $4    | $0.40        | $5           | $20    |
+| GPT-6 Astra                   | $10   | $1           | $12.50       | $50    |
+
+Above 272,000 input tokens, input, cached-input, and cache-write rates double; output rates increase by 50%. Batch and Flex cost half the standard rates. Fast mode (`fast` or `priority`) costs twice the standard rates. Regional processing adds 10%; Astra Fast mode is unavailable with EU data residency. Sol's promotional pricing runs at least through November 21, 2026. Rates verified September 9, 2026; see [OpenAI pricing](https://developers.openai.com/api/docs/pricing).
 
 For Chat Completions and Responses, set `inputCost` and `outputCost` to override rates in **dollars per token**, not per million tokens. For audio, use `audioInputCost` and `audioOutputCost`. The older `cost` and `audioCost` options are shared input/output fallbacks. These settings affect Promptfoo's estimates, not API billing.
 
@@ -466,7 +477,7 @@ prompts:
   - 'Look up order {{order_id}}.'
 
 providers:
-  - id: openai:chat:gpt-4.1-mini
+  - id: openai:chat:gpt-5.6-luna
     // highlight-start
     config:
       tools:

--- a/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/FoundationModelConfiguration.test.tsx
@@ -126,7 +126,7 @@ describe('FoundationModelConfiguration', () => {
     const modelIdInput = screen.getByRole('textbox', { name: /Model ID/i });
     expect(modelIdInput).toHaveAttribute(
       'placeholder',
-      'openai:gpt-6-astra, openai:gpt-5.6-sol, openai:gpt-5.5',
+      'openai:gpt-5.6-luna, openai:gpt-5.6-terra, openai:gpt-5.6-sol, openai:gpt-6-astra',
     );
 
     const documentationLink = screen.getByRole('link', { name: /OpenAI documentation/ });
@@ -251,7 +251,7 @@ describe('FoundationModelConfiguration', () => {
     let modelIdInput = screen.getByRole('textbox', { name: /Model ID/i });
     expect(modelIdInput).toHaveAttribute(
       'placeholder',
-      'openai:gpt-6-astra, openai:gpt-5.6-sol, openai:gpt-5.5',
+      'openai:gpt-5.6-luna, openai:gpt-5.6-terra, openai:gpt-5.6-sol, openai:gpt-6-astra',
     );
     let documentationLink = screen.getByRole('link', { name: /OpenAI documentation/ });
     expect(documentationLink).toHaveAttribute(

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderEditor.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderEditor.test.tsx
@@ -135,7 +135,7 @@ describe('ProviderEditor', () => {
 
     expect(setProvider).toHaveBeenCalledTimes(1);
     const expectedNewProvider: ProviderOptions = {
-      id: 'openai:gpt-5.5',
+      id: 'openai:gpt-5.6-terra',
       config: {},
       label: 'My Test Provider',
     };

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.test.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.test.tsx
@@ -455,7 +455,7 @@ describe('ProviderTypeSelector', () => {
     );
 
     expect(screen.getByText('OpenAI')).toBeVisible();
-    expect(screen.getByText('GPT-5.5, GPT-5.4, GPT-5.4 Mini and older models')).toBeVisible();
+    expect(screen.getByText('GPT-5.6 Luna, Terra, Sol and GPT-6 Astra')).toBeVisible();
   });
 
   it('should correctly update provider configuration when switching from Go provider to HTTP provider', async () => {

--- a/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.tsx
+++ b/src/app/src/pages/redteam/setup/components/Targets/ProviderTypeSelector.tsx
@@ -194,7 +194,7 @@ const allProviderOptions = [
   {
     value: 'openai',
     label: 'OpenAI',
-    description: 'GPT-5.5, GPT-5.4, GPT-5.4 Mini and older models',
+    description: 'GPT-5.6 Luna, Terra, Sol and GPT-6 Astra',
     tag: 'providers',
     recommended: true,
   },

--- a/src/app/src/pages/redteam/setup/components/constants.ts
+++ b/src/app/src/pages/redteam/setup/components/constants.ts
@@ -1,7 +1,8 @@
 import type { RedteamUITarget } from '../types';
 
-export const DEFAULT_OPENAI_TARGET_ID = 'openai:gpt-5.5';
-export const OPENAI_TARGET_PLACEHOLDER = 'openai:gpt-6-astra, openai:gpt-5.6-sol, openai:gpt-5.5';
+export const DEFAULT_OPENAI_TARGET_ID = 'openai:gpt-5.6-terra';
+export const OPENAI_TARGET_PLACEHOLDER =
+  'openai:gpt-5.6-luna, openai:gpt-5.6-terra, openai:gpt-5.6-sol, openai:gpt-6-astra';
 export const DEFAULT_GOOGLE_TARGET_ID = 'google:gemini-3.8-flash';
 export const DEFAULT_VERTEX_TARGET_ID = 'vertex:gemini-3.8-flash';
 
@@ -13,9 +14,9 @@ export const predefinedTargets: RedteamUITarget[] = [
   { value: 'openai:gpt-6-astra', label: 'OpenAI GPT-6 Astra' },
   { value: 'openai:gpt-5.6', label: 'OpenAI GPT-5.6 (Sol alias)' },
   { value: 'openai:gpt-5.6-sol', label: 'OpenAI GPT-5.6 Sol' },
-  { value: 'openai:gpt-5.6-terra', label: 'OpenAI GPT-5.6 Terra' },
+  { value: DEFAULT_OPENAI_TARGET_ID, label: 'OpenAI GPT-5.6 Terra' },
   { value: 'openai:gpt-5.6-luna', label: 'OpenAI GPT-5.6 Luna' },
-  { value: DEFAULT_OPENAI_TARGET_ID, label: 'OpenAI GPT-5.5' },
+  { value: 'openai:gpt-5.5', label: 'OpenAI GPT-5.5' },
   { value: 'openai:gpt-5.5-pro', label: 'OpenAI GPT-5.5 Pro' },
   { value: 'openai:gpt-5.4', label: 'OpenAI GPT-5.4' },
   { value: 'openai:gpt-5.4-mini', label: 'OpenAI GPT-5.4 Mini' },

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -468,14 +468,14 @@ export async function createDummyFiles(
     }
 
     const choices: { name: string; value: (string | ProviderOptions)[] }[] = [
-      { name: `I'll choose later`, value: ['openai:gpt-5-mini', 'openai:gpt-5'] },
+      { name: `I'll choose later`, value: ['openai:gpt-5.6-luna', 'openai:gpt-5.6-terra'] },
       {
-        name: '[OpenAI] GPT 5, GPT 4.1, ...',
+        name: '[OpenAI] GPT-5.6 Luna, Terra, Sol, GPT-6 Astra, ...',
         value:
           action === 'agent'
             ? [
                 {
-                  id: 'openai:gpt-5',
+                  id: 'openai:chat:gpt-5.6-terra',
                   config: {
                     tools: [
                       {
@@ -499,7 +499,7 @@ export async function createDummyFiles(
                   },
                 },
               ]
-            : ['openai:gpt-5-mini', 'openai:gpt-5'],
+            : ['openai:gpt-5.6-luna', 'openai:gpt-5.6-terra'],
       },
       {
         name: '[Anthropic] Claude Fable, Opus, Sonnet, Haiku, ...',
@@ -648,8 +648,8 @@ export async function createDummyFiles(
         });
       }
     } else {
-      providers.push('openai:gpt-5-mini');
-      providers.push('openai:gpt-5');
+      providers.push('openai:gpt-5.6-luna');
+      providers.push('openai:gpt-5.6-terra');
     }
 
     if (action === 'compare') {
@@ -687,8 +687,8 @@ export async function createDummyFiles(
     language = 'not_sure';
     prompts.push(`Write a tweet about {{topic}}`);
     prompts.push(`Write a concise, funny tweet about {{topic}}`);
-    providers.push('openai:gpt-5-mini');
-    providers.push('openai:gpt-5');
+    providers.push('openai:gpt-5.6-luna');
+    providers.push('openai:gpt-5.6-terra');
   }
 
   const nunjucks = getNunjucksEngine();

--- a/src/providers/openai/defaults.ts
+++ b/src/providers/openai/defaults.ts
@@ -3,7 +3,7 @@ import { OpenAiEmbeddingProvider } from './embedding';
 import { OpenAiModerationProvider } from './moderation';
 import { OpenAiResponsesProvider } from './responses';
 
-const DEFAULT_OPENAI_GRADING_MODEL = 'gpt-5.5-2026-04-23';
+const DEFAULT_OPENAI_GRADING_MODEL = 'gpt-5.6-sol';
 
 export const DefaultEmbeddingProvider = new OpenAiEmbeddingProvider('text-embedding-3-large');
 export const DefaultGradingProvider = new OpenAiChatCompletionProvider(
@@ -17,11 +17,9 @@ export const DefaultGradingJsonProvider = new OpenAiChatCompletionProvider(
     },
   },
 );
-export const DefaultSuggestionsProvider = new OpenAiChatCompletionProvider(
-  DEFAULT_OPENAI_GRADING_MODEL,
-);
+export const DefaultSuggestionsProvider = new OpenAiChatCompletionProvider('gpt-5.6-terra');
 export const DefaultModerationProvider = new OpenAiModerationProvider('omni-moderation-latest');
-export const DefaultWebSearchProvider = new OpenAiResponsesProvider('gpt-5.5-2026-04-23', {
+export const DefaultWebSearchProvider = new OpenAiResponsesProvider('gpt-5.6-terra', {
   config: {
     tools: [{ type: 'web_search_preview' }],
   },

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1021,7 +1021,7 @@ export const providerMap: ProviderFactory[] = [
       }
       if (modelType === 'chat') {
         return new OpenAiChatCompletionProvider(
-          modelName || configuredModel || 'gpt-4.1-2025-04-14',
+          modelName || configuredModel || 'gpt-5.6-terra',
           providerOptions,
         );
       }
@@ -1051,7 +1051,7 @@ export const providerMap: ProviderFactory[] = [
       }
       if (modelType === 'responses') {
         return new OpenAiResponsesProvider(
-          modelName || configuredModel || 'gpt-4.1-2025-04-14',
+          modelName || configuredModel || 'gpt-5.6-terra',
           providerOptions,
         );
       }

--- a/src/providers/webSearchUtils.ts
+++ b/src/providers/webSearchUtils.ts
@@ -148,10 +148,10 @@ export async function loadWebSearchProvider(
     }
   };
 
-  // OpenAI GPT-5.5 snapshot with web search tool (via responses API)
+  // OpenAI GPT-5.6 Terra with web search tool (via Responses API)
   const loadOpenAIWebSearch = async () => {
     try {
-      return await loadApiProvider('openai:responses:gpt-5.5-2026-04-23', {
+      return await loadApiProvider('openai:responses:gpt-5.6-terra', {
         options: {
           config: { tools: [{ type: 'web_search_preview' }] },
         },

--- a/test/onboarding.test.ts
+++ b/test/onboarding.test.ts
@@ -202,8 +202,8 @@ describe('createDummyFiles', () => {
     const config = validationResult.data!;
     expect(config.prompts).toHaveLength(2);
     expect(config.providers).toHaveLength(2);
-    expect(config.providers).toContain('openai:gpt-5-mini');
-    expect(config.providers).toContain('openai:gpt-5');
+    expect(config.providers).toContain('openai:gpt-5.6-luna');
+    expect(config.providers).toContain('openai:gpt-5.6-terra');
   });
 
   it('should generate valid YAML configuration for RAG setup', async () => {

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -1029,10 +1029,7 @@ describe('loadApiProvider', () => {
 
   it('should load OpenAI chat provider with default model', async () => {
     const provider = await loadApiProvider('openai:chat');
-    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith(
-      'gpt-4.1-2025-04-14',
-      expect.any(Object),
-    );
+    expect(OpenAiChatCompletionProvider).toHaveBeenCalledWith('gpt-5.6-terra', expect.any(Object));
     expect(provider).toBeDefined();
   });
 

--- a/test/providers/openai/defaults.test.ts
+++ b/test/providers/openai/defaults.test.ts
@@ -18,16 +18,16 @@ describe('OpenAI default providers', () => {
 
   describe('DefaultGradingProvider', () => {
     it('should use correct model version and configuration', () => {
-      expect(DefaultGradingProvider.modelName).toBe('gpt-5.5-2026-04-23');
-      expect(DefaultGradingProvider.id()).toBe('openai:gpt-5.5-2026-04-23');
+      expect(DefaultGradingProvider.modelName).toBe('gpt-5.6-sol');
+      expect(DefaultGradingProvider.id()).toBe('openai:gpt-5.6-sol');
       expect(DefaultGradingProvider.config).toEqual({});
     });
   });
 
   describe('DefaultGradingJsonProvider', () => {
     it('should use correct model version and JSON configuration', () => {
-      expect(DefaultGradingJsonProvider.modelName).toBe('gpt-5.5-2026-04-23');
-      expect(DefaultGradingJsonProvider.id()).toBe('openai:gpt-5.5-2026-04-23');
+      expect(DefaultGradingJsonProvider.modelName).toBe('gpt-5.6-sol');
+      expect(DefaultGradingJsonProvider.id()).toBe('openai:gpt-5.6-sol');
       expect(DefaultGradingJsonProvider.config).toEqual({
         response_format: { type: 'json_object' },
       });
@@ -36,8 +36,8 @@ describe('OpenAI default providers', () => {
 
   describe('DefaultSuggestionsProvider', () => {
     it('should use correct model version', () => {
-      expect(DefaultSuggestionsProvider.modelName).toBe('gpt-5.5-2026-04-23');
-      expect(DefaultSuggestionsProvider.id()).toBe('openai:gpt-5.5-2026-04-23');
+      expect(DefaultSuggestionsProvider.modelName).toBe('gpt-5.6-terra');
+      expect(DefaultSuggestionsProvider.id()).toBe('openai:gpt-5.6-terra');
       expect(DefaultSuggestionsProvider.config).toEqual({});
     });
   });
@@ -50,9 +50,9 @@ describe('OpenAI default providers', () => {
   });
 
   describe('DefaultWebSearchProvider', () => {
-    it('should use correct model snapshot and web search configuration', () => {
-      expect(DefaultWebSearchProvider.modelName).toBe('gpt-5.5-2026-04-23');
-      expect(DefaultWebSearchProvider.id()).toBe('openai:gpt-5.5-2026-04-23');
+    it('should use correct model and web search configuration', () => {
+      expect(DefaultWebSearchProvider.modelName).toBe('gpt-5.6-terra');
+      expect(DefaultWebSearchProvider.id()).toBe('openai:gpt-5.6-terra');
       expect(DefaultWebSearchProvider.config).toEqual({
         tools: [{ type: 'web_search_preview' }],
       });

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -299,6 +299,16 @@ describe('Provider Registry', () => {
 
     describe('OpenAI endpoint defaults', () => {
       it.each([
+        ['chat', OpenAiChatCompletionProvider],
+        ['responses', OpenAiResponsesProvider],
+      ])('uses Terra when openai:%s omits a model', async (endpoint, Provider) => {
+        const provider = await registry.create(`openai:${endpoint}`);
+
+        expect(provider).toBeInstanceOf(Provider);
+        expect(provider).toHaveProperty('modelName', 'gpt-5.6-terra');
+      });
+
+      it.each([
         'gpt-5.6',
         'gpt-5.6-sol',
         'gpt-5.6-terra',

--- a/test/providers/webSearchUtils.test.ts
+++ b/test/providers/webSearchUtils.test.ts
@@ -40,10 +40,8 @@ describe('webSearchUtils', () => {
     });
 
     it('should return false for provider-like values without an id function', () => {
-      expect(hasWebSearchCapability('openai:responses:gpt-5.5-2026-04-23' as any)).toBe(false);
-      expect(hasWebSearchCapability({ id: 'openai:responses:gpt-5.5-2026-04-23' } as any)).toBe(
-        false,
-      );
+      expect(hasWebSearchCapability('openai:responses:gpt-5.6-terra' as any)).toBe(false);
+      expect(hasWebSearchCapability({ id: 'openai:responses:gpt-5.6-terra' } as any)).toBe(false);
     });
 
     it('should return false when a provider id function throws', () => {
@@ -154,7 +152,7 @@ describe('webSearchUtils', () => {
 
     it('should return true for OpenAI responses provider with web_search_preview tool', () => {
       const provider: Partial<ApiProvider> = {
-        id: () => 'openai:responses:gpt-5.5-2026-04-23',
+        id: () => 'openai:responses:gpt-5.6-terra',
         config: {
           tools: [{ type: 'web_search_preview' }],
         },
@@ -164,7 +162,7 @@ describe('webSearchUtils', () => {
 
     it('should return true for OpenAI responses provider with the current web_search tool', () => {
       const provider: Partial<ApiProvider> = {
-        id: () => 'openai:responses:gpt-5.5-2026-04-23',
+        id: () => 'openai:responses:gpt-5.6-terra',
         config: {
           tools: [{ type: 'web_search' }],
         },
@@ -222,13 +220,13 @@ describe('webSearchUtils', () => {
     });
 
     it('should return true for a real OpenAI Responses provider whose id omits the responses prefix', () => {
-      const provider = new OpenAiResponsesProvider('gpt-5.5-2026-04-23', {
+      const provider = new OpenAiResponsesProvider('gpt-5.6-terra', {
         config: {
           tools: [{ type: 'web_search_preview' }],
         },
       });
 
-      expect(provider.id()).toBe('openai:gpt-5.5-2026-04-23');
+      expect(provider.id()).toBe('openai:gpt-5.6-terra');
       expect(hasWebSearchCapability(provider)).toBe(true);
     });
 
@@ -311,7 +309,7 @@ describe('webSearchUtils', () => {
 
     it('should return false for OpenAI responses provider without web_search_preview', () => {
       const provider: Partial<ApiProvider> = {
-        id: () => 'openai:responses:gpt-5.5-2026-04-23',
+        id: () => 'openai:responses:gpt-5.6-terra',
         config: {
           tools: [{ type: 'code_interpreter' }],
         },
@@ -358,7 +356,7 @@ describe('webSearchUtils', () => {
 
     it('should return false for provider with no tools configured', () => {
       const provider: Partial<ApiProvider> = {
-        id: () => 'openai:responses:gpt-5.5-2026-04-23',
+        id: () => 'openai:responses:gpt-5.6-terra',
         config: {},
       };
       expect(hasWebSearchCapability(provider as ApiProvider)).toBe(false);
@@ -383,7 +381,7 @@ describe('webSearchUtils', () => {
     });
     const mockOpenAiWebSearchProvider = (): Partial<ApiProvider> =>
       ({
-        id: () => 'openai:gpt-5.5-2026-04-23',
+        id: () => 'openai:gpt-5.6-terra',
         constructor: { name: 'OpenAiResponsesProvider' },
         config: {
           tools: [{ type: 'web_search_preview' }],
@@ -445,7 +443,7 @@ describe('webSearchUtils', () => {
 
       expect(result).toBe(mockProvider);
       expect(mockLoadApiProvider).toHaveBeenCalledWith(
-        'openai:responses:gpt-5.5-2026-04-23',
+        'openai:responses:gpt-5.6-terra',
         expect.objectContaining({
           options: expect.objectContaining({
             config: expect.objectContaining({
@@ -559,7 +557,7 @@ describe('webSearchUtils', () => {
 
       // Should try OpenAI first (since preferAnthropic defaults to false)
       expect(mockLoadApiProvider).toHaveBeenCalledWith(
-        'openai:responses:gpt-5.5-2026-04-23',
+        'openai:responses:gpt-5.6-terra',
         expect.anything(),
       );
     });


### PR DESCRIPTION
## Summary

Update OpenAI defaults and examples to use GPT-5.6 Luna, Terra, Sol, and GPT-6 Astra by task. Use Sol for grading, Terra for general requests and web search, and Luna plus Terra in starter configs. Keep explicit model overrides.

Add GPT-Image-2.5 Flare and Sunburst to the image example. Document current text and image rates, fix old image-price estimates, and update reasoning and prompt-cache settings. Astra, the new Sol rates, and GPT-Image-2.5 provider support are already on main; this change updates the remaining defaults and examples.

## Validation

- Build, type checks, lint, formatting, and documentation build passed.
- Full backend suite: 24,882 passed. One tracing test returned a transient 502; all 50 tests in that file passed on retry.
- 5,229 UI tests and 29 Python tests passed; 34 changed YAML configs passed schema validation.
- Local CLI runs against a mock OpenAI API passed for all four text models and both new image models. Checked request fields, the Sol grading default, exported outputs, and costs. No live model calls were made.

Pricing source: [OpenAI API pricing](https://developers.openai.com/api/docs/pricing), checked September 9, 2026.
