### PR TITLE
docs(site): protect enterprise inquiries with Turnstile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39020,6 +39020,16 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-turnstile": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-turnstile/-/react-turnstile-1.1.5.tgz",
+      "integrity": "sha512-VTL5OeHAatzCEVQxAZox70/TPmhKxEbNgtr++dg+8zm9QrWKuoU9E0+7gqmycOSCDZuJFzvMMLKQb5PVUPLV6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16.13.1",
+        "react-dom": ">= 16.13.1"
+      }
+    },
     "node_modules/read-excel-file": {
       "version": "9.3.10",
       "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-9.3.10.tgz",
@@ -46043,6 +46053,7 @@
         "dompurify": "^3.4.8",
         "js-yaml": "5.4.1",
         "react-countup": "^6.5.3",
+        "react-turnstile": "^1.1.5",
         "swiper": "^14.0.0"
       },
       "devDependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -95,6 +95,7 @@
     "dompurify": "^3.4.8",
     "js-yaml": "5.4.1",
     "react-countup": "^6.5.3",
+    "react-turnstile": "^1.1.5",
     "swiper": "^14.0.0"
   }
 }

--- a/site/src/pages/contact.test.tsx
+++ b/site/src/pages/contact.test.tsx
@@ -1,8 +1,32 @@
 import React from 'react';
 
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import ContactPage from './contact';
+
+interface TurnstileOptions {
+  callback: (token: string) => void;
+  'expired-callback': () => void;
+  'timeout-callback': () => void;
+  'error-callback': () => void;
+  'unsupported-callback': () => void;
+}
+
+// Keep the real React wrapper; replace only Cloudflare's remote browser API.
+const turnstile = vi.hoisted(() => {
+  const api = {
+    render: vi.fn<(_container: HTMLElement, _options: TurnstileOptions) => string>(
+      () => 'contact-widget',
+    ),
+    remove: vi.fn(),
+  };
+  vi.stubGlobal('turnstile', api);
+  return api;
+});
+
+function verify(token = 'test-turnstile-token') {
+  act(() => turnstile.render.mock.lastCall![1].callback(token));
+}
 
 describe('contact form', () => {
   it('submits contact details to Formspark in the POST body', () => {
@@ -19,6 +43,7 @@ describe('contact form', () => {
     fireEvent.change(screen.getByLabelText(/How can we help/), {
       target: { value: 'Please share a demo.' },
     });
+    verify();
 
     expect(form.method).toBe('post');
     expect(form.action).toBe('https://submit-form.com/ghriv7voL');
@@ -29,7 +54,66 @@ describe('contact form', () => {
       company: 'Example',
       'interested-in': 'Model Evaluation',
       message: 'Please share a demo.',
+      'cf-turnstile-response': 'test-turnstile-token',
     });
+    expect(screen.getByRole('button', { name: 'Contact sales' })).toBeEnabled();
+    expect(fireEvent.submit(form)).toBe(true);
+  });
+
+  it('blocks submission until the existing Turnstile widget verifies the visitor', () => {
+    render(<ContactPage />);
+
+    const button = screen.getByRole('button', { name: 'Contact sales' });
+    const form = button.closest('form')!;
+    expect(turnstile.render).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        sitekey: '0x4AAAAAAExEs4irtoVm_IKg',
+        action: 'contact',
+        'response-field': false,
+        'refresh-expired': 'auto',
+      }),
+    );
+    expect(button).toBeDisabled();
+    expect(fireEvent.submit(form)).toBe(false);
+    expect(new FormData(form).get('cf-turnstile-response')).toBe('');
+  });
+
+  it.each([
+    'expired-callback',
+    'timeout-callback',
+    'error-callback',
+    'unsupported-callback',
+  ] as const)('clears the token and blocks submission after %s', (callback) => {
+    render(<ContactPage />);
+    verify();
+
+    act(() => turnstile.render.mock.lastCall![1][callback]());
+
+    const button = screen.getByRole('button', { name: 'Contact sales' });
+    const form = button.closest('form')!;
+    expect(button).toBeDisabled();
+    expect(new FormData(form).get('cf-turnstile-response')).toBe('');
+    expect(fireEvent.submit(form)).toBe(false);
+    expect(screen.getByRole('status')).toBeVisible();
+
+    verify('fresh-token');
+    expect(button).toBeEnabled();
+    expect(new FormData(form).getAll('cf-turnstile-response')).toEqual(['fresh-token']);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('removes the widget on navigation and requires a fresh token on return', () => {
+    const { unmount } = render(<ContactPage />);
+    verify();
+    unmount();
+
+    expect(turnstile.remove).toHaveBeenCalledWith('contact-widget');
+    render(<ContactPage />);
+    expect(turnstile.render).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('button', { name: 'Contact sales' })).toBeDisabled();
+    verify();
+    expect(screen.getByRole('button', { name: 'Contact sales' })).toBeEnabled();
   });
 
   it('keeps the honeypot hidden and out of normal submissions', () => {

--- a/site/src/pages/contact.tsx
+++ b/site/src/pages/contact.tsx
@@ -19,6 +19,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import Layout from '@theme/Layout';
+import { Turnstile } from 'react-turnstile';
 import styles from './contact.module.css';
 
 const testimonials = [
@@ -53,6 +54,13 @@ const testimonials = [
 
 function Contact(): React.ReactElement {
   const isDarkTheme = useColorMode().colorMode === 'dark';
+  const [turnstileToken, setTurnstileToken] = React.useState('');
+  const [verificationError, setVerificationError] = React.useState(false);
+
+  const handleVerificationError = () => {
+    setTurnstileToken('');
+    setVerificationError(true);
+  };
 
   const theme = React.useMemo(
     () =>
@@ -99,6 +107,11 @@ function Contact(): React.ReactElement {
                 action="https://submit-form.com/ghriv7voL"
                 method="POST"
                 className={styles.contactForm}
+                onSubmit={(event) => {
+                  if (!turnstileToken) {
+                    event.preventDefault();
+                  }
+                }}
               >
                 {/* Formspark discards submissions when bots check this hidden field. */}
                 <input
@@ -184,9 +197,38 @@ function Contact(): React.ReactElement {
                   placeholder="Share a few details about your application, timeline, and deployment requirements."
                 />
 
+                {/* Formspark validates this token server-side using its stored secret. */}
+                <input type="hidden" name="cf-turnstile-response" value={turnstileToken} />
+                <Turnstile
+                  sitekey="0x4AAAAAAExEs4irtoVm_IKg"
+                  action="contact"
+                  theme={isDarkTheme ? 'dark' : 'light'}
+                  size="flexible"
+                  fixedSize
+                  responseField={false}
+                  refreshExpired="auto"
+                  onLoad={() => setTurnstileToken('')}
+                  onVerify={(token) => {
+                    setTurnstileToken(token);
+                    setVerificationError(false);
+                  }}
+                  onExpire={() => setTurnstileToken('')}
+                  onTimeout={() => setTurnstileToken('')}
+                  onError={handleVerificationError}
+                  onUnsupported={handleVerificationError}
+                />
+                {!turnstileToken && (
+                  <Typography variant="body2" color="text.secondary" role="status">
+                    {verificationError
+                      ? 'Verification failed. Please refresh the page or email us below.'
+                      : 'Complete the verification before submitting.'}
+                  </Typography>
+                )}
+
                 <Box className={styles.submitRow}>
                   <Button
                     type="submit"
+                    disabled={!turnstileToken}
                     variant="contained"
                     size="large"
                     endIcon={<ArrowForwardIcon />}


### PR DESCRIPTION
Add the existing Turnstile widget to the enterprise contact form and include its token in the Formspark POST. Block submissions until verification succeeds and clear expired or failed tokens.

Validated with 268 site tests, typecheck, a production site build, lint/format checks, and real widget verification in Chrome, including navigation away and back. Added the missing `promptfoo.dev` hostname to the existing Cloudflare widget.

Rollout verified: the production contact page is deployed and Formspark Turnstile protection is enabled. Two labeled valid test inquiries were saved; direct POSTs with missing, invalid, and previously accepted tokens each returned HTTP 403 and were not stored.
