### PR TITLE
fix(eval): keep media results for --no-write evals

### DIFF
--- a/src/blobs/extractor.ts
+++ b/src/blobs/extractor.ts
@@ -154,14 +154,45 @@ type StoreOnce = (
   minSizeBytes?: number,
 ) => Promise<BlobRef | null>;
 
+/**
+ * Evals run with --no-write have no database row to own stored media, and an unreferenced blob
+ * cannot be served or shared, so their media stays inline as PROMPTFOO_INLINE_MEDIA does. The
+ * lookup runs at most once, and only when a response has media to store or reference, so text-only
+ * and in-memory evaluations never query a database that may not be migrated. A failed lookup also
+ * keeps media inline.
+ */
+function createPersistenceCheck(context: BlobContext): () => Promise<boolean> {
+  let persisted: Promise<boolean> | undefined;
+  return () => {
+    const { evalId } = context;
+    if (!evalId) {
+      return Promise.resolve(true);
+    }
+    persisted ??= isEvalPersisted(evalId).catch((error: unknown) => {
+      logger.debug('[BlobExtractor] Could not confirm the eval is saved; keeping media inline', {
+        evalId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    });
+    return persisted;
+  };
+}
+
 function createStoreOnce(blobContext: BlobContext): StoreOnce {
   const cache = new Map<string, Promise<BlobRef | null>>();
+  const isPersisted = createPersistenceCheck(blobContext);
   return async (base64OrDataUrl, defaultMimeType, location, kind, minSizeBytes) => {
     // Canonicalize the cache key on the parsed bytes (not the raw input string)
     // so a `data:image/png;base64,XYZ` URL and the bare `XYZ` base64 hit the
     // same cache slot when they decode to the same buffer.
     const parsed = parseBinary(base64OrDataUrl, defaultMimeType);
-    if (!parsed || !shouldExternalize(parsed.buffer, minSizeBytes)) {
+    if (
+      !parsed ||
+      !shouldExternalize(parsed.buffer, minSizeBytes) ||
+      !isBlobStorageEnabled() ||
+      !(await isPersisted())
+    ) {
       return null;
     }
 
@@ -393,12 +424,6 @@ export async function extractAndStoreBinaryData(
     return response;
   }
 
-  // Evals run with --no-write have no database row to own stored media, and an unreferenced blob
-  // cannot be served or shared, so keep their media inline as PROMPTFOO_INLINE_MEDIA does.
-  if (context?.evalId && !(await isEvalPersisted(context.evalId))) {
-    return response;
-  }
-
   let mutated = false;
   const next: ProviderResponse = { ...response };
   const blobContext = context || {};
@@ -590,7 +615,12 @@ export async function extractAndStoreBinaryData(
 
   const finalResponse = mutated ? next : response;
   if (blobContext.evalId) {
-    await recordExistingBlobReferences(finalResponse, blobContext, 'response');
+    await recordExistingBlobReferences(
+      finalResponse,
+      blobContext,
+      'response',
+      createPersistenceCheck(blobContext),
+    );
   }
 
   return finalResponse;
@@ -605,9 +635,13 @@ async function recordExistingBlobReferences(
   value: unknown,
   context: BlobContext,
   location: string,
+  isPersisted: () => Promise<boolean>,
 ): Promise<void> {
   const hashes = [...new Set(extractBlobHashesFromValue(value))];
   if (hashes.length > 0) {
+    if (!(await isPersisted())) {
+      return;
+    }
     await Promise.all(hashes.map((hash) => recordBlobReference(hash, { ...context, location })));
     return;
   }
@@ -615,7 +649,7 @@ async function recordExistingBlobReferences(
   if (Array.isArray(value)) {
     await Promise.all(
       value.map((child, idx) =>
-        recordExistingBlobReferences(child, context, `${location}[${idx}]`),
+        recordExistingBlobReferences(child, context, `${location}[${idx}]`, isPersisted),
       ),
     );
     return;
@@ -623,7 +657,12 @@ async function recordExistingBlobReferences(
 
   if (value && typeof value === 'object') {
     for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-      await recordExistingBlobReferences(child, context, location ? `${location}.${key}` : key);
+      await recordExistingBlobReferences(
+        child,
+        context,
+        location ? `${location}.${key}` : key,
+        isPersisted,
+      );
     }
   }
 }

--- a/src/blobs/extractor.ts
+++ b/src/blobs/extractor.ts
@@ -4,7 +4,7 @@ import logger from '../logger';
 import { sha256 } from '../util/createHash';
 import { extractBlobHashesFromValue } from './blobRefs';
 import { BLOB_MAX_SIZE, BLOB_MIN_SIZE, BLOB_SCHEME } from './constants';
-import { type BlobRef, recordBlobReference, storeBlob } from './index';
+import { type BlobRef, isEvalPersisted, recordBlobReference, storeBlob } from './index';
 
 import type { ProviderResponse } from '../types/providers';
 
@@ -390,6 +390,12 @@ export async function extractAndStoreBinaryData(
   context?: BlobContext,
 ): Promise<ProviderResponse | null | undefined> {
   if (!response) {
+    return response;
+  }
+
+  // Evals run with --no-write have no database row to own stored media, and an unreferenced blob
+  // cannot be served or shared, so keep their media inline as PROMPTFOO_INLINE_MEDIA does.
+  if (context?.evalId && !(await isEvalPersisted(context.evalId))) {
     return response;
   }
 

--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { and, eq, isNotNull, or } from 'drizzle-orm';
 import { getDb } from '../database';
-import { blobAssetsTable, blobReferencesTable } from '../database/tables';
+import { blobAssetsTable, blobReferencesTable, evalsTable } from '../database/tables';
 import logger from '../logger';
 import { FilesystemBlobStorageProvider } from './filesystemProvider';
 
@@ -69,7 +69,7 @@ export async function storeBlob(
         .onConflictDoNothing()
         .run();
 
-      if (refContext?.evalId) {
+      if (refContext?.evalId && (await isPersistedEval(tx, refContext.evalId))) {
         await tx
           .insert(blobReferencesTable)
           .values({
@@ -148,6 +148,26 @@ export async function getBlobUrl(hash: string, expiresInSeconds?: number): Promi
   return provider.getUrl(hash, expiresInSeconds);
 }
 
+type BlobReferenceDb = Pick<Awaited<ReturnType<typeof getDb>>, 'select'>;
+
+/**
+ * Evals run with `--no-write` never get an `evals` row, so a reference to them would violate
+ * the foreign key and discard the stored media. Keep the blob without an eval association.
+ */
+async function isPersistedEval(db: BlobReferenceDb, evalId: string): Promise<boolean> {
+  const row = await db
+    .select({ id: evalsTable.id })
+    .from(evalsTable)
+    .where(eq(evalsTable.id, evalId))
+    .get();
+  if (!row) {
+    logger.debug('[BlobStorage] Skipping blob reference for an eval without a database row', {
+      evalId,
+    });
+  }
+  return Boolean(row);
+}
+
 export async function recordBlobReference(
   hash: string,
   refContext: {
@@ -162,6 +182,11 @@ export async function recordBlobReference(
     return;
   }
 
+  const db = await getDb();
+  if (!(await isPersistedEval(db, refContext.evalId))) {
+    return;
+  }
+
   const provider = getBlobStorageProvider();
   const exists = await provider.exists(hash).catch(() => false);
   if (!exists) {
@@ -173,7 +198,6 @@ export async function recordBlobReference(
     return;
   }
 
-  const db = await getDb();
   const existing = await db
     .select({
       id: blobReferencesTable.id,

--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -150,22 +150,21 @@ export async function getBlobUrl(hash: string, expiresInSeconds?: number): Promi
 
 type BlobReferenceDb = Pick<Awaited<ReturnType<typeof getDb>>, 'select'>;
 
-/**
- * Evals run with `--no-write` never get an `evals` row, so a reference to them would violate
- * the foreign key and discard the stored media. Keep the blob without an eval association.
- */
 async function isPersistedEval(db: BlobReferenceDb, evalId: string): Promise<boolean> {
   const row = await db
     .select({ id: evalsTable.id })
     .from(evalsTable)
     .where(eq(evalsTable.id, evalId))
     .get();
-  if (!row) {
-    logger.debug('[BlobStorage] Skipping blob reference for an eval without a database row', {
-      evalId,
-    });
-  }
   return Boolean(row);
+}
+
+/**
+ * Whether an eval has a database row. Evals run with `--no-write` never do, so a blob reference to
+ * them would violate the foreign key, and an unreferenced blob cannot be served or shared.
+ */
+export async function isEvalPersisted(evalId: string): Promise<boolean> {
+  return isPersistedEval(await getDb(), evalId);
 }
 
 export async function recordBlobReference(
@@ -184,6 +183,10 @@ export async function recordBlobReference(
 
   const db = await getDb();
   if (!(await isPersistedEval(db, refContext.evalId))) {
+    logger.debug('[BlobStorage] Skipping blob reference for an eval without a database row', {
+      hash,
+      evalId: refContext.evalId,
+    });
     return;
   }
 

--- a/test/blobs/extractor.test.ts
+++ b/test/blobs/extractor.test.ts
@@ -259,6 +259,33 @@ describe('Local blob extraction', () => {
     expect(blobIndexModule.recordBlobReference).not.toHaveBeenCalled();
   });
 
+  it('does not check eval persistence for a response without media', async () => {
+    const blobIndexModule = await import('../../src/blobs/index');
+    const response: ProviderResponse = { output: 'plain text answer' };
+
+    const result = await extractAndStoreBinaryData(response, { evalId: 'eval-in-memory' });
+
+    expect(result).toBe(response);
+    // In-memory evaluations may run without a migrated database.
+    expect(blobIndexModule.isEvalPersisted).not.toHaveBeenCalled();
+  });
+
+  it('keeps media inline when eval persistence cannot be checked', async () => {
+    const blobIndexModule = await import('../../src/blobs/index');
+    vi.mocked(blobIndexModule.isEvalPersisted).mockRejectedValue(new Error('no such table: evals'));
+    const largeBase64 = Buffer.alloc(2000).toString('base64');
+    const response: ProviderResponse = {
+      output: 'ok',
+      audio: { data: largeBase64, format: 'wav' },
+    };
+
+    const result = await extractAndStoreBinaryData(response, { evalId: 'eval-in-memory' });
+
+    expect(result?.audio?.data).toBe(largeBase64);
+    expect(result?.audio?.blobRef).toBeUndefined();
+    expect(mockStoreBlob).not.toHaveBeenCalled();
+  });
+
   it('should externalize image data URIs to blobRefs', async () => {
     const largeBase64 = Buffer.alloc(2000).toString('base64');
     const response: ProviderResponse = {

--- a/test/blobs/extractor.test.ts
+++ b/test/blobs/extractor.test.ts
@@ -22,6 +22,7 @@ vi.mock('../../src/blobs/index', () => ({
     },
   }),
   recordBlobReference: vi.fn().mockResolvedValue(undefined),
+  isEvalPersisted: vi.fn().mockResolvedValue(true),
 }));
 
 describe('normalizeAudioMimeType', () => {
@@ -215,6 +216,7 @@ describe('Local blob extraction', () => {
         hash: 'abc123def456',
       },
     });
+    vi.mocked(blobIndexModule.isEvalPersisted).mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -233,6 +235,28 @@ describe('Local blob extraction', () => {
     // Should store locally
     expect(mockStoreBlob).toHaveBeenCalledTimes(1);
     expect(mockUploadBlobRemote).not.toHaveBeenCalled();
+  });
+
+  it('keeps media inline for an eval without a database row', async () => {
+    const blobIndexModule = await import('../../src/blobs/index');
+    vi.mocked(blobIndexModule.isEvalPersisted).mockResolvedValue(false);
+    const largeBase64 = Buffer.alloc(2000).toString('base64');
+    const response: ProviderResponse = {
+      output: `data:image/png;base64,${largeBase64} promptfoo://blob/${'c'.repeat(64)}`,
+      audio: { data: largeBase64, format: 'wav' },
+    };
+
+    const result = await extractAndStoreBinaryData(response, {
+      evalId: 'eval-no-write',
+      testIdx: 0,
+      promptIdx: 0,
+    });
+
+    expect(result).toBe(response);
+    expect(result?.audio?.data).toBe(largeBase64);
+    expect(blobIndexModule.isEvalPersisted).toHaveBeenCalledWith('eval-no-write');
+    expect(mockStoreBlob).not.toHaveBeenCalled();
+    expect(blobIndexModule.recordBlobReference).not.toHaveBeenCalled();
   });
 
   it('should externalize image data URIs to blobRefs', async () => {

--- a/test/blobs/index.test.ts
+++ b/test/blobs/index.test.ts
@@ -318,4 +318,11 @@ describe('blob references for evals without a database row', () => {
     const { references } = await getRows();
     expect(references).toHaveLength(0);
   });
+
+  it('reports whether an eval has a database row', async () => {
+    const { isEvalPersisted } = await import('../../src/blobs');
+
+    await expect(isEvalPersisted(savedEvalId)).resolves.toBe(true);
+    await expect(isEvalPersisted(unsavedEvalId)).resolves.toBe(false);
+  });
 });

--- a/test/blobs/index.test.ts
+++ b/test/blobs/index.test.ts
@@ -1,13 +1,14 @@
 import { randomUUID } from 'node:crypto';
 
 import { eq, inArray } from 'drizzle-orm';
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getShareAuthorizedBlob,
   isBlobAllowedForShare,
   recordBlobReference,
   resetBlobStorageProvider,
   setBlobStorageProvider,
+  storeBlob,
 } from '../../src/blobs';
 import { getDb } from '../../src/database';
 import { blobAssetsTable, blobReferencesTable, evalsTable } from '../../src/database/tables';
@@ -213,5 +214,108 @@ describe('recordBlobReference provenance upgrades', () => {
     const rows = await getReferenceRows();
     expect(rows).toHaveLength(1);
     expect(rows[0].location).toBe('import');
+  });
+});
+
+describe('blob references for evals without a database row', () => {
+  // `promptfoo eval --no-write` runs an eval that is never inserted into the evals table.
+  const savedEvalId = `eval-${randomUUID()}`;
+  const unsavedEvalId = `eval-${randomUUID()}`;
+  const hash = 'f'.repeat(64);
+  const deleteByHash = vi.fn(async (_hash: string) => {});
+
+  const stubProvider: BlobStorageProvider = {
+    providerId: 'test-stub',
+    store: async (data, mimeType) => ({
+      ref: {
+        uri: `promptfoo://blob/${hash}`,
+        hash,
+        mimeType,
+        sizeBytes: data.length,
+        provider: 'test-stub',
+      },
+      deduplicated: false,
+    }),
+    getByHash: async () => {
+      throw new Error('not implemented');
+    },
+    exists: async () => true,
+    deleteByHash,
+    getUrl: async () => null,
+  };
+
+  beforeAll(async () => {
+    await runDbMigrations();
+  });
+
+  beforeEach(async () => {
+    setBlobStorageProvider(stubProvider);
+    deleteByHash.mockClear();
+    const db = await getDb();
+    await db.insert(evalsTable).values([{ id: savedEvalId, config: {}, results: {} }]);
+  });
+
+  afterEach(async () => {
+    resetBlobStorageProvider();
+    const db = await getDb();
+    await db.delete(blobReferencesTable).where(eq(blobReferencesTable.blobHash, hash));
+    await db.delete(blobAssetsTable).where(eq(blobAssetsTable.hash, hash));
+    await db.delete(evalsTable).where(eq(evalsTable.id, savedEvalId));
+  });
+
+  async function getRows() {
+    const db = await getDb();
+    return {
+      assets: await db.select().from(blobAssetsTable).where(eq(blobAssetsTable.hash, hash)),
+      references: await db
+        .select()
+        .from(blobReferencesTable)
+        .where(eq(blobReferencesTable.blobHash, hash)),
+    };
+  }
+
+  it('stores media for an unsaved eval without recording a reference', async () => {
+    const { ref } = await storeBlob(Buffer.from('audio-bytes'), 'audio/wav', {
+      evalId: unsavedEvalId,
+      location: 'response.audio',
+      kind: 'audio',
+    });
+
+    expect(ref.uri).toBe(`promptfoo://blob/${hash}`);
+    expect(deleteByHash).not.toHaveBeenCalled();
+    const { assets, references } = await getRows();
+    expect(assets).toHaveLength(1);
+    expect(references).toHaveLength(0);
+  });
+
+  it('still records references for saved evals', async () => {
+    await storeBlob(Buffer.from('audio-bytes'), 'audio/wav', {
+      evalId: savedEvalId,
+      location: 'response.audio',
+      kind: 'audio',
+    });
+
+    const { references } = await getRows();
+    expect(references).toHaveLength(1);
+    expect(references[0]).toMatchObject({
+      evalId: savedEvalId,
+      kind: 'audio',
+      location: 'response.audio',
+    });
+  });
+
+  it('does not record an existing blob against an unsaved eval', async () => {
+    await storeBlob(Buffer.from('audio-bytes'), 'audio/wav');
+
+    await expect(
+      recordBlobReference(hash, {
+        evalId: unsavedEvalId,
+        kind: 'audio',
+        location: 'response.audio',
+      }),
+    ).resolves.toBeUndefined();
+
+    const { references } = await getRows();
+    expect(references).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

`promptfoo eval --no-write` fails every row whose provider returns audio or image data large enough to externalize. Media extraction stores the blob and records a `blob_references` row that points at the eval, but `--no-write` evals never get an `evals` row, so the foreign key rejects the insert. The transaction then rolls back the stored blob, and the row becomes an ERROR with its media lost.

- **Inline media:** evals without a database row now keep extracted media inline, as `PROMPTFOO_INLINE_MEDIA=true` does. This avoids writing blobs that the blob route refuses to serve without a reference, that sharing cannot authorize, and that nothing cleans up. `-o` exports stay self-contained.
- **Lazy lookup:** the eval-row lookup runs at most once per response, and only when media would be stored or a blob reference recorded. Text-only responses never query the database. If the lookup fails, as it can in an in-memory `evaluate()` run whose database was never migrated, media stays inline.
- **Direct stores:** `storeBlob` and `recordBlobReference` also skip the reference for evals without a row, so providers that store generated video directly no longer fail the row under `--no-write`.

## Reproduction

On `main`:

- A local provider returning a 3-second WAV, run with `--no-write`, exits 100 with `Failed query: insert into "blob_references" ...`. The cause is `SQLITE_CONSTRAINT_FOREIGNKEY: FOREIGN KEY constraint failed`. The same config without `--no-write` passes.
- `openai:tts:gpt-4o-mini-tts` with `--no-write` fails the same way.

## Validation

- Regressions:
  - `test/blobs/extractor.test.ts`:
    - Media for an eval without a database row stays inline, with no store or reference calls.
    - A response without media never checks eval persistence.
    - A failed persistence lookup keeps media inline.
    - The last two fail against the previous head.
  - `test/blobs/index.test.ts`:
    - Storing media for an unsaved eval adds no reference and does not roll back.
    - References for saved evals are unchanged.
    - `recordBlobReference` skips unsaved evals.
    - `isEvalPersisted` reports both cases.
    - The storage regressions fail against `main` with `FOREIGN KEY constraint failed`.
- 577 tests passed across 18 files. They include the tracing and transform integration suites that failed on the previous head, plus `test/index.test.ts`, `EvalResult`, the in-memory store, and every test file that references blob storage, extraction, or blob references. TypeScript, lint, formatting, Knip, and the architecture check pass.
- Real CLI evals, each with an isolated `PROMPTFOO_CONFIG_DIR`:
  - Local WAV provider with `--no-write`: passes with inline audio, leaving no eval, blob asset, or reference rows and no blob files.
  - The same provider with writes enabled: passes with a blob reference, one eval, one asset, and one reference.
  - `openai:tts:gpt-4o-mini-tts` with `--no-write`: passes with inline audio, leaving no rows or blob files.
- In-memory `evaluate()` against a fresh, unmigrated config dir: a text-only provider and an audio provider both pass, with inline audio and no blob files.
