### PR TITLE
fix: honor SDK options and load AVIF/TIFF images

### DIFF
--- a/src/app/src/pages/redteam/setup/page.test.tsx
+++ b/src/app/src/pages/redteam/setup/page.test.tsx
@@ -156,6 +156,43 @@ describe('RedTeamSetupPage', () => {
     });
   });
 
+  it.each(['network', 'server', 'success'])(
+    'updates dirty state for the %s save outcome',
+    async (outcome) => {
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <RedTeamSetupPage />
+        </MemoryRouter>,
+      );
+      await user.click(screen.getByRole('button', { name: 'Config' }));
+      await user.click(screen.getByRole('menuitem', { name: 'Save Config' }));
+      await user.type(screen.getByLabelText('Configuration Name'), 'Test config');
+      expect(screen.getAllByText(/Unsaved changes/).length).toBeGreaterThan(0);
+      if (outcome === 'network') {
+        mockedCallApi.mockRejectedValueOnce(new Error('Save failed'));
+      } else {
+        mockedCallApi.mockResolvedValueOnce({
+          ok: outcome === 'success',
+          json: async () =>
+            outcome === 'success' ? { createdAt: '2026-09-11' } : { error: 'Save failed' },
+        } as Response);
+      }
+      await user.click(screen.getByRole('button', { name: /^Save$/ }));
+      await waitFor(() =>
+        expect(mockedUseToast().showToast).toHaveBeenCalledWith(
+          outcome === 'success' ? 'Configuration saved successfully' : 'Save failed',
+          outcome === 'success' ? 'success' : 'error',
+        ),
+      );
+      if (outcome === 'success') {
+        expect(screen.queryByText(/Unsaved changes/)).not.toBeInTheDocument();
+      } else {
+        expect(screen.getAllByText(/Unsaved changes/).length).toBeGreaterThan(0);
+      }
+    },
+  );
+
   describe('URL Hash Updates', () => {
     it('should update the URL hash when the tab state changes', async () => {
       const user = userEvent.setup();

--- a/src/app/src/pages/redteam/setup/page.tsx
+++ b/src/app/src/pages/redteam/setup/page.tsx
@@ -289,8 +289,6 @@ export default function RedTeamSetupPage() {
         'error',
       );
     }
-
-    setHasUnsavedChanges(false);
   };
 
   const loadConfigs = async () => {

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -2417,20 +2417,9 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
     return '[Anthropic Claude Agent SDK Provider]';
   }
 
-  /**
-   * For normal Claude Agent SDK support, just use the Anthropic API key
-   * Users can also use Bedrock (with CLAUDE_CODE_USE_BEDROCK env var) or Vertex (with CLAUDE_CODE_USE_VERTEX env var)
-   */
+  // Credentials may be supplied per prompt, so validate the merged config in callApi.
   requiresApiKey(): boolean {
-    if (this.config.apiKeyRequired === false) {
-      return false;
-    }
-    return !(
-      this.env?.CLAUDE_CODE_USE_BEDROCK ||
-      this.env?.CLAUDE_CODE_USE_VERTEX ||
-      getEnvString('CLAUDE_CODE_USE_BEDROCK') ||
-      getEnvString('CLAUDE_CODE_USE_VERTEX')
-    );
+    return false;
   }
 
   getApiKey(): string | undefined {

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -1638,7 +1638,7 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
       permissionMode: config.permission_mode === 'manual' ? 'default' : config.permission_mode,
       planModeInstructions: config.plan_mode_instructions,
       systemPrompt:
-        config.custom_system_prompt === undefined
+        config.custom_system_prompt == null
           ? {
               type: 'preset',
               preset: 'claude_code',

--- a/src/providers/claude-agent-sdk.ts
+++ b/src/providers/claude-agent-sdk.ts
@@ -363,7 +363,7 @@ async function loadClaudeCodeSDK(): Promise<typeof import('@anthropic-ai/claude-
   }
 
   try {
-    return importModule(claudeCodePath);
+    return await importModule(claudeCodePath);
   } catch (err) {
     logger.error(`Failed to load Claude Agent SDK: ${err}`);
     if ((err as any).stack) {
@@ -1490,9 +1490,10 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
       env.CLAUDE_CODE_ENABLE_TODO_TOOLS ??= '1';
     }
 
-    // Ensure API key is available to Claude Agent SDK
-    if (this.apiKey) {
-      env.ANTHROPIC_API_KEY = this.apiKey;
+    // Prompt config overrides provider config; explicit keys take precedence over env.
+    const effectiveApiKey = config.apiKey || this.apiKey;
+    if (effectiveApiKey) {
+      env.ANTHROPIC_API_KEY = effectiveApiKey;
     }
     // Subprocess environment can contain credentials under arbitrary names and value formats.
     // Keep it out of persistent key material and scope reuse to this provider instance instead.
@@ -1500,7 +1501,7 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
 
     // Could potentially do more to validate credentials for Bedrock/Vertex here, but Anthropic key is the main use case
     if (
-      !this.apiKey &&
+      !effectiveApiKey &&
       !(
         config.apiKeyRequired === false ||
         env.CLAUDE_CODE_USE_BEDROCK ||
@@ -1636,14 +1637,15 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
       strictMcpConfig: config.strict_mcp_config ?? true, // only allow MCP servers that are explicitly configured - true by default
       permissionMode: config.permission_mode === 'manual' ? 'default' : config.permission_mode,
       planModeInstructions: config.plan_mode_instructions,
-      systemPrompt: config.custom_system_prompt
-        ? config.custom_system_prompt
-        : {
-            type: 'preset',
-            preset: 'claude_code',
-            append: config.append_system_prompt,
-            ...(config.exclude_dynamic_sections ? { excludeDynamicSections: true } : {}),
-          },
+      systemPrompt:
+        config.custom_system_prompt === undefined
+          ? {
+              type: 'preset',
+              preset: 'claude_code',
+              append: config.append_system_prompt,
+              ...(config.exclude_dynamic_sections ? { excludeDynamicSections: true } : {}),
+            }
+          : config.custom_system_prompt,
       maxThinkingTokens: config.max_thinking_tokens,
       allowedTools,
       disallowedTools,
@@ -1715,7 +1717,8 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
     const settingsConfigurationBypassesCache =
       config.settings !== undefined || config.managed_settings !== undefined;
     const extraArgsBypassCache = Object.keys(config.extra_args ?? {}).length > 0;
-    const promptEnvironmentOverrideBypassesCache = config.env !== this.config.env;
+    const promptCredentialOverrideBypassesCache =
+      config.env !== this.config.env || config.apiKey !== this.config.apiKey;
     const statefulSessionBypassesCache = Boolean(
       config.continue || config.resume || config.session_id,
     );
@@ -1737,8 +1740,10 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
     if (extraArgsBypassCache) {
       logger.debug('[ClaudeCodeSDKProvider] Bypassing cache: extra_args is open-ended');
     }
-    if (promptEnvironmentOverrideBypassesCache) {
-      logger.debug('[ClaudeCodeSDKProvider] Bypassing cache: prompt config overrides environment');
+    if (promptCredentialOverrideBypassesCache) {
+      logger.debug(
+        '[ClaudeCodeSDKProvider] Bypassing cache: prompt config overrides credentials or environment',
+      );
     }
     if (statefulSessionBypassesCache) {
       logger.debug('[ClaudeCodeSDKProvider] Bypassing cache: session history is mutable');
@@ -1753,7 +1758,7 @@ export class ClaudeCodeSDKProvider implements ApiProvider {
       sensitiveMcpBypassesCache ||
       settingsConfigurationBypassesCache ||
       extraArgsBypassCache ||
-      promptEnvironmentOverrideBypassesCache ||
+      promptCredentialOverrideBypassesCache ||
       statefulSessionBypassesCache ||
       externalCredentialProviderBypassesCache
         ? { shouldCache: false, shouldReadCache: false, shouldWriteCache: false }

--- a/src/util/fileExtensions.ts
+++ b/src/util/fileExtensions.ts
@@ -20,7 +20,20 @@ export function isJavascriptFile(filePath: string): boolean {
  * @returns True if the file has an image extension, false otherwise.
  */
 export function isImageFile(filePath: string): boolean {
-  const imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg', 'heic', 'heif'];
+  const imageExtensions = [
+    'jpg',
+    'jpeg',
+    'png',
+    'gif',
+    'bmp',
+    'webp',
+    'svg',
+    'heic',
+    'heif',
+    'avif',
+    'tif',
+    'tiff',
+  ];
   const fileExtension = filePath.split('.').pop()?.toLowerCase() || '';
   return imageExtensions.includes(fileExtension);
 }

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -36,6 +36,7 @@ import {
   getErrorResultIds,
   recalculatePromptMetrics,
 } from '../../src/node/retry';
+import { ClaudeCodeSDKProvider } from '../../src/providers/claude-agent-sdk';
 import { loadApiProvider } from '../../src/providers/index';
 import { createShareableUrl, isSharingEnabled } from '../../src/share';
 import { generateTable } from '../../src/table';
@@ -49,6 +50,7 @@ import { ConfigResolutionError, maybeReadConfig, resolveConfigs } from '../../sr
 import { writeMultipleOutputs } from '../../src/util/index';
 import { checkProviderApiKeys } from '../../src/util/provider';
 import { TokenUsageTracker } from '../../src/util/tokenUsage';
+import { mockProcessEnv } from '../util/utils';
 
 import type { ApiProvider, TestSuite, UnifiedConfig } from '../../src/types/index';
 
@@ -1476,6 +1478,35 @@ describe('evalCommand', () => {
     } finally {
       vi.mocked(checkProviderApiKeys).mockReturnValue(new Map());
       process.exitCode = previousExitCode;
+    }
+  });
+
+  it('allows prompt-only Claude SDK credentials through CLI preflight', async () => {
+    mockProcessEnv({
+      ANTHROPIC_API_KEY: undefined,
+      CLAUDE_CODE_USE_VERTEX: undefined,
+      CLAUDE_CODE_USE_BEDROCK: undefined,
+    });
+    const actual =
+      await vi.importActual<typeof import('../../src/util/provider')>('../../src/util/provider');
+    vi.mocked(checkProviderApiKeys).mockReset().mockImplementation(actual.checkProviderApiKeys);
+    const provider = new ClaudeCodeSDKProvider();
+    const prompts = [{ raw: 'Hello', label: 'test', config: { apiKey: 'prompt-only-key' } }];
+    vi.mocked(resolveConfigs).mockResolvedValueOnce({
+      config: defaultConfig,
+      testSuite: { providers: [provider], prompts },
+      basePath: path.resolve('/'),
+    });
+    vi.mocked(evaluate).mockImplementationOnce(async (_suite, record) => record as Eval);
+    try {
+      await doEval({ write: false }, defaultConfig, defaultConfigPath, {});
+      expect(evaluate).toHaveBeenCalledWith(
+        expect.objectContaining({ providers: [provider], prompts }),
+        expect.anything(),
+        expect.anything(),
+      );
+    } finally {
+      vi.mocked(checkProviderApiKeys).mockReset().mockReturnValue(new Map());
     }
   });
 

--- a/test/commands/eval.test.ts
+++ b/test/commands/eval.test.ts
@@ -1482,7 +1482,7 @@ describe('evalCommand', () => {
   });
 
   it('allows prompt-only Claude SDK credentials through CLI preflight', async () => {
-    mockProcessEnv({
+    const restoreEnv = mockProcessEnv({
       ANTHROPIC_API_KEY: undefined,
       CLAUDE_CODE_USE_VERTEX: undefined,
       CLAUDE_CODE_USE_BEDROCK: undefined,
@@ -1506,6 +1506,7 @@ describe('evalCommand', () => {
         expect.anything(),
       );
     } finally {
+      restoreEnv();
       vi.mocked(checkProviderApiKeys).mockReset().mockReturnValue(new Map());
     }
   });

--- a/test/evaluatorHelpers.test.ts
+++ b/test/evaluatorHelpers.test.ts
@@ -1785,6 +1785,9 @@ describe('evaluatorHelpers', () => {
     it.each([
       ['heic', 'image/heic'],
       ['heif', 'image/heif'],
+      ['avif', 'image/avif'],
+      ['tif', 'image/tiff'],
+      ['tiff', 'image/tiff'],
     ])('should generate a data URL for %s images', async (extension, mimeType) => {
       const prompt = toPrompt('Test prompt with image: {{image}}');
       const renderedPrompt = await renderPrompt(prompt, {

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -307,6 +307,7 @@ describe('ClaudeCodeSDKProvider', () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     cliState.setActiveOtlpReceiver();
     await clearCache();
   });
@@ -319,21 +320,27 @@ describe('ClaudeCodeSDKProvider', () => {
     expect(result.error).toContain('npm install @anthropic-ai/claude-agent-sdk');
   });
 
-  it('honors an explicitly empty system prompt', async () => {
-    mockQuery.mockReturnValue(createMockResponse('Response'));
-    const provider = new ClaudeCodeSDKProvider({
-      config: { apiKey: 'test-key', custom_system_prompt: '' },
-    });
-    await provider.callApi('Empty system prompt');
-    expect(mockQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: expect.objectContaining({ systemPrompt: '' }),
-      }),
-    );
-  });
+  it.each(['', null])(
+    'honors empty system prompts while defaulting null (%j)',
+    async (systemPrompt) => {
+      mockQuery.mockReturnValue(createMockResponse('Response'));
+      const provider = new ClaudeCodeSDKProvider({
+        config: { apiKey: 'test-key', custom_system_prompt: systemPrompt as unknown as string },
+      });
+      await provider.callApi('Empty system prompt');
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            systemPrompt:
+              systemPrompt === null ? expect.objectContaining({ preset: 'claude_code' }) : '',
+          }),
+        }),
+      );
+    },
+  );
 
   it('uses prompt API keys without reusing responses across credentials', async () => {
-    mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+    vi.stubEnv('ANTHROPIC_API_KEY', undefined);
     enableCache();
     const provider = new ClaudeCodeSDKProvider();
     for (const key of ['prompt-key-one', 'prompt-key-two']) {

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -311,6 +311,66 @@ describe('ClaudeCodeSDKProvider', () => {
     await clearCache();
   });
 
+  it('reports installation guidance for an asynchronously rejected SDK import', async () => {
+    vi.mocked(importModule).mockRejectedValueOnce(new Error('module initialization failed'));
+    const provider = new ClaudeCodeSDKProvider({ config: { apiKey: 'test-key' } });
+    const result = await provider.callApi('Import failure');
+    expect(result.error).toContain('Failed to load @anthropic-ai/claude-agent-sdk');
+    expect(result.error).toContain('npm install @anthropic-ai/claude-agent-sdk');
+  });
+
+  it('honors an explicitly empty system prompt', async () => {
+    mockQuery.mockReturnValue(createMockResponse('Response'));
+    const provider = new ClaudeCodeSDKProvider({
+      config: { apiKey: 'test-key', custom_system_prompt: '' },
+    });
+    await provider.callApi('Empty system prompt');
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({ systemPrompt: '' }),
+      }),
+    );
+  });
+
+  it('uses prompt API keys without reusing responses across credentials', async () => {
+    mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
+    enableCache();
+    const provider = new ClaudeCodeSDKProvider();
+    for (const key of ['prompt-key-one', 'prompt-key-two']) {
+      mockQuery.mockReturnValue(createMockResponse(key));
+      const result = await provider.callApi('Same prompt', {
+        vars: {},
+        prompt: { raw: 'Same prompt', label: 'test', config: { apiKey: key } },
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.output).toBe(key);
+      expect(mockQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            env: expect.objectContaining({ ANTHROPIC_API_KEY: key }),
+          }),
+        }),
+      );
+    }
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives the merged prompt API key precedence over the provider key', async () => {
+    mockQuery.mockReturnValue(createMockResponse('Response'));
+    const provider = new ClaudeCodeSDKProvider({ config: { apiKey: 'provider-key' } });
+    await provider.callApi('Override', {
+      vars: {},
+      prompt: { raw: 'Override', label: 'test', config: { apiKey: 'prompt-key' } },
+    });
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          env: expect.objectContaining({ ANTHROPIC_API_KEY: 'prompt-key' }),
+        }),
+      }),
+    );
+  });
+
   describe('constructor', () => {
     it('should initialize with default config', () => {
       const provider = new ClaudeCodeSDKProvider();

--- a/test/providers/claude-agent-sdk.test.ts
+++ b/test/providers/claude-agent-sdk.test.ts
@@ -1714,15 +1714,18 @@ describe('ClaudeCodeSDKProvider', () => {
         mockProcessEnv({ CLAUDE_CODE_USE_BEDROCK: undefined });
       });
 
-      it('should report missing key when no Vertex/Bedrock env is set', () => {
+      it('defers missing-key validation until prompt config is available', async () => {
         mockProcessEnv({ ANTHROPIC_API_KEY: undefined });
         mockProcessEnv({ CLAUDE_CODE_USE_VERTEX: undefined });
         mockProcessEnv({ CLAUDE_CODE_USE_BEDROCK: undefined });
 
         const provider = new ClaudeCodeSDKProvider();
         const result = checkProviderApiKeys([provider]);
-        expect(result.size).toBe(1);
-        expect(result.get('ANTHROPIC_API_KEY')).toEqual(['anthropic:claude-agent-sdk']);
+        expect(result.size).toBe(0);
+        await expect(provider.callApi('Missing credentials')).rejects.toThrow(
+          'Anthropic API key is not set',
+        );
+        expect(mockQuery).not.toHaveBeenCalled();
       });
 
       it('should not report missing key when apiKeyRequired is false', () => {

--- a/test/providers/google/ai.studio.test.ts
+++ b/test/providers/google/ai.studio.test.ts
@@ -2463,7 +2463,7 @@ describe('AIStudioChatProvider', () => {
       );
     });
 
-    it('should handle Google Search retrieval for Gemini 1.5 models', async () => {
+    it('should handle Google Search retrieval for Gemini 2.5 models', async () => {
       // Reset the Nunjucks mock to return the non-rendered value for these tests
       vi.mocked(templates.getNunjucksEngine).mockImplementation(function () {
         return {


### PR DESCRIPTION
## Summary

Honor prompt-level Claude Agent SDK keys through CLI preflight and runtime validation, preserve explicitly empty system prompts while defaulting null/undefined, and report actionable installation errors for rejected SDK imports. Prompt-level credential overrides bypass response caching so responses cannot be reused across keys. Missing credentials still fail before an SDK call.

Preserve the redteam setup unsaved-change indicator after failed saves. Load AVIF/TIF/TIFF file variables as image data URLs, and correct the Gemini 2.5 search test description.

This covers seven of eight visible AI finding rows (the Gemini suggestion is duplicated). The remaining evaluator prompt-metrics finding is already fixed in #10889 and is not duplicated here.

## Validation

- Failing-first regressions cover SDK import errors, prompt-only credentials through doEval, empty/null system prompts, failed saves, and AVIF/TIFF loading.
- 650 focused backend tests and 24 frontend tests passed. TypeScript, production build, and lint/format passed; existing complexity warnings only.
- Full backend run: 25,412 passed; two unrelated tracing/database timeouts under local load passed on isolated rerun (55 tests). Ten existing skips.
- Built CLI: AVIF/TIF/TIFF echo evaluations produced exact MIME/base64 output, each with score 1 and no errors. Mocked SDK evaluations verified prompt-only credentials plus empty/default system prompts, each with score 1 and no errors; no remote provider calls.
