### PR TITLE
test: run agent skill examples against built CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -226,6 +226,8 @@ jobs:
         run: npm run test:package-artifact
 
       - name: Run built agent skill examples
+        env:
+          PROMPTFOO_POSTHOG_KEY: ''
         run: npm run test:smoke -- test/smoke/agent-skill-examples.test.ts
 
   style-check:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -132,6 +133,13 @@ jobs:
           PROMPTFOO_IGNORE_UNHANDLED_TEST_ERRORS: 'true'
         run: npm run test${{ matrix.shard && format(' -- --shard={0}/3', matrix.shard) || '' }}${{ matrix.os == 'ubuntu-latest' && matrix.node == '22.22' && !matrix.shard && ' -- --coverage' || '' }}
 
+      - name: Run built agent skill examples
+        if: matrix.os != 'ubuntu-latest' && (!matrix.shard || matrix.shard == '1')
+        run: |
+          npx tsdown
+          npm run postbuild
+          npm run test:smoke -- test/smoke/agent-skill-examples.test.ts
+
       - name: Check Backend Coverage Ratchets
         if: matrix.os == 'ubuntu-latest' && matrix.node == '22.22' && !matrix.shard
         run: npm run test:coverage:ratchet -- --report backend
@@ -165,6 +173,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -214,6 +224,9 @@ jobs:
         env:
           PROMPTFOO_DISABLE_TELEMETRY: 1
         run: npm run test:package-artifact
+
+      - name: Run built agent skill examples
+        run: npm run test:smoke -- test/smoke/agent-skill-examples.test.ts
 
   style-check:
     name: Style Check

--- a/test/smoke/agent-skill-examples.test.ts
+++ b/test/smoke/agent-skill-examples.test.ts
@@ -46,7 +46,7 @@ function httpJsonTransforms(markdown: string) {
 function runCli(args: string[]) {
   return promisify(execFile)(
     process.execPath,
-    ['--import', 'tsx', 'src/localEntrypoint.ts', ...args],
+    [path.join(repoRoot, 'dist/src/entrypoint.js'), ...args],
     {
       cwd: repoRoot,
       encoding: 'utf8',


### PR DESCRIPTION
The agent skill examples repeatedly start the TypeScript CLI inside the full backend suite. These tests have timed out on Windows across unrelated PRs.

Run the same 11 examples against the built CLI in the smoke suite. Keep the 30-second test timeout and preserve Linux Node 22/24/26, Windows Node 22, and macOS Node 22 coverage through the existing CI jobs.

The build-job smoke step clears its inherited telemetry key before running tests.

Validation: all 11 examples pass locally on Node 22 and 24; CLI build, TypeScript, changed-file lint/format, and actionlint pass. All current-head CI checks pass, including the built examples on Linux Node22/24/26, Windows Node22 and macOS Node22.
