### PR TITLE
docs(site): protect contact form submissions

### DIFF
--- a/site/src/pages/contact.test.tsx
+++ b/site/src/pages/contact.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ContactPage from './contact';
+
+describe('contact form', () => {
+  it('submits contact details to Formspark in the POST body', () => {
+    render(<ContactPage />);
+
+    const form = screen.getByRole('button', { name: 'Contact sales' }).closest('form')!;
+    fireEvent.change(screen.getByLabelText(/Full name/), { target: { value: 'Test Visitor' } });
+    fireEvent.change(screen.getByLabelText(/Work email/), {
+      target: { value: 'visitor@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/Company/), { target: { value: 'Example' } });
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: /I'm interested in/ }));
+    fireEvent.click(screen.getByRole('option', { name: 'Model Evaluation & Testing' }));
+    fireEvent.change(screen.getByLabelText(/How can we help/), {
+      target: { value: 'Please share a demo.' },
+    });
+
+    expect(form.method).toBe('post');
+    expect(form.action).toBe('https://submit-form.com/ghriv7voL');
+    expect(form.checkValidity()).toBe(true);
+    expect(Object.fromEntries(new FormData(form))).toMatchObject({
+      name: 'Test Visitor',
+      email: 'visitor@example.com',
+      company: 'Example',
+      'interested-in': 'Model Evaluation',
+      message: 'Please share a demo.',
+    });
+  });
+
+  it('keeps the honeypot hidden and out of normal submissions', () => {
+    render(<ContactPage />);
+
+    const form = screen.getByRole('button', { name: 'Contact sales' }).closest('form')!;
+    const honeypot = screen.getByRole('checkbox', { hidden: true });
+
+    expect(honeypot).toHaveAttribute('name', '_gotcha');
+    expect(honeypot).not.toBeVisible();
+    expect(honeypot).toHaveAttribute('aria-hidden', 'true');
+    expect(honeypot).toHaveAttribute('tabindex', '-1');
+    expect(honeypot).toHaveAttribute('autocomplete', 'off');
+    expect(honeypot).not.toBeRequired();
+    expect(new FormData(form).has('_gotcha')).toBe(false);
+  });
+
+  it('includes the honeypot signal when a bot checks it', () => {
+    render(<ContactPage />);
+
+    const form = screen.getByRole('button', { name: 'Contact sales' }).closest('form')!;
+    fireEvent.click(screen.getByRole('checkbox', { hidden: true }));
+
+    expect(new FormData(form).get('_gotcha')).toBe('on');
+  });
+});

--- a/site/src/pages/contact.tsx
+++ b/site/src/pages/contact.tsx
@@ -95,7 +95,20 @@ function Contact(): React.ReactElement {
                 </Typography>
               </Box>
 
-              <form action="https://submit-form.com/ghriv7voL" className={styles.contactForm}>
+              <form
+                action="https://submit-form.com/ghriv7voL"
+                method="POST"
+                className={styles.contactForm}
+              >
+                {/* Formspark discards submissions when bots check this hidden field. */}
+                <input
+                  type="checkbox"
+                  name="_gotcha"
+                  style={{ display: 'none' }}
+                  tabIndex={-1}
+                  autoComplete="off"
+                  aria-hidden="true"
+                />
                 <Box className={styles.formGrid}>
                   <TextField
                     fullWidth
@@ -146,6 +159,7 @@ function Contact(): React.ReactElement {
                     id="interested-in"
                     name="interested-in"
                     label="I'm interested in"
+                    defaultValue=""
                   >
                     <MenuItem value="Enterprise Security">
                       Enterprise Security & Red Teaming


### PR DESCRIPTION
## Summary

- Submit contact details with POST and add Formspark's hidden `_gotcha` checkbox.
- Keep the interest selector empty initially and cover normal submissions and the honeypot signal.

The honeypot follows [Formspark's documented integration](https://documentation.formspark.io/setup/spam-protection.html#honeypot). It is a lightweight filter, not protection against bots that submit directly to the public Formspark endpoint.

## Validation

- All 260 site tests pass; the three new tests fail against the original form.
- Site TypeScript, changed-file lint/format, and production build pass (`SKIP_OG_GENERATION=true`).
- Chrome QA of the built page: normal fields and selection work; POST is configured; the honeypot stays hidden. No submission was sent to Formspark.
