### PR TITLE
fix(cli): remove retired GitHub example downloads

### DIFF
--- a/src/commands/exampleAliases.ts
+++ b/src/commands/exampleAliases.ts
@@ -216,20 +216,10 @@ export const REMOVED_EXAMPLES: Record<
     legacyRef: '0.120.26',
     reason: 'gemma-vs-mistral was removed because the underlying model is no longer available.',
   },
-  'github-models': {
-    legacyRef: '0.120.26',
-    reason:
-      'github-models was removed because GitHub retired GitHub Models, including its inference API, on July 30, 2026.',
-  },
   'openai-deep-research': {
     legacyRef: '31b566872971532e6d428c0cbad4487d22d936c5',
     reason:
       'This historical example uses retired OpenAI deep-research models and cannot run against the current OpenAI API.',
-  },
-  'provider-github-models': {
-    legacyRef: '31b566872971532e6d428c0cbad4487d22d936c5',
-    reason:
-      'provider-github-models was removed because GitHub retired GitHub Models, including its inference API, on July 30, 2026.',
   },
   'redteam-dalle': {
     legacyRef: '31b566872971532e6d428c0cbad4487d22d936c5',

--- a/src/commands/exampleAliases.ts
+++ b/src/commands/exampleAliases.ts
@@ -187,6 +187,15 @@ export const EXAMPLE_REPLACEMENTS: Record<string, string> = {
   'dbrx-benchmark': 'dbrx-benchmark was removed because DBRX is no longer available.',
 };
 
+// These examples must not be downloaded even when an older release still contains them.
+export function getUnsupportedExampleReason(exampleName: string): string | undefined {
+  const root = exampleName.split('/')[0];
+  if (root === 'github-models' || root === 'provider-github-models') {
+    return 'GitHub Models has been retired, so this example is no longer supported.';
+  }
+  return undefined;
+}
+
 // Examples that were intentionally removed from current examples/
 // but can still be downloaded from a legacy git ref for backwards compatibility.
 export const REMOVED_EXAMPLES: Record<

--- a/src/commands/exampleAliases.ts
+++ b/src/commands/exampleAliases.ts
@@ -187,15 +187,6 @@ export const EXAMPLE_REPLACEMENTS: Record<string, string> = {
   'dbrx-benchmark': 'dbrx-benchmark was removed because DBRX is no longer available.',
 };
 
-// These examples must not be downloaded even when an older release still contains them.
-export function getUnsupportedExampleReason(exampleName: string): string | undefined {
-  const root = exampleName.split('/')[0];
-  if (root === 'github-models' || root === 'provider-github-models') {
-    return 'GitHub Models has been retired, so this example is no longer supported.';
-  }
-  return undefined;
-}
-
 // Examples that were intentionally removed from current examples/
 // but can still be downloaded from a legacy git ref for backwards compatibility.
 export const REMOVED_EXAMPLES: Record<

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -44,7 +44,12 @@ function getExampleDirectoryUrl(dirPath: string, ref: string): URL {
 
 function getUnsupportedExampleReason(exampleName: string): string | undefined {
   // Match the effective request path, including URL dot segments and backslashes.
-  const { pathname } = getExampleDirectoryUrl(exampleName, VERSION);
+  let { pathname } = getExampleDirectoryUrl(exampleName, VERSION);
+  try {
+    pathname = decodeURIComponent(pathname);
+  } catch {
+    // Preserve the original request behavior for malformed percent escapes.
+  }
   const root = pathname.startsWith(GITHUB_EXAMPLES_PATH)
     ? pathname.slice(GITHUB_EXAMPLES_PATH.length).split('/')[0]
     : undefined;
@@ -281,19 +286,9 @@ async function logExampleInstructions(
 
   if (exampleName.includes('redteam') || !isRunnableFromRoot) {
     if (readmeExists) {
-      logger.info(
-        dedent`
-
-        View the README file at ${chalk.bold(readmePath)} to get started!
-        `,
-      );
+      logger.info(`View the README file at ${chalk.bold(readmePath)} to get started!`);
     } else {
-      logger.info(
-        dedent`
-
-        View the example at ${chalk.bold(docsUrl)} to get started!
-        `,
-      );
+      logger.info(`View the example at ${chalk.bold(docsUrl)} to get started!`);
     }
     return;
   }
@@ -301,18 +296,18 @@ async function logExampleInstructions(
   const runCommand = promptfooCommand('eval');
   if (readmeExists) {
     logger.info(
-      dedent`
+      dedent(`
 
       View the README at ${chalk.bold(readmePath)} or run:
 
       \`${chalk.bold(`${cdCommand} && ${runCommand}`)}\`
 
       to get started!
-      `,
+      `),
     );
   } else {
     logger.info(
-      dedent`
+      dedent(`
 
       Run:
 
@@ -320,7 +315,7 @@ async function logExampleInstructions(
 
       to get started.
       Example docs: ${chalk.bold(docsUrl)}
-      `,
+      `),
     );
   }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,7 +11,12 @@ import { initializeProject } from '../onboarding';
 import telemetry from '../telemetry';
 import { fetchWithProxy } from '../util/fetch/index';
 import { promptfooCommand } from '../util/promptfooCommand';
-import { EXAMPLE_ALIASES, EXAMPLE_REPLACEMENTS, REMOVED_EXAMPLES } from './exampleAliases';
+import {
+  EXAMPLE_ALIASES,
+  EXAMPLE_REPLACEMENTS,
+  getUnsupportedExampleReason,
+  REMOVED_EXAMPLES,
+} from './exampleAliases';
 import type { Command } from 'commander';
 
 const GITHUB_API_BASE = 'https://api.github.com';
@@ -73,7 +78,7 @@ function extractRunnableExamples(tree: GitHubTreeItem[]): string[] {
     }
 
     const exampleDir = path.posix.dirname(item.path).replace(/^examples\//, '');
-    if (exampleDir && exampleDir !== '.') {
+    if (exampleDir && exampleDir !== '.' && !getUnsupportedExampleReason(exampleDir)) {
       examples.add(exampleDir);
     }
   }
@@ -140,6 +145,10 @@ export async function downloadDirectory(
   targetDir: string,
   refs: string[] = DEFAULT_EXAMPLE_REFS,
 ): Promise<void> {
+  const unsupportedReason = getUnsupportedExampleReason(dirPath);
+  if (unsupportedReason) {
+    throw new Error(`Example '${dirPath}' is unavailable. ${unsupportedReason}`);
+  }
   const contents = await fetchExampleDirectoryContents(dirPath, refs);
 
   for (const item of contents) {
@@ -346,6 +355,10 @@ export async function handleExampleDownload(
       attemptDownload = false;
     } catch (error) {
       logger.error(`Failed to download example: ${error instanceof Error ? error.message : error}`);
+      if (getUnsupportedExampleReason(exampleName)) {
+        process.exitCode = 1;
+        return exampleName;
+      }
       attemptDownload = await confirm({
         message: 'Would you like to try downloading a different example?',
         default: true,

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -11,16 +11,13 @@ import { initializeProject } from '../onboarding';
 import telemetry from '../telemetry';
 import { fetchWithProxy } from '../util/fetch/index';
 import { promptfooCommand } from '../util/promptfooCommand';
-import {
-  EXAMPLE_ALIASES,
-  EXAMPLE_REPLACEMENTS,
-  getUnsupportedExampleReason,
-  REMOVED_EXAMPLES,
-} from './exampleAliases';
+import { EXAMPLE_ALIASES, EXAMPLE_REPLACEMENTS, REMOVED_EXAMPLES } from './exampleAliases';
 import type { Command } from 'commander';
 
 const GITHUB_API_BASE = 'https://api.github.com';
+const GITHUB_EXAMPLES_PATH = '/repos/promptfoo/promptfoo/contents/examples/';
 const DEFAULT_EXAMPLE_REFS = [VERSION, 'main'];
+
 const EXAMPLE_CONFIG_FILENAMES = new Set([
   'promptfooconfig.yaml',
   'promptfooconfig.yml',
@@ -39,6 +36,22 @@ interface GitHubContentItem {
   name: string;
   type: 'file' | 'dir' | string;
   download_url: string | null;
+}
+
+function getExampleDirectoryUrl(dirPath: string, ref: string): URL {
+  return new URL(`${GITHUB_API_BASE}${GITHUB_EXAMPLES_PATH}${dirPath}?ref=${ref}`);
+}
+
+function getUnsupportedExampleReason(exampleName: string): string | undefined {
+  // Match the effective request path, including URL dot segments and backslashes.
+  const { pathname } = getExampleDirectoryUrl(exampleName, VERSION);
+  const root = pathname.startsWith(GITHUB_EXAMPLES_PATH)
+    ? pathname.slice(GITHUB_EXAMPLES_PATH.length).split('/')[0]
+    : undefined;
+  if (root === 'github-models' || root === 'provider-github-models') {
+    return 'GitHub Models has been retired, so this example is no longer supported.';
+  }
+  return undefined;
 }
 
 function getGitHubHeaders() {
@@ -116,7 +129,7 @@ async function fetchExampleDirectoryContents(
   const failedRefs: string[] = [];
 
   for (const ref of refs) {
-    const url = `${GITHUB_API_BASE}/repos/promptfoo/promptfoo/contents/examples/${dirPath}?ref=${ref}`;
+    const url = getExampleDirectoryUrl(dirPath, ref).toString();
     const response = await fetchWithProxy(url, {
       headers: getGitHubHeaders(),
     });

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import path from 'path';
 
 import confirm from '@inquirer/confirm';
 import select from '@inquirer/select';
@@ -165,7 +166,53 @@ describe('init command', () => {
       await init.downloadDirectory(example, '/path/to/target', ['0.122.2']);
 
       expect(mockFetchWithProxy).toHaveBeenCalledTimes(2);
-      expect(fs.writeFile).toHaveBeenCalledWith('/path/to/target/promptfooconfig.yaml', config);
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        path.join('/path/to/target', 'promptfooconfig.yaml'),
+        config,
+      );
+    });
+
+    it.each([
+      '%70rovider-github-models',
+      '%67ithub-models',
+      '%70rovider-github-models%2FREADME.md',
+      '%67ithub-models%2Fnested',
+    ])('rejects encoded retired example %s before requesting contents', async (example) => {
+      mockFetchWithProxy.mockResolvedValue(createMockResponse({ json: () => Promise.resolve([]) }));
+
+      await expect(init.downloadDirectory(example, '/path/to/target', ['0.122.2'])).rejects.toThrow(
+        'GitHub Models has been retired',
+      );
+      expect(mockFetchWithProxy).not.toHaveBeenCalled();
+    });
+
+    it('downloads a supported encoded example without rewriting its request path', async () => {
+      const fileUrl = 'https://example.com/promptfooconfig.yaml';
+      mockFetchWithProxy
+        .mockResolvedValueOnce(
+          createMockResponse({
+            json: () =>
+              Promise.resolve([
+                { type: 'file', name: 'promptfooconfig.yaml', download_url: fileUrl },
+              ]),
+          }),
+        )
+        .mockResolvedValueOnce(
+          createMockResponse({ text: () => Promise.resolve('description: encoded example') }),
+        );
+
+      await init.downloadDirectory('%63onfig-js', '/path/to/target', ['0.122.2']);
+
+      expect(mockFetchWithProxy).toHaveBeenNthCalledWith(
+        1,
+        'https://api.github.com/repos/promptfoo/promptfoo/contents/examples/%63onfig-js?ref=0.122.2',
+        expect.any(Object),
+      );
+      expect(mockFetchWithProxy).toHaveBeenCalledTimes(2);
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        path.join('/path/to/target', 'promptfooconfig.yaml'),
+        'description: encoded example',
+      );
     });
 
     it('should throw an error if fetching directory contents fails on both VERSION and main', async () => {
@@ -347,6 +394,85 @@ describe('init command', () => {
   });
 
   describe('handleExampleDownload', () => {
+    it.each([
+      [false, true],
+      [false, false],
+      [true, true],
+      [true, false],
+    ])(
+      'preserves literal backslashes in advice (runnable=%s, README=%s)',
+      async (runnable, readme) => {
+        const directory = 'workspace\\branch';
+        const example = 'provider-http\\basic';
+        const examplePath = path.join(directory, example);
+        const readmePath = path.join(examplePath, 'README.md');
+        const entries = [
+          ...(runnable ? ['promptfooconfig.yaml'] : []),
+          ...(readme ? ['README.md'] : []),
+        ];
+        mockFetchWithProxy.mockImplementation(async (input) =>
+          input.toString().startsWith('https://api.github.com/')
+            ? createMockResponse({
+                json: () =>
+                  Promise.resolve(
+                    entries.map((name) => ({
+                      type: 'file',
+                      name,
+                      download_url: `https://example.com/${name}`,
+                    })),
+                  ),
+              })
+            : createMockResponse({ text: () => Promise.resolve('harmless example content') }),
+        );
+        vi.mocked(fs.readdir).mockResolvedValue(
+          entries as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+        );
+        vi.mocked(fs.access).mockImplementation(async (target) => {
+          if (target.toString() === readmePath && !readme) {
+            throw new Error('ENOENT');
+          }
+        });
+
+        expect(await init.handleExampleDownload(directory, example)).toBe(example);
+
+        const advice = vi
+          .mocked(logger.info)
+          .mock.calls.map(([message]) => String(message))
+          .find((message) => message.includes('to get started'));
+        expect(advice).toBeDefined();
+        if (readme) {
+          expect(advice).toContain(readmePath);
+        } else {
+          expect(advice).toContain(
+            `https://github.com/promptfoo/promptfoo/tree/main/examples/${example}`,
+          );
+        }
+        if (runnable) {
+          expect(advice).toContain(`cd ${examplePath} && promptfoo eval`);
+        }
+        expect(advice).not.toContain('\u0008');
+        expect(fs.writeFile).toHaveBeenCalledTimes(entries.length);
+      },
+    );
+
+    it('preserves ordinary retry behavior for a malformed percent escape', async () => {
+      mockFetchWithProxy.mockResolvedValue(
+        createMockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+      );
+      vi.mocked(confirm).mockResolvedValue(false);
+
+      expect(await init.handleExampleDownload('.', 'config-%ZZ')).toBe('config-%ZZ');
+
+      expect(mockFetchWithProxy).toHaveBeenCalledTimes(2);
+      for (const [url] of mockFetchWithProxy.mock.calls) {
+        expect(url.toString()).toContain('/contents/examples/config-%ZZ?ref=');
+      }
+      expect(confirm).toHaveBeenCalledOnce();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch directory contents for refs:'),
+      );
+    });
+
     describe('alias resolution', () => {
       it('should resolve old example name to new name via EXAMPLE_ALIASES', async () => {
         // Download will fail, but we're testing alias resolution, not download
@@ -679,6 +805,10 @@ describe('init command', () => {
       'config-js/../provider-github-models',
       '.\\provider-github-models',
       'config-js\\..\\provider-github-models',
+      '%70rovider-github-models',
+      '%67ithub-models',
+      '%70rovider-github-models%2FREADME.md',
+      '%67ithub-models%2Fnested',
     ])(
       'reports unsupported example %s as a failed init without download or retry',
       async (example) => {

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -115,19 +115,58 @@ describe('init command', () => {
   });
 
   describe('downloadDirectory', () => {
-    it.each(['github-models', 'provider-github-models', 'provider-github-models/nested'])(
-      'rejects unsupported example %s before fetching directory contents',
-      async (example) => {
-        mockFetchWithProxy.mockResolvedValue(
-          createMockResponse({ json: () => Promise.resolve([]) }),
-        );
+    it.each(
+      ['github-models', 'provider-github-models'].flatMap((root) => [
+        root,
+        `${root}/nested`,
+        `./${root}`,
+        `config-js/../${root}`,
+        `.\\${root}`,
+        `config-js\\..\\${root}`,
+        `./${root}/nested`,
+      ]),
+    )('rejects unsupported example %s before fetching directory contents', async (example) => {
+      mockFetchWithProxy.mockResolvedValue(createMockResponse({ json: () => Promise.resolve([]) }));
 
-        await expect(
-          init.downloadDirectory(example, '/path/to/target', ['0.122.2']),
-        ).rejects.toThrow('GitHub Models has been retired');
-        expect(mockFetchWithProxy).not.toHaveBeenCalled();
-      },
-    );
+      await expect(init.downloadDirectory(example, '/path/to/target', ['0.122.2'])).rejects.toThrow(
+        'GitHub Models has been retired',
+      );
+      expect(mockFetchWithProxy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['config-js', 'config-js'],
+      ['./config-js', 'config-js'],
+      ['provider-http/../config-js', 'config-js'],
+      ['provider-github-models/../config-js', 'config-js'],
+      ['provider-http/basic', 'provider-http/basic'],
+      ['provider-http\\basic', 'provider-http/basic'],
+    ])('downloads supported effective path %s', async (example, effectivePath) => {
+      const contentsPath = `/repos/promptfoo/promptfoo/contents/examples/${effectivePath}`;
+      const fileUrl = 'https://example.com/promptfooconfig.yaml';
+      const config = 'description: supported example';
+      mockFetchWithProxy.mockImplementation(async (input) => {
+        const url = new URL(input.toString());
+        if (url.origin === 'https://api.github.com' && url.pathname === contentsPath) {
+          expect(url.searchParams.get('ref')).toBe('0.122.2');
+          return createMockResponse({
+            json: () =>
+              Promise.resolve([
+                { type: 'file', name: 'promptfooconfig.yaml', download_url: fileUrl },
+              ]),
+          });
+        }
+        if (url.href === fileUrl) {
+          return createMockResponse({ text: () => Promise.resolve(config) });
+        }
+        throw new Error(`Unexpected example request: ${url}`);
+      });
+
+      await init.downloadDirectory(example, '/path/to/target', ['0.122.2']);
+
+      expect(mockFetchWithProxy).toHaveBeenCalledTimes(2);
+      expect(fs.writeFile).toHaveBeenCalledWith('/path/to/target/promptfooconfig.yaml', config);
+    });
 
     it('should throw an error if fetching directory contents fails on both VERSION and main', async () => {
       const mockResponse = createMockResponse({
@@ -633,7 +672,14 @@ describe('init command', () => {
       }
     });
 
-    it.each(['github-models', 'provider-github-models'])(
+    it.each([
+      'github-models',
+      'provider-github-models',
+      './provider-github-models',
+      'config-js/../provider-github-models',
+      '.\\provider-github-models',
+      'config-js\\..\\provider-github-models',
+    ])(
       'reports unsupported example %s as a failed init without download or retry',
       async (example) => {
         const previousExitCode = process.exitCode;
@@ -652,6 +698,8 @@ describe('init command', () => {
           expect(process.exitCode).toBe(1);
           expect(mockFetchWithProxy).not.toHaveBeenCalled();
           expect(confirm).not.toHaveBeenCalled();
+          expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('written to:'));
+          expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('promptfoo eval'));
         } finally {
           process.exitCode = previousExitCode;
         }

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -394,28 +394,6 @@ describe('init command', () => {
         },
       );
 
-      it.each([
-        { example: 'github-models', ref: '0.120.26' },
-        { example: 'provider-github-models', ref: '31b566872971532e6d428c0cbad4487d22d936c5' },
-      ])(
-        'pins the retired GitHub Models example $example and explains the retirement',
-        async ({ example, ref }) => {
-          mockFetchWithProxy.mockResolvedValue(
-            createMockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
-          );
-          vi.mocked(confirm).mockResolvedValue(false);
-
-          expect(await init.handleExampleDownload('.', example)).toBe(example);
-          expect(mockFetchWithProxy).toHaveBeenCalledTimes(1);
-          expect(mockFetchWithProxy.mock.calls[0][0]).toContain(
-            `/repos/promptfoo/promptfoo/contents/examples/${example}?ref=${ref}`,
-          );
-          expect(logger.warn).toHaveBeenCalledWith(
-            expect.stringContaining('GitHub retired GitHub Models'),
-          );
-        },
-      );
-
       it('should reset to default refs when retrying after legacy example failure', async () => {
         const mockLegacyFailure = createMockResponse({
           ok: false,

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -115,6 +115,20 @@ describe('init command', () => {
   });
 
   describe('downloadDirectory', () => {
+    it.each(['github-models', 'provider-github-models', 'provider-github-models/nested'])(
+      'rejects unsupported example %s before fetching directory contents',
+      async (example) => {
+        mockFetchWithProxy.mockResolvedValue(
+          createMockResponse({ json: () => Promise.resolve([]) }),
+        );
+
+        await expect(
+          init.downloadDirectory(example, '/path/to/target', ['0.122.2']),
+        ).rejects.toThrow('GitHub Models has been retired');
+        expect(mockFetchWithProxy).not.toHaveBeenCalled();
+      },
+    );
+
     it('should throw an error if fetching directory contents fails on both VERSION and main', async () => {
       const mockResponse = createMockResponse({
         ok: false,
@@ -184,6 +198,37 @@ describe('init command', () => {
   });
 
   describe('getExamplesList', () => {
+    it.each([false, true])(
+      'excludes unsupported examples from discovery (VERSION unavailable=%s)',
+      async (versionUnavailable) => {
+        if (versionUnavailable) {
+          mockFetchWithProxy.mockResolvedValueOnce(
+            createMockResponse({ ok: false, status: 404, statusText: 'Not Found' }),
+          );
+        }
+        mockFetchWithProxy.mockResolvedValueOnce(
+          createMockResponse({
+            json: () =>
+              Promise.resolve({
+                tree: [
+                  { path: 'examples/provider-github-models/promptfooconfig.yaml', type: 'blob' },
+                  { path: 'examples/github-models/promptfooconfig.yaml', type: 'blob' },
+                  {
+                    path: 'examples/provider-github-models/nested/promptfooconfig.yaml',
+                    type: 'blob',
+                  },
+                  { path: 'examples/config-js/promptfooconfig.js', type: 'blob' },
+                  { path: 'examples/provider-http/basic/promptfooconfig.yaml', type: 'blob' },
+                ],
+              }),
+          }),
+        );
+
+        expect(await init.getExamplesList()).toEqual(['config-js', 'provider-http/basic']);
+        expect(mockFetchWithProxy).toHaveBeenCalledTimes(versionUnavailable ? 2 : 1);
+      },
+    );
+
     it('should return a list of examples', async () => {
       const mockResponse = createMockResponse({
         ok: true,
@@ -587,6 +632,31 @@ describe('init command', () => {
         throw new Error('initCmd not found');
       }
     });
+
+    it.each(['github-models', 'provider-github-models'])(
+      'reports unsupported example %s as a failed init without download or retry',
+      async (example) => {
+        const previousExitCode = process.exitCode;
+        mockFetchWithProxy.mockResolvedValue(
+          createMockResponse({ json: () => Promise.resolve([]) }),
+        );
+
+        try {
+          await program.parseAsync(['init', '--example', example, '--no-interactive'], {
+            from: 'user',
+          });
+
+          expect(logger.error).toHaveBeenCalledWith(
+            expect.stringContaining('GitHub Models has been retired'),
+          );
+          expect(process.exitCode).toBe(1);
+          expect(mockFetchWithProxy).not.toHaveBeenCalled();
+          expect(confirm).not.toHaveBeenCalled();
+        } finally {
+          process.exitCode = previousExitCode;
+        }
+      },
+    );
 
     it('should set up the init command correctly', () => {
       const initCmd = program.commands.find((cmd) => cmd.name() === 'init');


### PR DESCRIPTION
The CLI could still download the removed GitHub Models example from an older release and include it in example discovery. Remove its archive mappings and reject both retired names, including normalized and encoded paths, before requesting example contents.

Other examples retain their release fallback, aliases and retry behavior. Download instructions now preserve literal backslashes instead of interpreting them as escape sequences.

Validation:

- 70 focused init tests; the new regression cases failed before the fixes.
- Root and app TypeScript checks, core build and postbuild.
- 26 offline built-CLI cases: 15 retirement rejections before an example request and 11 supported download/discovery cases, including exact instruction text.
- Changed-file lint, direct formatting check and normal commit hooks. The formatting wrapper returned 123 on an empty Prettier invocation; the changed TypeScript files pass Biome.

Local checks used Node 24.20.0 and the recorded installed dependencies, including retained differences from the lockfile; no fresh full-lock install or Windows execution is claimed. No vendor inference calls were made.
