### PR TITLE
fix(assertions): bound tool-call parser state

### DIFF
--- a/site/docs/configuration/expected-outputs/deterministic.md
+++ b/site/docs/configuration/expected-outputs/deterministic.md
@@ -615,7 +615,7 @@ This assertion supports OpenAI Chat Completions tool calls, OpenAI Responses `fu
 
 In mixed text, JSON calls must start and end on their own lines and may span multiple lines. Inline JSON examples and Markdown code fences are ignored. Complete calls after an unfinished JSON fragment can still be scored.
 
-Complete calls inside malformed JSON blocks can also be recovered. If deeply nested malformed output exceeds the parsing work limit, the assertion fails with an explanation instead of reporting a partial F1 score. This failure also applies to `not-tool-call-f1`.
+Complete calls inside malformed JSON blocks can also be recovered. If malformed output exceeds limits on parsing work or unmatched JSON delimiters, the assertion fails with an explanation instead of reporting a partial F1 score. This failure also applies to `not-tool-call-f1`.
 
 For example, this OpenAI Responses item matches `value: [get_weather]`:
 

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -149,7 +149,7 @@ These metrics are programmatic tests that are run on LLM output. [See all detail
 | [is-valid-function-call](/docs/configuration/expected-outputs/deterministic/#is-valid-function-call)               | Ensure that the function call matches the function's JSON schema   |
 | [is-valid-openai-function-call](/docs/configuration/expected-outputs/deterministic/#is-valid-openai-function-call) | Ensure that the function call matches the function's JSON schema   |
 | [is-valid-openai-tools-call](/docs/configuration/expected-outputs/deterministic/#is-valid-openai-tools-call)       | Ensure all tool calls match the tools JSON schema                  |
-| [tool-call-f1](/docs/configuration/expected-outputs/deterministic/#tool-call-f1)                                   | Tool names in provider output meet the F1 threshold                |
+| [tool-call-f1](/docs/configuration/expected-outputs/deterministic/#tool-call-f1)                                   | Tool names meet the F1 threshold; incomplete parsing fails         |
 | [trace-span-count](/docs/configuration/expected-outputs/deterministic/#trace-span-count)                           | Count spans matching patterns with min/max thresholds              |
 | [trace-span-duration](/docs/configuration/expected-outputs/deterministic/#trace-span-duration)                     | Check span durations with percentile support                       |
 | [trace-error-spans](/docs/configuration/expected-outputs/deterministic/#trace-error-spans)                         | Detect errors in traces by status codes, attributes, and messages  |

--- a/site/docs/configuration/expected-outputs/index.md
+++ b/site/docs/configuration/expected-outputs/index.md
@@ -149,7 +149,7 @@ These metrics are programmatic tests that are run on LLM output. [See all detail
 | [is-valid-function-call](/docs/configuration/expected-outputs/deterministic/#is-valid-function-call)               | Ensure that the function call matches the function's JSON schema   |
 | [is-valid-openai-function-call](/docs/configuration/expected-outputs/deterministic/#is-valid-openai-function-call) | Ensure that the function call matches the function's JSON schema   |
 | [is-valid-openai-tools-call](/docs/configuration/expected-outputs/deterministic/#is-valid-openai-tools-call)       | Ensure all tool calls match the tools JSON schema                  |
-| [tool-call-f1](/docs/configuration/expected-outputs/deterministic/#tool-call-f1)                                   | Tool names meet the F1 threshold; incomplete parsing fails         |
+| [tool-call-f1](/docs/configuration/expected-outputs/deterministic/#tool-call-f1)                                   | Tool names meet the F1 threshold; parser limit exhaustion fails    |
 | [trace-span-count](/docs/configuration/expected-outputs/deterministic/#trace-span-count)                           | Count spans matching patterns with min/max thresholds              |
 | [trace-span-duration](/docs/configuration/expected-outputs/deterministic/#trace-span-duration)                     | Check span durations with percentile support                       |
 | [trace-error-spans](/docs/configuration/expected-outputs/deterministic/#trace-error-spans)                         | Detect errors in traces by status codes, attributes, and messages  |

--- a/src/assertions/toolCallF1.ts
+++ b/src/assertions/toolCallF1.ts
@@ -61,7 +61,11 @@ function* jsonDelimiters(text: string): Generator<JsonDelimiter | null> {
     const container = containers[containers.length - 1] ?? 0;
     const fenceText = list ? content.slice(list[0].length) : content;
     const marker = /^[ \t]*(`{3,}|~{3,})/.exec(fenceText);
