### PR TITLE
fix(assertions): reject file:// paths escaping basePath

### DIFF
--- a/src/assertions/index.ts
+++ b/src/assertions/index.ts
@@ -1,5 +1,4 @@
 import fs from 'fs/promises';
-import path from 'path';
 
 import async from 'async';
 import cliState from '../cliState';
@@ -38,6 +37,7 @@ import {
   type VarValue,
 } from '../types/index';
 import { isJavascriptFile } from '../util/fileExtensions';
+import { CallbackPathTraversalError, resolveCallbackPath } from '../util/functions/loadFunction';
 import invariant from '../util/invariant';
 import { getNunjucksEngine } from '../util/templates';
 import { sleep } from '../util/time';
@@ -490,7 +490,19 @@ async function runAssertionInternal({
         functionName = fileRef.slice(colonIndex + 1);
       }
 
-      filePath = path.resolve(basePath, filePath);
+      try {
+        filePath = resolveCallbackPath(filePath, basePath);
+      } catch (error) {
+        if (error instanceof CallbackPathTraversalError) {
+          return {
+            pass: false,
+            score: 0,
+            reason: error.message,
+            assertion,
+          };
+        }
+        throw error;
+      }
 
       if (isJavascriptFile(filePath)) {
         valueFromScript = await loadFromJavaScriptFile(filePath, functionName, [output, context]);

--- a/src/assertions/utils.ts
+++ b/src/assertions/utils.ts
@@ -5,6 +5,7 @@ import Clone from 'rfdc';
 import cliState from '../cliState';
 import { importModule } from '../esm';
 import { type Assertion, type TestCase } from '../types/index';
+import { resolveCallbackPath } from '../util/functions/loadFunction';
 import { loadYaml } from '../util/yamlLoad';
 
 const clone = Clone();
@@ -58,7 +59,7 @@ export async function loadFromJavaScriptFile(
 
 export function processFileReference(fileRef: string): object | string {
   const basePath = cliState.basePath || '';
-  const filePath = path.resolve(basePath, fileRef.slice('file://'.length));
+  const filePath = resolveCallbackPath(fileRef.slice('file://'.length), basePath);
   const fileContent = fs.readFileSync(filePath, 'utf8');
   const extension = path.extname(filePath);
   if (['.json', '.yaml', '.yml'].includes(extension)) {

--- a/src/matchers/rubric.ts
+++ b/src/matchers/rubric.ts
@@ -1,5 +1,4 @@
 import fs from 'fs/promises';
-import path from 'path';
 
 import { loadFromJavaScriptFile } from '../assertions/utils';
 import cliState from '../cliState';
@@ -8,7 +7,7 @@ import logger from '../logger';
 import { getDefaultProviders } from '../providers/defaults';
 import { getNunjucksEngineForFilePath, maybeLoadFromExternalFile } from '../util/file';
 import { isJavascriptFile } from '../util/fileExtensions';
-import { parseFileUrl } from '../util/functions/loadFunction';
+import { parseFileUrl, resolveCallbackPath } from '../util/functions/loadFunction';
 import invariant from '../util/invariant';
 import { extractJsonObjects, safeJsonStringify } from '../util/json';
 import { getNunjucksEngine } from '../util/templates';
@@ -79,7 +78,7 @@ export async function loadRubricPrompt(
     // Parse the file URL to extract file path and function name
     // This handles colon splitting correctly, including Windows drive letters and :functionName suffix
     const { filePath, functionName } = parseFileUrl(renderedFilePath);
-    const resolvedPath = path.resolve(basePath, filePath);
+    const resolvedPath = resolveCallbackPath(filePath, basePath);
 
     if (isJavascriptFile(filePath)) {
       rubricPrompt = await loadFromJavaScriptFile(resolvedPath, functionName, []);

--- a/test/assertions/scriptValueResolution.test.ts
+++ b/test/assertions/scriptValueResolution.test.ts
@@ -462,4 +462,64 @@ describe('Script value resolution', () => {
       expect(result.reason).toContain('Ruby execution error');
     });
   });
+
+  // REGRESSION TEST: `file://` assertion values must not be able to escape
+  // cliState.basePath via `../` traversal to load or read an arbitrary file.
+  describe('path traversal protection', () => {
+    it('should reject a javascript file:// value that escapes basePath', async () => {
+      const result = await runAssertion({
+        assertion: {
+          type: 'javascript',
+          value: 'file://../../../../../../../etc/passwd:handler',
+        },
+        test: { vars: {} },
+        providerResponse: baseProviderResponse,
+      });
+
+      expect(result.pass).toBe(false);
+      expect(result.reason).toMatch(/Path traversal rejected/);
+      expect(vi.mocked(importModule)).not.toHaveBeenCalled();
+    });
+
+    it('should reject a python file:// value that escapes basePath', async () => {
+      const result = await runAssertion({
+        assertion: {
+          type: 'python',
+          value: 'file://../../../../../../../etc/passwd:handler',
+        },
+        test: { vars: {} },
+        providerResponse: baseProviderResponse,
+      });
+
+      expect(result.pass).toBe(false);
+      expect(result.reason).toMatch(/Path traversal rejected/);
+    });
+
+    it('should reject a non-script (JSON/YAML/txt) file:// value that escapes basePath', async () => {
+      const result = await runAssertion({
+        assertion: {
+          type: 'equals',
+          value: 'file://../../../../../../../etc/passwd',
+        },
+        test: { vars: {} },
+        providerResponse: baseProviderResponse,
+      });
+
+      expect(result.pass).toBe(false);
+      expect(result.reason).toMatch(/Path traversal rejected/);
+    });
+
+    it('should reject a traversing file:// value inside an array assertion value', async () => {
+      await expect(
+        runAssertion({
+          assertion: {
+            type: 'contains-all',
+            value: ['file://../../../../../../../etc/passwd'],
+          },
+          test: { vars: {} },
+          providerResponse: baseProviderResponse,
+        }),
+      ).rejects.toThrow(/Path traversal rejected/);
+    });
+  });
 });

--- a/test/assertions/utils.test.ts
+++ b/test/assertions/utils.test.ts
@@ -15,12 +15,15 @@ import { createMockProvider as createFactoryProvider } from '../factories/provid
 import type { ApiProvider, Assertion, TestCase } from '../../src/types/index';
 
 vi.mock('fs');
-vi.mock('path');
 vi.mock('../../src/cliState');
 vi.mock('../../src/esm', () => ({
   importModule: vi.fn(),
 }));
 
+// `path` is intentionally NOT mocked here: `processFileReference` now routes
+// through `resolveCallbackPath`, whose path-traversal guard depends on real
+// `path.relative`/`path.isAbsolute` semantics (see resolveCallbackPath.test.ts
+// and loadCallbackFromFileUrl.test.ts for guard-specific coverage).
 describe('processFileReference', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -31,19 +34,15 @@ describe('processFileReference', () => {
     cliState.basePath = undefined;
     const jsonContent = JSON.stringify({ key: 'value' });
     vi.mocked(fs.readFileSync).mockReturnValue(jsonContent);
-    vi.mocked(path.resolve).mockReturnValue('/test.json');
-    vi.mocked(path.extname).mockReturnValue('.json');
 
     const result = processFileReference('file://test.json');
     expect(result).toEqual({ key: 'value' });
-    expect(fs.readFileSync).toHaveBeenCalledWith('/test.json', 'utf8');
+    expect(fs.readFileSync).toHaveBeenCalledWith(path.resolve(process.cwd(), 'test.json'), 'utf8');
   });
 
   it('should process JSON files correctly', () => {
     const jsonContent = JSON.stringify({ key: 'value' });
     vi.mocked(fs.readFileSync).mockReturnValue(jsonContent);
-    vi.mocked(path.resolve).mockReturnValue('/base/path/test.json');
-    vi.mocked(path.extname).mockReturnValue('.json');
 
     const result = processFileReference('file://test.json');
     expect(result).toEqual({ key: 'value' });
@@ -53,8 +52,6 @@ describe('processFileReference', () => {
   it('should process YAML files correctly', () => {
     const yamlContent = 'key: value';
     vi.mocked(fs.readFileSync).mockReturnValue(yamlContent);
-    vi.mocked(path.resolve).mockReturnValue('/base/path/test.yaml');
-    vi.mocked(path.extname).mockReturnValue('.yaml');
 
     const result = processFileReference('file://test.yaml');
     expect(result).toEqual({ key: 'value' });
@@ -64,8 +61,6 @@ describe('processFileReference', () => {
   it('should process YML files correctly', () => {
     const yamlContent = 'key: value';
     vi.mocked(fs.readFileSync).mockReturnValue(yamlContent);
-    vi.mocked(path.resolve).mockReturnValue('/base/path/test.yml');
-    vi.mocked(path.extname).mockReturnValue('.yml');
 
     const result = processFileReference('file://test.yml');
     expect(result).toEqual({ key: 'value' });
@@ -75,8 +70,6 @@ describe('processFileReference', () => {
   it('should process TXT files correctly', () => {
     const txtContent = 'plain text content\n';
     vi.mocked(fs.readFileSync).mockReturnValue(txtContent);
-    vi.mocked(path.resolve).mockReturnValue('/base/path/test.txt');
-    vi.mocked(path.extname).mockReturnValue('.txt');
 
     const result = processFileReference('file://test.txt');
     expect(result).toBe('plain text content');
@@ -84,10 +77,14 @@ describe('processFileReference', () => {
   });
 
   it('should throw an error for unsupported file types', () => {
-    vi.mocked(path.resolve).mockReturnValue('/base/path/test.unsupported');
-    vi.mocked(path.extname).mockReturnValue('.unsupported');
-
     expect(() => processFileReference('file://test.unsupported')).toThrow('Unsupported file type');
+  });
+
+  it('should reject a file:// reference that escapes basePath', () => {
+    expect(() => processFileReference('file://../../../etc/passwd')).toThrow(
+      /Path traversal rejected/,
+    );
+    expect(fs.readFileSync).not.toHaveBeenCalled();
   });
 });
 

--- a/test/matchers/llm-rubric.test.ts
+++ b/test/matchers/llm-rubric.test.ts
@@ -2347,6 +2347,29 @@ Evaluate the response
     expect(grading.provider.callApi).not.toHaveBeenCalled();
   });
 
+  // REGRESSION TEST: a rubricPrompt file:// reference must not be able to
+  // escape cliState.basePath via `../` traversal.
+  it('should reject a rubricPrompt file:// value that escapes basePath', async () => {
+    const rubric = 'Test rubric';
+    const llmOutput = 'Test output';
+    const grading = {
+      rubricPrompt: 'file://../../../../../../../etc/passwd',
+      provider: createMockProvider({
+        response: {
+          output: JSON.stringify({ pass: true, score: 1, reason: 'Test passed' }),
+          tokenUsage: { total: 10, prompt: 5, completion: 5 },
+        },
+      }),
+    };
+
+    await expect(matchesLlmRubric(rubric, llmOutput, grading)).rejects.toThrow(
+      /Path traversal rejected/,
+    );
+
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+    expect(grading.provider.callApi).not.toHaveBeenCalled();
+  });
+
   it('should not call remote when rubric prompt is overridden, even if redteam is enabled', async () => {
     const rubric = 'Test rubric';
     const llmOutput = 'Test output';


### PR DESCRIPTION
## Summary

`file://` assertion values (`assert[].value`) and `rubricPrompt` are resolved with a bare `path.resolve(basePath, filePath)` — no containment check. A `../` in the value walks the resolved path outside `basePath`, and depending on extension it gets read as a file, `require`'d as a JS module, or handed to the Python/Ruby runners.

We already have the fix for this exact shape of bug — `resolveCallbackPath()` in `src/util/functions/loadFunction.ts`, built for the provider-callback `file://` loader. Lexical `..` rejection, symlink-aware realpath re-check, `CallbackPathTraversalError`, documented `PROMPTFOO_DISABLE_CALLBACK_PATH_GUARD` opt-out. This just points the two other `file://` resolution sites (assertion dispatch, rubric prompt) at it instead of duplicating the logic.

Closes #10869

## Changes

- `src/assertions/index.ts`: the shared `filePath` resolution used by the js/py/rb branches now goes through `resolveCallbackPath`. A caught `CallbackPathTraversalError` becomes a normal `pass: false` assertion result instead of an uncaught throw, matching how the neighboring `.py`/`.rb` catch blocks already behave.
- `src/assertions/utils.ts`: `processFileReference()` (the JSON/YAML/txt non-script branch, and the array-of-values branch) uses the same guard.
- `src/matchers/rubric.ts`: `loadRubricPrompt()`'s file resolution uses the same guard. Errors propagate as a throw here, consistent with the existing "File does not exist" throw a few lines above it.
- `path` import dropped from `index.ts` and `rubric.ts` (no longer used after the change); kept in `utils.ts` for `path.extname`.

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run test/assertions test/matchers test/util/functions` — 1804/1804 passing
- `npx vitest run test/assertions/assertionsResult.test.ts test/assertions/runAssertions.test.ts test/assertions/trace.test.ts test/evaluator/assertions.test.ts` (shared-aggregation regression sweep) — 94/94 passing
- Added traversal-rejection tests at all three call sites: unit-level on `processFileReference` (`test/assertions/utils.test.ts`), end-to-end through `runAssertion` for the js/non-script/array-value branches (`test/assertions/scriptValueResolution.test.ts`), and `matchesLlmRubric`'s `rubricPrompt` (`test/matchers/llm-rubric.test.ts`)
- Manually reproduced both the file-read and the code-execution case against the pre-fix code (sandboxed `basePath`, file/script planted outside it, confirmed read/execution succeeded), then confirmed the fix blocks both with `Path traversal rejected: ...`
- `PROMPTFOO_DISABLE_CALLBACK_PATH_GUARD=true` still works as an escape hatch, since it's the same guard function already shipped for the callback-loader path
