### PR TITLE
fix(db): preserve shared blobs after persistence errors

### DIFF
--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -169,11 +169,6 @@ export async function getShareAuthorizedBlob(
   return getBlobByHash(hash);
 }
 
-export async function getBlobUrl(hash: string, expiresInSeconds?: number): Promise<string | null> {
-  const provider = getBlobStorageProvider();
-  return provider.getUrl(hash, expiresInSeconds);
-}
-
 export async function recordBlobReference(
   hash: string,
   refContext: {

--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -163,6 +163,17 @@ export async function recordBlobReference(
   }
 
   const db = await getDb();
+  // A failed store can retain bytes without committing their asset registration.
+  // Referencing those bytes must not adopt them or create an invalid foreign key.
+  const asset = await db
+    .select({ hash: blobAssetsTable.hash })
+    .from(blobAssetsTable)
+    .where(eq(blobAssetsTable.hash, hash))
+    .get();
+  if (!asset) {
+    return;
+  }
+
   const existing = await db
     .select({
       id: blobReferencesTable.id,

--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -56,47 +56,36 @@ export async function storeBlob(
 
   // Track asset and reference in DB for dedup/auth/cascade
   const db = await getDb();
-  try {
-    await db.transaction(async (tx) => {
+  // Keep stored bytes if persistence fails: another eval may already reference them,
+  // including bytes adopted after this store began. Unreferenced bytes are safer than data loss.
+  await db.transaction(async (tx) => {
+    await tx
+      .insert(blobAssetsTable)
+      .values({
+        hash: result.ref.hash,
+        sizeBytes: result.ref.sizeBytes,
+        mimeType: result.ref.mimeType,
+        provider: result.ref.provider,
+      })
+      .onConflictDoNothing()
+      .run();
+
+    if (refContext?.evalId) {
       await tx
-        .insert(blobAssetsTable)
+        .insert(blobReferencesTable)
         .values({
-          hash: result.ref.hash,
-          sizeBytes: result.ref.sizeBytes,
-          mimeType: result.ref.mimeType,
-          provider: result.ref.provider,
+          id: randomUUID(),
+          blobHash: result.ref.hash,
+          evalId: refContext.evalId,
+          testIdx: refContext.testIdx,
+          promptIdx: refContext.promptIdx,
+          location: refContext.location,
+          kind: refContext.kind,
         })
         .onConflictDoNothing()
         .run();
-
-      if (refContext?.evalId) {
-        await tx
-          .insert(blobReferencesTable)
-          .values({
-            id: randomUUID(),
-            blobHash: result.ref.hash,
-            evalId: refContext.evalId,
-            testIdx: refContext.testIdx,
-            promptIdx: refContext.promptIdx,
-            location: refContext.location,
-            kind: refContext.kind,
-          })
-          .onConflictDoNothing()
-          .run();
-      }
-    });
-  } catch (error) {
-    // Roll back filesystem write if DB persistence fails
-    try {
-      await provider.deleteByHash(result.ref.hash);
-    } catch (cleanupError) {
-      logger.warn('[BlobStorage] Failed to rollback blob after DB error', {
-        error: cleanupError,
-        hash: result.ref.hash,
-      });
     }
-    throw error;
-  }
+  });
 
   return result;
 }

--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -16,6 +16,26 @@ export {
   type StoredBlob,
 } from './types';
 
+// MIME types retained by portable imports and allowed for inline blob responses.
+const SAFE_INLINE_BLOB_MIME_TYPES = new Set([
+  'image/avif',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'video/mp4',
+  'video/ogg',
+  'video/webm',
+]);
+const SAFE_INLINE_AUDIO_MIME_TYPE_REGEX = /^audio\/[a-z0-9_+-]+$/i;
+
+export function isSafeInlineBlobMimeType(mimeType: string): boolean {
+  return (
+    SAFE_INLINE_BLOB_MIME_TYPES.has(mimeType.toLowerCase()) ||
+    SAFE_INLINE_AUDIO_MIME_TYPE_REGEX.test(mimeType)
+  );
+}
+
 let defaultProvider: BlobStorageProvider | null = null;
 
 function createDefaultProvider(): BlobStorageProvider {

--- a/src/blobs/index.ts
+++ b/src/blobs/index.ts
@@ -58,13 +58,15 @@ export async function storeBlob(
   const db = await getDb();
   // Keep stored bytes if persistence fails: another eval may already reference them,
   // including bytes adopted after this store began. Unreferenced bytes are safer than data loss.
-  await db.transaction(async (tx) => {
+  const registeredMimeType = await db.transaction(async (tx) => {
     await tx
       .insert(blobAssetsTable)
       .values({
         hash: result.ref.hash,
         sizeBytes: result.ref.sizeBytes,
-        mimeType: result.ref.mimeType,
+        // A deduplicated file may be an orphan from a failed transaction.
+        // Adopt it with the current caller's MIME type, which imports sanitize.
+        mimeType: result.deduplicated ? mimeType : result.ref.mimeType,
         provider: result.ref.provider,
       })
       .onConflictDoNothing()
@@ -85,14 +87,29 @@ export async function storeBlob(
         .onConflictDoNothing()
         .run();
     }
+
+    const asset = await tx
+      .select({ mimeType: blobAssetsTable.mimeType })
+      .from(blobAssetsTable)
+      .where(eq(blobAssetsTable.hash, result.ref.hash))
+      .get();
+    return asset!.mimeType;
   });
 
-  return result;
+  return { ...result, ref: { ...result.ref, mimeType: registeredMimeType } };
 }
 
 export async function getBlobByHash(hash: string): Promise<StoredBlob> {
   const provider = getBlobStorageProvider();
-  return provider.getByHash(hash);
+  const blob = await provider.getByHash(hash);
+  const db = await getDb();
+  const asset = await db
+    .select({ mimeType: blobAssetsTable.mimeType })
+    .from(blobAssetsTable)
+    .where(eq(blobAssetsTable.hash, hash))
+    .get();
+  // Registered metadata takes precedence over sidecars retained from failed stores.
+  return asset ? { ...blob, metadata: { ...blob.metadata, mimeType: asset.mimeType } } : blob;
 }
 
 export async function isBlobAllowedForShare(hash: string, evalId: string): Promise<boolean> {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs/promises';
 
-import { BLOB_MAX_SIZE, recordBlobReference, storeBlob } from '../blobs';
+import { BLOB_MAX_SIZE, isSafeInlineBlobMimeType, recordBlobReference, storeBlob } from '../blobs';
 import { BLOB_HASH_REGEX, collectBlobHashes } from '../blobs/blobRefs';
 import { getDb } from '../database/index';
 import { evalsTable } from '../database/tables';
@@ -99,17 +99,6 @@ function extractDurations(evalData: any) {
 const MAX_EXPORTED_BLOB_BASE64_LENGTH = Math.ceil(BLOB_MAX_SIZE / 3) * 4 + 4;
 // Portable exports are untrusted input; imported blobs must not become active same-origin content.
 const IMPORTED_BLOB_MIME_TYPE_FALLBACK = 'application/octet-stream';
-const SAFE_IMPORTED_BLOB_MIME_TYPES = new Set([
-  'image/avif',
-  'image/gif',
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'video/mp4',
-  'video/ogg',
-  'video/webm',
-]);
-const SAFE_IMPORTED_AUDIO_MIME_TYPE_REGEX = /^audio\/[a-z0-9_+-]+$/i;
 
 function isImportableV3Results(results: unknown): results is EvaluateSummaryV3 {
   const candidate = results as Partial<EvaluateSummaryV3>;
@@ -152,10 +141,7 @@ function isImportableBlobAsset(asset: unknown): asset is ExportedBlobAsset {
 
 function sanitizeImportedBlobMimeType(mimeType: string): string {
   const normalizedMimeType = mimeType.trim().toLowerCase();
-  if (
-    SAFE_IMPORTED_BLOB_MIME_TYPES.has(normalizedMimeType) ||
-    SAFE_IMPORTED_AUDIO_MIME_TYPE_REGEX.test(normalizedMimeType)
-  ) {
+  if (isSafeInlineBlobMimeType(normalizedMimeType)) {
     return normalizedMimeType;
   }
 

--- a/src/server/routes/blobs.ts
+++ b/src/server/routes/blobs.ts
@@ -1,6 +1,6 @@
 import { and, asc, desc, eq, like, sql } from 'drizzle-orm';
 import express from 'express';
-import { getBlobByHash, getBlobUrl, isSafeInlineBlobMimeType } from '../../blobs';
+import { getBlobStorageProvider, isSafeInlineBlobMimeType, type StoredBlob } from '../../blobs';
 import { isBlobStorageEnabled } from '../../blobs/extractor';
 import { getDb } from '../../database';
 import {
@@ -465,16 +465,21 @@ blobsRouter.get('/:hash', async (req: Request, res: Response): Promise<void> => 
     return;
   }
 
-  let blob: Awaited<ReturnType<typeof getBlobByHash>>;
+  let blob: StoredBlob;
   try {
-    // A provider URL can retain the original object's MIME after sanitized import.
-    // Proxy non-passive content so the registered MIME and download headers apply.
-    const presigned = isSafeInlineBlobMimeType(asset.mimeType) ? await getBlobUrl(hash) : null;
+    const provider = getBlobStorageProvider();
+    blob = await provider.getByHash(hash);
+    // Retained objects can have a different MIME from their later import registration.
+    // Only redirect when the stored MIME agrees with the registered passive type.
+    const presigned =
+      isSafeInlineBlobMimeType(asset.mimeType) &&
+      blob.metadata.mimeType.toLowerCase() === asset.mimeType.toLowerCase()
+        ? await provider.getUrl(hash)
+        : null;
     if (presigned) {
       res.redirect(302, presigned);
       return;
     }
-    blob = await getBlobByHash(hash);
   } catch (error) {
     logger.error('[BlobRoute] Failed to load blob', { error, hash });
     res.status(404).json({ error: 'Blob not found' });
@@ -488,7 +493,8 @@ blobsRouter.get('/:hash', async (req: Request, res: Response): Promise<void> => 
   }
 
   // Validate MIME type before setting header to prevent injection attacks
-  const mimeType = blob.metadata.mimeType || asset.mimeType;
+  // Match the registered-MIME getter while reusing the bytes already read above.
+  const mimeType = asset.mimeType;
   if (SAFE_MIME_TYPE_REGEX.test(mimeType)) {
     res.setHeader('Content-Type', mimeType);
   } else {

--- a/src/server/routes/blobs.ts
+++ b/src/server/routes/blobs.ts
@@ -1,6 +1,6 @@
 import { and, asc, desc, eq, like, sql } from 'drizzle-orm';
 import express from 'express';
-import { getBlobByHash, getBlobUrl } from '../../blobs';
+import { getBlobByHash, getBlobUrl, isSafeInlineBlobMimeType } from '../../blobs';
 import { isBlobStorageEnabled } from '../../blobs/extractor';
 import { getDb } from '../../database';
 import {
@@ -493,6 +493,12 @@ blobsRouter.get('/:hash', async (req: Request, res: Response): Promise<void> => 
     logger.warn('[BlobRoute] Invalid MIME type, using fallback', { mimeType, hash });
     res.setHeader('Content-Type', 'application/octet-stream');
   }
+  // Deduplicated bytes can retain MIME metadata from before a failed import/store.
+  // Keep opaque storage metadata intact, but never render active content inline here.
+  if (!isSafeInlineBlobMimeType(mimeType)) {
+    res.setHeader('Content-Disposition', 'attachment');
+  }
+  res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('Content-Length', (blob.metadata.sizeBytes ?? asset.sizeBytes).toString());
   res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
   res.setHeader('Accept-Ranges', 'none');

--- a/src/util/output.ts
+++ b/src/util/output.ts
@@ -483,7 +483,7 @@ export async function createOutputData(
   };
 
   if (options.includeMedia) {
-    const blobAssets = await exportBlobAssets(summary, output.traces);
+    const blobAssets = await exportBlobAssets(evalRecord.id, summary, output.traces);
     if (blobAssets.length > 0) {
       output.blobAssets = blobAssets;
     }
@@ -493,14 +493,18 @@ export async function createOutputData(
 }
 
 async function exportBlobAssets(
+  evalId: string,
   results: OutputFile['results'],
   traces?: OutputFile['traces'],
 ): Promise<ExportedBlobAsset[]> {
-  const { getBlobByHash } = await import('../blobs');
+  const { getShareAuthorizedBlob } = await import('../blobs');
   const assets: ExportedBlobAsset[] = [];
   for (const hash of collectBlobHashes({ results: resultsForMediaExportScan(results), traces })) {
     try {
-      const blob = await getBlobByHash(hash);
+      const blob = await getShareAuthorizedBlob(hash, evalId);
+      if (!blob) {
+        continue;
+      }
       if (blob.data.length > BLOB_MAX_SIZE) {
         logger.warn('[Output] Skipping oversized blob in eval export', {
           hash,

--- a/test/blobs/index.test.ts
+++ b/test/blobs/index.test.ts
@@ -1,17 +1,22 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
 
 import { eq, inArray } from 'drizzle-orm';
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getShareAuthorizedBlob,
   isBlobAllowedForShare,
   recordBlobReference,
   resetBlobStorageProvider,
   setBlobStorageProvider,
+  storeBlob,
 } from '../../src/blobs';
+import { FilesystemBlobStorageProvider } from '../../src/blobs/filesystemProvider';
 import { getDb } from '../../src/database';
 import { blobAssetsTable, blobReferencesTable, evalsTable } from '../../src/database/tables';
 import { runDbMigrations } from '../../src/migrate';
+import { createDeferred, createTempDir, mockProcessEnv, removeTempDir } from '../util/utils';
 
 import type { BlobStorageProvider } from '../../src/blobs';
 
@@ -213,5 +218,209 @@ describe('recordBlobReference provenance upgrades', () => {
     const rows = await getReferenceRows();
     expect(rows).toHaveLength(1);
     expect(rows[0].location).toBe('import');
+  });
+});
+
+describe('storeBlob persistence failures with shared files', () => {
+  const data = Buffer.from('shared blob rollback fixture');
+  const mimeType = 'application/octet-stream';
+  const hash = createHash('sha256').update(data).digest('hex');
+  const firstEvalId = `eval-${randomUUID()}`;
+  const secondEvalId = `eval-${randomUUID()}`;
+  const missingEvalId = `missing-${randomUUID()}`;
+  let tempDir: string;
+  let provider: FilesystemBlobStorageProvider;
+  let restoreEnv: () => void;
+  let db: Awaited<ReturnType<typeof getDb>>;
+  let transactionError: unknown;
+
+  beforeAll(async () => {
+    await runDbMigrations();
+  });
+
+  beforeEach(async () => {
+    tempDir = createTempDir('promptfoo-blob-rollback-');
+    restoreEnv = mockProcessEnv({ PROMPTFOO_CONFIG_DIR: tempDir });
+    provider = new FilesystemBlobStorageProvider({ basePath: path.join(tempDir, 'blobs') });
+    setBlobStorageProvider(provider);
+    db = await getDb();
+    await db.insert(evalsTable).values([
+      { id: firstEvalId, config: {}, results: {} },
+      { id: secondEvalId, config: {}, results: {} },
+    ]);
+    transactionError = undefined;
+    const transaction = db.transaction.bind(db);
+    vi.spyOn(db, 'transaction').mockImplementation((callback, config) =>
+      transaction(callback, config).catch((error: unknown) => {
+        transactionError = error;
+        throw error;
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    resetBlobStorageProvider();
+    try {
+      await db.delete(blobReferencesTable).where(eq(blobReferencesTable.blobHash, hash));
+      await db.delete(blobAssetsTable).where(eq(blobAssetsTable.hash, hash));
+      await db.delete(evalsTable).where(inArray(evalsTable.id, [firstEvalId, secondEvalId]));
+    } finally {
+      restoreEnv();
+      removeTempDir(tempDir);
+    }
+  });
+
+  async function snapshotFiles() {
+    const filePath = path.join(tempDir, 'blobs', hash.slice(0, 2), hash.slice(2, 4), hash);
+    return {
+      bytes: await readFile(filePath),
+      metadata: await readFile(`${filePath}.meta.json`, 'utf8'),
+    };
+  }
+
+  async function snapshotRows() {
+    return {
+      assets: await db.select().from(blobAssetsTable).where(eq(blobAssetsTable.hash, hash)),
+      references: await db
+        .select()
+        .from(blobReferencesTable)
+        .where(eq(blobReferencesTable.blobHash, hash)),
+    };
+  }
+
+  async function expectOriginalPersistenceError(pending: Promise<unknown>) {
+    const error = await pending.then(
+      () => {
+        throw new Error('Expected the real blob reference transaction to reject');
+      },
+      (rejection: unknown) => rejection,
+    );
+    expect(transactionError).toBeDefined();
+    expect(error).toBe(transactionError);
+  }
+
+  it('preserves already shared files when a later reference transaction fails', async () => {
+    await storeBlob(data, mimeType, { evalId: firstEvalId, location: 'import' });
+    const files = await snapshotFiles();
+    const rows = await snapshotRows();
+
+    await expectOriginalPersistenceError(storeBlob(data, mimeType, { evalId: missingEvalId }));
+
+    expect(await snapshotRows()).toEqual(rows);
+    expect(await provider.exists(hash)).toBe(true);
+    expect(await snapshotFiles()).toEqual(files);
+    expect((await getShareAuthorizedBlob(hash, firstEvalId))?.data).toEqual(data);
+    await expect(isBlobAllowedForShare(hash, missingEvalId)).resolves.toBe(false);
+  });
+
+  it('preserves newly created files adopted before their first transaction fails', async () => {
+    const created = createDeferred<boolean>();
+    const release = createDeferred<void>();
+    let firstStore = true;
+    const gatedProvider: BlobStorageProvider = {
+      providerId: provider.providerId,
+      store: async (bytes, type) => {
+        const pause = firstStore;
+        firstStore = false;
+        try {
+          const result = await provider.store(bytes, type);
+          if (pause) {
+            created.resolve(result.deduplicated);
+            await release.promise;
+          }
+          return result;
+        } catch (error) {
+          if (pause) {
+            created.reject(error);
+          }
+          throw error;
+        }
+      },
+      getByHash: (key) => provider.getByHash(key),
+      exists: (key) => provider.exists(key),
+      deleteByHash: (key) => provider.deleteByHash(key),
+      getUrl: (key, expires) => provider.getUrl(key, expires),
+    };
+    setBlobStorageProvider(gatedProvider);
+    // Attach the rejection observer before starting the other store.
+    const failingStore = expectOriginalPersistenceError(
+      storeBlob(data, mimeType, { evalId: missingEvalId }),
+    );
+    try {
+      expect(await created.promise).toBe(false);
+      const adopted = await storeBlob(data, mimeType, {
+        evalId: secondEvalId,
+        location: 'import',
+      });
+      expect(adopted.deduplicated).toBe(true);
+      const files = await snapshotFiles();
+      const rows = await snapshotRows();
+      expect(rows.references).toHaveLength(1);
+      expect(rows.references[0].evalId).toBe(secondEvalId);
+
+      release.resolve();
+      await failingStore;
+
+      expect(await snapshotRows()).toEqual(rows);
+      expect(await provider.exists(hash)).toBe(true);
+      expect(await snapshotFiles()).toEqual(files);
+      expect((await getShareAuthorizedBlob(hash, secondEvalId))?.data).toEqual(data);
+    } finally {
+      release.resolve();
+      await failingStore;
+    }
+  });
+
+  it('retains unreferenced files after failure and permits a later valid adoption', async () => {
+    await expectOriginalPersistenceError(storeBlob(data, mimeType, { evalId: missingEvalId }));
+
+    expect(await snapshotRows()).toEqual({ assets: [], references: [] });
+    expect(await provider.exists(hash)).toBe(true);
+    const files = await snapshotFiles();
+    await expect(getShareAuthorizedBlob(hash, firstEvalId)).resolves.toBeNull();
+    const adopted = await storeBlob(data, mimeType, { evalId: firstEvalId, location: 'import' });
+
+    expect(adopted.deduplicated).toBe(true);
+    expect(await snapshotFiles()).toEqual(files);
+    const rows = await snapshotRows();
+    expect(rows.assets).toHaveLength(1);
+    expect(rows.references).toHaveLength(1);
+    expect((await getShareAuthorizedBlob(hash, firstEvalId))?.data).toEqual(data);
+  });
+
+  it('keeps the remaining eval authorized when one shared reference cascades away', async () => {
+    const first = await storeBlob(data, mimeType, { evalId: firstEvalId, location: 'import' });
+    const second = await storeBlob(data, mimeType, { evalId: secondEvalId, location: 'import' });
+    const files = await snapshotFiles();
+    expect(first.deduplicated).toBe(false);
+    expect(second.deduplicated).toBe(true);
+    expect((await snapshotRows()).assets).toHaveLength(1);
+    expect((await snapshotRows()).references).toHaveLength(2);
+
+    await db.delete(evalsTable).where(eq(evalsTable.id, firstEvalId));
+
+    expect((await snapshotRows()).references).toHaveLength(1);
+    await expect(getShareAuthorizedBlob(hash, firstEvalId)).resolves.toBeNull();
+    expect((await getShareAuthorizedBlob(hash, secondEvalId))?.data).toEqual(data);
+    expect(await snapshotFiles()).toEqual(files);
+  });
+
+  it('preserves asset-first import storage without granting unclassified access', async () => {
+    const stored = await storeBlob(data, mimeType);
+    const files = await snapshotFiles();
+    expect(stored.ref.hash).toBe(hash);
+    expect((await snapshotRows()).assets).toHaveLength(1);
+    expect((await snapshotRows()).references).toHaveLength(0);
+    await expect(getShareAuthorizedBlob(hash, firstEvalId)).resolves.toBeNull();
+
+    await recordBlobReference(hash, { evalId: firstEvalId, location: 'response.output' });
+    await expect(getShareAuthorizedBlob(hash, firstEvalId)).resolves.toBeNull();
+    await recordBlobReference(hash, { evalId: firstEvalId, location: 'import' });
+
+    expect((await snapshotRows()).references).toHaveLength(1);
+    expect((await getShareAuthorizedBlob(hash, firstEvalId))?.data).toEqual(data);
+    await expect(getShareAuthorizedBlob(hash, secondEvalId)).resolves.toBeNull();
+    expect(await snapshotFiles()).toEqual(files);
   });
 });

--- a/test/blobs/index.test.ts
+++ b/test/blobs/index.test.ts
@@ -379,6 +379,14 @@ describe('storeBlob persistence failures with shared files', () => {
     expect(await provider.exists(hash)).toBe(true);
     const files = await snapshotFiles();
     await expect(getShareAuthorizedBlob(hash, firstEvalId)).resolves.toBeNull();
+
+    await expect(
+      recordBlobReference(hash, { evalId: firstEvalId, location: 'import' }),
+    ).resolves.toBeUndefined();
+    expect(await snapshotRows()).toEqual({ assets: [], references: [] });
+    expect(await snapshotFiles()).toEqual(files);
+    await expect(getShareAuthorizedBlob(hash, firstEvalId)).resolves.toBeNull();
+
     const adopted = await storeBlob(data, mimeType, { evalId: firstEvalId, location: 'import' });
 
     expect(adopted.deduplicated).toBe(true);
@@ -413,6 +421,12 @@ describe('storeBlob persistence failures with shared files', () => {
     expect((await snapshotRows()).assets).toHaveLength(1);
     expect((await snapshotRows()).references).toHaveLength(0);
     await expect(getShareAuthorizedBlob(hash, firstEvalId)).resolves.toBeNull();
+
+    // A registered asset does not make an invalid eval association safe to ignore.
+    await expect(
+      recordBlobReference(hash, { evalId: missingEvalId, location: 'import' }),
+    ).rejects.toThrow();
+    expect((await snapshotRows()).references).toHaveLength(0);
 
     await recordBlobReference(hash, { evalId: firstEvalId, location: 'response.output' });
     await expect(getShareAuthorizedBlob(hash, firstEvalId)).resolves.toBeNull();

--- a/test/blobs/index.test.ts
+++ b/test/blobs/index.test.ts
@@ -414,6 +414,33 @@ describe('storeBlob persistence failures with shared files', () => {
     expect(await snapshotFiles()).toEqual(files);
   });
 
+  it('preserves a registered MIME type when another caller deduplicates the bytes', async () => {
+    await storeBlob(data, 'image/png', { evalId: firstEvalId, location: 'import' });
+    const files = await snapshotFiles();
+
+    const stored = await storeBlob(data, 'audio/wav', { evalId: secondEvalId, location: 'import' });
+
+    expect(stored.deduplicated).toBe(true);
+    expect(stored.ref.mimeType).toBe('image/png');
+    expect((await snapshotRows()).assets[0].mimeType).toBe('image/png');
+    expect((await getShareAuthorizedBlob(hash, secondEvalId))?.metadata.mimeType).toBe('image/png');
+    expect(await snapshotFiles()).toEqual(files);
+  });
+
+  it('uses provider metadata when registering newly created bytes', async () => {
+    const store = provider.store.bind(provider);
+    vi.spyOn(provider, 'store').mockImplementation((bytes) => store(bytes, 'image/png'));
+
+    const stored = await storeBlob(data, 'application/octet-stream', {
+      evalId: firstEvalId,
+      location: 'import',
+    });
+
+    expect(stored.deduplicated).toBe(false);
+    expect(stored.ref.mimeType).toBe('image/png');
+    expect((await snapshotRows()).assets[0].mimeType).toBe('image/png');
+  });
+
   it('preserves asset-first import storage without granting unclassified access', async () => {
     const stored = await storeBlob(data, mimeType);
     const files = await snapshotFiles();

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -25,6 +25,7 @@ import EvalResult from '../../src/models/evalResult';
 import { TraceStore } from '../../src/tracing/store';
 import { ResultFailureReason } from '../../src/types/index';
 import { sha256 } from '../../src/util/createHash';
+import { createOutputData } from '../../src/util/output';
 import { createTempDir, mockProcessEnv, removeTempDir } from '../util/utils';
 
 vi.mock('../../src/logger', () => ({
@@ -475,6 +476,9 @@ describe('importCommand', () => {
         expect(fs.readFileSync(blobPath)).toEqual(data);
         expect(fs.readFileSync(`${blobPath}.meta.json`, 'utf8')).toBe(metadata);
         await expect(getShareAuthorizedBlob(hash, sampleData.evalId)).resolves.toBeNull();
+        const evalRecord = await Eval.findById(sampleData.evalId);
+        const exported = await createOutputData(evalRecord!, null, { includeMedia: true });
+        expect(exported.blobAssets).toBeUndefined();
       } finally {
         resetBlobStorageProvider();
         restoreEnv();
@@ -550,6 +554,13 @@ describe('importCommand', () => {
         expect((await getShareAuthorizedBlob(htmlHash, sampleData.evalId))?.metadata.mimeType).toBe(
           'application/octet-stream',
         );
+        const evalRecord = await Eval.findById(sampleData.evalId);
+        const exported = await createOutputData(evalRecord!, null, { includeMedia: true });
+        expect(exported.blobAssets).toHaveLength(2);
+        expect(exported.blobAssets?.map((asset) => asset.mimeType)).toEqual([
+          'application/octet-stream',
+          'application/octet-stream',
+        ]);
       } finally {
         resetBlobStorageProvider();
         removeTempDir(blobDir);

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -482,16 +482,20 @@ describe('importCommand', () => {
       }
     });
 
-    it('should downgrade active embedded blob MIME types during import', async () => {
+    it.each([false, true])('downgrades active imported MIME types (orphan=%s)', async (orphan) => {
       const blobDir = createTempDir('promptfoo-import-active-mime-blobs-');
       setBlobStorageProvider(new FilesystemBlobStorageProvider({ basePath: blobDir }));
 
       try {
         const sampleFilePath = path.join(__dirname, '../__fixtures__/sample-export.json');
         const sampleData = JSON.parse(fs.readFileSync(sampleFilePath, 'utf-8'));
-        const htmlData = Buffer.from('<script>alert(document.domain)</script>');
+        const htmlData = Buffer.from(
+          `<script>alert(document.domain) /* orphan=${orphan} */</script>`,
+        );
         const htmlHash = sha256(htmlData);
-        const svgData = Buffer.from('<svg onload="alert(document.domain)" />');
+        const svgData = Buffer.from(
+          `<svg data-orphan="${orphan}" onload="alert(document.domain)" />`,
+        );
         const svgHash = sha256(svgData);
         sampleData.results.results[0].response = {
           output: `promptfoo://blob/${htmlHash} promptfoo://blob/${svgHash}`,
@@ -511,6 +515,20 @@ describe('importCommand', () => {
           },
         ];
 
+        if (orphan) {
+          for (const asset of sampleData.blobAssets) {
+            await expect(
+              storeBlob(Buffer.from(asset.data, 'base64'), asset.mimeType, {
+                evalId: 'missing-active-mime-eval',
+              }),
+            ).rejects.toThrow();
+          }
+          const db = await getDb();
+          expect(
+            await db.all(sql`SELECT hash FROM blob_assets WHERE hash IN (${htmlHash}, ${svgHash})`),
+          ).toEqual([]);
+        }
+
         const filePath = path.join(__dirname, `temp-active-mime-blob-${Date.now()}.json`);
         fs.writeFileSync(filePath, JSON.stringify(sampleData));
         tempFilePath = filePath;
@@ -520,6 +538,18 @@ describe('importCommand', () => {
 
         expect((await getBlobByHash(htmlHash)).metadata.mimeType).toBe('application/octet-stream');
         expect((await getBlobByHash(svgHash)).metadata.mimeType).toBe('application/octet-stream');
+        const db = await getDb();
+        const assets = await db.all(
+          sql`SELECT mime_type FROM blob_assets WHERE hash IN (${htmlHash}, ${svgHash})`,
+        );
+        expect(assets).toHaveLength(2);
+        expect(assets).toEqual([
+          { mime_type: 'application/octet-stream' },
+          { mime_type: 'application/octet-stream' },
+        ]);
+        expect((await getShareAuthorizedBlob(htmlHash, sampleData.evalId))?.metadata.mimeType).toBe(
+          'application/octet-stream',
+        );
       } finally {
         resetBlobStorageProvider();
         removeTempDir(blobDir);

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -5,7 +5,13 @@ import { createClient } from '@libsql/client/node';
 import { Command } from 'commander';
 import { sql } from 'drizzle-orm';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getBlobByHash, resetBlobStorageProvider, setBlobStorageProvider } from '../../src/blobs';
+import {
+  getBlobByHash,
+  getShareAuthorizedBlob,
+  resetBlobStorageProvider,
+  setBlobStorageProvider,
+  storeBlob,
+} from '../../src/blobs';
 import * as blobRefs from '../../src/blobs/blobRefs';
 import { FilesystemBlobStorageProvider } from '../../src/blobs/filesystemProvider';
 import { importCommand } from '../../src/commands/import';
@@ -417,6 +423,61 @@ describe('importCommand', () => {
         });
       } finally {
         resetBlobStorageProvider();
+        removeTempDir(blobDir);
+      }
+    });
+
+    it('imports a reference-only v3 result without adopting a file from a failed store', async () => {
+      const blobDir = createTempDir('promptfoo-import-unregistered-blob-');
+      const restoreEnv = mockProcessEnv({ PROMPTFOO_INLINE_MEDIA: 'false' });
+      setBlobStorageProvider(new FilesystemBlobStorageProvider({ basePath: blobDir }));
+
+      try {
+        const sampleFilePath = path.join(__dirname, '../__fixtures__/sample-export.json');
+        const sampleData = JSON.parse(fs.readFileSync(sampleFilePath, 'utf-8'));
+        const data = Buffer.from(
+          'unregistered file retained after failed import-store transaction',
+        );
+        const hash = sha256(data);
+        const uri = `promptfoo://blob/${hash}`;
+        const db = await getDb();
+
+        await expect(
+          storeBlob(data, 'image/png', { evalId: 'missing-blob-import-eval' }),
+        ).rejects.toThrow();
+        const blobPath = path.join(blobDir, hash.slice(0, 2), hash.slice(2, 4), hash);
+        const metadata = fs.readFileSync(`${blobPath}.meta.json`, 'utf8');
+        expect(fs.readFileSync(blobPath)).toEqual(data);
+        expect(await db.all(sql`SELECT hash FROM blob_assets WHERE hash = ${hash}`)).toEqual([]);
+        expect(await db.all(sql`SELECT id FROM blob_references WHERE blob_hash = ${hash}`)).toEqual(
+          [],
+        );
+
+        expect(sampleData.results.version).toBe(3);
+        sampleData.results.results = [sampleData.results.results[0]];
+        sampleData.results.results[0].response = { output: uri };
+        delete sampleData.blobAssets;
+        const filePath = path.join(blobDir, 'reference-only.json');
+        fs.writeFileSync(filePath, JSON.stringify(sampleData));
+
+        importCommand(program);
+        await program.parseAsync(['node', 'test', 'import', filePath]);
+
+        expect(process.exitCode).toBeUndefined();
+        expect(logger.error).not.toHaveBeenCalled();
+        const imported = await EvalResult.findManyByEvalId(sampleData.evalId);
+        expect(imported).toHaveLength(1);
+        expect(imported[0].toEvaluateResult().response?.output).toBe(uri);
+        expect(await db.all(sql`SELECT hash FROM blob_assets WHERE hash = ${hash}`)).toEqual([]);
+        expect(await db.all(sql`SELECT id FROM blob_references WHERE blob_hash = ${hash}`)).toEqual(
+          [],
+        );
+        expect(fs.readFileSync(blobPath)).toEqual(data);
+        expect(fs.readFileSync(`${blobPath}.meta.json`, 'utf8')).toBe(metadata);
+        await expect(getShareAuthorizedBlob(hash, sampleData.evalId)).resolves.toBeNull();
+      } finally {
+        resetBlobStorageProvider();
+        restoreEnv();
         removeTempDir(blobDir);
       }
     });

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -490,20 +490,57 @@ describe('importCommand', () => {
     });
 
     it.each([
-      ['text/html', '<!doctype html><title>retained fixture</title>'],
-      [
-        'image/svg+xml',
-        '<svg xmlns="http://www.w3.org/2000/svg"><title>retained fixture</title></svg>',
-      ],
+      {
+        storedMimeType: 'text/html',
+        importedMimeType: 'text/html',
+        expectedMimeType: 'application/octet-stream',
+        redirect: false,
+        contents: Buffer.from('<!doctype html><title>retained fixture</title>'),
+      },
+      {
+        storedMimeType: 'image/svg+xml',
+        importedMimeType: 'image/svg+xml',
+        expectedMimeType: 'application/octet-stream',
+        redirect: false,
+        contents: Buffer.from(
+          '<svg xmlns="http://www.w3.org/2000/svg"><title>retained fixture</title></svg>',
+        ),
+      },
+      {
+        storedMimeType: 'text/html',
+        importedMimeType: 'image/png',
+        expectedMimeType: 'image/png',
+        redirect: false,
+        contents: Buffer.from('<!doctype html><title>cross-label fixture</title>'),
+      },
+      {
+        storedMimeType: 'image/svg+xml',
+        importedMimeType: 'audio/wav',
+        expectedMimeType: 'audio/wav',
+        redirect: false,
+        contents: Buffer.from(
+          '<svg xmlns="http://www.w3.org/2000/svg"><title>cross-label fixture</title></svg>',
+        ),
+      },
+      {
+        storedMimeType: 'image/png',
+        importedMimeType: 'image/png',
+        expectedMimeType: 'image/png',
+        redirect: true,
+        contents: Buffer.from(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a5K0AAAAASUVORK5CYII=',
+          'base64',
+        ),
+      },
     ])(
-      'proxies imported retained %s instead of its active custom URL',
-      async (mimeType, contents) => {
+      'serves retained $storedMimeType imported as $importedMimeType with registered MIME',
+      async ({ storedMimeType, importedMimeType, expectedMimeType, redirect, contents }) => {
         const blobDir = createTempDir('promptfoo-import-retained-mime-');
         const restoreEnv = mockProcessEnv({ PROMPTFOO_INLINE_MEDIA: 'false' });
         const provider = new FilesystemBlobStorageProvider({ basePath: blobDir });
         setBlobStorageProvider(provider);
         const destination = express().get('/asset', (_req, res) => {
-          res.setHeader('Content-Type', mimeType);
+          res.setHeader('Content-Type', storedMimeType);
           res.send(Buffer.from(contents));
         });
         const destinationServer = destination.listen(0, '127.0.0.1');
@@ -525,14 +562,14 @@ describe('importCommand', () => {
           const hash = sha256(data);
           const uri = `promptfoo://blob/${hash}`;
           const db = await getDb();
-          const failure = await storeBlob(data, mimeType, {
+          const failure = await storeBlob(data, storedMimeType, {
             evalId: 'missing-orphan-mime-eval',
           }).catch((error: Error) => error);
           expect(failure).toBeInstanceOf(Error);
           expect(String((failure as Error).cause)).toMatch(/FOREIGN KEY constraint failed/);
           const blobPath = path.join(blobDir, hash.slice(0, 2), hash.slice(2, 4), hash);
           const metadata = fs.readFileSync(`${blobPath}.meta.json`, 'utf8');
-          expect(JSON.parse(metadata).mimeType).toBe(mimeType);
+          expect(JSON.parse(metadata).mimeType).toBe(storedMimeType);
           expect(await db.all(sql`SELECT hash FROM blob_assets WHERE hash = ${hash}`)).toEqual([]);
           expect((await request(app).get(`/api/blobs/${hash}`)).status).toBe(404);
 
@@ -542,7 +579,12 @@ describe('importCommand', () => {
           sampleData.results.results = [sampleData.results.results[0]];
           sampleData.results.results[0].response = { output: uri };
           sampleData.blobAssets = [
-            { hash, mimeType, sizeBytes: data.length, data: data.toString('base64') },
+            {
+              hash,
+              mimeType: importedMimeType,
+              sizeBytes: data.length,
+              data: data.toString('base64'),
+            },
           ];
           const filePath = path.join(blobDir, 'retained-mime.json');
           fs.writeFileSync(filePath, JSON.stringify(sampleData));
@@ -552,7 +594,7 @@ describe('importCommand', () => {
           expect(process.exitCode).toBeUndefined();
           expect(logger.error).not.toHaveBeenCalled();
           expect(await db.all(sql`SELECT mime_type FROM blob_assets WHERE hash = ${hash}`)).toEqual(
-            [{ mime_type: 'application/octet-stream' }],
+            [{ mime_type: expectedMimeType }],
           );
           expect(
             await db.all(
@@ -570,10 +612,17 @@ describe('importCommand', () => {
             });
           expect(response.status).toBe(200);
           expect(response.body).toEqual(data);
-          expect(response.headers['content-type']).toBe('application/octet-stream');
-          expect(getUrl).not.toHaveBeenCalled();
-          expect(response.headers['content-disposition']).toBe('attachment');
-          expect(response.headers['x-content-type-options']).toBe('nosniff');
+          expect(response.headers['content-type']).toBe(expectedMimeType);
+          if (redirect) {
+            expect(getUrl).toHaveBeenCalledOnce();
+            expect(getUrl.mock.calls[0][0]).toBe(hash);
+          } else {
+            expect(getUrl).not.toHaveBeenCalled();
+            expect(response.headers['x-content-type-options']).toBe('nosniff');
+          }
+          expect(response.headers['content-disposition']).toBe(
+            expectedMimeType === 'application/octet-stream' ? 'attachment' : undefined,
+          );
           expect(fs.readFileSync(blobPath)).toEqual(data);
           expect(fs.readFileSync(`${blobPath}.meta.json`, 'utf8')).toBe(metadata);
           await expect(getShareAuthorizedBlob(hash, 'unrelated-eval')).resolves.toBeNull();

--- a/test/commands/import.test.ts
+++ b/test/commands/import.test.ts
@@ -4,6 +4,8 @@ import path from 'path';
 import { createClient } from '@libsql/client/node';
 import { Command } from 'commander';
 import { sql } from 'drizzle-orm';
+import express from 'express';
+import request from 'supertest';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getBlobByHash,
@@ -22,6 +24,7 @@ import logger from '../../src/logger';
 import { runDbMigrations } from '../../src/migrate';
 import Eval from '../../src/models/eval';
 import EvalResult from '../../src/models/evalResult';
+import { blobsRouter } from '../../src/server/routes/blobs';
 import { TraceStore } from '../../src/tracing/store';
 import { ResultFailureReason } from '../../src/types/index';
 import { sha256 } from '../../src/util/createHash';
@@ -475,6 +478,83 @@ describe('importCommand', () => {
         expect(fs.readFileSync(blobPath)).toEqual(data);
         expect(fs.readFileSync(`${blobPath}.meta.json`, 'utf8')).toBe(metadata);
         await expect(getShareAuthorizedBlob(hash, sampleData.evalId)).resolves.toBeNull();
+      } finally {
+        resetBlobStorageProvider();
+        restoreEnv();
+        removeTempDir(blobDir);
+      }
+    });
+
+    it.each([
+      ['text/html', '<!doctype html><title>retained fixture</title>'],
+      [
+        'image/svg+xml',
+        '<svg xmlns="http://www.w3.org/2000/svg"><title>retained fixture</title></svg>',
+      ],
+    ])('serves imported retained %s bytes as a download', async (mimeType, contents) => {
+      const blobDir = createTempDir('promptfoo-import-retained-mime-');
+      const restoreEnv = mockProcessEnv({ PROMPTFOO_INLINE_MEDIA: 'false' });
+      setBlobStorageProvider(new FilesystemBlobStorageProvider({ basePath: blobDir }));
+      const app = express().use('/api/blobs', blobsRouter);
+
+      try {
+        const data = Buffer.from(contents);
+        const hash = sha256(data);
+        const uri = `promptfoo://blob/${hash}`;
+        const db = await getDb();
+        const failure = await storeBlob(data, mimeType, {
+          evalId: 'missing-orphan-mime-eval',
+        }).catch((error: Error) => error);
+        expect(failure).toBeInstanceOf(Error);
+        expect(String((failure as Error).cause)).toMatch(/FOREIGN KEY constraint failed/);
+        const blobPath = path.join(blobDir, hash.slice(0, 2), hash.slice(2, 4), hash);
+        const metadata = fs.readFileSync(`${blobPath}.meta.json`, 'utf8');
+        expect(JSON.parse(metadata).mimeType).toBe(mimeType);
+        expect(await db.all(sql`SELECT hash FROM blob_assets WHERE hash = ${hash}`)).toEqual([]);
+        expect((await request(app).get(`/api/blobs/${hash}`)).status).toBe(404);
+
+        const sampleFilePath = path.join(__dirname, '../__fixtures__/sample-export.json');
+        const sampleData = JSON.parse(fs.readFileSync(sampleFilePath, 'utf-8'));
+        expect(sampleData.results.version).toBe(3);
+        sampleData.results.results = [sampleData.results.results[0]];
+        sampleData.results.results[0].response = { output: uri };
+        sampleData.blobAssets = [
+          { hash, mimeType, sizeBytes: data.length, data: data.toString('base64') },
+        ];
+        const filePath = path.join(blobDir, 'retained-mime.json');
+        fs.writeFileSync(filePath, JSON.stringify(sampleData));
+        importCommand(program);
+        await program.parseAsync(['node', 'test', 'import', filePath]);
+
+        expect(process.exitCode).toBeUndefined();
+        expect(logger.error).not.toHaveBeenCalled();
+        expect(await db.all(sql`SELECT mime_type FROM blob_assets WHERE hash = ${hash}`)).toEqual([
+          { mime_type: mimeType },
+        ]);
+        expect(
+          await db.all(
+            sql`SELECT eval_id, location FROM blob_references WHERE blob_hash = ${hash}`,
+          ),
+        ).toEqual([{ eval_id: sampleData.evalId, location: 'import' }]);
+        const response = await request(app)
+          .get(`/api/blobs/${hash}`)
+          .buffer(true)
+          .parse((res, callback) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (chunk: Buffer) => chunks.push(chunk));
+            res.on('end', () => callback(null, Buffer.concat(chunks)));
+          });
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(data);
+        expect(response.headers['content-type']).toBe(mimeType);
+        expect(response.headers['content-disposition']).toBe('attachment');
+        expect(response.headers['x-content-type-options']).toBe('nosniff');
+        expect(fs.readFileSync(blobPath)).toEqual(data);
+        expect(fs.readFileSync(`${blobPath}.meta.json`, 'utf8')).toBe(metadata);
+        await expect(getShareAuthorizedBlob(hash, 'unrelated-eval')).resolves.toBeNull();
+        await db.run(sql`DELETE FROM blob_references WHERE blob_hash = ${hash}`);
+        expect((await request(app).get(`/api/blobs/${hash}`)).status).toBe(403);
+        expect(fs.readFileSync(blobPath)).toEqual(data);
       } finally {
         resetBlobStorageProvider();
         restoreEnv();

--- a/test/server/routes/blobs.test.ts
+++ b/test/server/routes/blobs.test.ts
@@ -6,7 +6,11 @@ import { createApp } from '../../../src/server/server';
 
 // Mock dependencies
 vi.mock('../../../src/blobs/extractor');
-vi.mock('../../../src/blobs');
+vi.mock('../../../src/blobs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/blobs')>()),
+  getBlobByHash: vi.fn(),
+  getBlobUrl: vi.fn(),
+}));
 vi.mock('../../../src/database');
 
 // Import after mocking
@@ -153,6 +157,7 @@ describe('Blobs Routes', () => {
       expect(response.header.location).toBe(presignedUrl);
       expect(mockedGetBlobUrl).toHaveBeenCalledWith(validHash);
       expect(mockedGetBlobByHash).not.toHaveBeenCalled();
+      expect(response.header['content-disposition']).toBeUndefined();
     });
 
     it('should serve blob data directly when no presigned URL', async () => {
@@ -219,6 +224,71 @@ describe('Blobs Routes', () => {
           response.header['transfer-encoding'] === 'chunked',
       ).toBe(true);
     });
+
+    it.each([
+      'image/avif',
+      'image/gif',
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+      'video/mp4',
+      'video/ogg',
+      'video/webm',
+      'audio/wav',
+      'audio/x-custom',
+      'IMAGE/PNG',
+    ])('keeps passive %s blobs inline', async (mimeType) => {
+      setupDbWithAssetAndReference({
+        hash: validHash,
+        mimeType,
+        sizeBytes: 16,
+        provider: 'custom',
+      });
+      mockedGetBlobUrl.mockResolvedValue(null);
+      mockedGetBlobByHash.mockResolvedValue(createBlobResponse(mimeType, 16));
+
+      const response = await api.get(`/api/blobs/${validHash}`);
+
+      expect(response.status).toBe(200);
+      expect(response.header['content-type']).toBe(mimeType);
+      expect(response.header['content-disposition']).toBeUndefined();
+      expect(response.header['x-content-type-options']).toBe('nosniff');
+    });
+
+    it.each([
+      'text/html',
+      'image/svg+xml',
+      'application/xhtml+xml',
+      'application/xml',
+      'application/pdf',
+      'text/plain',
+      'application/json',
+      'application/octet-stream',
+      'application/x-custom',
+    ])(
+      'serves non-passive %s metadata as a download without changing its type',
+      async (mimeType) => {
+        // Custom/provider metadata remains authoritative over a different asset MIME.
+        setupDbWithAssetAndReference({
+          hash: validHash,
+          mimeType: 'image/png',
+          sizeBytes: 16,
+          provider: 'custom',
+        });
+        mockedGetBlobUrl.mockResolvedValue(null);
+        mockedGetBlobByHash.mockResolvedValue({
+          ...createBlobResponse(mimeType, 16),
+          data: Buffer.from('{"fixture":true}'),
+        });
+
+        const response = await api.get(`/api/blobs/${validHash}`);
+
+        expect(response.status).toBe(200);
+        expect(response.header['content-type']).toBe(mimeType);
+        expect(response.header['content-disposition']).toBe('attachment');
+        expect(response.header['x-content-type-options']).toBe('nosniff');
+      },
+    );
 
     it('should return 404 when getBlobByHash throws error', async () => {
       setupDbWithAssetAndReference(

--- a/test/server/routes/blobs.test.ts
+++ b/test/server/routes/blobs.test.ts
@@ -8,19 +8,26 @@ import { createApp } from '../../../src/server/server';
 vi.mock('../../../src/blobs/extractor');
 vi.mock('../../../src/blobs', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../src/blobs')>()),
-  getBlobByHash: vi.fn(),
-  getBlobUrl: vi.fn(),
+  getBlobStorageProvider: vi.fn(),
 }));
 vi.mock('../../../src/database');
 
 // Import after mocking
-import { getBlobByHash, getBlobUrl } from '../../../src/blobs';
+import { getBlobStorageProvider } from '../../../src/blobs';
 import { isBlobStorageEnabled } from '../../../src/blobs/extractor';
 import { getDb } from '../../../src/database';
 
 const mockedIsBlobStorageEnabled = vi.mocked(isBlobStorageEnabled);
-const mockedGetBlobUrl = vi.mocked(getBlobUrl);
-const mockedGetBlobByHash = vi.mocked(getBlobByHash);
+const mockedProvider = {
+  providerId: 'test',
+  store: vi.fn(),
+  getByHash: vi.fn(),
+  exists: vi.fn(),
+  deleteByHash: vi.fn(),
+  getUrl: vi.fn(),
+};
+const mockedGetUrl = mockedProvider.getUrl;
+const mockedGetByHash = mockedProvider.getByHash;
 const mockedGetDb = vi.mocked(getDb);
 
 describe('Blobs Routes', () => {
@@ -86,6 +93,7 @@ describe('Blobs Routes', () => {
 
     beforeEach(() => {
       vi.resetAllMocks();
+      vi.mocked(getBlobStorageProvider).mockReturnValue(mockedProvider);
     });
 
     afterEach(() => {
@@ -151,14 +159,15 @@ describe('Blobs Routes', () => {
         });
 
         const presignedUrl = 'https://s3.amazonaws.com/bucket/blob?signature=xyz';
-        mockedGetBlobUrl.mockResolvedValue(presignedUrl);
+        mockedGetUrl.mockResolvedValue(presignedUrl);
+        mockedGetByHash.mockResolvedValue(createBlobResponse(mimeType, 1024));
 
         const response = await api.get(`/api/blobs/${validHash}`);
 
         expect(response.status).toBe(302);
         expect(response.header.location).toBe(presignedUrl);
-        expect(mockedGetBlobUrl).toHaveBeenCalledWith(validHash);
-        expect(mockedGetBlobByHash).not.toHaveBeenCalled();
+        expect(mockedGetUrl).toHaveBeenCalledWith(validHash);
+        expect(mockedGetByHash).toHaveBeenCalledExactlyOnceWith(validHash);
         expect(response.header['content-disposition']).toBeUndefined();
       },
     );
@@ -171,8 +180,8 @@ describe('Blobs Routes', () => {
         provider: 'local',
       });
 
-      mockedGetBlobUrl.mockResolvedValue(null);
-      mockedGetBlobByHash.mockResolvedValue(createBlobResponse('image/png', 1024));
+      mockedGetUrl.mockResolvedValue(null);
+      mockedGetByHash.mockResolvedValue(createBlobResponse('image/png', 1024));
 
       const response = await api.get(`/api/blobs/${validHash}`);
 
@@ -185,7 +194,7 @@ describe('Blobs Routes', () => {
         response.header['content-length'] === '1024' ||
           response.header['transfer-encoding'] === 'chunked',
       ).toBe(true);
-      expect(mockedGetBlobByHash).toHaveBeenCalledWith(validHash);
+      expect(mockedGetByHash).toHaveBeenCalledExactlyOnceWith(validHash);
     });
 
     it('should use fallback MIME type for invalid MIME types', async () => {
@@ -194,8 +203,8 @@ describe('Blobs Routes', () => {
         { evalId: 'eval-456' },
       );
 
-      mockedGetBlobUrl.mockResolvedValue(null);
-      mockedGetBlobByHash.mockResolvedValue(createBlobResponse('audio/wav.html', 2048));
+      mockedGetUrl.mockResolvedValue(null);
+      mockedGetByHash.mockResolvedValue(createBlobResponse('audio/wav.html', 2048));
 
       const response = await api.get(`/api/blobs/${validHash}`);
 
@@ -205,20 +214,22 @@ describe('Blobs Routes', () => {
       expect(response.header['accept-ranges']).toBe('none');
     });
 
-    it('should use blob metadata MIME type when available', async () => {
+    it('uses registered MIME and reuses stored bytes when passive types disagree', async () => {
       setupDbWithAssetAndReference(
         { hash: validHash, mimeType: 'image/png', sizeBytes: 1024, provider: 'local' },
         { evalId: 'eval-789' },
       );
 
-      mockedGetBlobUrl.mockResolvedValue(null);
-      // Blob metadata has different MIME type and size than the asset record
-      mockedGetBlobByHash.mockResolvedValue(createBlobResponse('image/jpeg', 2048));
+      mockedGetUrl.mockResolvedValue('https://storage.example/mismatched-type');
+      // A different stored label must not override registered MIME or authorize a redirect.
+      mockedGetByHash.mockResolvedValue(createBlobResponse('image/jpeg', 2048));
 
       const response = await api.get(`/api/blobs/${validHash}`);
 
       expect(response.status).toBe(200);
-      expect(response.header['content-type']).toBe('image/jpeg');
+      expect(response.header['content-type']).toBe('image/png');
+      expect(mockedGetUrl).not.toHaveBeenCalled();
+      expect(mockedGetByHash).toHaveBeenCalledExactlyOnceWith(validHash);
       expect(response.header['cache-control']).toBe('public, max-age=31536000, immutable');
       expect(response.header['accept-ranges']).toBe('none');
       // Content-Length may be absent if response is gzipped
@@ -247,8 +258,8 @@ describe('Blobs Routes', () => {
         sizeBytes: 16,
         provider: 'custom',
       });
-      mockedGetBlobUrl.mockResolvedValue(null);
-      mockedGetBlobByHash.mockResolvedValue(createBlobResponse(mimeType, 16));
+      mockedGetUrl.mockResolvedValue(null);
+      mockedGetByHash.mockResolvedValue(createBlobResponse(mimeType, 16));
 
       const response = await api.get(`/api/blobs/${validHash}`);
 
@@ -271,15 +282,15 @@ describe('Blobs Routes', () => {
     ])(
       'serves non-passive %s metadata as a download without changing its type',
       async (mimeType) => {
-        // The real getter supplies registered MIME; the route preserves valid download types.
+        // The route preserves registered MIME for valid download types.
         setupDbWithAssetAndReference({
           hash: validHash,
           mimeType,
           sizeBytes: 16,
           provider: 'custom',
         });
-        mockedGetBlobUrl.mockResolvedValue('https://storage.example/active-object');
-        mockedGetBlobByHash.mockResolvedValue({
+        mockedGetUrl.mockResolvedValue('https://storage.example/active-object');
+        mockedGetByHash.mockResolvedValue({
           ...createBlobResponse(mimeType, 16),
           data: Buffer.from('{"fixture":true}'),
         });
@@ -290,7 +301,7 @@ describe('Blobs Routes', () => {
         expect(response.header['content-type']).toBe(mimeType);
         expect(response.header['content-disposition']).toBe('attachment');
         expect(response.header['x-content-type-options']).toBe('nosniff');
-        expect(mockedGetBlobUrl).not.toHaveBeenCalled();
+        expect(mockedGetUrl).not.toHaveBeenCalled();
       },
     );
 
@@ -301,23 +312,24 @@ describe('Blobs Routes', () => {
         sizeBytes: 16,
         provider: 'custom',
       });
-      mockedGetBlobUrl.mockRejectedValue(new Error('URL generation failed'));
+      mockedGetUrl.mockRejectedValue(new Error('URL generation failed'));
+      mockedGetByHash.mockResolvedValue(createBlobResponse('image/png', 16));
 
       const response = await api.get(`/api/blobs/${validHash}`);
 
       expect(response.status).toBe(404);
       expect(response.body).toEqual({ error: 'Blob not found' });
-      expect(mockedGetBlobByHash).not.toHaveBeenCalled();
+      expect(mockedGetByHash).toHaveBeenCalledExactlyOnceWith(validHash);
     });
 
-    it('should return 404 when getBlobByHash throws error', async () => {
+    it('should return 404 when the provider cannot read the blob', async () => {
       setupDbWithAssetAndReference(
         { hash: validHash, mimeType: 'text/plain', sizeBytes: 512, provider: 'local' },
         { evalId: 'eval-error' },
       );
 
-      mockedGetBlobUrl.mockResolvedValue(null);
-      mockedGetBlobByHash.mockRejectedValue(new Error('File system error'));
+      mockedGetUrl.mockResolvedValue(null);
+      mockedGetByHash.mockRejectedValue(new Error('File system error'));
 
       const response = await api.get(`/api/blobs/${validHash}`);
 

--- a/test/server/routes/serverRouteSmoke.test.ts
+++ b/test/server/routes/serverRouteSmoke.test.ts
@@ -44,7 +44,6 @@ const mocks = vi.hoisted(() => ({
   fetchWithProxy: vi.fn(),
   getAvailableProviders: vi.fn(),
   getBlobByHash: vi.fn(),
-  getBlobUrl: vi.fn(),
   getDb: vi.fn(),
   getEnvBool: vi.fn(),
   getEnvFloat: vi.fn(),
@@ -91,7 +90,6 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../../../src/blobs', () => ({
   getBlobByHash: mocks.getBlobByHash,
-  getBlobUrl: mocks.getBlobUrl,
 }));
 
 vi.mock('../../../src/blobs/extractor', () => ({

--- a/test/util/jsonExport.test.ts
+++ b/test/util/jsonExport.test.ts
@@ -111,7 +111,7 @@ describe('JSON export with improved error handling', () => {
         results: [{ response: { output: `promptfoo://blob/${hash}` } }],
         stats: { successes: 1, failures: 0 },
       });
-      vi.spyOn(blobs, 'getBlobByHash').mockResolvedValue({
+      vi.spyOn(blobs, 'getShareAuthorizedBlob').mockResolvedValue({
         data,
         metadata: {
           mimeType: 'image/png',
@@ -126,6 +126,7 @@ describe('JSON export with improved error handling', () => {
       expect(JSON.parse(fs.readFileSync(tempFilePath, 'utf8'))).not.toHaveProperty('blobAssets');
 
       await writeOutput(tempFilePath, mockEval, null, { includeMedia: true });
+      expect(blobs.getShareAuthorizedBlob).toHaveBeenCalledWith(hash, mockEval.id);
       const parsed = JSON.parse(fs.readFileSync(tempFilePath, 'utf8'));
       expect(parsed.blobAssets).toEqual([
         {
@@ -149,7 +150,7 @@ describe('JSON export with improved error handling', () => {
           spans: [],
         },
       ]);
-      vi.spyOn(blobs, 'getBlobByHash').mockResolvedValue({
+      vi.spyOn(blobs, 'getShareAuthorizedBlob').mockResolvedValue({
         data,
         metadata: {
           mimeType: 'image/png',
@@ -181,7 +182,7 @@ describe('JSON export with improved error handling', () => {
     it('should not embed response blob bytes when response output stripping is enabled', async () => {
       const restoreEnv = mockProcessEnv({ PROMPTFOO_STRIP_RESPONSE_OUTPUT: 'true' });
       const hash = 'c'.repeat(64);
-      const getBlobSpy = vi.spyOn(blobs, 'getBlobByHash');
+      const getBlobSpy = vi.spyOn(blobs, 'getShareAuthorizedBlob');
       mockEval.toEvaluateSummary.mockResolvedValue({
         version: 3,
         timestamp: '2025-01-01T00:00:00.000Z',


### PR DESCRIPTION
A failed blob database write can delete bytes already referenced by another evaluation. Preserve those bytes and propagate the original database error. Reference-only imports require a registered asset, and portable media exports retain per-evaluation authorization.

When a later import adopts an orphaned file, register its sanitized MIME type. Downloads use that registered type. Redirect to a provider URL only when its stored MIME agrees with the registered passive type; otherwise serve the already loaded bytes locally. Remove the unused URL wrapper and its stale test mocks.

Unregistered files remain after failed writes; this change adds no cleanup policy.

## Validation

- 327 tests across seven blob, route, import/export and hygiene suites; TypeScript, architecture and full Knip pass.
- Lint, explicit affected-file formatting and normal commit hooks pass. The changed-file formatting script reports an empty Prettier input; that command is not counted as passing.
- Core build/postbuild, two built-CLI import/export commands and an emitted-server PNG download pass, verifying four assets and the registered response type.
- The earlier failure, access-control and cross-label MIME regressions remain covered. The final merge preserves the tested source tree exactly.

Validation uses isolated local SQLite, filesystem and loopback fixtures. Browser, cloud-storage and live model behavior were not tested.
