### PR TITLE
fix(cli): preserve in-memory results for extensions

### DIFF
--- a/src/models/eval.ts
+++ b/src/models/eval.ts
@@ -1380,7 +1380,9 @@ export default class Eval {
   }
 
   async loadResults() {
-    this.results = await EvalResult.findManyByEvalId(this.id);
+    if (this.persisted) {
+      this.results = await EvalResult.findManyByEvalId(this.id);
+    }
     this._resultsLoaded = true;
   }
 

--- a/test/evaluator/metadata.test.ts
+++ b/test/evaluator/metadata.test.ts
@@ -415,7 +415,7 @@ describeEvaluator('evaluator metadata', () => {
     expect(capturedContext.result.metadata.sessionId).toBeUndefined();
   });
 
-  it('should persist afterEach hook namedScores, metadata, and response.metadata into result and metrics', async () => {
+  it.each([true, false])('retains afterEach results (persisted: %s)', async (persisted) => {
     const mockExtension = 'file://test-extension.js:afterEach';
 
     const mockedRunExtensionHook = vi.mocked(runExtensionHook);
@@ -459,14 +459,16 @@ describeEvaluator('evaluator metadata', () => {
       extensions: [mockExtension],
     };
 
-    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    const evalRecord = persisted
+      ? await Eval.create({}, testSuite.prompts, { id: randomUUID() })
+      : new Eval({});
     await evaluate(testSuite, evalRecord, {});
     const summary = (await evalRecord.toEvaluateSummary()) as EvaluateSummaryV3;
 
     // Verify hook's namedScores flowed into prompt metrics
     expect(summary.prompts[0].metrics?.namedScores).toHaveProperty('hook_metric', 42);
 
-    // Verify hook's metadata and namedScores are in the persisted result
+    // Verify hook's metadata and namedScores are in the result
     const result = summary.results[0];
     expect(result.metadata).toHaveProperty('hook_key', 'hook_value');
     expect(result.namedScores).toHaveProperty('hook_metric', 42);

--- a/test/evaluator/options.test.ts
+++ b/test/evaluator/options.test.ts
@@ -6,7 +6,7 @@ import { expect, it, vi } from 'vitest';
 import { evaluate } from '../../src/evaluator';
 import { runExtensionHook } from '../../src/evaluatorHelpers';
 import Eval from '../../src/models/eval';
-import { type ApiProvider, type TestSuite } from '../../src/types/index';
+import { type ApiProvider, ResultFailureReason, type TestSuite } from '../../src/types/index';
 import { mockApiProvider, mockApiProvider2, toPrompt } from './helpers';
 import { describeEvaluator } from './lifecycle';
 
@@ -157,7 +157,7 @@ describeEvaluator('evaluator options and hooks', () => {
     );
   });
 
-  it('should call runExtensionHook with correct parameters at appropriate times', async () => {
+  it.each([true, false])('calls hooks with results (persisted: %s)', async (persisted) => {
     const mockExtension = 'file:./path/to/extension.js:extensionFunction';
     const testSuite: TestSuite = {
       providers: [mockApiProvider],
@@ -173,7 +173,9 @@ describeEvaluator('evaluator options and hooks', () => {
 
     const mockedRunExtensionHook = vi.mocked(runExtensionHook);
     mockedRunExtensionHook.mockClear();
-    const evalRecord = await Eval.create({}, testSuite.prompts, { id: randomUUID() });
+    const evalRecord = persisted
+      ? await Eval.create({}, testSuite.prompts, { id: randomUUID() })
+      : new Eval({});
     await evaluate(testSuite, evalRecord, {});
 
     // Check if runExtensionHook was called 4 times (beforeAll, beforeEach, afterEach, afterAll)
@@ -241,10 +243,55 @@ describeEvaluator('evaluator options and hooks', () => {
             }),
           }),
         ]),
-        results: expect.any(Array),
+        results: [
+          expect.objectContaining({
+            testIdx: 0,
+            promptIdx: 0,
+            success: true,
+            score: 1,
+            response: expect.objectContaining({ output: 'Test output' }),
+          }),
+        ],
         suite: testSuite,
       }),
     );
+  });
+
+  it('retains an in-memory timeout row for afterAll and summary reads', async () => {
+    vi.useFakeTimers();
+    const provider: ApiProvider = {
+      id: () => 'local-timeout-provider',
+      callApi: vi.fn(() => new Promise<never>(() => {})),
+    };
+    const testSuite: TestSuite = {
+      providers: [provider],
+      prompts: [toPrompt('Test prompt')],
+      tests: [{}],
+      extensions: ['file://test-extension.js:afterAll'],
+    };
+    const evaluation = new Eval({});
+    const pendingEvaluation = evaluate(testSuite, evaluation, { timeoutMs: 100 });
+    await vi.advanceTimersByTimeAsync(100);
+    await pendingEvaluation;
+
+    const expectedResult = expect.objectContaining({
+      success: false,
+      score: 0,
+      failureReason: ResultFailureReason.ERROR,
+      latencyMs: 100,
+      error: expect.stringContaining('Evaluation timed out after 100ms'),
+    });
+    expect(runExtensionHook).toHaveBeenCalledWith(
+      testSuite.extensions,
+      'afterAll',
+      expect.objectContaining({ results: [expectedResult] }),
+    );
+    expect(vi.mocked(runExtensionHook).mock.calls.some((call) => call[1] === 'afterEach')).toBe(
+      false,
+    );
+    const summary = await evaluation.toEvaluateSummary();
+    expect(summary.results).toEqual([expectedResult]);
+    expect(summary.stats).toMatchObject({ successes: 0, failures: 0, errors: 1 });
   });
 
   it('should handle multiple providers', async () => {

--- a/test/models/eval.test.ts
+++ b/test/models/eval.test.ts
@@ -14,6 +14,7 @@ import Eval, {
 } from '../../src/models/eval';
 import { getCachedResultsCount } from '../../src/models/evalPerformance';
 import EvalResult from '../../src/models/evalResult';
+import { EvalEvaluationStore } from '../../src/node/evaluationStore';
 import { TraceStore } from '../../src/tracing/store';
 import { type EvaluateResult, type Prompt, ResultFailureReason } from '../../src/types/index';
 import { updateResult, writeResultsToDatabase } from '../../src/util/database';
@@ -106,6 +107,117 @@ describe('evaluator', () => {
       ]);
 
       expect(updateSignalFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loadResults', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('preserves real in-memory rows across model and store reads and later appends', async () => {
+      const evaluation = new Eval({});
+      const store = new EvalEvaluationStore(evaluation);
+      await store.appendResult(createEvaluateResult({ response: { output: 'First result' } }));
+      const results = evaluation.results;
+      const firstResult = results[0];
+      const findResults = vi.spyOn(EvalResult, 'findManyByEvalId');
+
+      await evaluation.loadResults();
+      expect(evaluation._resultsLoaded).toBe(true);
+      expect(await store.readResults()).toBe(results);
+      expect(evaluation.results[0]).toBe(firstResult);
+      expect(firstResult.response?.output).toBe('First result');
+
+      await store.appendResult(
+        createEvaluateResult({
+          testIdx: 1,
+          success: false,
+          score: 0,
+          failureReason: ResultFailureReason.ERROR,
+          error: 'Local provider failed',
+          response: undefined,
+        }),
+      );
+      expect(await store.readResults()).toBe(results);
+      expect(results).toHaveLength(2);
+      expect(results[1]).toMatchObject({
+        testIdx: 1,
+        success: false,
+        score: 0,
+        failureReason: ResultFailureReason.ERROR,
+        error: 'Local provider failed',
+      });
+      const summary = await evaluation.toEvaluateSummary();
+      expect(summary.results).toEqual(results.map((result) => result.toEvaluateResult()));
+      const batches: EvalResult[][] = [];
+      for await (const batch of evaluation.fetchResultsBatched(1)) {
+        batches.push(batch);
+      }
+      expect(batches.flat()).toEqual(results);
+      expect(findResults).not.toHaveBeenCalled();
+    });
+
+    it('preserves explicitly assigned in-memory results', async () => {
+      const evaluation = new Eval({});
+      await evaluation.addResult(createEvaluateResult());
+      const results = [evaluation.results[0]];
+      await evaluation.setResults(results);
+      const findResults = vi.spyOn(EvalResult, 'findManyByEvalId');
+
+      expect(await evaluation.getResults()).toBe(results);
+      expect(await evaluation.getResults()).toBe(results);
+      expect(findResults).not.toHaveBeenCalled();
+    });
+
+    it('reads empty in-memory results and summaries without querying the database', async () => {
+      const evaluation = new Eval({});
+      const results = evaluation.results;
+      const findResults = vi.spyOn(EvalResult, 'findManyByEvalId');
+
+      expect(await evaluation.getResults()).toBe(results);
+      expect(await evaluation.toEvaluateSummary()).toMatchObject({
+        results: [],
+        stats: { successes: 0, failures: 0, errors: 0 },
+      });
+      expect(evaluation._resultsLoaded).toBe(true);
+      expect(findResults).not.toHaveBeenCalled();
+    });
+
+    it('refreshes persisted results after a previous read and an independent append', async () => {
+      const evaluation = await EvalFactory.create({ numResults: 0 });
+      expect((await evaluation.toEvaluateSummary()).results).toEqual([]);
+      await evaluation.addResult(createEvaluateResult({ response: { output: 'First result' } }));
+      const reloaded = await Eval.findById(evaluation.id);
+      expect(reloaded).not.toBeNull();
+      const store = new EvalEvaluationStore(reloaded!);
+
+      await reloaded!.loadResults();
+      expect(reloaded!._resultsLoaded).toBe(true);
+      expect(await store.readResults()).toHaveLength(1);
+      await evaluation.addResult(
+        createEvaluateResult({ testIdx: 1, response: { output: 'Second result' } }),
+      );
+      expect((await store.readResults()).map((result) => result.response?.output)).toEqual([
+        'First result',
+        'Second result',
+      ]);
+    });
+
+    it('keeps legacy result and summary reads on their existing path', async () => {
+      const stored = await EvalFactory.createOldResult();
+      const evaluation = (await Eval.findById(stored.id))!;
+      const findResults = vi.spyOn(EvalResult, 'findManyByEvalId');
+
+      expect(evaluation.useOldResults()).toBe(true);
+      expect(await evaluation.getResults()).toBe(evaluation.oldResults!.results);
+      expect(await evaluation.toEvaluateSummary()).toMatchObject({
+        version: 2,
+        results: evaluation.oldResults!.results,
+        table: evaluation.oldResults!.table,
+        stats: evaluation.oldResults!.stats,
+      });
+      expect(findResults).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Evaluations using `--no-write` can lose their accumulated results when an `afterAll` extension reads them. `Eval.loadResults()` now reloads the database only for persisted evaluations, preserving in-memory rows for callbacks and exports.

## Validation

- 414 focused model, store and database tests passed. The final test-only type annotation was subsequently checked by TypeScript and builds.
- Eight built CLI cases used local echo providers with `--no-write --no-cache`; JSON and JSONL each retained 13 expected rows, including intentional failure and timeout cases.
- Core/app build components and type checks passed. The ordinary postbuild launcher hit the sandbox IPC restriction; the same script passed through `node --import tsx`.
- Lint, TypeScript formatting and normal commit hooks passed. The aggregate formatter retained its existing empty-input Prettier failure.
