### PR TITLE
fix(cli): handle large values during result export

### DIFF
--- a/src/util/sanitizer.ts
+++ b/src/util/sanitizer.ts
@@ -358,7 +358,8 @@ export function looksLikeSecret(value: string): boolean {
 
   // Long base64-like strings (likely tokens/keys) - 64+ chars of alphanumeric
   // Using 64 chars to reduce false positives on concatenated IDs, base64 content, or long model names
-  if (/^[a-zA-Z0-9+/=_-]{64,}$/.test(value)) {
+  // Scan for disallowed characters without growing the regex stack for large values.
+  if (value.length >= 64 && !/[^a-zA-Z0-9+/=_-]/.test(value)) {
     return true;
   }
 

--- a/test/util/output.test.ts
+++ b/test/util/output.test.ts
@@ -171,6 +171,28 @@ describe('writeOutput', () => {
     expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
   });
 
+  it('exports very large token-like config values with secret redaction intact', async () => {
+    const eval_ = new Eval({
+      tests: [{ vars: { media: 'A'.repeat(16_369_336), message: 'Public fixture text.' } }],
+      providers: [{ id: 'echo', config: { apiKey: 'fixture-api-key', max_tokens: 37 } }],
+    });
+
+    await writeOutput('output.json', eval_, null);
+
+    expect(fsPromises.writeFile).toHaveBeenCalledTimes(1);
+    const outputJson = vi.mocked(fsPromises.writeFile).mock.calls[0][1] as string;
+    const parsed = JSON.parse(outputJson);
+    expect(parsed.config.tests[0].vars).toEqual({
+      media: '[REDACTED]',
+      message: 'Public fixture text.',
+    });
+    expect(parsed.config.providers[0].config).toEqual({
+      apiKey: '[REDACTED]',
+      max_tokens: 37,
+    });
+    expect(outputJson).not.toContain('fixture-api-key');
+  });
+
   it('redacts env and secret config fields in JSON output', async () => {
     const outputPath = 'output.json';
     const eval_ = new Eval({

--- a/test/util/sanitizer.test.ts
+++ b/test/util/sanitizer.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   isSecretEnvVarName,
+  looksLikeSecret,
   preserveTracingCredentialReferences,
   redactAzureBlobSasTokens,
   restoreAzureBlobSasTokens,
@@ -37,6 +38,34 @@ describe('sanitizeRuntimeOptions', () => {
         providerFilter: 'selected-target',
       }),
     ).toEqual({ providerFilter: 'selected-target' });
+  });
+});
+
+describe('looksLikeSecret', () => {
+  it.each([
+    ['below the minimum length', 'A'.repeat(63), false],
+    ['at the minimum length', 'A'.repeat(64), true],
+    ['above the minimum length', 'A'.repeat(65), true],
+    ['the complete token alphabet', 'aZ09+/=_-'.repeat(8), true],
+    ['a trailing space', `${'A'.repeat(64)} `, false],
+    ['a trailing newline', `${'A'.repeat(64)}\n`, false],
+    ['a trailing carriage return', `${'A'.repeat(64)}\r`, false],
+    ['a trailing CRLF', `${'A'.repeat(64)}\r\n`, false],
+    ['a line separator', `${'A'.repeat(64)}\u2028`, false],
+    ['a paragraph separator', `${'A'.repeat(64)}\u2029`, false],
+    ['an embedded tab', `${'A'.repeat(32)}\t${'A'.repeat(32)}`, false],
+    ['a non-ASCII letter', `${'A'.repeat(63)}é`, false],
+    ['an astral character', `${'A'.repeat(63)}😀`, false],
+    ['a NUL character', `${'A'.repeat(64)}\0`, false],
+  ])('classifies %s without changing token detection', (_name, value, expected) => {
+    expect(looksLikeSecret(value as string)).toBe(expected);
+  });
+
+  it('classifies very large token-like values without overflowing the stack', () => {
+    const value = 'A'.repeat(16_369_336);
+
+    expect(looksLikeSecret(value)).toBe(true);
+    expect(looksLikeSecret(`${value}.`)).toBe(false);
   });
 });
 


### PR DESCRIPTION
JSON export can fail after a successful evaluation when a config value contains a large base64-like string. The secret classifier's regex overflows the stack.

Keep the same 64-character minimum and token alphabet, using a scan for disallowed characters. Token-like values and secret config fields remain redacted; ordinary large strings remain intact.

## Validation

- Reproduced the classifier and JSON writer failures before the fix; checked length, newline and Unicode boundaries.
- Passed 349 sanitizer/output tests, 71 app store tests, core/app type checks and builds.
- Ran one built CLI evaluation with two echo cases and inspected the exported JSON for results, redaction and preservation of the ordinary large value. No provider requests.
- Biome and normal commit hooks passed. The aggregate formatter encountered an existing empty-input Prettier failure; the changed TypeScript files passed their scoped check.
