### PR TITLE
fix(fetch): decode URL credentials and match Authorization case-insensitively

### DIFF
--- a/src/util/fetch/index.ts
+++ b/src/util/fetch/index.ts
@@ -205,27 +205,35 @@ export async function fetchWithProxy(
     try {
       const parsedUrl = new URL(url);
       if (parsedUrl.username || parsedUrl.password) {
-        if (
-          finalOptions.headers &&
-          'Authorization' in (finalOptions.headers as Record<string, string>)
-        ) {
+        const headers = (finalOptions.headers ?? {}) as Record<string, string>;
+        // Header names are case-insensitive, and a Headers instance or array lowercases them.
+        // Matching only `Authorization` would add a second value that servers receive combined.
+        if (Object.keys(headers).some((name) => name.toLowerCase() === 'authorization')) {
           logger.warn(
             'Both URL credentials and Authorization header present - URL credentials will be ignored',
           );
         } else {
-          // Move credentials to Authorization header
-          const username = parsedUrl.username || '';
-          const password = parsedUrl.password || '';
-          const credentials = Buffer.from(`${username}:${password}`).toString('base64');
+          // Userinfo percent-encodes reserved characters, and HTTP clients decode it before
+          // Basic auth, so a password written as p%40ss must authenticate as p@ss. A malformed
+          // escape has no decoding and stays as written.
+          const credentials = [parsedUrl.username, parsedUrl.password]
+            .map((part) => {
+              try {
+                return decodeURIComponent(part);
+              } catch {
+                return part;
+              }
+            })
+            .join(':');
           finalOptions.headers = {
-            ...(finalOptions.headers as Record<string, string>),
-            Authorization: `Basic ${credentials}`,
+            ...headers,
+            Authorization: `Basic ${Buffer.from(credentials).toString('base64')}`,
           };
         }
         parsedUrl.username = '';
         parsedUrl.password = '';
         finalUrl = parsedUrl.toString();
-        finalUrlString = finalUrl.toString();
+        finalUrlString = finalUrl;
       }
     } catch (e) {
       logger.debug(`URL parsing failed in fetchWithProxy: ${e}`);

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -445,6 +445,61 @@ describe('fetchWithProxy', () => {
     );
   });
 
+  it('should decode percent-encoded URL credentials before sending Basic auth', async () => {
+    const url = 'https://us%40er:p%40ss%3Aword@example.com/api';
+
+    await fetchWithProxy(url);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/api',
+      expect.objectContaining({
+        headers: {
+          Authorization: `Basic ${Buffer.from('us@er:p@ss:word').toString('base64')}`,
+          'x-promptfoo-version': VERSION,
+        },
+      }),
+    );
+  });
+
+  it('should keep malformed percent escapes in URL credentials as written', async () => {
+    const url = 'https://user:bad%zzsecret@example.com/api';
+
+    await fetchWithProxy(url);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/api',
+      expect.objectContaining({
+        headers: {
+          Authorization: `Basic ${Buffer.from('user:bad%zzsecret').toString('base64')}`,
+          'x-promptfoo-version': VERSION,
+        },
+      }),
+    );
+  });
+
+  it('should not add Basic auth beside a lowercase authorization header', async () => {
+    const url = 'https://username:password@example.com/api';
+
+    await fetchWithProxy(url, { headers: new Headers({ authorization: 'Bearer token123' }) });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Both URL credentials and Authorization header present'),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.com/api',
+      expect.objectContaining({
+        headers: {
+          authorization: 'Bearer token123',
+          'x-promptfoo-version': VERSION,
+        },
+      }),
+    );
+    const [, calledOptions] = vi.mocked(global.fetch).mock.calls.at(-1)!;
+    expect(new Headers(calledOptions?.headers as HeadersInit).get('authorization')).toBe(
+      'Bearer token123',
+    );
+  });
+
   it('should use custom CA certificate when PROMPTFOO_CA_CERT_PATH is set', async () => {
     const mockCertPath = path.normalize('/path/to/cert.pem');
     const mockCertContent = 'mock-cert-content';


### PR DESCRIPTION
## Summary

`fetchWithProxy` moves credentials from a URL's userinfo into a Basic `Authorization` header. Two defects in that path send the wrong credential. Both are reachable from any provider whose endpoint carries userinfo, such as `apiBaseUrl: https://user:pass@gateway.example/v1`.

- **Percent-encoded credentials were not decoded.** Userinfo has to percent-encode reserved characters, so a password written as `p%40ss` was sent as the literal `p%40ss` rather than `p@ss`, and the gateway rejected it. Credentials are now decoded before the header is built, and a malformed escape such as `%zz` stays as written.
- **The existing-header check was case-sensitive.** It looked only for the exact key `Authorization`, but `headersInitToRecord` lowercases header names whenever a caller passes a `Headers` instance or an array of tuples. Such a caller got a second `Authorization` header, which servers receive as one combined `Bearer …, Basic …` value. The check is now case-insensitive, so the caller's header wins and the existing warning fires.

## Validation

- New regressions in `test/fetch.test.ts`:
  - encoded userinfo (`us%40er:p%40ss%3Aword`) produces Basic auth for `us@er:p@ss:word`
  - a malformed escape is kept as written
  - URL credentials beside a lowercase `authorization` header warn, leave the caller's header untouched, and send no combined value

  The first and third fail against `main`.
- The fetch suites pass (`test/fetch.test.ts`, `test/fetch.compression.test.ts`, `test/util/fetch`), as do the consumer suites for cloud, OAuth, server, and telemetry. TypeScript (root and the app's ES2020 project), lint, formatting, Knip, and the architecture check pass.
- End-to-end through the local CLI against a recording server, using an `http` provider whose URL carries `us%40er:p%40ss%3Aword%2F3333`:
  - **Before:** the server received Basic auth built from the still-encoded `us%40er:p%40ss%3Aword%2F3333`. With an `authorization` header also configured, it received a single combined `Bearer …, Basic …` value, and no warning was logged.
  - **After:** the server receives Basic auth for the decoded `us@er:p@ss:word/3333`. A configured `authorization` header arrives unchanged, and the existing warning is logged.

Found while reviewing #10892, where the Agents API provider now decodes userinfo itself and keeps it out of request URLs. This fixes the shared helper for every other provider.
