### PR TITLE
fix(fetch): treat credit_balance_exhausted as a hard quota error

### DIFF
--- a/src/util/fetch/errors.ts
+++ b/src/util/fetch/errors.ts
@@ -28,6 +28,11 @@ export const HARD_QUOTA_ERROR_CODES: ReadonlySet<string> = new Set([
   'billing_not_active',
   'access_terminated',
   'quota_exceeded',
+  // Returned by OpenAI when a prepaid credit balance is fully consumed
+  // (HTTP 429, no Retry-After header). Without this entry the error falls
+  // through to the per-window retry loop and a single test can take ~20 min
+  // before failing. References: https://github.com/promptfoo/promptfoo/issues/10855
+  'credit_balance_exhausted',
 ]);
 
 /**

--- a/test/util/fetch/errors.test.ts
+++ b/test/util/fetch/errors.test.ts
@@ -222,6 +222,7 @@ describe('isHardQuotaCode', () => {
     ['billing_not_active', true],
     ['access_terminated', true],
     ['quota_exceeded', true],
+    ['credit_balance_exhausted', true],
     ['rate_limit_exceeded', false],
     ['tokens_per_min', false],
     ['', false],
@@ -281,6 +282,17 @@ describe('HttpRateLimitError', () => {
     expect(err.message).toContain('Quota exceeded');
     expect(err.message).toContain('429');
     expect(err.message).toContain('insufficient_quota');
+  });
+
+  it('classifies credit_balance_exhausted as kind="quota" (fixes #10855)', () => {
+    // OpenAI returns HTTP 429 with code "credit_balance_exhausted" when a prepaid
+    // account has no credits left. Previously this code was missing from
+    // HARD_QUOTA_ERROR_CODES so the error fell through to the retry loop and a
+    // single test took ~20 minutes before failing.
+    const err = new HttpRateLimitError({ status: 429, code: 'credit_balance_exhausted' });
+    expect(err.kind).toBe('quota');
+    expect(err.message).toContain('Quota exceeded');
+    expect(err.message).toContain('credit_balance_exhausted');
   });
 
   it('classifies unknown / per-window codes as kind="rate_limit"', () => {


### PR DESCRIPTION
## Summary

OpenAI returns HTTP 429 with rror.code = "credit_balance_exhausted" when a prepaid account has no credits remaining. This code was missing from HARD_QUOTA_ERROR_CODES in src/util/fetch/errors.ts, so the fail-fast path never fired.

### Impact

Because the 429 carries no Retry-After header, each retry used the 60-second fallback. A single test against a depleted key took **~20 minutes** before eventually failing with a misleading generic rate-limit message (Rate limit exceeded: HTTP 429 ... (code: credit_balance_exhausted)), with no hint that it was a billing problem.

### Fix

Add 'credit_balance_exhausted' to HARD_QUOTA_ERROR_CODES. The error is now classified as kind: 'quota', surfaces the billing-focused message (Quota exceeded … Retries will not help — check your billing or daily quota.), and aborts immediately.

### Testing

- Added 'credit_balance_exhausted' to the isHardQuotaCode parametrised test table.
- Added a dedicated HttpRateLimitError test verifying kind === 'quota' and the correct message prefix.
- All 83 tests pass. Lint clean (Biome).

### To reproduce (before fix)

`yaml
providers:
  - openai:chat:gpt-4o-mini
prompts:
  - "Say hi"
tests:
  - assert:
      - type: contains
        value: hi
`

Run promptfoo eval with an OpenAI key whose prepaid balance is 0. Before this fix the eval runs for ~20 minutes. After this fix it fails immediately.

Closes #10855