-    if (marker && (list || indent <= container + 3)) {
+    if (
+      marker &&
+      (list || indent <= container + 3) &&
+      (marker[1][0] !== '`' || !fenceText.slice(marker[0].length).includes('`'))
+    ) {
       fence = marker[1];
       fenceContainer = container;
       yield null;
@@ -105,6 +109,8 @@ function* jsonDelimiters(text: string): Generator<JsonDelimiter | null> {
 
 class ToolCallParseError extends Error {}
 
+const MAX_UNMATCHED_DELIMITERS = 65_536;
+
 function* jsonBlocks(text: string, skipRoot = false): Generator<string> {
   // Pop complete pairs so independent blocks do not accumulate in memory.
   const unmatched: number[] = [];
@@ -123,6 +129,11 @@ function* jsonBlocks(text: string, skipRoot = false): Generator<string> {
       unmatched.push(token.index);
       stackStart = unmatched.length;
     }
+    if (unmatched.length > MAX_UNMATCHED_DELIMITERS) {
+      throw new ToolCallParseError(
+        'Tool Call F1 could not finish parsing malformed output within its delimiter limit',
+      );
+    }
   }
 
   // Yield disjoint blocks; nested recovery skips the enclosing root.
@@ -139,7 +150,7 @@ function* jsonBlocks(text: string, skipRoot = false): Generator<string> {
       continue;
     }
     if (token.char === '{' || token.char === '[') {
-      if (start < 0 && token.startsLine && (!skipRoot || token.index > 0)) {
+      if (start < 0 && token.startsLine && depth === (skipRoot ? 1 : 0)) {
         start = token.index;
         startDepth = depth;
       }

--- a/src/assertions/toolCallF1.ts
+++ b/src/assertions/toolCallF1.ts
@@ -111,7 +111,10 @@ class ToolCallParseError extends Error {}
 
 const MAX_UNMATCHED_DELIMITERS = 65_536;
 
-function* jsonBlocks(text: string, skipRoot = false): Generator<string> {
+function* jsonBlocks(
+  text: string,
+  skipRoot = false,
+): Generator<{ text: string; startsLine: boolean }> {
   // Pop complete pairs so independent blocks do not accumulate in memory.
   const unmatched: number[] = [];
   let stackStart = 0;
@@ -131,7 +134,7 @@ function* jsonBlocks(text: string, skipRoot = false): Generator<string> {
     }
     if (unmatched.length > MAX_UNMATCHED_DELIMITERS) {
       throw new ToolCallParseError(
-        'Tool Call F1 could not finish parsing malformed output within its delimiter limit',
+        `Tool Call F1 exceeded its delimiter limit (${MAX_UNMATCHED_DELIMITERS})`,
       );
     }
   }
@@ -141,6 +144,7 @@ function* jsonBlocks(text: string, skipRoot = false): Generator<string> {
   let depth = 0;
   let start = -1;
   let startDepth = 0;
+  let startsLine = false;
   for (const token of jsonDelimiters(text)) {
     if (!token) {
       continue;
@@ -150,9 +154,10 @@ function* jsonBlocks(text: string, skipRoot = false): Generator<string> {
       continue;
     }
     if (token.char === '{' || token.char === '[') {
-      if (start < 0 && token.startsLine && depth === (skipRoot ? 1 : 0)) {
+      if (start < 0 && depth === (skipRoot ? 1 : 0)) {
         start = token.index;
         startDepth = depth;
+        startsLine = token.startsLine;
       }
       depth++;
       continue;
@@ -160,7 +165,7 @@ function* jsonBlocks(text: string, skipRoot = false): Generator<string> {
     depth--;
     if (start >= 0 && depth === startDepth) {
       if (token.endsLine) {
-        yield text.slice(start, token.index + 1);
+        yield { text: text.slice(start, token.index + 1), startsLine };
       }
       start = -1;
     }
@@ -176,7 +181,7 @@ function* extractJsonBlocks(text: string): Generator<unknown> {
       pending.pop();
       continue;
     }
-    const block = next.value;
+    const { text: block, startsLine } = next.value;
     if (block.length > remaining) {
       throw new ToolCallParseError(
         'Tool Call F1 could not finish parsing malformed output within its work limit',
@@ -184,7 +189,10 @@ function* extractJsonBlocks(text: string): Generator<unknown> {
     }
     remaining -= block.length;
     try {
-      yield JSON.parse(block);
+      const parsed: unknown = JSON.parse(block);
+      if (startsLine) {
+        yield parsed;
+      }
     } catch {
       // Each rescan is paid for by the failed parse, keeping total work linear.
       pending.push(jsonBlocks(block, true));

--- a/test/assertions/toolCallF1.test.ts
+++ b/test/assertions/toolCallF1.test.ts
@@ -447,6 +447,39 @@ describe('handleToolCallF1', () => {
       expect(result).toMatchObject({ pass: true, score: 1 });
     });
 
+    it.each(['```json {"example":true} ```', '```info`invalid', '- ```info`invalid'])(
+      'keeps calls after an invalid backtick fence opener: %s',
+      (example) => {
+        const output = [
+          '{"type":"tool_use","name":"get_weather"}',
+          example,
+          '{"type":"tool_use","name":"delete_account"}',
+        ].join('\n');
+        const result = handleToolCallF1(createParams(output, ['get_weather']));
+
+        expect(result.pass).toBe(false);
+        expect(result.score).toBeCloseTo(2 / 3);
+        expect(result.reason).toContain('Called: [delete_account, get_weather]');
+      },
+    );
+
+    it.each([
+      ['Example: {\n"payload":', '}'],
+      ['Example: [', ']'],
+    ])('ignores calls nested inside an inline example wrapper: %s', (opening, closing) => {
+      const output = [
+        '{"type":"tool_use","name":"get_weather"}',
+        opening,
+        '{"type":"tool_use","name":"delete_account"}',
+        closing,
+      ].join('\n');
+
+      expect(handleToolCallF1(createParams(output, ['get_weather']))).toMatchObject({
+        pass: true,
+        score: 1,
+      });
+    });
+
     it('ignores an example in an unclosed fence', () => {
       const output = 'Example:\n```json\n{"type":"tool_use","name":"delete_account"}';
       const result = handleToolCallF1(createParams(output, ['delete_account']));
@@ -563,6 +596,29 @@ describe('handleToolCallF1', () => {
       });
     });
 
+    it.each(['{', '[', '}', ']'])(
+      'fails explicitly when unmatched %s delimiters exceed the recovery limit',
+      (delimiter) => {
+        const output = '{"type":"tool_use","name":"get_weather"}\n' + delimiter.repeat(200_000);
+        for (const inverse of [false, true]) {
+          const params = {
+            ...createParams(output, ['get_weather'], { threshold: 0 }),
+            inverse,
+          };
+          expect(handleToolCallF1(params)).toMatchObject({
+            pass: false,
+            score: 0,
+            reason: expect.stringContaining('delimiter limit'),
+          });
+          expect(handleToolCallF1({ ...params, output: JSON.stringify(output) })).toMatchObject({
+            pass: false,
+            score: 0,
+            reason: expect.stringContaining('delimiter limit'),
+          });
+        }
+      },
+    );
+
     it('recovers a call after many unmatched opening braces', () => {
       const output = `${'{\n'.repeat(10_000)}{"type":"tool_use","name":"get_weather"}`;
       const result = handleToolCallF1(createParams(output, ['get_weather']));
@@ -600,13 +656,13 @@ describe('handleToolCallF1', () => {
         {
           cwd: fileURLToPath(new URL('../..', import.meta.url)),
           encoding: 'utf8',
-          timeout: 60_000,
+          timeout: 20_000,
         },
       );
 
       expect(result.error).toBeUndefined();
       expect(result.status, result.stderr).toBe(0);
-    }, 75_000);
+    });
 
     it('should handle Anthropic output with only one tool call in string', () => {
       const output = `I'll help you with that.

--- a/test/assertions/toolCallF1.test.ts
+++ b/test/assertions/toolCallF1.test.ts
@@ -548,6 +548,23 @@ describe('handleToolCallF1', () => {
       });
     });
 
+    it.each([
+      ['Actual call: {', '}'],
+      ['Actual call: [\ninvalid', ']'],
+    ])('recovers calls from an inline malformed wrapper: %s', (opening, closing) => {
+      const output = [
+        opening,
+        '{"type":"tool_use","name":"delete_account"}',
+        closing,
+        '{"type":"tool_use","name":"get_weather"}',
+      ].join('\n');
+      const result = handleToolCallF1(createParams(output, ['get_weather']));
+
+      expect(result.pass).toBe(false);
+      expect(result.score).toBeCloseTo(2 / 3);
+      expect(result.reason).toContain('Called: [delete_account, get_weather]');
+    });
+
     it('recovers unexpected calls from long malformed wrappers', () => {
       const output = [
         '{',


### PR DESCRIPTION
Follow up #10877 to bound retained delimiter state and preserve the distinction between calls and examples.

Malformed output with many unmatched braces can exhaust the heap before parsing reaches its work budget. Stop after 65,536 retained delimiters and fail the assertion explicitly, including inverted assertions. Also keep calls following invalid backtick-fence markers visible and exclude valid inline JSON examples while recovering complete calls from malformed wrappers. Backtick-fence info strings follow the [CommonMark rule](https://spec.commonmark.org/0.31.2/#fenced-code-blocks).

Keep the existing 1.25-million-block heap regression, remove its 75-second test-timeout override, and shorten the child-process deadline to 20 seconds. Update the assertion reference and index.

## Validation

- 115 focused parser tests pass after the inline-wrapper follow-up; both new recovery cases fail on the preceding head. The earlier broader assertion run passed all 1,473 tests.
- Under a 128 MB heap, the parent aborts on 10 MB of unmatched opening or closing braces. The fix returns an explicit failed assertion. The existing streaming regression still rejects the earlier unbounded candidate map and completes within the default test timeout.
- Source and built CLI each match all 17 expected pass/fail/score outcomes, including parsing limits, inverted assertions, fences, examples, and malformed-wrapper recovery. No provider errors.
- Full backend suite before the inline-wrapper follow-up: 25,104 passed; seven known local dependency mismatches and two unrelated route failures. All 64 tests in the affected route files pass on retry.
- Production build/postbuild, types, lint, and formatting pass on this update. Documentation build, architecture, compiler coverage, and Knip passed before the inline-wrapper follow-up.
