### PR TITLE
docs(model-graded): document defaultTest.provider as undocumented grader fallback

### DIFF
--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -260,6 +260,31 @@ override the grader. There are several ways to do this, depending on your prefer
            provider: openai:gpt-5.6
    ```
 
+:::caution `defaultTest.provider` also sets the grader
+
+`defaultTest.provider` is the field that pins the **target model** for every test in a suite. As a
+side-effect it is also consulted as a grader fallback — before the dedicated
+`defaultTest.options.provider` slot — when no explicit grader is configured.
+
+This means the following config generates responses **and** grades them with `gpt-4.1`:
+
+```yaml
+defaultTest:
+  provider: openai:gpt-4.1 # ← also becomes the judge
+tests:
+  - assert:
+      - type: llm-rubric
+        value: Answers the question accurately
+```
+
+To use a dedicated judge while still pinning the target, set `defaultTest.options.provider`
+separately (option 2 above) or use `--grader` on the CLI. Only the
+`defaultTest.options.provider` / `test.options.provider` slots are documented grader
+configuration points; `defaultTest.provider` is an undocumented fallback that exists purely
+for backwards compatibility.
+
+:::
+
 Use the `provider.config` field to set custom parameters such as `temperature`, `max_tokens`, or API host:
 
 ```yaml

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -260,17 +260,19 @@ override the grader. There are several ways to do this, depending on your prefer
            provider: openai:gpt-5.6
    ```
 
-:::caution `defaultTest.provider` also sets the grader
+:::caution `defaultTest.provider` also sets the grader for output-based assertions
 
-`defaultTest.provider` is the field that pins the **target model** for every test in a suite. As a
-side-effect it is also consulted as a grader fallback — before the dedicated
-`defaultTest.options.provider` slot — when no explicit grader is configured.
+`defaultTest.provider` is the field that pins the **target model** for every test in a suite.
+For output-based model-graded assertions (`llm-rubric`, `factuality`, `g-eval`,
+`model-graded-closedqa`, `answer-relevance`, etc.) it is also consulted as a grader fallback when
+no explicit grader is configured — **after** `--grader`, `assertion.provider`, and
+`test.options.provider` / `defaultTest.options.provider` have all been checked and found absent.
 
-This means the following config generates responses **and** grades them with `gpt-4.1`:
+In practice this means the following config generates responses **and** grades them with `gpt-4.1`:
 
 ```yaml
 defaultTest:
-  provider: openai:gpt-4.1 # ← also becomes the judge
+  provider: openai:gpt-4.1 # ← also becomes the judge when no grader is set
 tests:
   - assert:
       - type: llm-rubric
@@ -278,10 +280,22 @@ tests:
 ```
 
 To use a dedicated judge while still pinning the target, set `defaultTest.options.provider`
-separately (option 2 above) or use `--grader` on the CLI. Only the
-`defaultTest.options.provider` / `test.options.provider` slots are documented grader
-configuration points; `defaultTest.provider` is an undocumented fallback that exists purely
-for backwards compatibility.
+(option 2 above) or pass `--grader` on the CLI:
+
+```yaml
+defaultTest:
+  provider: openai:gpt-4.1 # target model
+  options:
+    provider: openai:gpt-5.6 # explicit judge — takes precedence over the fallback
+```
+
+**Notes:**
+
+- This fallback applies to the output-based assertions listed above. `agent-rubric` and
+  `search-rubric` use capability-specific provider selection and are not affected.
+- For **red-team** runs (`promptfoo redteam run`), grader selection follows a separate code path
+  (`RedteamProviderManager`). Neither `defaultTest.options.provider` nor `--grader` is guaranteed
+  to override the judge there; consult the red-team configuration docs for the correct override.
 
 :::
 

--- a/site/docs/configuration/expected-outputs/model-graded/index.md
+++ b/site/docs/configuration/expected-outputs/model-graded/index.md
@@ -293,9 +293,18 @@ defaultTest:
 
 - This fallback applies to the output-based assertions listed above. `agent-rubric` and
   `search-rubric` use capability-specific provider selection and are not affected.
-- For **red-team** runs (`promptfoo redteam run`), grader selection follows a separate code path
-  (`RedteamProviderManager`). Neither `defaultTest.options.provider` nor `--grader` is guaranteed
-  to override the judge there; consult the red-team configuration docs for the correct override.
+  **Red-team runs (`promptfoo redteam run`):** `RedteamProviderManager` selects `defaultTest.provider`
+  _before_ `defaultTest.options.provider`, so setting `defaultTest.options.provider` alone does not
+  override the judge. The reliable pattern is to move the target to the top-level `providers` list
+  and reserve `defaultTest.options.provider` for the judge:
+
+```yaml
+providers:
+  - openai:gpt-4.1 # target — no longer in defaultTest.provider
+defaultTest:
+  options:
+    provider: openai:gpt-5.6 # judge — now effective in both standard and red-team grading
+```
 
 :::
 


### PR DESCRIPTION
## Summary

The **"Overriding the LLM grader"** section in the model-graded docs listed three explicit grader configuration points:

1. --grader CLI flag
2. defaultTest.options.provider
3. ssertion.provider

It did not mention that **defaultTest.provider** — the field used to pin the *target model* for every test — is also consulted as a grader fallback **before** those slots (see src/matchers/providers.ts lines 196–202).

### Impact

A user who sets defaultTest.provider to pin their target model unknowingly pins the judge to the same model. The only signal is a logger.debug line buried in the grading provider resolution. This is especially surprising in red-team / safety configs where the target and judge should be independent.

Example that hits the undocumented behaviour:

`yaml
defaultTest:
  provider: openai:gpt-4.1   # ← also becomes the LLM judge
tests:
  - assert:
      - type: llm-rubric
        value: Answers the question accurately
`

### Fix

Add a :::caution callout block immediately after the numbered grader override list explaining:

- defaultTest.provider doubles as a grader fallback
- A concrete YAML example showing the dual role
- The recommended workaround: use defaultTest.options.provider or --grader

No code changes — documentation only.

Closes #10581