### PR TITLE
fix(providers): prevent duplicate Realtime prompts and correct transcription metrics

### DIFF
--- a/src/providers/openai/realtime.ts
+++ b/src/providers/openai/realtime.ts
@@ -818,20 +818,8 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
         return event.event_id;
       };
 
-      ws.on('open', async () => {
+      ws.on('open', () => {
         logger.debug('WebSocket connection established successfully');
-
-        // Create a conversation item with the user's prompt - immediately after connection
-        // Don't send ping event as it's not supported
-        sendEvent({
-          type: 'conversation.item.create',
-          previous_item_id: null,
-          item: {
-            type: 'message',
-            role: 'user',
-            content: promptContent,
-          },
-        });
       });
 
       ws.on('message', async (data: Buffer) => {
@@ -1115,18 +1103,13 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
 
               ws.close();
 
-              // Check if audio was generated based on usage tokens (for gpt-realtime)
+              // Usage may report audio tokens even when no audio delta arrived.
               if (
                 usage?.output_token_details?.audio_tokens &&
                 usage.output_token_details.audio_tokens > 0
               ) {
-                if (!hasAudioContent) {
-                  hasAudioContent = true;
-                }
-                // For gpt-realtime model, audio data is PCM16 but we need to convert to WAV for browser playback
-                audioFormat = 'wav';
                 logger.debug(
-                  `Audio detected from usage tokens: ${usage.output_token_details.audio_tokens} audio tokens, converting PCM16 to WAV format`,
+                  `Audio tokens reported in usage: ${usage.output_token_details.audio_tokens}`,
                 );
               }
 
@@ -1171,7 +1154,7 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
                   usage,
                   usageEvents,
                   // Include audio data in metadata if available
-                  ...(hasAudioContent && {
+                  ...(finalAudioData !== null && {
                     audio: {
                       data: finalAudioData,
                       format: audioFormat,

--- a/src/providers/openai/realtime.ts
+++ b/src/providers/openai/realtime.ts
@@ -818,6 +818,23 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
         return event.event_id;
       };
 
+      let initialPromptSent = false;
+      const sendInitialPrompt = () => {
+        if (initialPromptSent) {
+          return;
+        }
+        initialPromptSent = true;
+        sendEvent({
+          type: 'conversation.item.create',
+          previous_item_id: null,
+          item: {
+            type: 'message',
+            role: 'user',
+            content: promptContent,
+          },
+        });
+      };
+
       ws.on('open', () => {
         logger.debug('WebSocket connection established successfully');
       });
@@ -838,22 +855,12 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
           switch (message.type) {
             case 'session.ready':
               logger.debug('Session ready on WebSocket');
-
-              // Create a conversation item with the user's prompt
-              sendEvent({
-                type: 'conversation.item.create',
-                previous_item_id: null,
-                item: {
-                  type: 'message',
-                  role: 'user',
-                  content: promptContent,
-                },
-              });
+              sendInitialPrompt();
               break;
 
             case 'session.created':
               logger.debug('Session created on WebSocket');
-              // No need to do anything here as we'll wait for session.ready
+              sendInitialPrompt();
               break;
 
             case 'conversation.item.created':

--- a/src/providers/openai/realtime.ts
+++ b/src/providers/openai/realtime.ts
@@ -951,8 +951,10 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
                 // Store the audio data for later use
                 try {
                   const audioBuffer = Buffer.from(audioData, 'base64');
-                  audioContent.push(audioBuffer);
-                  hasAudioContent = true;
+                  if (audioBuffer.length > 0) {
+                    audioContent.push(audioBuffer);
+                    hasAudioContent = true;
+                  }
                   logger.debug(
                     `Successfully processed audio chunk: ${audioBuffer.length} bytes, total chunks: ${audioContent.length}`,
                   );
@@ -1663,8 +1665,10 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
                 // Store the audio data for later use
                 try {
                   const audioBuffer = Buffer.from(audioData, 'base64');
-                  audioContent.push(audioBuffer);
-                  hasAudioContent = true;
+                  if (audioBuffer.length > 0) {
+                    audioContent.push(audioBuffer);
+                    hasAudioContent = true;
+                  }
                   logger.debug(
                     `Successfully processed audio chunk: ${audioBuffer.length} bytes, total chunks: ${audioContent.length}`,
                   );
@@ -1815,18 +1819,13 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
 
               ws.close();
 
-              // Check if audio was generated based on usage tokens (for gpt-realtime)
+              // Usage may report audio tokens even when no audio delta arrived.
               if (
                 usage?.output_token_details?.audio_tokens &&
                 usage.output_token_details.audio_tokens > 0
               ) {
-                if (!hasAudioContent) {
-                  hasAudioContent = true;
-                }
-                // For gpt-realtime model, audio data is PCM16 but we need to convert to WAV for browser playback
-                audioFormat = 'wav';
                 logger.debug(
-                  `Audio detected from usage tokens: ${usage.output_token_details.audio_tokens} audio tokens, converting PCM16 to WAV format`,
+                  `Audio tokens reported in usage: ${usage.output_token_details.audio_tokens}`,
                 );
               }
 
@@ -1871,7 +1870,7 @@ export class OpenAiRealtimeProvider extends OpenAiGenericProvider {
                   usage,
                   usageEvents,
                   // Include audio data in metadata if available
-                  ...(hasAudioContent && {
+                  ...(finalAudioData !== null && {
                     audio: {
                       data: finalAudioData,
                       format: audioFormat,

--- a/src/providers/openai/transcription.ts
+++ b/src/providers/openai/transcription.ts
@@ -318,43 +318,17 @@ export class OpenAiTranscriptionProvider extends OpenAiGenericProvider {
 
       // Calculate average quality metrics from segments
       const segments = data.segments || [];
-      let avgLogprob: number | undefined;
-      let avgCompressionRatio: number | undefined;
-      let avgNoSpeechProb: number | undefined;
-
-      if (segments.length > 0) {
-        const validSegments = segments.filter(
-          (s: any) =>
-            s.avg_logprob !== undefined ||
-            s.compression_ratio !== undefined ||
-            s.no_speech_prob !== undefined,
-        );
-
-        if (validSegments.length > 0) {
-          const sumLogprob = validSegments.reduce(
-            (sum: number, s: any) => sum + (s.avg_logprob || 0),
-            0,
-          );
-          const sumCompressionRatio = validSegments.reduce(
-            (sum: number, s: any) => sum + (s.compression_ratio || 0),
-            0,
-          );
-          const sumNoSpeechProb = validSegments.reduce(
-            (sum: number, s: any) => sum + (s.no_speech_prob || 0),
-            0,
-          );
-
-          avgLogprob = validSegments.some((s: any) => s.avg_logprob !== undefined)
-            ? sumLogprob / validSegments.length
-            : undefined;
-          avgCompressionRatio = validSegments.some((s: any) => s.compression_ratio !== undefined)
-            ? sumCompressionRatio / validSegments.length
-            : undefined;
-          avgNoSpeechProb = validSegments.some((s: any) => s.no_speech_prob !== undefined)
-            ? sumNoSpeechProb / validSegments.length
-            : undefined;
-        }
-      }
+      const averageMetric = (key: 'avg_logprob' | 'compression_ratio' | 'no_speech_prob') => {
+        const values = segments
+          .map((segment: any) => segment[key])
+          .filter((value: unknown): value is number => typeof value === 'number');
+        return values.length > 0
+          ? values.reduce((sum: number, value: number) => sum + value, 0) / values.length
+          : undefined;
+      };
+      const avgLogprob = averageMetric('avg_logprob');
+      const avgCompressionRatio = averageMetric('compression_ratio');
+      const avgNoSpeechProb = averageMetric('no_speech_prob');
 
       // Format output based on response format
       let output: string;

--- a/test/providers/openai/image.test.ts
+++ b/test/providers/openai/image.test.ts
@@ -249,19 +249,16 @@ describe('OpenAiImageProvider', () => {
 
   describe('Error handling', () => {
     it('should handle missing API key', async () => {
-      const provider = new OpenAiImageProvider('dall-e-3');
-
-      vi.mocked(fetchWithCache).mockResolvedValueOnce({
-        data: { error: { message: 'OpenAI API key is not set' } },
-        cached: false,
-        status: 401,
-        statusText: 'Unauthorized',
-      });
-
-      const result = await provider.callApi('test prompt');
-
-      expect(result).toHaveProperty('error');
-      expect(result.error).toContain('OpenAI API key is not set');
+      const restoreEnv = mockProcessEnv({ OPENAI_API_KEY: undefined });
+      try {
+        const provider = new OpenAiImageProvider('dall-e-3');
+        await expect(provider.callApi('test prompt')).rejects.toThrow(
+          getOpenAiMissingApiKeyMessage('OPENAI_API_KEY'),
+        );
+        expect(fetchWithCache).not.toHaveBeenCalled();
+      } finally {
+        restoreEnv();
+      }
     });
 
     it('should handle API errors', async () => {

--- a/test/providers/openai/realtime.test.ts
+++ b/test/providers/openai/realtime.test.ts
@@ -183,6 +183,10 @@ describe('OpenAI Realtime Provider', () => {
       );
 
       const handler = mockHandlers.message[0];
+      handler(Buffer.from(JSON.stringify({ type: 'session.created' })));
+      expect(
+        sentWebSocketEvents(mockWs).filter((event) => event.type === 'conversation.item.create'),
+      ).toHaveLength(1);
       handler(Buffer.from(JSON.stringify({ type: 'session.ready' })));
       expect(
         sentWebSocketEvents(mockWs).filter((event) => event.type === 'conversation.item.create'),

--- a/test/providers/openai/realtime.test.ts
+++ b/test/providers/openai/realtime.test.ts
@@ -173,6 +173,52 @@ describe('OpenAI Realtime Provider', () => {
   });
 
   describe('Basic Functionality', () => {
+    it('sends one user item after session readiness on the client-secret socket', async () => {
+      const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview');
+      const promise = provider.webSocketRequest('test-secret', 'hello');
+
+      mockHandlers.open.forEach((handler) => handler());
+      expect(sentWebSocketEvents(mockWs)).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'conversation.item.create' })]),
+      );
+
+      const handler = mockHandlers.message[0];
+      handler(Buffer.from(JSON.stringify({ type: 'session.ready' })));
+      expect(
+        sentWebSocketEvents(mockWs).filter((event) => event.type === 'conversation.item.create'),
+      ).toHaveLength(1);
+
+      emitOutputTextDone(handler, 'hello back');
+      emitResponseDone(handler);
+      await promise;
+    });
+
+    it('does not expose audio when usage reports tokens without audio bytes', async () => {
+      const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview');
+      const promise = provider.webSocketRequest('test-secret', 'hello');
+      mockHandlers.open.forEach((handler) => handler());
+
+      const handler = mockHandlers.message[0];
+      handler(
+        Buffer.from(
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              usage: {
+                total_tokens: 2,
+                input_tokens: 1,
+                output_tokens: 1,
+                output_token_details: { audio_tokens: 1 },
+              },
+            },
+          }),
+        ),
+      );
+      const result = await promise;
+      expect(result.metadata).not.toHaveProperty('audio');
+      expect(result.output).toBe('');
+    });
+
     it('should initialize with correct model and config', () => {
       const config = {
         modalities: ['text'],

--- a/test/providers/openai/realtime.test.ts
+++ b/test/providers/openai/realtime.test.ts
@@ -219,6 +219,30 @@ describe('OpenAI Realtime Provider', () => {
       expect(result.output).toBe('');
     });
 
+    it('does not expose missing audio on a direct socket response', async () => {
+      const provider = new OpenAiRealtimeProvider('gpt-4o-realtime-preview');
+      const promise = provider.directWebSocketRequest('hello');
+      const handler = mockHandlers.message[0];
+
+      handler(
+        Buffer.from(
+          JSON.stringify({
+            type: 'response.done',
+            response: {
+              usage: {
+                total_tokens: 2,
+                input_tokens: 1,
+                output_tokens: 1,
+                output_token_details: { audio_tokens: 1 },
+              },
+            },
+          }),
+        ),
+      );
+      const result = await promise;
+      expect(result.metadata).not.toHaveProperty('audio');
+    });
+
     it('should initialize with correct model and config', () => {
       const config = {
         modalities: ['text'],

--- a/test/providers/openai/transcription.test.ts
+++ b/test/providers/openai/transcription.test.ts
@@ -334,6 +334,28 @@ describe('OpenAiTranscriptionProvider', () => {
       });
     });
 
+    it('averages each segment quality metric over only segments with that metric', async () => {
+      vi.mocked(fetchWithCache).mockResolvedValueOnce({
+        ...mockTranscriptionResponse,
+        data: {
+          ...mockTranscriptionResponse.data,
+          segments: [
+            { avg_logprob: -0.4 },
+            { compression_ratio: 1.2, no_speech_prob: 0 },
+            { avg_logprob: -0.2, no_speech_prob: 0.3 },
+          ],
+        },
+      });
+      const provider = new OpenAiTranscriptionProvider('gpt-4o-transcribe', {
+        config: { apiKey: 'test-key' },
+      });
+
+      const result = await provider.callApi('/path/to/audio.mp3');
+      expect(result.metadata?.avgLogprob).toBeCloseTo(-0.3);
+      expect(result.metadata?.avgCompressionRatio).toBe(1.2);
+      expect(result.metadata?.avgNoSpeechProb).toBeCloseTo(0.15);
+    });
+
     it('should strip case-insensitive Content-Type overrides from transcription uploads', async () => {
       const provider = new OpenAiTranscriptionProvider('gpt-4o-transcribe', {
         config: {

--- a/test/providers/registry.test.ts
+++ b/test/providers/registry.test.ts
@@ -5,6 +5,7 @@ import { isFoundationModelProvider } from '../../src/providers/constants';
 import { LlamaApiProvider } from '../../src/providers/llamaApi';
 import { OpenAiChatCompletionProvider } from '../../src/providers/openai/chat';
 import { OpenAiResponsesProvider } from '../../src/providers/openai/responses';
+import { PythonProvider } from '../../src/providers/pythonCompletion';
 import { getProviderFactories, providerMap } from '../../src/providers/registry';
 
 import type { CometApiImageProvider } from '../../src/providers/cometapi';
@@ -1242,41 +1243,25 @@ describe('Provider Registry', () => {
     });
 
     it('should resolve relative paths correctly for file-based providers', async () => {
-      // We'll test the path resolution by looking at the provider IDs, which contain the path
-
-      // Test Golang provider
-      const golangFactory = providerMap.find((f) => f.test('golang:script.go'));
-      expect(golangFactory).toBeDefined();
-
-      // These variables would be used in actual implementation tests
-      // Adding underscore prefix to mark as intentionally unused
-      const _customContext = {
-        basePath: '/custom/path',
-      };
-
-      // For relative paths, they should be joined with basePath
-      const _relativePath = 'script.go';
-      const _expectedRelativePath = path.join('/custom/path', _relativePath);
-
-      // For absolute paths, they should remain unchanged
-      const _absolutePath = path.resolve('/absolute/path/script.go');
-
-      // Test Python provider with file:// URL
       const pythonFactory = providerMap.find((f) => f.test('file://script.py'));
       expect(pythonFactory).toBeDefined();
+      const customContext = { ...mockContext, basePath: '/custom/path' };
 
-      // Test exec provider
-      const execFactory = providerMap.find((f) => f.test('exec:script.sh'));
-      expect(execFactory).toBeDefined();
+      // Local script paths remain relative; the config loader has already resolved its base path.
+      await pythonFactory!.create('file://script.py', mockProviderOptions, customContext);
+      expect(PythonProvider).toHaveBeenLastCalledWith('script.py', mockProviderOptions);
 
-      // Instead of testing the exact path resolution logic (which involves mocking),
-      // we'll verify that the registry factories exist and are configured correctly.
-      // The actual path resolution logic is now identical in all three providers,
-      // so testing one provider's implementation would effectively test all of them.
+      // Cloud configs resolve script paths from the process working directory.
+      const cloudOptions = { ...mockProviderOptions, config: { isCloudConfig: true } };
+      await pythonFactory!.create('file://script.py', cloudOptions, customContext);
+      expect(PythonProvider).toHaveBeenLastCalledWith(
+        path.join(process.cwd(), 'script.py'),
+        cloudOptions,
+      );
 
-      // For actual end-to-end tests of the path resolution, integration tests would be more
-      // appropriate than these unit tests, especially if we need to mock or spy on
-      // the provider constructors.
+      const absolutePath = path.resolve('/absolute/path/script.py');
+      await pythonFactory!.create(`file://${absolutePath}`, cloudOptions, customContext);
+      expect(PythonProvider).toHaveBeenLastCalledWith(absolutePath, cloudOptions);
     });
 
     it('should preserve absolute paths in file-based providers', async () => {

--- a/test/utils/modelAuditCliParser.test.ts
+++ b/test/utils/modelAuditCliParser.test.ts
@@ -100,10 +100,19 @@ describe('parseModelAuditArgs', () => {
     expect(result).toEqual(['scan', 'model.pkl']);
   });
 
-  it('should reject invalid format and timeout options', () => {
+  it('should reject an invalid format option', () => {
     expect(() =>
       parseModelAuditArgs(['model.pkl'], {
         format: 'xml',
+        timeout: 300,
+      }),
+    ).toThrow();
+  });
+
+  it('should reject an invalid timeout option', () => {
+    expect(() =>
+      parseModelAuditArgs(['model.pkl'], {
+        format: 'json',
         timeout: -1,
       }),
     ).toThrow();


### PR DESCRIPTION
## Summary

- Send a Realtime user item once on `session.created`, retaining a guarded `session.ready` compatibility path, and expose audio metadata only when actual audio bytes were encoded on both socket paths.
- Average transcription segment quality metrics independently over segments that supplied each metric.
- Make missing-key, script-path, and model-audit option tests assert the behavior they name.

GitHub's AI findings page showed 7 findings in 5 files on September 9. The custom transcription ID suggestion is a false positive: `OpenAiGenericProvider` installs a supplied ID on the instance, and the existing custom-ID test passed in this branch. The registry suggestion assumed `context.basePath` resolves script files, but the current factory intentionally preserves local relative paths and resolves cloud paths from `process.cwd()`; the test now checks the actual constructor arguments for both cases and for absolute paths.

## Validation

- 433 focused tests passed across affected files. The `session.created` regression failed before the corrective commit and passed afterward.
- 1,824 OpenAI provider tests passed; 9 skipped on the final source.
- `npm run tsc`, `npm run build`, `npm run l`, and `npm run f` passed on the final source (existing complexity warnings).
- Local echo-provider CLI smoke eval passed with score 1 and no errors; this verifies the CLI build, while mocked WebSocket and transcription tests cover the changed provider behavior without contacting OpenAI.
