### PR TITLE
fix(providers): honor prompt Gemini tool policy over passthrough

### DIFF
--- a/src/providers/google/util.ts
+++ b/src/providers/google/util.ts
@@ -299,6 +299,23 @@ export function mergeGoogleCompletionOptions(
         }
       }
     }
+
+    // A provider-level passthrough policy must not override a prompt's tool choice.
+    // Preserve unrelated passthrough fields and non-function tool settings.
+    if (promptConfig?.passthrough === undefined && baseConfig.passthrough) {
+      const passthrough = { ...baseConfig.passthrough };
+      const inheritedToolConfig = normalizePassthroughGoogleToolConfig(baseConfig);
+      delete passthrough.toolConfig;
+      delete passthrough.tool_config;
+      if (inheritedToolConfig) {
+        const { functionCallingConfig: _functionCallingConfig, ...nonFunctionToolConfig } =
+          inheritedToolConfig;
+        if (Object.keys(nonFunctionToolConfig).length > 0) {
+          passthrough.toolConfig = nonFunctionToolConfig;
+        }
+      }
+      mergedConfig.passthrough = passthrough;
+    }
   }
 
   return mergedConfig;

--- a/test/providers/google/ai.studio.test.ts
+++ b/test/providers/google/ai.studio.test.ts
@@ -2334,6 +2334,36 @@ describe('AIStudioChatProvider', () => {
       expect(body.tools).toBeUndefined();
     });
 
+    it('disables inherited passthrough function declarations for a prompt-level tool choice', async () => {
+      vi.mocked(templates.getNunjucksEngine).mockImplementation(function () {
+        return { renderString: vi.fn((str) => str) } as any;
+      });
+      provider = new AIStudioChatProvider('gemini-pro', {
+        config: {
+          apiKey: 'test-key',
+          tools: [{ functionDeclarations: [{ name: 'lookup' }] }],
+          passthrough: {
+            toolConfig: { functionCallingConfig: { mode: 'ANY' } },
+            tools: [{ functionDeclarations: [{ name: 'other' }] }, { googleSearch: {} }],
+          },
+        } as any,
+      });
+      vi.mocked(cache.fetchWithCache).mockResolvedValueOnce({
+        data: { candidates: [{ content: { parts: [{ text: 'ok' }] } }] },
+        cached: false,
+      } as any);
+
+      await provider.callGemini('hi', {
+        prompt: { raw: 'hi', label: 'hi', config: { tool_choice: 'none' } },
+      } as any);
+
+      const body = JSON.parse(
+        vi.mocked(cache.fetchWithCache).mock.calls.at(-1)![1]!.body as string,
+      );
+      expect(body.toolConfig).toEqual({ functionCallingConfig: { mode: 'NONE' } });
+      expect(body.tools).toEqual([{ googleSearch: {} }]);
+    });
+
     it('should handle Google Search as a tool', async () => {
       // Reset the Nunjucks mock to return the non-rendered value for these tests
       vi.mocked(templates.getNunjucksEngine).mockImplementation(function () {

--- a/test/providers/google/util.test.ts
+++ b/test/providers/google/util.test.ts
@@ -4397,6 +4397,52 @@ describe('util', () => {
   });
 
   describe('mergeGoogleCompletionOptions', () => {
+    it('lets a prompt disable provider-level passthrough function calls', () => {
+      const merged = mergeGoogleCompletionOptions(
+        {
+          passthrough: {
+            toolConfig: {
+              functionCallingConfig: { mode: 'ANY', allowedFunctionNames: ['lookup'] },
+              retrievalConfig: { languageCode: 'en-US' },
+            },
+          },
+        },
+        { tool_choice: 'none' },
+      );
+
+      expect(resolveGoogleToolConfig(merged)).toEqual({
+        toolConfig: {
+          functionCallingConfig: { mode: 'NONE' },
+          retrievalConfig: { languageCode: 'en-US' },
+        },
+        toolsDisabled: true,
+      });
+    });
+
+    it('retains non-function snake-case passthrough settings under a prompt override', () => {
+      const merged = mergeGoogleCompletionOptions(
+        {
+          passthrough: {
+            tool_config: {
+              function_calling_config: { mode: 'ANY' },
+              retrieval_config: { language_code: 'en-US' },
+            },
+            customField: 'retained',
+          },
+        },
+        { tool_choice: 'none' },
+      );
+
+      expect(merged.passthrough?.customField).toBe('retained');
+      expect(resolveGoogleToolConfig(merged)).toEqual({
+        toolConfig: {
+          functionCallingConfig: { mode: 'NONE' },
+          retrievalConfig: { languageCode: 'en-US' },
+        },
+        toolsDisabled: true,
+      });
+    });
+
     it('treats prompt-level undefined as "not set" and preserves base policy', () => {
       const merged = mergeGoogleCompletionOptions(
         {


### PR DESCRIPTION
## Summary
- Honor prompt-level Gemini function-calling overrides when provider configuration has an inherited passthrough tool policy.
- Keep non-function tool settings and other passthrough options, while stripping function declarations when the prompt disables tools.
- Cover camel-case and snake-case passthrough policies and the AI Studio request body.

## Bug and verification
A provider-level `passthrough.toolConfig.functionCallingConfig.mode: ANY` survived a prompt's `tool_choice: none`. The merged resolver re-enabled function declarations and local callbacks. The new focused test failed on the previous code with `mode: ANY` and `toolsDisabled: false`, then passed after the fix.

- `npx vitest run test/providers/google --sequence.shuffle=false`: 1,130 passed
- `npm run tsc -- --pretty false`: passed
- `npm run l && npm run f`: passed; two pre-existing complexity warnings in Google utilities
- `npm run build`: passed
- `git diff --check`: passed

The provider request is covered with mocked HTTP; no live Google API call was made.
